### PR TITLE
Hostrup: Sange og Digte fra tredive År (1872)

### DIFF
--- a/1872.txt
+++ b/1872.txt
@@ -1,0 +1,5 @@
+KILDE:
+DIGTER:
+
+<!-- Digtet "Ved Bryllup og Sølvbryllup" i hostrup/1884.xml henviser til Hostrups Sange og Digte fra 30 Aar, S. 213.-->
+


### PR DESCRIPTION
- [x] Facsimile er bestilt.
- [ ] Tekst
- [ ] Titelblad
- [ ] Facsimiler
- [ ] Der henvises til visen på side 274 fra "Ved Bryllup og Sølvbryllup" i hostrup/1884.xml