### PR TITLE
Prevent duplicate notes groups in work XML

### DIFF
--- a/__tests__/poem-lines.js
+++ b/__tests__/poem-lines.js
@@ -10,6 +10,29 @@ import { fileExists, loadText } from '../tools/libs/helpers.js';
 function flatten(arr) {
   return [].concat(...arr);
 }
+
+function checkNotesGroups(filename, data) {
+  const headRegexp = /<(workhead|head)>[\s\S]*?<\/\1>/g;
+  const idRegexp = /<(?:text|section)[^>]*\sid="([^"]+)"/g;
+  let currentId = 'workhead';
+  const ids = Array.from(data.matchAll(idRegexp));
+  let idIndex = 0;
+  let headMatch;
+
+  while ((headMatch = headRegexp.exec(data)) != null) {
+    while (idIndex < ids.length && ids[idIndex].index < headMatch.index) {
+      currentId = ids[idIndex][1];
+      idIndex += 1;
+    }
+    const notesGroups = headMatch[0].match(/<notes>/g) || [];
+    if (notesGroups.length > 1) {
+      throw new Error(
+        `fdirs/${filename} ${currentId} has ${notesGroups.length} <notes> groups.`
+      );
+    }
+  }
+}
+
 // Regulære expressions som fanger typiske fejl i vores XML.
 // Disse kan enten være et regexp direkte eller et regexp med en whitelist.
 const regexps = [
@@ -100,6 +123,7 @@ describe('Check workfiles', () => {
     it(`Workfile fdirs/${filename} is fine`, () => {
       expect(fileExists(fullpath)).toBeTruthy;
       expect(data.length > 0);
+      checkNotesGroups(filename, data);
       regexps.forEach((rule) => {
         let regexp = rule.regexp || rule;
         let whitelist = rule.whitelist || [];

--- a/fdirs/bagger/1834.xml
+++ b/fdirs/bagger/1834.xml
@@ -2096,8 +2096,6 @@ Lad ogsaa der Din varme Maisol skinne!
    <indextitle>Et Sendebrev</indextitle>
    <firstline>Det som sig lønligst rører</firstline>
    <notes>
-   </notes>    
-   <notes>
       <note>Mottoet er sidste strofe i Byrons <xref poem="byron2002021401,41-48"/>.</note>
    </notes>
    <source pages="75-79"/>
@@ -2714,8 +2712,6 @@ At blanke blev Moderens Skjolde.
    <toctitle>Den engelske Kapitain</toctitle>
    <indextitle>Den engelske Kapitain</indextitle>
    <firstline>Fra Kullagunnarstorp de Svenske saae</firstline>
-   <notes>
-   </notes>    
    <notes>
       <note type="credits">Indtastet af Sven Sørensen.</note>
       <note>Mottoet stammer fra Malthe Conrad Bruuns <xref poem="bruunmc2017101319,43-46"/> fra <i>Aristokraternes Catechismus</i> (1796).</note>

--- a/fdirs/bruunmc/1796.xml
+++ b/fdirs/bruunmc/1796.xml
@@ -443,12 +443,10 @@ Til Kamp! Til Kamp imod Kjætterskokken!
    <notes>
       <note>Teksten følger Malthe Conrad Bruun: <i>Akristokraternes Catechismus</i>, K.F. Plesner (red.), Fagskolen for Boghaandværk, Kbh., 1945, pp. 37-39.</note>
       <note>Melodien er fra Jens Zetlitz' vise <xref poem="zetlitz2001070701"/>.</note>
+      <note type="credits">Bidrag fra Sven Sørensen.</note>
    </notes>
    <keywords>zetlitz</keywords>
    <quality>korrektur1,kilde,side</quality>
-   <notes>
-      <note type="credits">Bidrag fra Sven Sørensen.</note>
-   </notes>
 </head>
 <body>
 <poetry>

--- a/fdirs/schneider/1909.xml
+++ b/fdirs/schneider/1909.xml
@@ -6,13 +6,11 @@
     <year>1909</year>
     <notes>
         <note>Teksten følger Marinus Schneider: <i>Forår mellem Mure</i>, Gyldendalske Boghandel, Nordisk Forlag, Kbh., 1909.</note>
+        <note>Afsnittet <i>Alene</i> har mottoet ,,<sc>ej nogen evighed sig om dig hvælver, / skønt du til tider frygtsomt hvisker: tøv! / nej, du min sjæl! min sjæl, som bange skælver, / du er lidt støv!</sc>''</note><!-- TODO: Hvor stammer dette citat fra? -->
     </notes>
     <pictures>
         <picture src="1909-p1.jpg">Titelbladet til <i>Forår mellem Mure</i> (1909) lyder ,,Marinus Schneider / Forår / mellem Mure // Gyldendalsk Boghandel / Nordisk Forlag // MDCCCCIX''.</picture>
     </pictures>
-    <notes>
-        <note>Afsnittet <i>Alene</i> har mottoet ,,<sc>ej nogen evighed sig om dig hvælver, / skønt du til tider frygtsomt hvisker: tøv! / nej, du min sjæl! min sjæl, som bange skælver, / du er lidt støv!</sc>''</note><!-- TODO: Hvor stammer dette citat fra? -->
-    </notes>
     <source facsimile="115408005278_color" facsimile-pages-num="98" facsimile-pages-offset="6">Marinus Schneider: <i>Forår mellem Mure</i>, Gyldendalske Boghandel, Nordisk Forlag, Kbh., 1909.</source>
 </workhead>
 <workbody>


### PR DESCRIPTION
## Summary
- Add a lightweight text-based test that rejects multiple <notes> groups in work XML heads
- Merge existing duplicate notes groups in Bagger, Bruun, and Schneider XML files

## Verification
- npm test -- --runTestsByPath __tests__/poem-lines.js