### PR TITLE
Move Kletke original note to primary variant

### DIFF
--- a/fdirs/henriksen/1906.xml
+++ b/fdirs/henriksen/1906.xml
@@ -944,6 +944,9 @@ O mig skilte fra Barndommens År.
 <head>
     <title>Elverdrøm</title>
     <firstline>O, vogt for Fare vel din Fod</firstline>
+    <notes>
+        <note unknown-original-by="kletke" />
+    </notes>
     <source pages="48-49"/>
     <!-- TODO: Find originalen -->
     <quality>korrektur1,kilde,side</quality>

--- a/fdirs/henriksen/1916.xml
+++ b/fdirs/henriksen/1916.xml
@@ -750,9 +750,6 @@ alene mellem Grave staa!
 <head>
     <title>Elverdrøm</title>
     <firstline>O, vogt for Fare vel din Fod</firstline>
-    <notes>
-        <note unknown-original-by="kletke" />
-    </notes>
     <source pages="40-41"/>
     <quality>korrektur1,korrektur2,kilde,side</quality>
 </head>


### PR DESCRIPTION
## Summary
- Move the Kletke unknown-original note from the later variant to the primary text variant
- Make Kletke's mentions page show a real translation reference instead of an empty page

Fixes #872.

## Verification
- npm test -- --runTestsByPath __tests__/poem-lines.js
- git diff --check