### PR TITLE
Tilføj test for løse bogstaver

### DIFF
--- a/__tests__/poem-lines.js
+++ b/__tests__/poem-lines.js
@@ -11,6 +11,10 @@ function flatten(arr) {
   return [].concat(...arr);
 }
 
+function fail(message) {
+  throw new Error(message);
+}
+
 function checkNotesGroups(filename, data) {
   const headRegexp = /<(workhead|head)>[\s\S]*?<\/\1>/g;
   const idRegexp = /<(?:text|section)[^>]*\sid="([^"]+)"/g;
@@ -57,6 +61,40 @@ function textAliases(data) {
   });
 }
 
+function ignoredTestsAtLine(data) {
+  const partRegexp = /<(?:text|section)\b[^>]*>/g;
+  const lineStarts = [0];
+  let lineBreakIndex = -1;
+
+  while ((lineBreakIndex = data.indexOf('\n', lineBreakIndex + 1)) !== -1) {
+    lineStarts.push(lineBreakIndex + 1);
+  }
+
+  const ignoredAtLine = new Map();
+  let currentIgnoredTests = [];
+  let partIndex = 0;
+  const parts = Array.from(data.matchAll(partRegexp));
+
+  lineStarts.forEach((lineStart, lineIndex) => {
+    while (partIndex < parts.length && parts[partIndex].index <= lineStart) {
+      const ignoreTestsMatch = parts[partIndex][0].match(
+        /\signore-tests="([^"]*)"/
+      );
+      currentIgnoredTests =
+        ignoreTestsMatch == null
+          ? []
+          : ignoreTestsMatch[1]
+              .split(',')
+              .map((testName) => testName.trim())
+              .filter((testName) => testName.length > 0);
+      partIndex += 1;
+    }
+    ignoredAtLine.set(lineIndex, currentIgnoredTests);
+  });
+
+  return ignoredAtLine;
+}
+
 // Regulære expressions som fanger typiske fejl i vores XML.
 // Disse kan enten være et regexp direkte eller et regexp med en whitelist.
 const regexps = [
@@ -69,6 +107,8 @@ const regexps = [
   /<firstline><\/firstline>/, // Tom <firstline> ...
   /<source pages="">/,
   /^.*[^\.]\.\s*[a-z;]\s*$/, // Løse bogstaver efter sidste punktum
+  { testName: 'loose-letters', regexp: / [a-hj-np-z]\s*$/m, onlylangs: ['da'] }, // Løst bogstav sidst på dansk linje. Tillad i og o.
+  { testName: 'loose-letters', regexp: / [b-z]\s*$/m, onlylangs: ['en'] }, // Løst bogstav sidst på engelsk linje. Tillad a.
   { regexp: /[a-zæøå],[a-zæøå]/, whitelist: [/<keywords>/, /<quality>/] },
   { regexp: /mmm/, whitelist: [/<note>.*\]/] },
   ///iii/, // Problematisk da den rammer lowercase romertal. Fiks fejlere og drop reglen.
@@ -181,6 +221,7 @@ describe('Check workfiles', () => {
     const lang = filenameLangs[filename];
     it(`Workfile fdirs/${filename} is fine`, () => {
       const data = loadText(fullpath);
+      const ignoredTests = ignoredTestsAtLine(data);
       expect(fileExists(fullpath)).toBeTruthy;
       expect(data.length > 0);
       checkNotesGroups(filename, data);
@@ -188,8 +229,12 @@ describe('Check workfiles', () => {
         let regexp = rule.regexp || rule;
         let whitelist = rule.whitelist || [];
         let ignorelangs = rule.ignorelangs || [];
+        let onlylangs = rule.onlylangs || [];
 
         if (ignorelangs.indexOf(lang) > -1) {
+          return;
+        }
+        if (onlylangs.length > 0 && onlylangs.indexOf(lang) === -1) {
           return;
         }
         if (!regexp) {
@@ -197,9 +242,11 @@ describe('Check workfiles', () => {
         }
 
         if (regexp.test(data)) {
-          data.split('\n').forEach((line) => {
+          data.split('\n').forEach((line, lineIndex) => {
             if (
               regexp.test(line) &&
+              (rule.testName == null ||
+                ignoredTests.get(lineIndex).indexOf(rule.testName) === -1) &&
               !whitelist.find((w) => {
                 return w.test(line);
               })

--- a/fdirs/andersen/1830.xml
+++ b/fdirs/andersen/1830.xml
@@ -777,7 +777,7 @@ Tilsidst jeg Tingene begreb, som her jeg nu forkynder.
 Naar Fisken rører Havsens Bund, den gaaer som vi paa tvende,
 Men stiger den syv Favne op, den bli'er en Fisk behænde.
 Da Sligt jeg saae, jeg blev saa sær, jeg hørte Hjertet banke,
-Og i mit Hoved kom, maaskee, den lidt bizarre Tanke, a
+Og i mit Hoved kom, maaskee, den lidt bizarre Tanke,
 Om ligerviis ei Mennesket, som hist paa Jord spadserer,
 Naar han i Himlen trlkker op, som Flynder debuterer.
 Thi naar vi see paa Tingen ret, vi ere Fisk i Grunden,

--- a/fdirs/andersen/andre.xml
+++ b/fdirs/andersen/andre.xml
@@ -1234,7 +1234,7 @@ Faaborg den 7 August.
 </body>
 </text>
 
-<text id="andersen2001091301">
+<text id="andersen2001091301" ignore-tests="loose-letters">
 <head>
    <title>Formens evige Magie</title>
    <subtitle>

--- a/fdirs/drachmann/1879.xml
+++ b/fdirs/drachmann/1879.xml
@@ -7283,7 +7283,7 @@ Jeg iler i Natten
 Jeg hører dem alle sige
 — og Folk, som studered det - Rette —
 at Livet ej slukkes med Læbens Pust,
-at der er et Liv efter dette. s
+at der er et Liv efter dette.
 Jeg vilde saa gerne vide Besked
 om, hvor det var henne og hvad det hed,
 jeg vilde saa grumme nødig

--- a/fdirs/drachmann/1884.xml
+++ b/fdirs/drachmann/1884.xml
@@ -1360,7 +1360,7 @@ og saa sank den med Rejling og Essing.
 Haardt mod Haardt!
 det Motto var vort
 fra det gryende Tidevands Mørke;
-Slag mod Slag l
+Slag mod Slag!
 fra den glødende Dag,
 da Jorden fik Bugvrid af Tørke;
 Fatum rejser sig kæmpestor

--- a/fdirs/fibiger/1884.xml
+++ b/fdirs/fibiger/1884.xml
@@ -4420,7 +4420,7 @@ og skjærer løs med Tidens Tænder,
 med sære Skrig og kvalte Suk,
 
 Her var det værdt sin Røst at røre,
-her er engang en Menighed, t
+her er engang en Menighed,
 her var det værdt at bøie Øre
 til Lovsang i al Evighed.
 

--- a/fdirs/fonss/1900.xml
+++ b/fdirs/fonss/1900.xml
@@ -2490,7 +2490,7 @@ Javist, som en jaget Vilddyrsflok!
 - slængt er Gevær og Hue.
 De fare forbi. Da myldrer frem
 de Bønder fra Stald og Stue.
-De sender med Fynd den forhadte Gæst a
+De sender med Fynd den forhadte Gæst
 et Hurra, som Lungerne renser.
 Og Raabet besvares fra Vejen i Nord:
 Der kommer de danske »Jenser«!

--- a/fdirs/fonss/1919.xml
+++ b/fdirs/fonss/1919.xml
@@ -577,7 +577,7 @@ Hedens Himmel Luftsyn spejler -
     vend fra dem dig bort!
 Moser, Bakker, Lyng og Hjejler
     - det, kun <w>det</w> er vort.
-Tykkes armt det nu og øde, e
+Tykkes armt det nu og øde,
 dyrk det, til det bærer Grøde.
 Bryd dets Muld med stærke Lemmer,
   <w>den</w> din Fremtid gemmer!

--- a/fdirs/hostrup/1884.xml
+++ b/fdirs/hostrup/1884.xml
@@ -3069,7 +3069,7 @@ han finde maa sig først en Vraa,
   hvori der er Plads til Frede.
 Han søger den til sin Jomfru.
 
-Og Huset snart blev hexet frem - d
+Og Huset snart blev hexet frem -
   et Hus er nok ej saa ilde —
 men før han førte Skatten hjem,
   han maatte med os til Gilde.

--- a/fdirs/joergensen/1918.xml
+++ b/fdirs/joergensen/1918.xml
@@ -801,7 +801,7 @@ Hør Havets Hulk og Leg med Brinkens Sten!
 Se, Bølgen, sig for Vindens Kræfter krummer!
 Med skumhvid,Kam de møder en for en
 og flades ud og synker hen i Slummer.
-r » . t
+
 Hvor Bølgen dør, der tripper fattig Fugl
 i Flint og Tang og søger Livets Føde.
 En blaalig Maage kyses fra sit Skjul

--- a/fdirs/kokm/1883.xml
+++ b/fdirs/kokm/1883.xml
@@ -1341,7 +1341,7 @@ Og Støvskyen sænked sig tæt og sort . . .
 
 Men atter Krudtrøgen vejredes bort,
 Som skjulte den dødssvangre Scene,
-Da laa de alle paa Jorden strakt, j
+Da laa de alle paa Jorden strakt,
 Kun to stod oprejst paa Helte vagt:
 Løjtnant Anker, det var den ene,
 Men hvo er den <i>anden</i>, som stolt og kjækt

--- a/fdirs/levy/1906.xml
+++ b/fdirs/levy/1906.xml
@@ -692,8 +692,8 @@ hvorhen, ak hvorhen?
 er du vor Ven?
 
 I Vildgæs, I Ænder,
-min Bøsse er ladt. w
-t - Hvad Skade kan ske os,
+min Bøsse er ladt.
+- Hvad Skade kan ske os,
 mulmsorte Nat!
 
 I Skarer, jeg ræddes
@@ -1216,7 +1216,7 @@ fløjtende Fugle tæt om Gren.
 Jorden du suger,
 Himlen du bærer,
 brusende Ask paa dit stærke Skjold
-Duggen i Dale m
+Duggen i Dale
 kølende lindrer
 Tidernes vilde Ve og Vold.
 

--- a/fdirs/nalbandian/1905.xml
+++ b/fdirs/nalbandian/1905.xml
@@ -321,9 +321,9 @@ ud i den frieste Hvile,
 henter et bølgende Aandedrag,
 mens tusinde Stjerner smile -
 
-synker saa hen i Drømme, f
-som Maaneskinsglansen forgylder, I
-- indtil den dødstause, dybe Nat £
+synker saa hen i Drømme,
+som Maaneskinsglansen forgylder,
+- indtil den dødstause, dybe Nat
 sin Kaabe omkring den hyller.
 
 Og medens Bølgernes Vuggesang

--- a/fdirs/nielsenlc/1905.xml
+++ b/fdirs/nielsenlc/1905.xml
@@ -1667,7 +1667,7 @@ og Sorg, som ej kan siges!
     en sagte sukkende Vind;
     hjemløst flagrer dens Vinge
     mellem de nøgne Mure —
-        Men Solen hviler i Dalens Skød m
+        Men Solen hviler i Dalens Skød
         ed træt og blussende Kind.
 
 Verden er fuld af Skønhed

--- a/fdirs/nielsenz/1902.xml
+++ b/fdirs/nielsenz/1902.xml
@@ -125,7 +125,7 @@ kan varme i et Hjerte.
 
 Naar ret han fæstede sit Blik
 paa mig med kærlig Dvælen,
-da var det, som hans Tanker gik m
+da var det, som hans Tanker gik
 ig lige ind i Sjælen.
 
 Han førte mig ved Haand omkring

--- a/fdirs/wessel/1772.xml
+++ b/fdirs/wessel/1772.xml
@@ -2244,7 +2244,7 @@ Paa dens Medlidenhed jeg forud er saa sikker,
 At jeg et Ønske giør, i det at jeg mig stikker,
 Hvorved jeg vidne vil min Tak for hver en Taar.<note>For hver en Taar, Taare (forældet).</note>
 I Efterlevende! troer! det fra Hiertet gaaer.
-Gid det ei Eder gaae, som det gik denne Stømper l
+Gid det ei Eder gaae, som det gik denne Stømper!
 <w>Gid Eders Kierlighed maa aldrig mangle Strømper!</w>
 
 <nonum>   (Han stikker sig.)</nonum>


### PR DESCRIPTION
## Ændringer

- Tilføjer en testregel, der fanger løse enkeltbogstaver sidst på linjer i danske og engelske tekster.
- Tillader sproglige undtagelser: `i` og `o` på dansk samt `a` på engelsk.
- Tilføjer `ignore-tests="loose-letters"`, så enkelte tekster kan markeres som bevidste undtagelser.
- Retter de fundne løse bogstaver i tekstkorpusset.

## Test

- `npm test -- --runTestsByPath __tests__/poem-lines.js --runInBand`
- `git diff --check`

Fixes #441
