### PR TITLE
Tilføj download af originale billeder

### DIFF
--- a/components/icons.js
+++ b/components/icons.js
@@ -153,6 +153,59 @@ export const RightArrow = ({ onClick, inactive, color = 'black' }) => {
   );
 };
 
+export const DownArrow = ({ onClick, inactive, color = 'black' }) => {
+  const strokeColor = inactive == true ? '#888' : color;
+  const className = inactive == true ? 'inactive' : 'active';
+  return (
+    <svg width="30" height="30" onClick={onClick} className={className}>
+      <circle
+        className="icon-background"
+        cx="15"
+        cy="15"
+        r="14"
+        fill="white"
+        stroke="black"
+        strokeWidth="1"
+        vectorEffect="non-scaling-stroke"
+      />
+      <line
+        x1="15"
+        y1="8"
+        x2="15"
+        y2="22"
+        strokeWidth="1"
+        stroke={strokeColor}
+        vectorEffect="non-scaling-stroke"
+      />
+      <line
+        x1="9"
+        y1="15"
+        x2="15"
+        y2="22"
+        strokeWidth="1"
+        stroke={strokeColor}
+        vectorEffect="non-scaling-stroke"
+      />
+      <line
+        x1="21"
+        y1="15"
+        x2="15"
+        y2="22"
+        strokeWidth="1"
+        stroke={strokeColor}
+        vectorEffect="non-scaling-stroke"
+      />
+      <circle
+        className="button-overlay"
+        cx="15"
+        cy="15"
+        r="14"
+        fill="transparent"
+      />
+    </svg>
+  );
+};
+
 export const CloseButton = ({ onClick }) => {
   return (
     <svg width="30" height="30" onClick={onClick} className="active">

--- a/components/pictureoverlay.js
+++ b/components/pictureoverlay.js
@@ -1,7 +1,12 @@
 import { useEffect, useState } from 'react';
 import CommonData from '../common/commondata.js';
-import { CloseButton, LeftArrow, RightArrow } from './icons.js';
+import { CloseButton, DownArrow, LeftArrow, RightArrow } from './icons.js';
 import { FigCaption } from './picture.js';
+
+const filenameFromSrc = (src) => {
+  const path = src.split('?')[0];
+  return path.substring(path.lastIndexOf('/') + 1);
+};
 
 const BiggerPicture = ({ picture }) => {
   const src = picture.src;
@@ -145,6 +150,16 @@ const PictureOverlay = ({ pictures, startIndex, closeCallback }) => {
     );
   }
   const picture = pictures[currentIndex];
+  buttons.push(
+    <a
+      className="download-icon"
+      href={picture.src}
+      download={filenameFromSrc(picture.src)}
+      title="Download originalbillede"
+      key="download">
+      <DownArrow />
+    </a>
+  );
   return (
     <div className="overlay-background" onClick={hideOverlay}>
       <div className="overlay-container" onClick={eatClick}>
@@ -197,14 +212,19 @@ const PictureOverlay = ({ pictures, startIndex, closeCallback }) => {
           top: -15px;
         }
 
-        .overlay-container .overlay-icon svg {
+        .overlay-container .overlay-icon :global(svg),
+        .overlay-container .overlay-icon :global(a.download-icon) {
           display: block;
         }
 
-        :global(.overlay-icon svg.active:hover .icon-background) {
+        .overlay-container .overlay-icon :global(> * + *) {
+          margin-top: 5px;
+        }
+
+        :global(.overlay-icon .active:hover .icon-background) {
           fill: #eee;
         }
-        :global(.overlay-icon svg.active) {
+        :global(.overlay-icon .active) {
           cursor: pointer;
         }
 


### PR DESCRIPTION
## Ændringer

- Tilføjer et download-ikon i billed-popupen.
- Download-knappen peger på originalfilen via `picture.src` og bruger browserens `download`-attribut.
- Tilføjer et egentligt `DownArrow`-ikon i samme stil som de eksisterende bladreikoner.
- Justerer ikonlayoutet, så afstanden mellem popup-knapperne er eksplicit.

## Test

- `npm run build`
- `git diff --check`
