### PR TITLE
Tilføj litterære perioder til digtere

### DIFF
--- a/common/literary-periods.js
+++ b/common/literary-periods.js
@@ -1,0 +1,129 @@
+const literaryPeriods = [
+  {
+    id: 'antikken',
+    title: {
+      da: 'Antikken',
+      en: 'Antiquity',
+      de: 'Antike',
+      fr: 'Antiquité',
+      it: 'Antichità',
+    },
+  },
+  {
+    id: 'middelalderen',
+    title: {
+      da: 'Middelalderen',
+      en: 'The Middle Ages',
+      de: 'Mittelalter',
+      fr: 'Moyen Âge',
+      it: 'Medioevo',
+    },
+  },
+  {
+    id: 'renaessance-og-humanisme',
+    title: {
+      da: 'Renæssance og humanisme',
+      en: 'Renaissance and humanism',
+      de: 'Renaissance und Humanismus',
+      fr: 'Renaissance et humanisme',
+      it: 'Rinascimento e umanesimo',
+    },
+  },
+  {
+    id: 'barok-og-tidlig-modernitet',
+    title: {
+      da: 'Barok og tidlig modernitet',
+      en: 'Baroque and early modernity',
+      de: 'Barock und Frühe Neuzeit',
+      fr: 'Baroque et première modernité',
+      it: 'Barocco e prima modernità',
+    },
+  },
+  {
+    id: 'oplysningstid-og-klassicisme',
+    title: {
+      da: 'Oplysningstid og klassicisme',
+      en: 'The Enlightenment and classicism',
+      de: 'Aufklärung und Klassizismus',
+      fr: 'Lumières et classicisme',
+      it: 'Illuminismo e classicismo',
+    },
+  },
+  {
+    id: 'romantik-og-praeromantik',
+    title: {
+      da: 'Romantik og præromantik',
+      en: 'Romanticism and pre-romanticism',
+      de: 'Romantik und Präromantik',
+      fr: 'Romantisme et préromantisme',
+      it: 'Romanticismo e preromanticismo',
+    },
+  },
+  {
+    id: 'realisme-og-naturalisme',
+    title: {
+      da: 'Realisme og naturalisme',
+      en: 'Realism and naturalism',
+      de: 'Realismus und Naturalismus',
+      fr: 'Réalisme et naturalisme',
+      it: 'Realismo e naturalismo',
+    },
+  },
+  {
+    id: 'symbolisme-og-fin-de-siecle',
+    title: {
+      da: 'Symbolisme og fin de siècle',
+      en: 'Symbolism and fin de siècle',
+      de: 'Symbolismus und Fin de Siècle',
+      fr: 'Symbolisme et fin de siècle',
+      it: 'Simbolismo e fin de siècle',
+    },
+  },
+  {
+    id: 'modernisme-og-avantgarde',
+    title: {
+      da: 'Modernisme og avantgarde',
+      en: 'Modernism and avant-garde',
+      de: 'Modernismus und Avantgarde',
+      fr: 'Modernisme et avant-garde',
+      it: 'Modernismo e avanguardia',
+    },
+  },
+  {
+    id: 'efterkrigstid',
+    title: {
+      da: 'Efterkrigstid',
+      en: 'Post-war period',
+      de: 'Nachkriegszeit',
+      fr: 'Après-guerre',
+      it: 'Dopoguerra',
+    },
+  },
+  {
+    id: 'postmodernisme',
+    title: {
+      da: 'Postmodernisme',
+      en: 'Postmodernism',
+      de: 'Postmoderne',
+      fr: 'Postmodernisme',
+      it: 'Postmodernismo',
+    },
+  },
+  {
+    id: 'samtid',
+    title: {
+      da: 'Samtid',
+      en: 'Contemporary literature',
+      de: 'Gegenwartsliteratur',
+      fr: 'Littérature contemporaine',
+      it: 'Letteratura contemporanea',
+    },
+  },
+];
+
+const literaryPeriodIds = new Set(literaryPeriods.map((period) => period.id));
+
+module.exports = {
+  literaryPeriods,
+  literaryPeriodIds,
+};

--- a/fdirs/aarestrup/info.xml
+++ b/fdirs/aarestrup/info.xml
@@ -15,6 +15,7 @@
       <place>Odense</place>
     </dead>
   </period>
+  <literary-periods>romantik-og-praeromantik</literary-periods>
   <works>1838,1863,1976,1976-1,1976-2,1976-3,1976-4,1976-5,1976-6</works>
   <identifiers>
     <wikidata>Q350408</wikidata>

--- a/fdirs/aasen/info.xml
+++ b/fdirs/aasen/info.xml
@@ -15,6 +15,7 @@
       <place>Christiania (nu Oslo)</place>
     </dead>
   </period>
+  <literary-periods>romantik-og-praeromantik</literary-periods>
   <works>1863</works>
   <identifiers>
     <wikidata>Q106812</wikidata>

--- a/fdirs/almqvist/info.xml
+++ b/fdirs/almqvist/info.xml
@@ -14,6 +14,7 @@
       <place>Bremen</place>
     </dead>
   </period>
+  <literary-periods>romantik-og-praeromantik</literary-periods>
   <identifiers>
     <wikidata>Q316381</wikidata>
     <gravsted-dk>carljonaslovealmqvist</gravsted-dk>

--- a/fdirs/andersen/info.xml
+++ b/fdirs/andersen/info.xml
@@ -15,6 +15,7 @@
       <place>København</place>
     </dead>
   </period>
+  <literary-periods>romantik-og-praeromantik</literary-periods>
   <works>1830,1831,1832,1833,1833S,1838,1847,1849,1851,1854,1863,1867,1879,eventyr,andre</works>
   <identifiers>
     <wikidata>Q5673</wikidata>

--- a/fdirs/aquino/info.xml
+++ b/fdirs/aquino/info.xml
@@ -15,6 +15,7 @@
       <note>eller 1279</note>
     </dead>
   </period>
+  <literary-periods>middelalderen</literary-periods>
   <identifiers>
     <wikidata>Q644181</wikidata>
     <viaf>90388189</viaf>

--- a/fdirs/aretino/info.xml
+++ b/fdirs/aretino/info.xml
@@ -14,6 +14,7 @@
       <place>Venedig</place>
     </dead>
   </period>
+  <literary-periods>renaessance-og-humanisme</literary-periods>
   <identifiers>
     <wikidata>Q296272</wikidata>
     <viaf>66609417</viaf>

--- a/fdirs/arezzo/info.xml
+++ b/fdirs/arezzo/info.xml
@@ -14,6 +14,7 @@
       <place>Firenze</place>
     </dead>
   </period>
+  <literary-periods>middelalderen</literary-periods>
   <identifiers>
     <wikidata>Q1246333</wikidata>
     <viaf>94146462671627771794</viaf>

--- a/fdirs/ariosto/info.xml
+++ b/fdirs/ariosto/info.xml
@@ -14,6 +14,7 @@
       <place>Ferrara</place>
     </dead>
   </period>
+  <literary-periods>renaessance-og-humanisme</literary-periods>
   <works>1532</works>
   <identifiers>
     <wikidata>Q48900</wikidata>

--- a/fdirs/arnold/info.xml
+++ b/fdirs/arnold/info.xml
@@ -14,6 +14,7 @@
       <place>Liverpool</place>
     </dead>
   </period>
+  <literary-periods>realisme-og-naturalisme</literary-periods>
   <works>andre</works>
   <identifiers>
     <wikidata>Q271032</wikidata>

--- a/fdirs/atterbom/info.xml
+++ b/fdirs/atterbom/info.xml
@@ -14,6 +14,7 @@
       <place>Stockholm</place>
     </dead>
   </period>
+  <literary-periods>romantik-og-praeromantik</literary-periods>
   <works>1824,1836,1858</works>
   <identifiers>
     <wikidata>Q444538</wikidata>

--- a/fdirs/baggesen/info.xml
+++ b/fdirs/baggesen/info.xml
@@ -15,6 +15,7 @@
       <place>Hamburg</place>
     </dead>
   </period>
+  <literary-periods>oplysningstid-og-klassicisme,romantik-og-praeromantik</literary-periods>
   <works>1785,1791,1801,1803,1807,1807e,1807s,1808,1808h,1814,1816,1816d,1819,andre</works>
   <identifiers>
     <wikidata>Q215945</wikidata>

--- a/fdirs/bandello/info.xml
+++ b/fdirs/bandello/info.xml
@@ -14,6 +14,7 @@
       <place>Bazens</place>
     </dead>
   </period>
+  <literary-periods>renaessance-og-humanisme</literary-periods>
   <identifiers>
     <wikidata>Q19054</wikidata>
     <viaf>22150523</viaf>

--- a/fdirs/bang/info.xml
+++ b/fdirs/bang/info.xml
@@ -15,6 +15,7 @@
       <place>Ogden City, Utah, USA</place>
     </dead>
   </period>
+  <literary-periods>realisme-og-naturalisme</literary-periods>
   <works>1889,p1879,p1890</works>
   <identifiers>
     <wikidata>Q439370</wikidata>

--- a/fdirs/bartas/info.xml
+++ b/fdirs/bartas/info.xml
@@ -14,6 +14,7 @@
       <place>Coudons</place>
     </dead>
   </period>
+  <literary-periods>renaessance-og-humanisme</literary-periods>
   <works>1578,1584</works>
   <identifiers>
     <wikidata>Q2087052</wikidata>

--- a/fdirs/baudelaire/info.xml
+++ b/fdirs/baudelaire/info.xml
@@ -15,6 +15,7 @@
       <place>Paris</place>
     </dead>
   </period>
+  <literary-periods>symbolisme-og-fin-de-siecle</literary-periods>
   <works>1857,1866</works>
   <identifiers>
     <wikidata>Q501</wikidata>

--- a/fdirs/bellman/info.xml
+++ b/fdirs/bellman/info.xml
@@ -14,6 +14,7 @@
       <place>Stockholm</place>
     </dead>
   </period>
+  <literary-periods>oplysningstid-og-klassicisme</literary-periods>
   <works>1760,1790,1791</works>
   <identifiers>
     <wikidata>Q312498</wikidata>

--- a/fdirs/beranger/info.xml
+++ b/fdirs/beranger/info.xml
@@ -14,6 +14,7 @@
       <place>Paris</place>
     </dead>
   </period>
+  <literary-periods>romantik-og-praeromantik</literary-periods>
   <works>andre</works>
   <identifiers>
     <wikidata>Q324998</wikidata>

--- a/fdirs/berni/info.xml
+++ b/fdirs/berni/info.xml
@@ -14,6 +14,7 @@
       <place>Firenze</place>
     </dead>
   </period>
+  <literary-periods>renaessance-og-humanisme</literary-periods>
   <identifiers>
     <wikidata>Q655618</wikidata>
     <viaf>36959897</viaf>

--- a/fdirs/bjoernson/info.xml
+++ b/fdirs/bjoernson/info.xml
@@ -14,6 +14,7 @@
       <place>Paris</place>
     </dead>
   </period>
+  <literary-periods>realisme-og-naturalisme</literary-periods>
   <works>1870,1895,andre</works>
   <identifiers>
     <wikidata>Q46405</wikidata>

--- a/fdirs/blake/info.xml
+++ b/fdirs/blake/info.xml
@@ -14,6 +14,7 @@
       <place>London</place>
     </dead>
   </period>
+  <literary-periods>romantik-og-praeromantik</literary-periods>
   <works>inno,1790,expe,1804a,1804</works>
   <identifiers>
     <wikidata>Q41513</wikidata>

--- a/fdirs/blicher/info.xml
+++ b/fdirs/blicher/info.xml
@@ -14,6 +14,7 @@
       <place>Spentrup, Jylland</place>
     </dead>
   </period>
+  <literary-periods>romantik-og-praeromantik,realisme-og-naturalisme</literary-periods>
   <works>1807,1814,1817,1824,1825,1826,1837,1838,andre,1847</works>
   <identifiers>
     <wikidata>Q347953</wikidata>

--- a/fdirs/boccaccio/info.xml
+++ b/fdirs/boccaccio/info.xml
@@ -14,6 +14,7 @@
       <place>Certaldo, nær Firenze</place>
     </dead>
   </period>
+  <literary-periods>renaessance-og-humanisme</literary-periods>
   <identifiers>
     <wikidata>Q1402</wikidata>
     <viaf>64002165</viaf>

--- a/fdirs/boennelycke/info.xml
+++ b/fdirs/boennelycke/info.xml
@@ -15,6 +15,7 @@
       <place>Halmstad, Sverige</place>
     </dead>
   </period>
+  <literary-periods>modernisme-og-avantgarde</literary-periods>
   <works>1917,1918,1918a,1918t,1919,1920,1921</works>
   <identifiers>
     <wikidata>Q3817727</wikidata>

--- a/fdirs/boiardo/info.xml
+++ b/fdirs/boiardo/info.xml
@@ -15,6 +15,7 @@
       <place>Reggio nell'Emilia</place>
     </dead>
   </period>
+  <literary-periods>renaessance-og-humanisme</literary-periods>
   <identifiers>
     <wikidata>Q319557</wikidata>
     <viaf>39400425</viaf>

--- a/fdirs/boileau/info.xml
+++ b/fdirs/boileau/info.xml
@@ -15,6 +15,7 @@
       <place>Paris</place>
     </dead>
   </period>
+  <literary-periods>oplysningstid-og-klassicisme</literary-periods>
   <works>1674</works>
   <identifiers>
     <wikidata>Q188857</wikidata>

--- a/fdirs/bording/info.xml
+++ b/fdirs/bording/info.xml
@@ -14,6 +14,7 @@
       <place>Kbh.</place>
     </dead>
   </period>
+  <literary-periods>barok-og-tidlig-modernitet</literary-periods>
   <works>andre</works>
   <identifiers>
     <wikidata>Q347476</wikidata>

--- a/fdirs/boyek/info.xml
+++ b/fdirs/boyek/info.xml
@@ -15,6 +15,7 @@
       <place>Alingsås</place>
     </dead>
   </period>
+  <literary-periods>modernisme-og-avantgarde</literary-periods>
   <works/>
   <identifiers>
     <wikidata>Q237413</wikidata>

--- a/fdirs/brandes/info.xml
+++ b/fdirs/brandes/info.xml
@@ -15,6 +15,7 @@
       <place>Kbh.</place>
     </dead>
   </period>
+  <literary-periods>realisme-og-naturalisme</literary-periods>
   <works>1902</works>
   <identifiers>
     <wikidata>Q316045</wikidata>

--- a/fdirs/brorson/info.xml
+++ b/fdirs/brorson/info.xml
@@ -15,6 +15,7 @@
       <place>Ribe</place>
     </dead>
   </period>
+  <literary-periods>barok-og-tidlig-modernitet</literary-periods>
   <works>1732,1739,1765,andre</works>
   <identifiers>
     <wikidata>Q348003</wikidata>

--- a/fdirs/browningeb/info.xml
+++ b/fdirs/browningeb/info.xml
@@ -14,6 +14,7 @@
       <place>Firenze</place>
     </dead>
   </period>
+  <literary-periods>romantik-og-praeromantik</literary-periods>
   <works>1820,1844,1850,1851,1860,1862</works>
   <identifiers>
     <wikidata>Q228494</wikidata>

--- a/fdirs/browningr/info.xml
+++ b/fdirs/browningr/info.xml
@@ -14,6 +14,7 @@
       <place>Venedig</place>
     </dead>
   </period>
+  <literary-periods>romantik-og-praeromantik</literary-periods>
   <works>1842,1855,1864,andre</works>
   <identifiers>
     <wikidata>Q233265</wikidata>

--- a/fdirs/bryant/info.xml
+++ b/fdirs/bryant/info.xml
@@ -14,6 +14,7 @@
       <place>New York City</place>
     </dead>
   </period>
+  <literary-periods>romantik-og-praeromantik</literary-periods>
   <works>andre</works>
   <identifiers>
     <wikidata>Q454840</wikidata>

--- a/fdirs/burger/info.xml
+++ b/fdirs/burger/info.xml
@@ -14,6 +14,7 @@
       <place>Göttingen</place>
     </dead>
   </period>
+  <literary-periods>romantik-og-praeromantik</literary-periods>
   <works>andre</works>
   <identifiers>
     <wikidata>Q213675</wikidata>

--- a/fdirs/burns/info.xml
+++ b/fdirs/burns/info.xml
@@ -14,6 +14,7 @@
       <place>Dumfries, Dumfriesshire, England</place>
     </dead>
   </period>
+  <literary-periods>romantik-og-praeromantik</literary-periods>
   <works>1786,1787,1788,1789,1786p,andre</works>
   <identifiers>
     <wikidata>Q81960</wikidata>

--- a/fdirs/byron/info.xml
+++ b/fdirs/byron/info.xml
@@ -15,6 +15,7 @@
       <place>Missolonghi, Grækenland</place>
     </dead>
   </period>
+  <literary-periods>romantik-og-praeromantik</literary-periods>
   <works>1812,1812c,1813,1813a,1814,1814a,1814b,1815,1816,1816a,1817,1817a,1818,1819,1821,1821a,1821b,andre</works>
   <identifiers>
     <wikidata>Q5679</wikidata>

--- a/fdirs/calderon/info.xml
+++ b/fdirs/calderon/info.xml
@@ -15,6 +15,7 @@
       <place>Madrid</place>
     </dead>
   </period>
+  <literary-periods>barok-og-tidlig-modernitet</literary-periods>
   <identifiers>
     <wikidata>Q170800</wikidata>
     <viaf>73850932</viaf>

--- a/fdirs/campbell/info.xml
+++ b/fdirs/campbell/info.xml
@@ -14,6 +14,7 @@
       <place>Boulogne, Frankrig</place>
     </dead>
   </period>
+  <literary-periods>romantik-og-praeromantik</literary-periods>
   <works>andre</works>
   <identifiers>
     <wikidata>Q1361189</wikidata>

--- a/fdirs/carducci/info.xml
+++ b/fdirs/carducci/info.xml
@@ -14,6 +14,7 @@
       <place>Bologna</place>
     </dead>
   </period>
+  <literary-periods>realisme-og-naturalisme</literary-periods>
   <works>andre</works>
   <identifiers>
     <wikidata>Q43440</wikidata>

--- a/fdirs/cavalcanti/info.xml
+++ b/fdirs/cavalcanti/info.xml
@@ -13,6 +13,7 @@
       <place>Firenze</place>
     </dead>
   </period>
+  <literary-periods>middelalderen</literary-periods>
   <identifiers>
     <wikidata>Q316876</wikidata>
     <viaf>86760252</viaf>

--- a/fdirs/cervantes/info.xml
+++ b/fdirs/cervantes/info.xml
@@ -15,6 +15,7 @@
       <place>Madrid</place>
     </dead>
   </period>
+  <literary-periods>renaessance-og-humanisme</literary-periods>
   <identifiers>
     <wikidata>Q5682</wikidata>
     <viaf>17220427</viaf>

--- a/fdirs/chamisso/info.xml
+++ b/fdirs/chamisso/info.xml
@@ -15,6 +15,7 @@
       <place>Berlin</place>
     </dead>
   </period>
+  <literary-periods>romantik-og-praeromantik</literary-periods>
   <works>andre</works>
   <identifiers>
     <wikidata>Q154782</wikidata>

--- a/fdirs/chaucer/info.xml
+++ b/fdirs/chaucer/info.xml
@@ -13,6 +13,7 @@
       <place>London</place>
     </dead>
   </period>
+  <literary-periods>middelalderen</literary-periods>
   <works>troilus,duchess,canterbury,andre</works>
   <identifiers>
     <wikidata>Q5683</wikidata>

--- a/fdirs/clare/info.xml
+++ b/fdirs/clare/info.xml
@@ -14,6 +14,7 @@
       <place>Northampton General Lunatic Asylum</place>
     </dead>
   </period>
+  <literary-periods>romantik-og-praeromantik</literary-periods>
   <works>andre</works>
   <identifiers>
     <wikidata>Q981572</wikidata>

--- a/fdirs/claussen/info.xml
+++ b/fdirs/claussen/info.xml
@@ -15,6 +15,7 @@
       <place>Gentofte</place>
     </dead>
   </period>
+  <literary-periods>symbolisme-og-fin-de-siecle</literary-periods>
   <works>1887,1899,1901,1902,1904,1910,1912,1917,1925,1927,1930,ovs,digtefraprosa,andre</works>
   <identifiers>
     <wikidata>Q24494</wikidata>

--- a/fdirs/coleridge/info.xml
+++ b/fdirs/coleridge/info.xml
@@ -14,6 +14,7 @@
       <place>Highgate, ved London</place>
     </dead>
   </period>
+  <literary-periods>romantik-og-praeromantik</literary-periods>
   <works>1796,1798,1816,1817,andre</works>
   <identifiers>
     <wikidata>Q82409</wikidata>

--- a/fdirs/corneille/info.xml
+++ b/fdirs/corneille/info.xml
@@ -14,6 +14,7 @@
       <place>Paris</place>
     </dead>
   </period>
+  <literary-periods>barok-og-tidlig-modernitet,oplysningstid-og-klassicisme</literary-periods>
   <works>1635,1637,1640,1641,1643,1643m,1649,1650,1659</works>
   <identifiers>
     <wikidata>Q747</wikidata>

--- a/fdirs/cowper/info.xml
+++ b/fdirs/cowper/info.xml
@@ -14,6 +14,7 @@
       <place>East Dereham, Norfolk</place>
     </dead>
   </period>
+  <literary-periods>oplysningstid-og-klassicisme,romantik-og-praeromantik</literary-periods>
   <works>1779,andre</works>
   <identifiers>
     <wikidata>Q315537</wikidata>

--- a/fdirs/dante/info.xml
+++ b/fdirs/dante/info.xml
@@ -15,6 +15,7 @@
       <place>Ravenna</place>
     </dead>
   </period>
+  <literary-periods>middelalderen</literary-periods>
   <works>commedia</works>
   <identifiers>
     <wikidata>Q1067</wikidata>

--- a/fdirs/dass/info.xml
+++ b/fdirs/dass/info.xml
@@ -13,6 +13,7 @@
       <date>1707-08-17</date>
     </dead>
   </period>
+  <literary-periods>barok-og-tidlig-modernitet</literary-periods>
   <works>1739,bib,kate,evang,andre</works>
   <identifiers>
     <wikidata>Q558590</wikidata>

--- a/fdirs/dickinson/info.xml
+++ b/fdirs/dickinson/info.xml
@@ -14,6 +14,7 @@
       <place>Amherst, Mass., USA</place>
     </dead>
   </period>
+  <literary-periods>realisme-og-naturalisme</literary-periods>
   <works>digte</works>
   <identifiers>
     <wikidata>Q4441</wikidata>

--- a/fdirs/donne/info.xml
+++ b/fdirs/donne/info.xml
@@ -13,6 +13,7 @@
       <place>London</place>
     </dead>
   </period>
+  <literary-periods>barok-og-tidlig-modernitet</literary-periods>
   <works>1601,andre</works>
   <identifiers>
     <wikidata>Q140412</wikidata>

--- a/fdirs/drachmann/info.xml
+++ b/fdirs/drachmann/info.xml
@@ -15,6 +15,7 @@
       <place>Hornbæk</place>
     </dead>
   </period>
+  <literary-periods>realisme-og-naturalisme,symbolisme-og-fin-de-siecle</literary-periods>
   <works>1872,1875,1877,1877t,1877d,1879r,1879,1881,1884,1885,1890,1889,1892,1899,1901,andre</works>
   <identifiers>
     <wikidata>Q966764</wikidata>

--- a/fdirs/dryden/info.xml
+++ b/fdirs/dryden/info.xml
@@ -14,6 +14,7 @@
       <place>London</place>
     </dead>
   </period>
+  <literary-periods>barok-og-tidlig-modernitet,oplysningstid-og-klassicisme</literary-periods>
   <works>andre</works>
   <identifiers>
     <wikidata>Q213355</wikidata>

--- a/fdirs/dyer/info.xml
+++ b/fdirs/dyer/info.xml
@@ -14,6 +14,7 @@
       <place>London</place>
     </dead>
   </period>
+  <literary-periods>renaessance-og-humanisme</literary-periods>
   <works>andre</works>
   <identifiers>
     <wikidata>Q5342682</wikidata>

--- a/fdirs/eichendorff/info.xml
+++ b/fdirs/eichendorff/info.xml
@@ -15,6 +15,7 @@
       <place>Neisse, Oberschlesien</place>
     </dead>
   </period>
+  <literary-periods>romantik-og-praeromantik</literary-periods>
   <works>1837,andre</works>
   <identifiers>
     <wikidata>Q77204</wikidata>

--- a/fdirs/eliot/info.xml
+++ b/fdirs/eliot/info.xml
@@ -15,6 +15,7 @@
       <place>Chelsea, Middlesex</place>
     </dead>
   </period>
+  <literary-periods>realisme-og-naturalisme</literary-periods>
   <works>andre</works>
   <identifiers>
     <wikidata>Q131333</wikidata>

--- a/fdirs/emerson/info.xml
+++ b/fdirs/emerson/info.xml
@@ -14,6 +14,7 @@
       <place>Concord, Mass.</place>
     </dead>
   </period>
+  <literary-periods>romantik-og-praeromantik</literary-periods>
   <works>1836,1847,1867</works>
   <identifiers>
     <wikidata>Q48226</wikidata>

--- a/fdirs/ewald/info.xml
+++ b/fdirs/ewald/info.xml
@@ -14,6 +14,7 @@
       <place>København</place>
     </dead>
   </period>
+  <literary-periods>oplysningstid-og-klassicisme,romantik-og-praeromantik</literary-periods>
   <works>1766,1769,1770,1771,1772,1779,andre,p1780</works>
   <identifiers>
     <wikidata>Q553844</wikidata>

--- a/fdirs/fontaine/info.xml
+++ b/fdirs/fontaine/info.xml
@@ -14,6 +14,7 @@
       <place>Paris</place>
     </dead>
   </period>
+  <literary-periods>oplysningstid-og-klassicisme</literary-periods>
   <identifiers>
     <wikidata>Q49496</wikidata>
     <gravsted-dk>jeandelafontaine</gravsted-dk>

--- a/fdirs/fontane/info.xml
+++ b/fdirs/fontane/info.xml
@@ -16,6 +16,7 @@
       <place>Berlin</place>
     </dead>
   </period>
+  <literary-periods>realisme-og-naturalisme</literary-periods>
   <works>andre</works>
   <identifiers>
     <wikidata>Q76632</wikidata>

--- a/fdirs/foscolo/info.xml
+++ b/fdirs/foscolo/info.xml
@@ -14,6 +14,7 @@
       <place>Turnham Green, London</place>
     </dead>
   </period>
+  <literary-periods>romantik-og-praeromantik</literary-periods>
   <works>andre</works>
   <identifiers>
     <wikidata>Q166234</wikidata>

--- a/fdirs/fouque/info.xml
+++ b/fdirs/fouque/info.xml
@@ -15,6 +15,7 @@
       <place>Berlin</place>
     </dead>
   </period>
+  <literary-periods>romantik-og-praeromantik</literary-periods>
   <works>andre</works>
   <identifiers>
     <wikidata>Q77371</wikidata>

--- a/fdirs/froeding/info.xml
+++ b/fdirs/froeding/info.xml
@@ -14,6 +14,7 @@
       <place>Stockholm</place>
     </dead>
   </period>
+  <literary-periods>symbolisme-og-fin-de-siecle</literary-periods>
   <works>1896,andre</works>
   <identifiers>
     <wikidata>Q366801</wikidata>

--- a/fdirs/gautier/info.xml
+++ b/fdirs/gautier/info.xml
@@ -14,6 +14,7 @@
       <place>Neuilly-sur-Seine, Frankrig</place>
     </dead>
   </period>
+  <literary-periods>romantik-og-praeromantik,symbolisme-og-fin-de-siecle</literary-periods>
   <works>1832,1838,1852,andre</works>
   <identifiers>
     <wikidata>Q183713</wikidata>

--- a/fdirs/geijer/info.xml
+++ b/fdirs/geijer/info.xml
@@ -14,6 +14,7 @@
       <place>Stockholm</place>
     </dead>
   </period>
+  <literary-periods>romantik-og-praeromantik</literary-periods>
   <works>andre</works>
   <identifiers>
     <wikidata>Q380937</wikidata>

--- a/fdirs/gellert/info.xml
+++ b/fdirs/gellert/info.xml
@@ -15,6 +15,7 @@
       <place>Leipzig</place>
     </dead>
   </period>
+  <literary-periods>oplysningstid-og-klassicisme</literary-periods>
   <works>1746</works>
   <identifiers>
     <wikidata>Q60584</wikidata>

--- a/fdirs/goethe/info.xml
+++ b/fdirs/goethe/info.xml
@@ -14,6 +14,7 @@
       <place>Weimar</place>
     </dead>
   </period>
+  <literary-periods>oplysningstid-og-klassicisme,romantik-og-praeromantik</literary-periods>
   <works>1795,1808,1819,1832,romi,andre</works>
   <identifiers>
     <wikidata>Q5879</wikidata>

--- a/fdirs/gray/info.xml
+++ b/fdirs/gray/info.xml
@@ -14,6 +14,7 @@
       <place>Cambridge, Cambridgeshire, England</place>
     </dead>
   </period>
+  <literary-periods>oplysningstid-og-klassicisme,romantik-og-praeromantik</literary-periods>
   <works>andre</works>
   <identifiers>
     <wikidata>Q315516</wikidata>

--- a/fdirs/grundtvig/info.xml
+++ b/fdirs/grundtvig/info.xml
@@ -15,6 +15,7 @@
       <place>København</place>
     </dead>
   </period>
+  <literary-periods>romantik-og-praeromantik</literary-periods>
   <works>1808,1810a,1810b,1811a,1811b,1814a,1814b,1815a,1815b,1820,1824,1829,1838,1840,1853,1868,1868-1881,1870,1873,1875,1881,julesalmer,pinsesalmer,andresalmer,andre</works>
   <identifiers>
     <wikidata>Q331893</wikidata>

--- a/fdirs/guinizelli/info.xml
+++ b/fdirs/guinizelli/info.xml
@@ -14,6 +14,7 @@
       <place>Monselice ved Padua</place>
     </dead>
   </period>
+  <literary-periods>middelalderen</literary-periods>
   <identifiers>
     <wikidata>Q366270</wikidata>
     <viaf>64045504</viaf>

--- a/fdirs/hafez/info.xml
+++ b/fdirs/hafez/info.xml
@@ -16,6 +16,7 @@
       <place>Shiraz</place>
     </dead>
   </period>
+  <literary-periods>middelalderen</literary-periods>
   <identifiers>
     <wikidata>Q6240</wikidata>
     <viaf>92145857106822922504</viaf>

--- a/fdirs/hardy/info.xml
+++ b/fdirs/hardy/info.xml
@@ -14,6 +14,7 @@
       <place>Dorchester, Dorset, England</place>
     </dead>
   </period>
+  <literary-periods>realisme-og-naturalisme</literary-periods>
   <works>1898,1902,1903,1909,1914,1917,1922,1925,1928,andre</works>
   <identifiers>
     <wikidata>Q132805</wikidata>

--- a/fdirs/heibergjl/info.xml
+++ b/fdirs/heibergjl/info.xml
@@ -14,6 +14,7 @@
       <place>Bonderup ved Ringsted</place>
     </dead>
   </period>
+  <literary-periods>romantik-og-praeromantik</literary-periods>
   <works>1817,1819,1841,1842,1849,andre,drama</works>
   <identifiers>
     <wikidata>Q402274</wikidata>

--- a/fdirs/heine/info.xml
+++ b/fdirs/heine/info.xml
@@ -14,6 +14,7 @@
       <place>Paris</place>
     </dead>
   </period>
+  <literary-periods>romantik-og-praeromantik</literary-periods>
   <works>1822,1823,1827,1834,1844,1851,1854,andre,deutsch</works>
   <identifiers>
     <wikidata>Q44403</wikidata>

--- a/fdirs/herder/info.xml
+++ b/fdirs/herder/info.xml
@@ -14,6 +14,7 @@
       <place>Weimar</place>
     </dead>
   </period>
+  <literary-periods>oplysningstid-og-klassicisme,romantik-og-praeromantik</literary-periods>
   <works>1778,1778v,1779,andre</works>
   <identifiers>
     <wikidata>Q155547</wikidata>

--- a/fdirs/herrick/info.xml
+++ b/fdirs/herrick/info.xml
@@ -14,6 +14,7 @@
       <place>Devon</place>
     </dead>
   </period>
+  <literary-periods>barok-og-tidlig-modernitet</literary-periods>
   <works>andre</works>
   <identifiers>
     <wikidata>Q553554</wikidata>

--- a/fdirs/hoelderlin/info.xml
+++ b/fdirs/hoelderlin/info.xml
@@ -15,6 +15,7 @@
       <place>Tübingen</place>
     </dead>
   </period>
+  <literary-periods>romantik-og-praeromantik</literary-periods>
   <works>oedip,1804,1826,andre</works>
   <identifiers>
     <wikidata>Q75889</wikidata>

--- a/fdirs/holberg/info.xml
+++ b/fdirs/holberg/info.xml
@@ -14,6 +14,7 @@
       <place>København</place>
     </dead>
   </period>
+  <literary-periods>oplysningstid-og-klassicisme</literary-periods>
   <works>1719,metam,skiemte,andre</works>
   <identifiers>
     <wikidata>Q216692</wikidata>

--- a/fdirs/holty/info.xml
+++ b/fdirs/holty/info.xml
@@ -15,6 +15,7 @@
       <place>Hannover</place>
     </dead>
   </period>
+  <literary-periods>romantik-og-praeromantik</literary-periods>
   <works>andre</works>
   <identifiers>
     <wikidata>Q71456</wikidata>

--- a/fdirs/hopkins/info.xml
+++ b/fdirs/hopkins/info.xml
@@ -14,6 +14,7 @@
       <place>Dublin</place>
     </dead>
   </period>
+  <literary-periods>symbolisme-og-fin-de-siecle,modernisme-og-avantgarde</literary-periods>
   <works>andre</works>
   <identifiers>
     <wikidata>Q313693</wikidata>

--- a/fdirs/howard/info.xml
+++ b/fdirs/howard/info.xml
@@ -15,6 +15,7 @@
       <note>Henrettet</note>
     </dead>
   </period>
+  <literary-periods>renaessance-og-humanisme</literary-periods>
   <works>andre</works>
   <identifiers>
     <wikidata>Q372211</wikidata>

--- a/fdirs/hugo/info.xml
+++ b/fdirs/hugo/info.xml
@@ -15,6 +15,7 @@
       <place>Paris</place>
     </dead>
   </period>
+  <literary-periods>romantik-og-praeromantik</literary-periods>
   <works>1822,1829,1831,1837,1840,1853,1856,1859,1865,1881,1881L,andre</works>
   <identifiers>
     <wikidata>Q535</wikidata>

--- a/fdirs/ibsen/info.xml
+++ b/fdirs/ibsen/info.xml
@@ -15,6 +15,7 @@
       <place>Christiania (nu Oslo)</place>
     </dead>
   </period>
+  <literary-periods>realisme-og-naturalisme</literary-periods>
   <works>andre</works>
   <identifiers>
     <wikidata>Q36661</wikidata>

--- a/fdirs/ingemann/info.xml
+++ b/fdirs/ingemann/info.xml
@@ -15,6 +15,7 @@
       <place>Sorø</place>
     </dead>
   </period>
+  <literary-periods>romantik-og-praeromantik</literary-periods>
   <works>1811,1812,1813,1816,1820,1821,1823,1824,1825,1831,1832,1833,1837,1837h,1838,1839,1842,1842S,1855,andre</works>
   <identifiers>
     <wikidata>Q583636</wikidata>

--- a/fdirs/jacobsen/info.xml
+++ b/fdirs/jacobsen/info.xml
@@ -15,6 +15,7 @@
       <place>Thisted</place>
     </dead>
   </period>
+  <literary-periods>realisme-og-naturalisme</literary-periods>
   <works>1868,1871,andre,noveller</works>
   <identifiers>
     <wikidata>Q370246</wikidata>

--- a/fdirs/jensenjv/info.xml
+++ b/fdirs/jensenjv/info.xml
@@ -15,6 +15,7 @@
       <place>København</place>
     </dead>
   </period>
+  <literary-periods>modernisme-og-avantgarde</literary-periods>
   <works>1906,1923,1926,1930,1931,1937</works>
   <identifiers>
     <wikidata>Q159552</wikidata>

--- a/fdirs/jonson/info.xml
+++ b/fdirs/jonson/info.xml
@@ -15,6 +15,7 @@
       <place>London</place>
     </dead>
   </period>
+  <literary-periods>barok-og-tidlig-modernitet</literary-periods>
   <works>andre</works>
   <identifiers>
     <wikidata>Q193857</wikidata>

--- a/fdirs/keats/info.xml
+++ b/fdirs/keats/info.xml
@@ -14,6 +14,7 @@
       <place>Rom</place>
     </dead>
   </period>
+  <literary-periods>romantik-og-praeromantik</literary-periods>
   <works>1817,1818,1820,otho,king,post</works>
   <identifiers>
     <wikidata>Q82083</wikidata>

--- a/fdirs/kerner/info.xml
+++ b/fdirs/kerner/info.xml
@@ -15,6 +15,7 @@
       <place>Weinsberg, Baden-Württemberg</place>
     </dead>
   </period>
+  <literary-periods>romantik-og-praeromantik</literary-periods>
   <works>andre</works>
   <identifiers>
     <wikidata>Q77280</wikidata>

--- a/fdirs/khayyam/info.xml
+++ b/fdirs/khayyam/info.xml
@@ -15,6 +15,7 @@
       <place>Nishabur, Khorasan, nuværende Iran</place>
     </dead>
   </period>
+  <literary-periods>middelalderen</literary-periods>
   <identifiers>
     <wikidata>Q35900</wikidata>
     <viaf>100210377</viaf>

--- a/fdirs/kingo/info.xml
+++ b/fdirs/kingo/info.xml
@@ -15,6 +15,7 @@
       <place>Odense</place>
     </dead>
   </period>
+  <literary-periods>barok-og-tidlig-modernitet</literary-periods>
   <works>1667,1674,1681,1689,1699,andre</works>
   <identifiers>
     <wikidata>Q348827</wikidata>

--- a/fdirs/klopstock/info.xml
+++ b/fdirs/klopstock/info.xml
@@ -14,6 +14,7 @@
       <place>Hamburg</place>
     </dead>
   </period>
+  <literary-periods>oplysningstid-og-klassicisme,romantik-og-praeromantik</literary-periods>
   <works>1749,1758,1769,1771,1784,1787,andre</works>
   <identifiers>
     <wikidata>Q154367</wikidata>

--- a/fdirs/lamartine/info.xml
+++ b/fdirs/lamartine/info.xml
@@ -14,6 +14,7 @@
       <place>Paris</place>
     </dead>
   </period>
+  <literary-periods>romantik-og-praeromantik</literary-periods>
   <works>1820,1830</works>
   <identifiers>
     <wikidata>Q188697</wikidata>

--- a/fdirs/langland/info.xml
+++ b/fdirs/langland/info.xml
@@ -12,6 +12,7 @@
       <date>1400?</date>
     </dead>
   </period>
+  <literary-periods>middelalderen</literary-periods>
   <identifiers>
     <wikidata>Q467672</wikidata>
     <viaf>61560236</viaf>

--- a/fdirs/lautreamont/info.xml
+++ b/fdirs/lautreamont/info.xml
@@ -15,6 +15,7 @@
       <place>Paris</place>
     </dead>
   </period>
+  <literary-periods>symbolisme-og-fin-de-siecle</literary-periods>
   <identifiers>
     <wikidata>Q294181</wikidata>
     <viaf>6065</viaf>

--- a/fdirs/lenau/info.xml
+++ b/fdirs/lenau/info.xml
@@ -16,6 +16,7 @@
       <place>Oberdöbling nær Wien</place>
     </dead>
   </period>
+  <literary-periods>romantik-og-praeromantik</literary-periods>
   <works>1822,1832,1835,1836,1837,1838,1840,1842,1843,blick,eitel,1844,andre</works>
   <identifiers>
     <wikidata>Q84280</wikidata>

--- a/fdirs/leopardi/info.xml
+++ b/fdirs/leopardi/info.xml
@@ -15,6 +15,7 @@
       <place>Napoli</place>
     </dead>
   </period>
+  <literary-periods>romantik-og-praeromantik</literary-periods>
   <works>andre</works>
   <identifiers>
     <wikidata>Q172599</wikidata>

--- a/fdirs/lessing/info.xml
+++ b/fdirs/lessing/info.xml
@@ -14,6 +14,7 @@
       <place>Braunschweig</place>
     </dead>
   </period>
+  <literary-periods>oplysningstid-og-klassicisme</literary-periods>
   <works>1779,andre</works>
   <identifiers>
     <wikidata>Q34628</wikidata>

--- a/fdirs/lie/info.xml
+++ b/fdirs/lie/info.xml
@@ -15,6 +15,7 @@
       <place>Stavern, Norge</place>
     </dead>
   </period>
+  <literary-periods>realisme-og-naturalisme</literary-periods>
   <works>1867</works>
   <identifiers>
     <wikidata>Q469681</wikidata>

--- a/fdirs/longfellow/info.xml
+++ b/fdirs/longfellow/info.xml
@@ -14,6 +14,7 @@
       <place>Cambridge, Mass., USA</place>
     </dead>
   </period>
+  <literary-periods>romantik-og-praeromantik</literary-periods>
   <works>1839,1842,1847,1855,1858,1863,1865,andre</works>
   <identifiers>
     <wikidata>Q152513</wikidata>

--- a/fdirs/luther/info.xml
+++ b/fdirs/luther/info.xml
@@ -14,6 +14,7 @@
       <place>Eisleben, Sachsen (nu Tyskland)</place>
     </dead>
   </period>
+  <literary-periods>renaessance-og-humanisme</literary-periods>
   <works>salmer,andre</works>
   <identifiers>
     <wikidata>Q9554</wikidata>

--- a/fdirs/mallarme/info.xml
+++ b/fdirs/mallarme/info.xml
@@ -14,6 +14,7 @@
       <place>Valvins, nær Fontainebleau, Frankrig</place>
     </dead>
   </period>
+  <literary-periods>symbolisme-og-fin-de-siecle</literary-periods>
   <works>1871,1876,1897,poesies</works>
   <identifiers>
     <wikidata>Q767</wikidata>

--- a/fdirs/manzoni/info.xml
+++ b/fdirs/manzoni/info.xml
@@ -15,6 +15,7 @@
       <place>Milano</place>
     </dead>
   </period>
+  <literary-periods>romantik-og-praeromantik</literary-periods>
   <works>1822,andre</works>
   <identifiers>
     <wikidata>Q1064</wikidata>

--- a/fdirs/marlowe/info.xml
+++ b/fdirs/marlowe/info.xml
@@ -15,6 +15,7 @@
       <place>Deptford, nær London</place>
     </dead>
   </period>
+  <literary-periods>renaessance-og-humanisme</literary-periods>
   <identifiers>
     <wikidata>Q28975</wikidata>
     <viaf>32000005</viaf>

--- a/fdirs/marot/info.xml
+++ b/fdirs/marot/info.xml
@@ -14,6 +14,7 @@
       <place>Turino, Savoy (nu Italien)</place>
     </dead>
   </period>
+  <literary-periods>renaessance-og-humanisme</literary-periods>
   <works>1532,1544,andre</works>
   <identifiers>
     <wikidata>Q108926</wikidata>

--- a/fdirs/martial/info.xml
+++ b/fdirs/martial/info.xml
@@ -13,6 +13,7 @@
       <date>0103 ca.</date>
     </dead>
   </period>
+  <literary-periods>antikken</literary-periods>
   <identifiers>
     <wikidata>Q2098</wikidata>
     <viaf>71385642</viaf>

--- a/fdirs/michelangelo/info.xml
+++ b/fdirs/michelangelo/info.xml
@@ -14,6 +14,7 @@
       <place>Rom</place>
     </dead>
   </period>
+  <literary-periods>renaessance-og-humanisme</literary-periods>
   <identifiers>
     <wikidata>Q5592</wikidata>
     <gravsted-dk>michelangelo</gravsted-dk>

--- a/fdirs/milton/info.xml
+++ b/fdirs/milton/info.xml
@@ -14,6 +14,7 @@
       <place>Chalfont St. Giles, Buckinghamshire, England</place>
     </dead>
   </period>
+  <literary-periods>barok-og-tidlig-modernitet</literary-periods>
   <works>1667,1671,1671s</works>
   <identifiers>
     <wikidata>Q79759</wikidata>

--- a/fdirs/moe/info.xml
+++ b/fdirs/moe/info.xml
@@ -14,6 +14,7 @@
       <place>Kristiansand</place>
     </dead>
   </period>
+  <literary-periods>romantik-og-praeromantik</literary-periods>
   <works>1849,1851,1855,1860,1877</works>
   <identifiers>
     <wikidata>Q470002</wikidata>

--- a/fdirs/moellerpm/info.xml
+++ b/fdirs/moellerpm/info.xml
@@ -14,6 +14,7 @@
       <place>Kbh.</place>
     </dead>
   </period>
+  <literary-periods>romantik-og-praeromantik</literary-periods>
   <works>andre</works>
   <identifiers>
     <wikidata>Q137571</wikidata>

--- a/fdirs/moliere/info.xml
+++ b/fdirs/moliere/info.xml
@@ -14,6 +14,7 @@
       <place>Paris</place>
     </dead>
   </period>
+  <literary-periods>oplysningstid-og-klassicisme</literary-periods>
   <works>1664,1666</works>
   <identifiers>
     <wikidata>Q687</wikidata>

--- a/fdirs/moore/info.xml
+++ b/fdirs/moore/info.xml
@@ -14,6 +14,7 @@
       <place>Wiltshire, England</place>
     </dead>
   </period>
+  <literary-periods>romantik-og-praeromantik</literary-periods>
   <works>1801,1801t,1806,1808,1813,1818,1834,1835,andre</works>
   <identifiers>
     <wikidata>Q315346</wikidata>

--- a/fdirs/morike/info.xml
+++ b/fdirs/morike/info.xml
@@ -14,6 +14,7 @@
       <place>Stuttgart</place>
     </dead>
   </period>
+  <literary-periods>romantik-og-praeromantik</literary-periods>
   <works>1838,1839,1840,1844,1846,andre</works>
   <identifiers>
     <wikidata>Q63699</wikidata>

--- a/fdirs/mueller/info.xml
+++ b/fdirs/mueller/info.xml
@@ -14,6 +14,7 @@
       <place>København</place>
     </dead>
   </period>
+  <literary-periods>romantik-og-praeromantik</literary-periods>
   <works>1832,1833,1834,1837,1838,1841,1842,1844,1844t,1853,1854,1857,1861,1874,andre</works>
   <identifiers>
     <wikidata>Q586453</wikidata>

--- a/fdirs/muellerw/info.xml
+++ b/fdirs/muellerw/info.xml
@@ -14,6 +14,7 @@
       <place>Dessau, Anhalt</place>
     </dead>
   </period>
+  <literary-periods>romantik-og-praeromantik</literary-periods>
   <works>andre</works>
   <identifiers>
     <wikidata>Q57879</wikidata>

--- a/fdirs/munch/info.xml
+++ b/fdirs/munch/info.xml
@@ -14,6 +14,7 @@
       <place>Vedbæk ved København</place>
     </dead>
   </period>
+  <literary-periods>romantik-og-praeromantik</literary-periods>
   <works>1836,1837,1842b,1842d,1852,1855,1861,1866,1867,1877</works>
   <identifiers>
     <wikidata>Q499674</wikidata>

--- a/fdirs/munchp/info.xml
+++ b/fdirs/munchp/info.xml
@@ -15,6 +15,7 @@
       <place>Spanien</place>
     </dead>
   </period>
+  <literary-periods>modernisme-og-avantgarde</literary-periods>
   <works>1932,1933,1934,1937,andre</works>
   <identifiers>
     <wikidata>Q1364400</wikidata>

--- a/fdirs/munk/info.xml
+++ b/fdirs/munk/info.xml
@@ -15,6 +15,7 @@
       <place inon="on">Hørbylunde Bakke ved Silkeborg</place>
     </dead>
   </period>
+  <literary-periods>modernisme-og-avantgarde</literary-periods>
   <works>1934,1936,1941,1942,1944,andre</works>
   <identifiers>
     <wikidata>Q551699</wikidata>

--- a/fdirs/musset/info.xml
+++ b/fdirs/musset/info.xml
@@ -15,6 +15,7 @@
       <place>Paris</place>
     </dead>
   </period>
+  <literary-periods>romantik-og-praeromantik</literary-periods>
   <works>1829,1850,andre</works>
   <identifiers>
     <wikidata>Q179680</wikidata>

--- a/fdirs/nathansen/info.xml
+++ b/fdirs/nathansen/info.xml
@@ -14,6 +14,7 @@
       <place>Lund</place>
     </dead>
   </period>
+  <literary-periods>modernisme-og-avantgarde</literary-periods>
   <works>1928,1951</works>
   <identifiers>
     <wikidata>Q1768826</wikidata>

--- a/fdirs/nerval/info.xml
+++ b/fdirs/nerval/info.xml
@@ -15,6 +15,7 @@
       <place>Paris</place>
     </dead>
   </period>
+  <literary-periods>romantik-og-praeromantik,symbolisme-og-fin-de-siecle</literary-periods>
   <works>1854,1855</works>
   <identifiers>
     <wikidata>Q191305</wikidata>

--- a/fdirs/nielsenm/info.xml
+++ b/fdirs/nielsenm/info.xml
@@ -15,6 +15,7 @@
       <place>København</place>
     </dead>
   </period>
+  <literary-periods>modernisme-og-avantgarde</literary-periods>
   <works>1943</works>
   <identifiers>
     <wikidata>Q284847</wikidata>

--- a/fdirs/nietzsche/info.xml
+++ b/fdirs/nietzsche/info.xml
@@ -15,6 +15,7 @@
       <place>Weimar</place>
     </dead>
   </period>
+  <literary-periods>symbolisme-og-fin-de-siecle</literary-periods>
   <works>1888</works>
   <identifiers>
     <wikidata>Q9358</wikidata>

--- a/fdirs/nilsen/info.xml
+++ b/fdirs/nilsen/info.xml
@@ -15,6 +15,7 @@
       <place>Paris</place>
     </dead>
   </period>
+  <literary-periods>modernisme-og-avantgarde</literary-periods>
   <works>1924,1926,1929</works>
   <identifiers>
     <wikidata>Q2165126</wikidata>

--- a/fdirs/novalis/info.xml
+++ b/fdirs/novalis/info.xml
@@ -14,6 +14,7 @@
       <place>Weißenfels</place>
     </dead>
   </period>
+  <literary-periods>romantik-og-praeromantik</literary-periods>
   <works>1797,1798,1802,1802h,andre</works>
   <identifiers>
     <wikidata>Q60684</wikidata>

--- a/fdirs/obstfelder/info.xml
+++ b/fdirs/obstfelder/info.xml
@@ -14,6 +14,7 @@
       <place>København</place>
     </dead>
   </period>
+  <literary-periods>symbolisme-og-fin-de-siecle,modernisme-og-avantgarde</literary-periods>
   <works>1893,1903</works>
   <identifiers>
     <wikidata>Q539525</wikidata>

--- a/fdirs/oehlenschlaeger/info.xml
+++ b/fdirs/oehlenschlaeger/info.xml
@@ -15,6 +15,7 @@
       <place>Kbh.</place>
     </dead>
   </period>
+  <literary-periods>romantik-og-praeromantik</literary-periods>
   <works>1803,1805,1807,1811,1813,1814,1817,1819,1828,1841,1845-1850,1846-11,1846-12,1846-13,1846-14,1846-15,1846-16,1846-17,1849-18,1849,1849d,1857-1862,1860-19,1860-20,1860-21,1860-22,1861-23,1861-24,andre</works>
   <identifiers>
     <wikidata>Q168356</wikidata>

--- a/fdirs/opitz/info.xml
+++ b/fdirs/opitz/info.xml
@@ -15,6 +15,7 @@
       <place>Danzig</place>
     </dead>
   </period>
+  <literary-periods>barok-og-tidlig-modernitet</literary-periods>
   <works>andre</works>
   <identifiers>
     <wikidata>Q60946</wikidata>

--- a/fdirs/petrarca/info.xml
+++ b/fdirs/petrarca/info.xml
@@ -14,6 +14,7 @@
       <place>Arquà</place>
     </dead>
   </period>
+  <literary-periods>renaessance-og-humanisme</literary-periods>
   <works>1347,1360</works>
   <identifiers>
     <wikidata>Q1401</wikidata>

--- a/fdirs/platen/info.xml
+++ b/fdirs/platen/info.xml
@@ -15,6 +15,7 @@
       <place>Siracusa på Sicilien</place>
     </dead>
   </period>
+  <literary-periods>romantik-og-praeromantik</literary-periods>
   <works>andre</works>
   <identifiers>
     <wikidata>Q62432</wikidata>

--- a/fdirs/poe/info.xml
+++ b/fdirs/poe/info.xml
@@ -14,6 +14,7 @@
       <place>Baltimore, Md., USA</place>
     </dead>
   </period>
+  <literary-periods>romantik-og-praeromantik,symbolisme-og-fin-de-siecle</literary-periods>
   <works>1827,1829,1831,1840,1841,1845,andre</works>
   <identifiers>
     <wikidata>Q16867</wikidata>

--- a/fdirs/poliziano/info.xml
+++ b/fdirs/poliziano/info.xml
@@ -14,6 +14,7 @@
       <place>Firenze</place>
     </dead>
   </period>
+  <literary-periods>renaessance-og-humanisme</literary-periods>
   <identifiers>
     <wikidata>Q250414</wikidata>
     <viaf>9867884</viaf>

--- a/fdirs/pope/info.xml
+++ b/fdirs/pope/info.xml
@@ -14,6 +14,7 @@
       <place>Twickenham, England</place>
     </dead>
   </period>
+  <literary-periods>oplysningstid-og-klassicisme</literary-periods>
   <works>andre,1733,1714</works>
   <identifiers>
     <wikidata>Q164047</wikidata>

--- a/fdirs/prior/info.xml
+++ b/fdirs/prior/info.xml
@@ -14,6 +14,7 @@
       <place>Wimpole</place>
     </dead>
   </period>
+  <literary-periods>oplysningstid-og-klassicisme</literary-periods>
   <works>andre</works>
   <identifiers>
     <wikidata>Q1256302</wikidata>

--- a/fdirs/pulci/info.xml
+++ b/fdirs/pulci/info.xml
@@ -13,6 +13,7 @@
       <date>1484-11-11</date>
     </dead>
   </period>
+  <literary-periods>renaessance-og-humanisme</literary-periods>
   <works>1481</works>
   <identifiers>
     <wikidata>Q631635</wikidata>

--- a/fdirs/rabelais/info.xml
+++ b/fdirs/rabelais/info.xml
@@ -14,6 +14,7 @@
       <place>Paris</place>
     </dead>
   </period>
+  <literary-periods>renaessance-og-humanisme</literary-periods>
   <works/>
   <identifiers>
     <wikidata>Q131018</wikidata>

--- a/fdirs/racine/info.xml
+++ b/fdirs/racine/info.xml
@@ -16,6 +16,7 @@
       <place>Paris</place>
     </dead>
   </period>
+  <literary-periods>oplysningstid-og-klassicisme</literary-periods>
   <identifiers>
     <wikidata>Q742</wikidata>
     <viaf>88809641</viaf>

--- a/fdirs/reenberg/info.xml
+++ b/fdirs/reenberg/info.xml
@@ -13,6 +13,7 @@
       <date>1742-06-24</date>
     </dead>
   </period>
+  <literary-periods>barok-og-tidlig-modernitet</literary-periods>
   <works>1742,andre</works>
   <identifiers>
     <wikidata>Q6065994</wikidata>

--- a/fdirs/rilke/info.xml
+++ b/fdirs/rilke/info.xml
@@ -15,6 +15,7 @@
       <place>Valmont, Schweiz</place>
     </dead>
   </period>
+  <literary-periods>symbolisme-og-fin-de-siecle,modernisme-og-avantgarde</literary-periods>
   <works>1899,1902,1904,1905,1906,1907,1908,1909,1910,1912,1923,1923s,andre</works>
   <identifiers>
     <wikidata>Q76483</wikidata>

--- a/fdirs/rimbaud/info.xml
+++ b/fdirs/rimbaud/info.xml
@@ -15,6 +15,7 @@
       <place>Marseille</place>
     </dead>
   </period>
+  <literary-periods>symbolisme-og-fin-de-siecle</literary-periods>
   <works>1873</works>
   <identifiers>
     <wikidata>Q493</wikidata>

--- a/fdirs/rossettic/info.xml
+++ b/fdirs/rossettic/info.xml
@@ -14,6 +14,7 @@
       <place>London</place>
     </dead>
   </period>
+  <literary-periods>symbolisme-og-fin-de-siecle</literary-periods>
   <works>1862,1866,1872,1881,1885,1892,andre</works>
   <identifiers>
     <wikidata>Q236596</wikidata>

--- a/fdirs/rossettid/info.xml
+++ b/fdirs/rossettid/info.xml
@@ -14,6 +14,7 @@
       <place>Birchington-on-Sea, Kent, England</place>
     </dead>
   </period>
+  <literary-periods>symbolisme-og-fin-de-siecle</literary-periods>
   <works>1861,1881,andre</works>
   <identifiers>
     <wikidata>Q186748</wikidata>

--- a/fdirs/rueckert/info.xml
+++ b/fdirs/rueckert/info.xml
@@ -15,6 +15,7 @@
       <place>Neuses</place>
     </dead>
   </period>
+  <literary-periods>romantik-og-praeromantik</literary-periods>
   <works>1814,1822,1836,1836b,1836b-1,1836b-2,1836b-3,1836b-4,1836b-5,1836b-6,1837,1839,1844,1872,andre</works>
   <identifiers>
     <wikidata>Q60644</wikidata>

--- a/fdirs/runeberg/info.xml
+++ b/fdirs/runeberg/info.xml
@@ -15,6 +15,7 @@
       <place>Porvoo/Borgå</place>
     </dead>
   </period>
+  <literary-periods>romantik-og-praeromantik</literary-periods>
   <works>1830,1848,andre</works>
   <identifiers>
     <wikidata>Q215339</wikidata>

--- a/fdirs/saadi/info.xml
+++ b/fdirs/saadi/info.xml
@@ -16,6 +16,7 @@
       <place>Shiraz, Persien</place>
     </dead>
   </period>
+  <literary-periods>middelalderen</literary-periods>
   <identifiers>
     <wikidata>Q170302</wikidata>
     <viaf>100206721</viaf>

--- a/fdirs/schiller/info.xml
+++ b/fdirs/schiller/info.xml
@@ -15,6 +15,7 @@
       <place>Weimar</place>
     </dead>
   </period>
+  <literary-periods>oplysningstid-og-klassicisme,romantik-og-praeromantik</literary-periods>
   <works>andre</works>
   <identifiers>
     <wikidata>Q22670</wikidata>

--- a/fdirs/scott/info.xml
+++ b/fdirs/scott/info.xml
@@ -14,6 +14,7 @@
       <place>Abbotsford, Roxburgh, Scotland</place>
     </dead>
   </period>
+  <literary-periods>romantik-og-praeromantik</literary-periods>
   <works>1802,1804,1805,1808,1810,1811,1813r,1813,1815l,1815,1817,andre</works>
   <identifiers>
     <wikidata>Q79025</wikidata>

--- a/fdirs/shakespeare/info.xml
+++ b/fdirs/shakespeare/info.xml
@@ -15,6 +15,7 @@
       <place>Stratford-upon-Avon, Warwickshire, England</place>
     </dead>
   </period>
+  <literary-periods>renaessance-og-humanisme</literary-periods>
   <works>1593,1594,1601,lovers,sonnets,andre</works>
   <identifiers>
     <wikidata>Q692</wikidata>

--- a/fdirs/shelley/info.xml
+++ b/fdirs/shelley/info.xml
@@ -14,6 +14,7 @@
       <place>Livorno, Italien</place>
     </dead>
   </period>
+  <literary-periods>romantik-og-praeromantik</literary-periods>
   <works>1810,1813,1816,1818,1819,1823,1824,ovs,andre</works>
   <identifiers>
     <wikidata>Q93343</wikidata>

--- a/fdirs/sidney/info.xml
+++ b/fdirs/sidney/info.xml
@@ -14,6 +14,7 @@
       <place>Arnhem, Nederlandene</place>
     </dead>
   </period>
+  <literary-periods>renaessance-og-humanisme</literary-periods>
   <works>1591,andre</works>
   <identifiers>
     <wikidata>Q315509</wikidata>

--- a/fdirs/soedergran/info.xml
+++ b/fdirs/soedergran/info.xml
@@ -15,6 +15,7 @@
       <place>Raivola, Finland (nu Roshchino, Rusland)</place>
     </dead>
   </period>
+  <literary-periods>modernisme-og-avantgarde</literary-periods>
   <works/>
   <identifiers>
     <wikidata>Q466595</wikidata>

--- a/fdirs/solstad/info.xml
+++ b/fdirs/solstad/info.xml
@@ -13,6 +13,7 @@
       <date>1918-07-27</date>
     </dead>
   </period>
+  <literary-periods>postmodernisme,samtid</literary-periods>
   <identifiers>
     <wikidata>Q17120322</wikidata>
     <viaf>3178153472518245360008</viaf>

--- a/fdirs/southey/info.xml
+++ b/fdirs/southey/info.xml
@@ -14,6 +14,7 @@
       <place>London</place>
     </dead>
   </period>
+  <literary-periods>romantik-og-praeromantik</literary-periods>
   <works>andre</works>
   <identifiers>
     <wikidata>Q216838</wikidata>

--- a/fdirs/spenser/info.xml
+++ b/fdirs/spenser/info.xml
@@ -14,6 +14,7 @@
       <place>London</place>
     </dead>
   </period>
+  <literary-periods>renaessance-og-humanisme</literary-periods>
   <works>1569,1579,1590,1591,1595,1595e,1596</works>
   <identifiers>
     <wikidata>Q4352055</wikidata>

--- a/fdirs/staffeldt/info.xml
+++ b/fdirs/staffeldt/info.xml
@@ -15,6 +15,7 @@
       <place>Slesvig</place>
     </dead>
   </period>
+  <literary-periods>romantik-og-praeromantik</literary-periods>
   <works>1804,1808,andre</works>
   <identifiers>
     <wikidata>Q365558</wikidata>

--- a/fdirs/stub/info.xml
+++ b/fdirs/stub/info.xml
@@ -12,6 +12,7 @@
       <date>1758-07-15</date>
     </dead>
   </period>
+  <literary-periods>oplysningstid-og-klassicisme</literary-periods>
   <works>1771,gudelige,moralske,ovs,andre</works>
   <identifiers>
     <wikidata>Q459770</wikidata>

--- a/fdirs/swift/info.xml
+++ b/fdirs/swift/info.xml
@@ -14,6 +14,7 @@
       <place>Dublin</place>
     </dead>
   </period>
+  <literary-periods>oplysningstid-og-klassicisme</literary-periods>
   <works>andre</works>
   <identifiers>
     <wikidata>Q41166</wikidata>

--- a/fdirs/swinburne/info.xml
+++ b/fdirs/swinburne/info.xml
@@ -15,6 +15,7 @@
       <place>London</place>
     </dead>
   </period>
+  <literary-periods>symbolisme-og-fin-de-siecle</literary-periods>
   <works>andre</works>
   <identifiers>
     <wikidata>Q315511</wikidata>

--- a/fdirs/tasso/info.xml
+++ b/fdirs/tasso/info.xml
@@ -14,6 +14,7 @@
       <place>Rom</place>
     </dead>
   </period>
+  <literary-periods>renaessance-og-humanisme</literary-periods>
   <works>1581</works>
   <identifiers>
     <wikidata>Q168962</wikidata>

--- a/fdirs/tegner/info.xml
+++ b/fdirs/tegner/info.xml
@@ -14,6 +14,7 @@
       <place>Växjö</place>
     </dead>
   </period>
+  <literary-periods>romantik-og-praeromantik</literary-periods>
   <works>andre</works>
   <identifiers>
     <wikidata>Q366765</wikidata>

--- a/fdirs/tennyson/info.xml
+++ b/fdirs/tennyson/info.xml
@@ -14,6 +14,7 @@
       <place>Aldworth, Surrey, England</place>
     </dead>
   </period>
+  <literary-periods>romantik-og-praeromantik</literary-periods>
   <works>1827,1830,1833,1842,1847,1850,1855,1859,1864,1870,1872,1875,1876,1880,1885,1886,1889,1892a,1892b,andre</works>
   <identifiers>
     <wikidata>Q173869</wikidata>

--- a/fdirs/thomson/info.xml
+++ b/fdirs/thomson/info.xml
@@ -14,6 +14,7 @@
       <place>Richmond, England</place>
     </dead>
   </period>
+  <literary-periods>oplysningstid-og-klassicisme,romantik-og-praeromantik</literary-periods>
   <works>1730s,1730,1740,1745,andre</works>
   <identifiers>
     <wikidata>Q984402</wikidata>

--- a/fdirs/tieck/info.xml
+++ b/fdirs/tieck/info.xml
@@ -14,6 +14,7 @@
       <place>Berlin</place>
     </dead>
   </period>
+  <literary-periods>romantik-og-praeromantik</literary-periods>
   <works>andre</works>
   <identifiers>
     <wikidata>Q57239</wikidata>

--- a/fdirs/todi/info.xml
+++ b/fdirs/todi/info.xml
@@ -14,6 +14,7 @@
       <place>Collazzone</place>
     </dead>
   </period>
+  <literary-periods>middelalderen</literary-periods>
   <identifiers>
     <wikidata>Q317267</wikidata>
     <viaf>6645158792823139040006</viaf>

--- a/fdirs/uhland/info.xml
+++ b/fdirs/uhland/info.xml
@@ -14,6 +14,7 @@
       <place>Tübingen</place>
     </dead>
   </period>
+  <literary-periods>romantik-og-praeromantik</literary-periods>
   <works>1815,andre</works>
   <identifiers>
     <wikidata>Q61058</wikidata>

--- a/fdirs/verlaine/info.xml
+++ b/fdirs/verlaine/info.xml
@@ -15,6 +15,7 @@
       <place>Paris</place>
     </dead>
   </period>
+  <literary-periods>symbolisme-og-fin-de-siecle</literary-periods>
   <works>1866,1869,1870,1874,1880,1884,1885,1892</works>
   <identifiers>
     <wikidata>Q755</wikidata>

--- a/fdirs/vigny/info.xml
+++ b/fdirs/vigny/info.xml
@@ -15,6 +15,7 @@
       <place>Paris</place>
     </dead>
   </period>
+  <literary-periods>romantik-og-praeromantik</literary-periods>
   <works>1822,1826,1864</works>
   <identifiers>
     <wikidata>Q309702</wikidata>

--- a/fdirs/villon/info.xml
+++ b/fdirs/villon/info.xml
@@ -15,6 +15,7 @@
       <date>1485</date>
     </dead>
   </period>
+  <literary-periods>middelalderen</literary-periods>
   <works>1489,andre</works>
   <identifiers>
     <wikidata>Q849</wikidata>

--- a/fdirs/vogelweide/info.xml
+++ b/fdirs/vogelweide/info.xml
@@ -12,6 +12,7 @@
       <date>1230 ca.</date>
     </dead>
   </period>
+  <literary-periods>middelalderen</literary-periods>
   <works>andre</works>
   <identifiers>
     <wikidata>Q44385</wikidata>

--- a/fdirs/voltaire/info.xml
+++ b/fdirs/voltaire/info.xml
@@ -14,6 +14,7 @@
       <place>Paris</place>
     </dead>
   </period>
+  <literary-periods>oplysningstid-og-klassicisme</literary-periods>
   <works>andre</works>
   <identifiers>
     <wikidata>Q9068</wikidata>

--- a/fdirs/wackenroder/info.xml
+++ b/fdirs/wackenroder/info.xml
@@ -14,6 +14,7 @@
       <place>Berlin</place>
     </dead>
   </period>
+  <literary-periods>romantik-og-praeromantik</literary-periods>
   <works>andre</works>
   <identifiers>
     <wikidata>Q60576</wikidata>

--- a/fdirs/wadskiaer/info.xml
+++ b/fdirs/wadskiaer/info.xml
@@ -14,6 +14,7 @@
       <place>København</place>
     </dead>
   </period>
+  <literary-periods>oplysningstid-og-klassicisme</literary-periods>
   <works>1743,andre</works>
   <identifiers>
     <wikidata>Q15135696</wikidata>

--- a/fdirs/welhaven/info.xml
+++ b/fdirs/welhaven/info.xml
@@ -15,6 +15,7 @@
       <place>Christiania (nu Oslo)</place>
     </dead>
   </period>
+  <literary-periods>romantik-og-praeromantik</literary-periods>
   <works>1834,1838,1844,1847,1851,1859,andre</works>
   <identifiers>
     <wikidata>Q954720</wikidata>

--- a/fdirs/wergeland/info.xml
+++ b/fdirs/wergeland/info.xml
@@ -14,6 +14,7 @@
       <place>Christiania (nu Oslo)</place>
     </dead>
   </period>
+  <literary-periods>romantik-og-praeromantik</literary-periods>
   <works>1829,1830,1833s,1833d,1838,1840,1844e,1844j,1845,andre</works>
   <identifiers>
     <wikidata>Q351705</wikidata>

--- a/fdirs/wessel/info.xml
+++ b/fdirs/wessel/info.xml
@@ -14,6 +14,7 @@
       <place>København</place>
     </dead>
   </period>
+  <literary-periods>oplysningstid-og-klassicisme</literary-periods>
   <works>1772,1776,1785,1862</works>
   <identifiers>
     <wikidata>Q649747</wikidata>

--- a/fdirs/whitman/info.xml
+++ b/fdirs/whitman/info.xml
@@ -15,6 +15,7 @@
       <place>Camden, New Jersey, USA</place>
     </dead>
   </period>
+  <literary-periods>realisme-og-naturalisme</literary-periods>
   <works>1865,1871,1891</works>
   <identifiers>
     <wikidata>Q81438</wikidata>

--- a/fdirs/whittier/info.xml
+++ b/fdirs/whittier/info.xml
@@ -14,6 +14,7 @@
       <place>Hampton Halls, New Hampshire,.</place>
     </dead>
   </period>
+  <literary-periods>romantik-og-praeromantik</literary-periods>
   <works>1831,1838,1843,1850,1853,1856,1860,1864,1866,1867,1869,1871,1875,1878,1886,1888,1890</works>
   <identifiers>
     <wikidata>Q458372</wikidata>

--- a/fdirs/wied/info.xml
+++ b/fdirs/wied/info.xml
@@ -15,6 +15,7 @@
       <place>Roskilde</place>
     </dead>
   </period>
+  <literary-periods>realisme-og-naturalisme</literary-periods>
   <works>andre</works>
   <identifiers>
     <wikidata>Q1556531</wikidata>

--- a/fdirs/wilde/info.xml
+++ b/fdirs/wilde/info.xml
@@ -15,6 +15,7 @@
       <place>Paris</place>
     </dead>
   </period>
+  <literary-periods>symbolisme-og-fin-de-siecle</literary-periods>
   <works>1881,andre</works>
   <identifiers>
     <wikidata>Q30875</wikidata>

--- a/fdirs/winther/info.xml
+++ b/fdirs/winther/info.xml
@@ -15,6 +15,7 @@
       <place>Paris</place>
     </dead>
   </period>
+  <literary-periods>romantik-og-praeromantik</literary-periods>
   <works>1828,1832,1835,1840,1840h,1843,1846,1849,1851,1853,1856,1858,1860,1860-1,1860-2,1860-3,1860-4,1860-5,1860-6,1860-7,1865,1872,1879,andre</works>
   <identifiers>
     <wikidata>Q981722</wikidata>

--- a/fdirs/wordsworth/info.xml
+++ b/fdirs/wordsworth/info.xml
@@ -14,6 +14,7 @@
       <place>Rydal Mount, Westmorland, England</place>
     </dead>
   </period>
+  <literary-periods>romantik-og-praeromantik</literary-periods>
   <works>1798,1814,1815,1819,1820,1822,1835,1888,andre</works>
   <identifiers>
     <wikidata>Q45546</wikidata>

--- a/fdirs/wyatt/info.xml
+++ b/fdirs/wyatt/info.xml
@@ -14,6 +14,7 @@
       <place>Sherborne, Dorset</place>
     </dead>
   </period>
+  <literary-periods>renaessance-og-humanisme</literary-periods>
   <works>andre</works>
   <identifiers>
     <wikidata>Q314325</wikidata>

--- a/fdirs/yeats/info.xml
+++ b/fdirs/yeats/info.xml
@@ -15,6 +15,7 @@
       <place>Roquebrune-Cap-Martin, Frankrig</place>
     </dead>
   </period>
+  <literary-periods>symbolisme-og-fin-de-siecle,modernisme-og-avantgarde</literary-periods>
   <works>1889,1893,1899,1904,1910,1914,1919,1921,1928,1933,1935,1938a,1938</works>
   <identifiers>
     <wikidata>Q40213</wikidata>

--- a/tools/build-static.js
+++ b/tools/build-static.js
@@ -27,6 +27,7 @@ const {
   build_poets_first_pass,
   build_poets_json,
   build_poets_by_country_json,
+  build_literary_periods_json,
 } = require('./build-static/poets.js');
 const {
   build_dict_first_pass,
@@ -968,6 +969,11 @@ const main = async () => {
   await b(
     'build_poets_by_country_json',
     build_poets_by_country_json,
+    collected
+  );
+  await b(
+    'build_literary_periods_json',
+    build_literary_periods_json,
     collected
   );
   await b('build_museum_pages', build_museum_pages, collected);

--- a/tools/build-static/poets.js
+++ b/tools/build-static/poets.js
@@ -1,5 +1,9 @@
 const fs = require('fs');
 const {
+  literaryPeriods,
+  literaryPeriodIds,
+} = require('../../common/literary-periods.js');
+const {
   isFileModified,
   loadCachedJSON,
   writeCachedJSON,
@@ -36,6 +40,22 @@ const all_poet_ids = () => {
     _all_poet_ids = fs.readdirSync('fdirs').filter(p => p.indexOf('.') === -1);
   }
   return _all_poet_ids;
+};
+
+const parseLiteraryPeriods = (id, value) => {
+  if (value == null || value.trim() === '') {
+    return [];
+  }
+  const periods = value
+    .split(',')
+    .map(period => period.trim())
+    .filter(period => period !== '');
+  periods.forEach(period => {
+    if (!literaryPeriodIds.has(period)) {
+      throw `${id} har ukendt litterær periode: ${period}`;
+    }
+  });
+  return periods;
 };
 
 const build_poets_first_pass = collected => {
@@ -98,10 +118,14 @@ const build_poets_first_pass = collected => {
     const nameE = getChildByTagName(p, 'name');
     const periodE = getChildByTagName(p, 'period');
     const works = safeGetText(p, 'works');
+    const literary_periods = parseLiteraryPeriods(
+      id,
+      safeGetText(p, 'literary-periods')
+    );
     if (!country.match(/(dk|se|no|gb|de|fr|us|it|un)/)) {
       throw `${id} har ukendt land: ${country}`;
     }
-    if (!lang.match(/(da|sv|no|en|de|fr||un|it)/)) {
+    if (!lang.match(/(da|sv|no|en|de|fr|la|pe|sp|un|it)/)) {
       throw `${id} har ukendt sprog: ${country}`;
     }
 
@@ -180,6 +204,7 @@ const build_poets_first_pass = collected => {
         sortname,
       },
       period,
+      literary_periods,
       has_portraits,
       has_square_portrait,
       has_works: has.has_works,
@@ -245,9 +270,57 @@ const build_poets_by_country_json = collected => {
   });
 };
 
+const build_literary_periods_json = collected => {
+  const poetListItem = poet => {
+    return {
+      id: poet.id,
+      type: poet.type,
+      country: poet.country,
+      lang: poet.lang,
+      name: {
+        firstname: poet.name.firstname,
+        lastname: poet.name.lastname,
+        sortname: poet.name.sortname,
+      },
+      period:
+        poet.period == null
+          ? null
+          : {
+              born:
+                poet.period.born == null
+                  ? null
+                  : { date: poet.period.born.date },
+              dead:
+                poet.period.dead == null
+                  ? null
+                  : { date: poet.period.dead.date },
+            },
+    };
+  };
+  const periods = literaryPeriods.map(period => {
+    const poets = [];
+    collected.poets.forEach(poet => {
+      if ((poet.literary_periods || []).includes(period.id)) {
+        poets.push(poetListItem(poet));
+      }
+    });
+    poets.sort((a, b) => {
+      const aName = a.name.sortname || a.name.lastname || a.id;
+      const bName = b.name.sortname || b.name.lastname || b.id;
+      return aName.localeCompare(bName, 'da');
+    });
+    return {
+      ...period,
+      poets,
+    };
+  });
+  writeJSON('public/api/literary-periods.json', { periods });
+};
+
 module.exports = {
   all_poet_ids,
   build_poets_json,
   build_poets_first_pass,
   build_poets_by_country_json,
+  build_literary_periods_json,
 };


### PR DESCRIPTION
## Resumé
- tilføjer en central liste over litterære perioder med titler på dansk, engelsk, tysk, fransk og italiensk
- parser og validerer feltet `<literary-periods>... </literary-periods>` fra digternes `info.xml`
- bygger `public/api/literary-periods.json` med digtere grupperet efter periode
- markerer foreløbig 183 digtere med en eller flere litterære perioder

## Test
- `git diff --check`
- `npm run build-static`

Bemærk: `npm run build-static` viser fortsat den kendte besked om manglende Elasticsearch på `localhost:9200`.