### PR TITLE
Brug gange-tegn i billedmål

### DIFF
--- a/data/about/muse_da.xml
+++ b/data/about/muse_da.xml
@@ -5,7 +5,7 @@
     <author>Henrik Nielsen</author>
     <pictures>
         <picture src="vouet.jpg">Simon Vouet (Frankrig, 1590-1649): <i>The Muses Urania and Calliope</i>, ca. 1634, olie på panel, 79,8 ×125cm. National Gallery of Art, Washington, D.C.</picture>
-        <picture src="pajoua.jpg">Augustin Pajou (Frankrig, 1730-1809): <i>Calliope</i>, ca. 1763, marmor, 158x60,8x46,1cm. Samuel H. Kress Collection.</picture>
+        <picture src="pajoua.jpg">Augustin Pajou (Frankrig, 1730-1809): <i>Calliope</i>, ca. 1763, marmor, 158 × 60,8 × 46,1 cm. Samuel H. Kress Collection.</picture>
     </pictures>
 </head>
 <body>

--- a/data/artwork.xml
+++ b/data/artwork.xml
@@ -6,7 +6,7 @@
     <picture id="rafael-leone-x-1518" wikidata="Q2610729" year="1518 ca.">
         Rafael: <i>Papa Leone X con i cugini, i cardinali Giulio de' Medici e Luigi de' Rossi.</i>, mellem 1518 og 1519, olie på panel. Uffizierne, Firenze.
     </picture>
-    <picture id="loeffler-anna-nielsen-1836"  year="1836" museum="smk" invnr="KMS8660">Carl Løffler: <i>Skuespilleren Anna Nielsen</i>, ca. 1836, olie på lærred, 23,3x20,7 cm.</picture>
+    <picture id="loeffler-anna-nielsen-1836"  year="1836" museum="smk" invnr="KMS8660">Carl Løffler: <i>Skuespilleren Anna Nielsen</i>, ca. 1836, olie på lærred, 23,3 × 20,7 cm.</picture>
     <picture id="tizian-amor-sacro-e-amor-profano-1515">Tizian: <i>L'Amor sacro e Amor profano</i>, ca. 1515, olie på træ, 118×279 cm. Galleria Borghese, Rom.</picture> <!-- https://en.wikipedia.org/wiki/Sacred_and_Profane_Love --> 
     <picture id="rivett-carnac-edward-fitzgerald-oval" museum="npg" year="1873">Eva Rivett-Carnac: <i>Edward Fitzgerald</i>, miniature efter et fotografi fra 1873.</picture>
 </pictures>

--- a/data/keywords/enhedstanken.xml
+++ b/data/keywords/enhedstanken.xml
@@ -4,7 +4,7 @@
     <title>Enhedstanken</title>
     <pictures>
         <picture src="lorentzen_henrik_steffens_1804.jpg">C. A. Lorentzen: <i>Henrik Steffens</i>, 1804, Det Nationalhistoriske Museum på Frederiksborg.</picture>
-        <picture src="friedrich1.jpg">Caspar David Friedrich: <i>Kreuz im Gebirge</i>, 1812, olie på lærred, 45x38cm. Museum Kunstpalast, Düsseldorf.</picture>
+        <picture src="friedrich1.jpg">Caspar David Friedrich: <i>Kreuz im Gebirge</i>, 1812, olie på lærred, 45 × 38 cm. Museum Kunstpalast, Düsseldorf.</picture>
         <picture src="ribera-platon.jpg">José de Ribera: <i>Platon</i>, 1637. Musée de Picardie, Amiens.</picture>
     </pictures>
     <related>romantikken</related>

--- a/data/keywords/romantismen.xml
+++ b/data/keywords/romantismen.xml
@@ -3,7 +3,7 @@
   <head>
     <title>Romantisme</title>
     <pictures>
-        <picture src="friedrich7.jpg">Den romantiske udlængsel ifølge Caspar David Friedrich: <i>View from the Artist's Studio, Right Window</i>, 1805-1806. 31x24cm. Sepia på papir. Wien Kunsthistorisches Museum.</picture>
+        <picture src="friedrich7.jpg">Den romantiske udlængsel ifølge Caspar David Friedrich: <i>View from the Artist's Studio, Right Window</i>, 1805-1806. 31 × 24 cm. Sepia på papir. Wien Kunsthistorisches Museum.</picture>
     <picture src="Hugo.jpg">Victor Hugo (1802-1885)</picture>
     <picture src="ingres8.jpg">Jean Auguste Dominique Ingres: <i>Grande Odalisque</i>, 1814. Musée du Louvre.</picture>
     <picture src="Heine.jpg">Moritz Daniel Oppenheim: <i>Heinrich Heine</i> (1797-1856)</picture>

--- a/data/keywords/symbolismen.xml
+++ b/data/keywords/symbolismen.xml
@@ -4,7 +4,7 @@
     <title>Symbolismen</title>
     <pictures>
       <picture src="Baudelaire.jpg"><i>Charles Baudelaire</i>, fotografi.</picture>
-      <picture src="monet.st-lazare.jpg">Claude Monet: <i>Saint-Lazare Station</i>, 1877, olie på lærred, 54,3 x 73,6 cm, National Gallery, London.</picture>
+      <picture src="monet.st-lazare.jpg">Claude Monet: <i>Saint-Lazare Station</i>, 1877, olie på lærred, 54,3 × 73,6 cm, National Gallery, London.</picture>
     </pictures>
   </head>
   <body>

--- a/fdirs/ahlmann/1907.xml
+++ b/fdirs/ahlmann/1907.xml
@@ -947,7 +947,7 @@ Hellere glemt — end en bitter Dag
     <firstline>Dit Smil er som en Sejersfærd</firstline>
     <source pages="51"/>
     <pictures>
-        <picture src="ahlmann2022051823-p1.jpg">Leonardo da Vinci: <i>Ritratto di Monna Lisa del Giocondo</i>, 1503-06, olie på panel, 77x53cm. Louvre.</picture>
+        <picture src="ahlmann2022051823-p1.jpg">Leonardo da Vinci: <i>Ritratto di Monna Lisa del Giocondo</i>, 1503-06, olie på panel, 77 × 53 cm. Louvre.</picture>
     </pictures>
     <quality>korrektur1,kilde,side</quality>
 </head>

--- a/fdirs/ahlmann/1910.xml
+++ b/fdirs/ahlmann/1910.xml
@@ -1844,7 +1844,7 @@ bagved den vældige, hærgede Fugl.
     <firstline>Carlyle, du strenge Mester, saa er jeg atter her</firstline>
     <source pages="78-79"/>
     <pictures>
-        <picture src="ahlmann2023071529-p1.jpg">James McNeill Whistler: <i>Arrangement in Grey and Black, No. 2: Portrait of Thomas Carlyle</i>, olie på lærred, 171x143,5 cm, 1872-73, Kelvingrove Art Gallery and Museum, Glasgow.</picture>
+        <picture src="ahlmann2023071529-p1.jpg">James McNeill Whistler: <i>Arrangement in Grey and Black, No. 2: Portrait of Thomas Carlyle</i>, olie på lærred, 171 × 143,5 cm, 1872-73, Kelvingrove Art Gallery and Museum, Glasgow.</picture>
     </pictures>
     <quality>korrektur1,kilde,side</quality>
 </head>

--- a/fdirs/ahlmann/1913.xml
+++ b/fdirs/ahlmann/1913.xml
@@ -393,7 +393,7 @@ Kæreste Du, som er bleven saa saaret og stille.
         <note>Rogier van der Weyden (1399/1400-1464), flamsk maler.</note>
     </notes>
     <pictures>
-        <picture src="ahlmann2024041309-p1.jpg">Rogier van der Weyden (kopi efter): <i>Portrait de Philippe le Bon</i>, olie på træ, 31,5x22,5 cm, 1400-tallet, Muséee des Beaux-arts de Dijon.</picture>
+        <picture src="ahlmann2024041309-p1.jpg">Rogier van der Weyden (kopi efter): <i>Portrait de Philippe le Bon</i>, olie på træ, 31,5 × 22,5 cm, 1400-tallet, Muséee des Beaux-arts de Dijon.</picture>
     </pictures>
     <source pages="21-22"/>
     <quality>korrektur1,kilde,side</quality>

--- a/fdirs/almqvist/portraits.xml
+++ b/fdirs/almqvist/portraits.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <pictures>
   <picture src="p1.jpg" primary="true" square-src="p1-square.jpg" museum="natmus.se" objid="39402">
-      Carl Peter Mazér (1807–1884): <i>Carl Jonas Ludvig (Love) Almquist (1793-1866), författare, gift med Anna Maria Andersdotter Lundström</i>, u.å., olie på lærred, 49x63 cm.
+      Carl Peter Mazér (1807–1884): <i>Carl Jonas Ludvig (Love) Almquist (1793-1866), författare, gift med Anna Maria Andersdotter Lundström</i>, u.å., olie på lærred, 49 × 63 cm.
   </picture>
 </pictures>
 

--- a/fdirs/arbuthnot/portraits.xml
+++ b/fdirs/arbuthnot/portraits.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <pictures>
   <picture src="p1.jpg" primary="true" square-src="p1-square.jpg" year="1723">
-      Godfrey Kneller: <i>Portrait of John Arbuthnot (1667-1735), the physician</i>, 1723, olie på lærred, 75,5x63cm. Hunterian Museum and Art Gallery, University of Glasgow.
+      Godfrey Kneller: <i>Portrait of John Arbuthnot (1667-1735), the physician</i>, 1723, olie på lærred, 75,5 × 63 cm. Hunterian Museum and Art Gallery, University of Glasgow.
   </picture>
 </pictures>
 

--- a/fdirs/ariosto/portraits.xml
+++ b/fdirs/ariosto/portraits.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <pictures>
   <picture src="p1.jpg" primary="true" square-src="p1-square.jpg">
-      Tizian: <i>Ritratto dell'Ariosto</i>, ca. 1515, olie på lærred, 59,5x45,5 cm. Indianapolis Museum of Art.
+      Tizian: <i>Ritratto dell'Ariosto</i>, ca. 1515, olie på lærred, 59,5 × 45,5 cm. Indianapolis Museum of Art.
   </picture>
 </pictures>
 

--- a/fdirs/arnold/portraits.xml
+++ b/fdirs/arnold/portraits.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <pictures>
   <picture src="p1.jpg" primary="true" square-src="p1-square.jpg"  objid="mw00185" invnr="NPG 1000" museum="npg" year="1880">
-    George Frederic Watts: <i>Matthew Arnold</i>, 1880, olie på lærred, 66x52cm.
+    George Frederic Watts: <i>Matthew Arnold</i>, 1880, olie på lærred, 66 × 52 cm.
   </picture>
 </pictures>
     

--- a/fdirs/atterbom/portraits.xml
+++ b/fdirs/atterbom/portraits.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <pictures>
   <picture src="p1.jpg" primary="true" square-src="p1-square.jpg" objid="39069" museum="natmus.se" year="1831">
-      Johann Gustaf Sandberg: <i>Per Daniel Amadeus Atterbom</i>, olie på lærred, 23x19cm, 1831. Gripsholms slott, Sverige.
+      Johann Gustaf Sandberg: <i>Per Daniel Amadeus Atterbom</i>, olie på lærred, 23 × 19 cm, 1831. Gripsholms slott, Sverige.
   </picture>
 </pictures>

--- a/fdirs/bache/artwork.xml
+++ b/fdirs/bache/artwork.xml
@@ -7,7 +7,7 @@
     <i>Christian IVs kroningstog</i>, 1887, olie på lærred.
   </picture>
   <picture id="1886-sankelmark" year="1886" museum="ribe" invnr="RKMm0009">
-    <i>Oberst Max Müller ved Sankelmark Sø den 6. februar 1864</i>, 1886, olie på lærred, 84x60cm.
+    <i>Oberst Max Müller ved Sankelmark Sø den 6. februar 1864</i>, 1886, olie på lærred, 84 × 60 cm.
   </picture>
   <picture id="1894-soldaternes-hjemkomst" year="1894" museum="fnm">
     <i>Soldaternes hjemkomst til København</i>, 1894, olie på lærred.

--- a/fdirs/barton/portraits.xml
+++ b/fdirs/barton/portraits.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <pictures>
   <picture src="p1.jpg" primary="true" square-src="p1-square.jpg" objid="mw35139" invnr="NPG D1023" museum="npg" year="1850">
-      James Henry Lynch, efter Samuel Laurence: <i>Bernard Barton</i>, midten af 1800-tallet, litografi, 169x111mm.
+      James Henry Lynch, efter Samuel Laurence: <i>Bernard Barton</i>, midten af 1800-tallet, litografi, 169 × 111 mm.
   </picture>
 </pictures>
     

--- a/fdirs/berntsen/1908.xml
+++ b/fdirs/berntsen/1908.xml
@@ -188,7 +188,7 @@ og Livets onde Skygge.
     <firstline>Alle Fugle synge</firstline>
     <source pages="14-15"/>
     <pictures>
-        <picture src="berntsen2022052104-p1.jpg" museum="digitalmuseum.no" objid="0110495978">Edvard Munch: <i>Vår</i>, 1889, olie på lærred, 169,5 x 264,2 cm, Nasjonalmuseet for kunst, arkitektur og design, Oslo.</picture>
+        <picture src="berntsen2022052104-p1.jpg" museum="digitalmuseum.no" objid="0110495978">Edvard Munch: <i>Vår</i>, 1889, olie på lærred, 169,5 × 264,2 cm, Nasjonalmuseet for kunst, arkitektur og design, Oslo.</picture>
         <!-- https://www.nasjonalmuseet.no/samlingen/objekt/NG.M.00498 -->
     </pictures>
     <quality>korrektur1,kilde,side</quality>

--- a/fdirs/blake/artwork.xml
+++ b/fdirs/blake/artwork.xml
@@ -11,13 +11,13 @@
       <!-- Canto II 139-141 -->
   </picture>
   <picture id="1824-inscription" year="1824-1-03">
-      <i>The Inscription over the Gate</i>, 1824-27, blyant, blæk og vandfarve på papir, 527x374mm. Tate Gallery, London.
+      <i>The Inscription over the Gate</i>, 1824-27, blyant, blæk og vandfarve på papir, 527 × 374 mm. Tate Gallery, London.
   </picture>
   <picture id="1824-francesca-da-rimini" year="1824-1-05">
-      <i>The Circle of the Lustful: Francesca da Rimini (‘The Whirlwind of Lovers’)</i>, 1824-27, blyant, blæk og vandfarve på papir, 243x335mm. Tate Gallery, London.
+      <i>The Circle of the Lustful: Francesca da Rimini (‘The Whirlwind of Lovers’)</i>, 1824-27, blyant, blæk og vandfarve på papir, 243 × 335 mm. Tate Gallery, London.
   </picture>
   <picture id="1824-cerberus" year="1824-1-06">
-      <i>Cerberus</i>, 1824-27, blyant, blæk og vandfarve på papir, 372x528mm. Tate Gallery, London.
+      <i>Cerberus</i>, 1824-27, blyant, blæk og vandfarve på papir, 372 × 528 mm. Tate Gallery, London.
   </picture>
   <picture id="1824-wood-of-the-self-murderers" year="1824-1-12">
       <i>The Wood of the Self-Murderers: The Harpies and the Suicides</i>, 1824-27, blyant, blæk og vandfarve på papir, 372×527 mm. Tate Gallery, London.
@@ -25,7 +25,7 @@
       <!-- Illustration til Dantes Inferno, Cirkel VII, Ring II, Canto XIII. -->
   </picture>
   <picture id="1824-simoniac-pope" year="1824-1-19">
-      <i>The Simoniac Pope</i>, 1824-27, blyant, blæk og vandfarve på papir, 527x368mm. Tate Gallery, London.
+      <i>The Simoniac Pope</i>, 1824-27, blyant, blæk og vandfarve på papir, 527 × 368 mm. Tate Gallery, London.
   </picture>
   <picture id="1824-beatrice-adressing-dante" year="1824-2-29">
       <i>Beatrice Addressing Dante from the Car</i>, 1824-27, blyant, blæk og vandfarve på papir, 372×527 mm. Tate Gallery, London.

--- a/fdirs/blunck/artwork.xml
+++ b/fdirs/blunck/artwork.xml
@@ -7,7 +7,7 @@
     <i>Danske kunstnere på osteriet La Gensola i Trastevere i Rom</i>, 1836-37.
   </picture>
   <picture id="1848-selvportraet" museum="nivaagaard" objid="ditlev-blunck-2"> 
-      <i>Selvportræt som friskarer</i>, olie på lærred, 26x20cm, 1848.<!-- https://commons.wikimedia.org/wiki/File:Ditlev_Blunck,_Selvportræt_som_friskarer,_1848,_0214NMK,_Nivaagaards_Malerisamling.jpg -->
+      <i>Selvportræt som friskarer</i>, olie på lærred, 26 × 20 cm, 1848.<!-- https://commons.wikimedia.org/wiki/File:Ditlev_Blunck,_Selvportræt_som_friskarer,_1848,_0214NMK,_Nivaagaards_Malerisamling.jpg -->
   </picture>
 </pictures>
 

--- a/fdirs/boedtcher/1870.xml
+++ b/fdirs/boedtcher/1870.xml
@@ -3625,7 +3625,7 @@ Med flammende Begeistring tømmes ud!
        <picture ref="lundbye/1846-piazza-barberini" />
        <picture ref="marstrand/piazza-barberini-1840erne" />
        <picture src="boedtcher1870a22-p1.jpg" museum="smk" invnr="KMS196">
-           Ditlev Martens: <i>Pave Leo Xll aflægger besøg i Thorvaldsens værksteder ved Piazza Barberini, 18. oktober 1826</i>, 1828-29, olie på lærred, 100x138 cm.
+           Ditlev Martens: <i>Pave Leo Xll aflægger besøg i Thorvaldsens værksteder ved Piazza Barberini, 18. oktober 1826</i>, 1828-29, olie på lærred, 100 × 138 cm.
        </picture>
    </pictures>
    <source pages="142-147"/>

--- a/fdirs/boedtcher/1940.xml
+++ b/fdirs/boedtcher/1940.xml
@@ -3740,7 +3740,7 @@ Med flammende Begeistring tømmes ud!
    <pictures>
        <picture ref="marstrand/piazza-barberini-1840erne" />
        <picture src="boedtcher1870a22-p1.jpg" museum="smk" invnr="KMS196">
-           Ditlev Martens: <i>Pave Leo Xll aflægger besøg i Thorvaldsens værksteder ved Piazza Barberini, 18. oktober 1826</i>, 1828-29, olie på lærred, 100x138 cm.
+           Ditlev Martens: <i>Pave Leo Xll aflægger besøg i Thorvaldsens værksteder ved Piazza Barberini, 18. oktober 1826</i>, 1828-29, olie på lærred, 100 × 138 cm.
        </picture>
    </pictures>
    <notes>

--- a/fdirs/boennelycke/1921.xml
+++ b/fdirs/boennelycke/1921.xml
@@ -94,7 +94,7 @@ er din unge Kærlighed. -
     <firstline>Berust af Kyssenes Aande</firstline>
     <source pages="12-14"/>
     <pictures>
-        <picture src="boennelycke2024091702-p1.jpg">Paolo Veronese: <i>Venus og Adonis</i>, olie på lærred, 163x192 cm, Museo del Prado</picture>
+        <picture src="boennelycke2024091702-p1.jpg">Paolo Veronese: <i>Venus og Adonis</i>, olie på lærred, 163 × 192 cm, Museo del Prado</picture>
         <!-- https://en.wikipedia.org/wiki/File:Venus_y_Adonis_(Veronese).jpg -->
     </pictures>
     <quality>korrektur1,kilde,side</quality>
@@ -394,7 +394,7 @@ Han vrider de hvide Hænder -.
     <firstline>Hvem er du, som er standset paa Vejen</firstline>
     <source pages="24-26"/>
     <pictures>
-        <picture src="boennelycke2024091705-p1.jpg">Matthias Grünewald: <i>Crucifixion</i>, ca. 1515, 74,9x54,4cm, Kunstmuseum Basel</picture>
+        <picture src="boennelycke2024091705-p1.jpg">Matthias Grünewald: <i>Crucifixion</i>, ca. 1515, 74,9 × 54,4 cm, Kunstmuseum Basel</picture>
         <!-- https://commons.wikimedia.org/wiki/File:Mathis_Gothart_Grünewald_047.jpg -->
     </pictures>
     <quality>korrektur1,kilde,side</quality>

--- a/fdirs/boennelycke/portraits.xml
+++ b/fdirs/boennelycke/portraits.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <pictures>
   <picture src="p1.jpg" primary="true" square-src="p1-square.jpg" museum="smk" year="1921" invnr="KMS8760">
-      Vilhelm Lundstrøm: <i>Portræt af Emil Bønnelycke</i>, 1921, olie på lærred, 166x100,7 cm.
+      Vilhelm Lundstrøm: <i>Portræt af Emil Bønnelycke</i>, 1921, olie på lærred, 166 × 100,7 cm.
   </picture>
 </pictures>
     

--- a/fdirs/brandes/portraits.xml
+++ b/fdirs/brandes/portraits.xml
@@ -9,6 +9,6 @@
   <picture ref="kroyer/1900-brandes-2" />
   <picture ref="kroyer/1883-brandes-3" primary="true" square-src="p5-square.jpg" />
   <picture src="p4.jpg" museum="skagen" year="1915">
-    Michael Ancher: <i>Georg Brandes</i>, 1915, olie på lærred, 31x34cm.
+    Michael Ancher: <i>Georg Brandes</i>, 1915, olie på lærred, 31 × 34 cm.
   </picture>
 </pictures>

--- a/fdirs/campbell/portraits.xml
+++ b/fdirs/campbell/portraits.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <pictures>
   <picture src="p1.jpg" primary="true" square-src="p1-square.jpg" objid="mw01033" invnr="NPG 198" museum="npg" year="1820">
-      Sir Thomas Lawrence: <i>Thomas Campbell</i>, c. 1820, olie på lærred, 914x711mm.
+      Sir Thomas Lawrence: <i>Thomas Campbell</i>, c. 1820, olie på lærred, 914 × 711 mm.
   </picture>
 </pictures>
     

--- a/fdirs/chamisso/portraits.xml
+++ b/fdirs/chamisso/portraits.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <pictures>
   <picture src="p2.jpg" primary="true" square-src="p2-square.jpg">
-    <i>Chamisso</i>. Litografi af C. Barth efter en tegning af L. F. Heine og maleri af P. Reinich. 10.5 x 8 cm.
+    <i>Chamisso</i>. Litografi af C. Barth efter en tegning af L. F. Heine og maleri af P. Reinich. 10.5 × 8 cm.
   </picture>
   <picture src="p3.jpg">
     Adelbert von Chamisso under sin jordomrejse 1815-18. Tegning af Louis Choris.

--- a/fdirs/clare/portraits.xml
+++ b/fdirs/clare/portraits.xml
@@ -1,9 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <pictures>
   <picture src="p1.jpg" primary="true" square-src="p1-square.jpg" objid="mw01307" invnr="NPG 1469" museum="npg" year="1820">
-      William Hilton: <i>John Clare</i>, 1820, olie på lærred, 76,2x64,5cm.
+      William Hilton: <i>John Clare</i>, 1820, olie på lærred, 76,2 × 64,5 cm.
   </picture>
   <picture src="p2.jpg" objid="mw113260" invnr="NPG P1101" museum="npg" year="1862">
-    W.W. Law: <i>John Clare</i>, 1852, albuminfotografi, 89x66mm.
+    W.W. Law: <i>John Clare</i>, 1852, albuminfotografi, 89 × 66 mm.
   </picture>
 </pictures>

--- a/fdirs/claussen/1912.xml
+++ b/fdirs/claussen/1912.xml
@@ -2332,7 +2332,7 @@ Og jeg gad sé dig korsfæstet en Gang
       <note type="credits">Bidraget af Mads Geisler.</note>
    </notes>
    <pictures>
-       <picture src="claussen2002090101-p1.jpg">J.F. Willumsen: <i>Sophus Claussen læser sit digt »Imperia« for <a poet="rodeh">Helge Rode</a> og J. F. Willumsen</i>, 1915, olie på lærred, 147x187cm, ARoS, Aarhus.</picture>
+       <picture src="claussen2002090101-p1.jpg">J.F. Willumsen: <i>Sophus Claussen læser sit digt »Imperia« for <a poet="rodeh">Helge Rode</a> og J. F. Willumsen</i>, 1915, olie på lærred, 147 × 187 cm, ARoS, Aarhus.</picture>
    </pictures>
    <quality>korrektur1,korrektur2,kilde,side</quality>
 </head>

--- a/fdirs/coleridge/portraits.xml
+++ b/fdirs/coleridge/portraits.xml
@@ -1,9 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <pictures>
   <picture src="p1.jpg" primary="true" square-src="p1-square.jpg" objid="mw01398" invnr="NPG 184" museum="npg" year="1814">
-      Washington Allston (1779-1843): <i>Portrait of Samuel Taylor Coleridge</i>, 1814, olie på lærred, 114,3x87,6cm.
+      Washington Allston (1779-1843): <i>Portrait of Samuel Taylor Coleridge</i>, 1814, olie på lærred, 114,3 × 87,6 cm.
   </picture>
   <picture src="p2.jpg" objid="mw01396" invnr="NPG 192" museum="npg" year="1795">
-      Peter Vandyke: <i>Samuel Taylor Coleridge</i>, 1795, olie på lærred, 55,9x45,7cm.
+      Peter Vandyke: <i>Samuel Taylor Coleridge</i>, 1795, olie på lærred, 55,9 × 45,7 cm.
   </picture>
 </pictures>

--- a/fdirs/cunningham/portraits.xml
+++ b/fdirs/cunningham/portraits.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <pictures>
   <picture src="p1.jpg" primary="true" square-src="p1-square.jpg" objid="mw01673" invnr="NPG 1823" museum="npg" year="1840">
-      Henry Room: <i>Allan Cunningham</i>, ca. 1840, olie på lærred, 914x711mm.
+      Henry Room: <i>Allan Cunningham</i>, ca. 1840, olie på lærred, 914 × 711 mm.
   </picture>
 </pictures>
     

--- a/fdirs/daugaard/portraits.xml
+++ b/fdirs/daugaard/portraits.xml
@@ -4,6 +4,6 @@
       Carl Thomsen: <i>Frk. Daugård i sit hjem i Ribe</i>, 1900, olie på lærred, 56×47cm.
   </picture>
   <picture src="p2.jpg" year="1906" museum="ribe" invnr="RKMm0162">
-      Caja Prytz (1877-1916): <i>Forfatterinden frk. Christine Daugaard</i>, 1906, olie på lærred, 27x26,5cm.
+      Caja Prytz (1877-1916): <i>Forfatterinden frk. Christine Daugaard</i>, 1906, olie på lærred, 27 × 26,5 cm.
   </picture>
 </pictures>

--- a/fdirs/drachmann/1875.xml
+++ b/fdirs/drachmann/1875.xml
@@ -3444,7 +3444,7 @@ I La Plataflodens Vande.
     <firstline>Som Baaden, der sagte glider</firstline>
     <source pages="139-141"/>
     <pictures>
-        <picture src="drachmann2018012928-p1.jpg">Marc Gabriel Charles Gleyre: <i>Le Soir Ou Les Illusions Perdues</i>, ca. 1843, olie på lærred, 238x157cm. Louvre.</picture>
+        <picture src="drachmann2018012928-p1.jpg">Marc Gabriel Charles Gleyre: <i>Le Soir Ou Les Illusions Perdues</i>, ca. 1843, olie på lærred, 238 × 157 cm. Louvre.</picture>
     </pictures>
     <quality>korrektur1,korrektur2,kilde,side</quality>
 </head>

--- a/fdirs/drachmann/1879.xml
+++ b/fdirs/drachmann/1879.xml
@@ -4603,7 +4603,7 @@ mens Sol gaar bag den danske Scene ned.
     <subtitle>(Til G. O. Cederströms Maleri.)</subtitle>
     <firstline>Blød og tavs er Bjærgets Sti</firstline>
     <pictures>
-        <picture src="drachmann1999111027-p1.jpg" museum="natmus.se" objid="18366">Gustaf Cederström (1845-1933): <i>Karl XII:s likfärd</i>, 1878, oliemaleri, 256x370 cm. Nationalmuseum, Stockholm.</picture>
+        <picture src="drachmann1999111027-p1.jpg" museum="natmus.se" objid="18366">Gustaf Cederström (1845-1933): <i>Karl XII:s likfärd</i>, 1878, oliemaleri, 256 × 370 cm. Nationalmuseum, Stockholm.</picture>
     </pictures>
     <source pages="174-177"/>
     <quality>korrektur1,kilde,side</quality>

--- a/fdirs/eckersberg/artwork.xml
+++ b/fdirs/eckersberg/artwork.xml
@@ -5,17 +5,17 @@
     <!-- Ovenstående er et farvelagt stik af G.L. Lahde efter en akvarel af C.W. Eckersberg -->
   </picture>
   <picture id="apistemplet-1809" year="1809" museum="smk" invnr="KKSgb4236">
-    <i>Prospekt fra Frederiksberg have ved slottet og Apistemplet</i>, 1809, vandfarve, 265x324mm.
+    <i>Prospekt fra Frederiksberg have ved slottet og Apistemplet</i>, 1809, vandfarve, 265 × 324 mm.
   </picture>
   <picture id="1812-odysseus-hjemkomst" year="1812" invnr="KMS7256" museum="smk">
-      <i>Odysseus' hjemkomst. Motiv fra Odysséen XIX sang</i>, 1812, olie på lærred, 60x72cm.
+      <i>Odysseus' hjemkomst. Motiv fra Odysséen XIX sang</i>, 1812, olie på lærred, 60 × 72 cm.
   </picture>
   <picture id="thorvaldsen-1814" year="1814" subject="thorvaldsen">
-    <i>Bertel Thorvaldsen</i>, 1814, 90x74 cm. Kunstakademiet.
+    <i>Bertel Thorvaldsen</i>, 1814, 90 × 74 cm. Kunstakademiet.
     <!-- Findes i tre versioner: 1. Nærværende på Kunstakademiet. 2. Nationalmuseum, Stockholm. https://digitaltmuseum.se/021046502180/den-danske-skulptoren-bertel-thorvaldsen og 3. Glyptoteket. https://artsandculture.google.com/asset/bertel-thorvaldsen/ygFcme7z95CiAg -->
   </picture>
   <picture id="udsigt-gennem-tre-buer-i-colosseum-1815" year="1815" invnr="KMS3123" museum="smk">
-      <i>Udsigt gennem tre buer i Colosseums tredje stokværk</i>, 1815, olie på lærred, 32x49,5cm.
+      <i>Udsigt gennem tre buer i Colosseums tredje stokværk</i>, 1815, olie på lærred, 32 × 49,5 cm.
   </picture>
   <picture id="1816-ingemann" year="1816-18 ca." subject="ingemann" museum="fnm" invnr="a-4570">
     <i>Bernhard Severin Ingemann</i>, ca. 1816-18, olie på lærred.
@@ -24,19 +24,19 @@
     <i>Friederike Brun</i>, ca. 1816.
   </picture>
   <picture id="familien-nathanson-1818" year="1818" museum="smk" invnr="KMS1241">
-      <i>Familien Nathanson</i>, 1818, olie på lærred, 126x172,5cm.
+      <i>Familien Nathanson</i>, 1818, olie på lærred, 126 × 172,5 cm.
   </picture>
   <picture id="nathanson-1819" year="1819">
       <i>Mendel Levin Nathanson</i>, 1819.
   </picture>
   <picture id="1820-thorvaldsen" year="1820" subject="thorvaldsen" museum="thorvaldsens" invnr="B454">
-    <i>Portræt af Thorvaldsen</i>, 1820, 49,8x40cm.
+    <i>Portræt af Thorvaldsen</i>, 1820, 49,8 × 40 cm.
   </picture>
   <picture id="bella-hanna-1820" year="1820" museum="smk" invnr="KMS3498">
-      <i>Mendel Levin Nathansons ældste døtre, Bella og Hanna</i>, 1820, olie på lærred, 125x85,5cm.
+      <i>Mendel Levin Nathansons ældste døtre, Bella og Hanna</i>, 1820, olie på lærred, 125 × 85,5 cm.
   </picture>
   <picture id="as-oersted-1821" year="1821" museum="smk" invnr="KMS1495">
-      <i>Juristen og statsmanden Anders Sandøe Ørsted</i>, 1821, olie på lærred, 53,5x43cm.
+      <i>Juristen og statsmanden Anders Sandøe Ørsted</i>, 1821, olie på lærred, 53,5 × 43 cm.
   </picture>
   <!-- TODO: Find Oehlenschläger-portrættet https://dnm.dk/kunstvaerk/a-7555/ -->
   <picture id="frederik3-kongeloven-1824" year="1824" subject="frederik3">
@@ -46,7 +46,7 @@
       <i>Kong Frederik VI af Danmark</i>, 1825, olie på lærred.
   </picture>
   <picture id="jomfruen-fra-afar-1830" year="1830" museum="hirschsprungske">
-      <i>Jomfruen fra Afar</i>, 1830, olie på lærred, 34,8x40cm.
+      <i>Jomfruen fra Afar</i>, 1830, olie på lærred, 34,8 × 40 cm.
   </picture>
 </pictures>
 

--- a/fdirs/eschenburg/portraits.xml
+++ b/fdirs/eschenburg/portraits.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <pictures>
   <picture src="p1.jpg" primary="true" square-src="p1-square.jpg" museum="gleimhaus" objid="854" year="1793">
-      Friedrich Georg Weitsch (1758-1828): <i>Johann Joachim Eschenburg</i>, ca. 1793, olie på lærred, 47,3x38 cm.
+      Friedrich Georg Weitsch (1758-1828): <i>Johann Joachim Eschenburg</i>, ca. 1793, olie på lærred, 47,3 × 38 cm.
   </picture>
 </pictures>
     

--- a/fdirs/falk/portraits.xml
+++ b/fdirs/falk/portraits.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <pictures>
   <picture src="p1.jpg" primary="true" square-src="p1-square.jpg" year="1800" museum="gleimhaus" objid="954">
-      Ukendt kunster: <i>Johann Daniel Falk</i>, 1800, pastel, 43x35cm.
+      Ukendt kunster: <i>Johann Daniel Falk</i>, 1800, pastel, 43 × 35 cm.
   </picture>
 </pictures>
     

--- a/fdirs/fonss/1896.xml
+++ b/fdirs/fonss/1896.xml
@@ -878,7 +878,7 @@ bliver Du maaske selv engang i Tiden.
     <firstline>Har vi vel mere Vidnesbyrd behov</firstline>
     <source pages="37"/>
     <pictures>
-        <picture src="fonss2019101510-p1.jpg">Leonardo da Vinci: <i>Den sidste nadver</i>, 1895-98, tempera, 460x880cm. Santa Maria delle Grazie, Milano.</picture>
+        <picture src="fonss2019101510-p1.jpg">Leonardo da Vinci: <i>Den sidste nadver</i>, 1895-98, tempera, 460 × 880 cm. Santa Maria delle Grazie, Milano.</picture>
     </pictures>
     <keywords>sonnet</keywords>
     <quality>korrektur1,kilde,side</quality>

--- a/fdirs/fonss/1900.xml
+++ b/fdirs/fonss/1900.xml
@@ -492,7 +492,7 @@ som lukker Dig i Mindets Verden ind.
     <toctitle><num>II.</num>Et Steds i Napolimuseets Sale</toctitle>
     <firstline>Et Steds i Napolimuseets Sale</firstline>
     <pictures>
-        <picture src="fonss2018041909-p1.jpg">Titian: <i>Danaë</i>, 1544-46, olie på lærred, 120x172cm. Museo di Capodimonte, Napoli.</picture> <!-- https://en.wikipedia.org/wiki/Danaë_(Titian_series)#/media/File:Tizian_011.jpg -->
+        <picture src="fonss2018041909-p1.jpg">Titian: <i>Danaë</i>, 1544-46, olie på lærred, 120 × 172 cm. Museo di Capodimonte, Napoli.</picture> <!-- https://en.wikipedia.org/wiki/Danaë_(Titian_series)#/media/File:Tizian_011.jpg -->
     </pictures>
     <source pages="19"/>
     <keywords>sonnet</keywords>

--- a/fdirs/franzen/portraits.xml
+++ b/fdirs/franzen/portraits.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <pictures>
   <picture src="p1.jpg" primary="true" square-src="p1-square.jpg" museum="natmus.se" objid="40327">
-      Johan Gustaf Sandberg: <i>Frans Mikael Franzén, 1772-1847, biskop, skald</i>, 1828, olie på panel, 23x18cm. National Museum, Gripsholm Slot.
+      Johan Gustaf Sandberg: <i>Frans Mikael Franzén, 1772-1847, biskop, skald</i>, 1828, olie på panel, 23 × 18 cm. National Museum, Gripsholm Slot.
   </picture>
 </pictures>

--- a/fdirs/freiligrath/portraits.xml
+++ b/fdirs/freiligrath/portraits.xml
@@ -2,5 +2,5 @@
 <pictures>
   <picture src="p1.jpg">
   </picture>
-  <picture src="p2.jpg" primary="true" square-src="p2-square.jpg" museum="smb" objid="958720">Johann Peter Hasenclever: <i>Der Dichter Ferdinand Freiligrath</i>, 1851, olie på lærred, 65,5x55,3cm. Alte Nationalgalerie, Berlin.</picture>
+  <picture src="p2.jpg" primary="true" square-src="p2-square.jpg" museum="smb" objid="958720">Johann Peter Hasenclever: <i>Der Dichter Ferdinand Freiligrath</i>, 1851, olie på lærred, 65,5 × 55,3 cm. Alte Nationalgalerie, Berlin.</picture>
 </pictures>

--- a/fdirs/geijer/portraits.xml
+++ b/fdirs/geijer/portraits.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <pictures>
   <picture src="p1.jpg" primary="true" square-src="p1-square.jpg">
-      Karl Vilhelm Nordgren: <i>Erik Gustaf Geijer</i>, ca. 1830-1840, olie på lærred, 76x63 cm. Skoklosters slott.
+      Karl Vilhelm Nordgren: <i>Erik Gustaf Geijer</i>, ca. 1830-1840, olie på lærred, 76 × 63 cm. Skoklosters slott.
   </picture>
 </pictures>

--- a/fdirs/goethe/portraits.xml
+++ b/fdirs/goethe/portraits.xml
@@ -1,15 +1,15 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <pictures>
     <picture src="p7.jpg" year="1787">
-        Johann Heinrich Wilhelm Tischbein: <i>Goethe in der Campagna</i>, Rom, 1787, olie på lærred, 164x206cm. Städel Museum, Frankfurt.
+        Johann Heinrich Wilhelm Tischbein: <i>Goethe in der Campagna</i>, Rom, 1787, olie på lærred, 164 × 206 cm. Städel Museum, Frankfurt.
     </picture>
     <picture src="p6.jpg" year="1810">
-        Gerhard von Kügelgen (1772-1820): <i>Johann Wolfgang von Goethe</i>, Dresden, 1810, olie på lærred, 73,8x63,5cm. Deutsches Historisches Museum, Berlin.
+        Gerhard von Kügelgen (1772-1820): <i>Johann Wolfgang von Goethe</i>, Dresden, 1810, olie på lærred, 73,8 × 63,5 cm. Deutsches Historisches Museum, Berlin.
     </picture>
     <picture src="p3.jpg" primary="true" square-src="p3-square.jpg" year="1822">
         Heinrich Christoph Kolbe: <i>Goethe</i>, 1822, olie på lærred. Goethe-Nationalmuseum, Weimar.
     </picture>
     <picture src="p8.jpg" year="1828">
-        Joseph Karl Stieler (1781-1858): <i>Johann Wolfgang von Goethe</i>, 1828, olie på lærred, 78x63,8cm. Neue Pinakothek, München.
+        Joseph Karl Stieler (1781-1858): <i>Johann Wolfgang von Goethe</i>, 1828, olie på lærred, 78 × 63,8 cm. Neue Pinakothek, München.
     </picture>
 </pictures>

--- a/fdirs/goldstein/portraits.xml
+++ b/fdirs/goldstein/portraits.xml
@@ -4,7 +4,7 @@
       Edvard Munch: <i>Emanuel Goldstein</i>.
   </picture>
   <picture src="p2.jpg">
-      Edvard Munch: <i>Panterhode. Goldstein som panter</i>, 1908-1909, kul på velinpapir, 164x223mm. Munch Museet, Oslo.
+      Edvard Munch: <i>Panterhode. Goldstein som panter</i>, 1908-1909, kul på velinpapir, 164 × 223 mm. Munch Museet, Oslo.
   </picture>
 </pictures>
 

--- a/fdirs/gruen/portraits.xml
+++ b/fdirs/gruen/portraits.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <pictures>
   <picture src="p1.jpg" primary="true" square-src="p1-square.jpg" year="1831">
-      Franz Eybl (1806-1880): <i>Portröt des Dichters Anastasius Grün</i>, 1831, olie på lærred, 22x17cm.
+      Franz Eybl (1806-1880): <i>Portröt des Dichters Anastasius Grün</i>, 1831, olie på lærred, 22 × 17 cm.
   </picture>
 </pictures>
 

--- a/fdirs/hansenc/artwork.xml
+++ b/fdirs/hansenc/artwork.xml
@@ -4,16 +4,16 @@
       <i>Selvportræt</i>, 1825, olie på lærred, 63×50 cm.
     </picture>
     <picture id="tre-unge-piger-1827" year="1827" invnr="KMS125" museum="smk">
-        <i>Tre unge piger. Kunstnerens søstre Alvilde, Ida og Henriette</i>, 1827, olie på lærred, 62,5x81cm.
+        <i>Tre unge piger. Kunstnerens søstre Alvilde, Ida og Henriette</i>, 1827, olie på lærred, 62,5 × 81 cm.
     </picture>
     <picture id="slottet-kronborg-1834" year="1834" invnr="KMS6815" museum="smk">
-        <i>Slottet Kronborg</i>, 1834, olie på lærred, 28,5x42,5cm.
+        <i>Slottet Kronborg</i>, 1834, olie på lærred, 28,5 × 42,5 cm.
     </picture>
     <picture id="kuchler-1837" invnr="KMS4961" year="1837" museum="smk">
         <i>Maleren Albert Küchler</i>, 1837, olie på papir opsat på lærred.
     </picture>
     <picture id="et-selskab-af-danske-kunstnere-i-rom-1837" year="1837" invnr="KMS3236" museum="smk">
-        <i>Et Selskab af danske Kunstnere i Rom</i>, 1837, olie på lærred, 62x74cm.
+        <i>Et Selskab af danske Kunstnere i Rom</i>, 1837, olie på lærred, 62 × 74 cm.
     </picture>
     <picture id="monrad-1846" year="1846">
         <i>Ditlev Gothard Monrad</i>, 1846. Folketinget, Christiansborg.
@@ -41,6 +41,6 @@
         <i>Christian Winther</i>, 1857.
     </picture>
     <picture id="jessen-1830" year="1830" invnr="KMS1788" museum="smk">
-        <i>Forfatterinden Juliane Marie Jessen</i>, ca. 1830, olie på lærred, 31x25.5 cm.
+        <i>Forfatterinden Juliane Marie Jessen</i>, ca. 1830, olie på lærred, 31 × 25.5 cm.
     </picture>
 </pictures>

--- a/fdirs/heber/portraits.xml
+++ b/fdirs/heber/portraits.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <pictures>
   <picture src="p1.jpg" primary="true" square-src="p1-square.jpg">
-      Thomas Phillips (1770-1845): <i>Portrait of Reginald Heber</i>, ca. 1822, olie på lærred, 35,5x30,5cm. British Library.
+      Thomas Phillips (1770-1845): <i>Portrait of Reginald Heber</i>, ca. 1822, olie på lærred, 35,5 × 30,5 cm. British Library.
   </picture>
 </pictures>
     

--- a/fdirs/hertzb/portraits.xml
+++ b/fdirs/hertzb/portraits.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <pictures>
   <picture src="p1-oval.jpg" primary="true" square-src="p1-square.jpg" museum="smk" invnr="KKS8257" year="1702">
-      Terkel Kleeve: <i>Madame B. C. Boye</i>, 1702, crayonstik, 188x113 mm.
+      Terkel Kleeve: <i>Madame B. C. Boye</i>, 1702, crayonstik, 188 × 113 mm.
   </picture>
 </pictures>

--- a/fdirs/hertzh/portraits.xml
+++ b/fdirs/hertzh/portraits.xml
@@ -4,6 +4,6 @@
   <picture src="p2.jpg">
   </picture>
   <picture src="p3.jpg" museum="smk" invnr="KKS11662">
-    Franz Wilhelm Obermann: <i>Henrik Hertz</i>, Henrik Olrik (forlæg), xylografi, 155x140mm.
+    Franz Wilhelm Obermann: <i>Henrik Hertz</i>, Henrik Olrik (forlæg), xylografi, 155 × 140 mm.
   </picture>
 </pictures>

--- a/fdirs/hildebrandt/portraits.xml
+++ b/fdirs/hildebrandt/portraits.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <pictures>
   <picture src="p1.jpg" primary="true" square-src="p1-square.jpg" year="1943">
-      <i>Karen Hildebrandt</i>, 1943, fotografi, 6x7cm. Glamsbjerg Lokalhistoriske Arkiv.<!-- https://arkiv.dk/vis/566359 -->
+      <i>Karen Hildebrandt</i>, 1943, fotografi, 6 × 7 cm. Glamsbjerg Lokalhistoriske Arkiv.<!-- https://arkiv.dk/vis/566359 -->
   </picture>
 </pictures>
 

--- a/fdirs/hood/portraits.xml
+++ b/fdirs/hood/portraits.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <pictures>
   <picture src="p1.jpg" primary="true" square-src="p1-square.jpg" museum="npg" objid="mw03226">
-    Ukendt maler: <i>Thomas Hood</i>, ukendt år, olie på træ, 305x299mm.
+    Ukendt maler: <i>Thomas Hood</i>, ukendt år, olie på træ, 305 × 299 mm.
   </picture>
 </pictures>

--- a/fdirs/hornc/portraits.xml
+++ b/fdirs/hornc/portraits.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <pictures>
   <picture src="p1.jpg" primary="true" square-src="p1-square.jpg" museum="smk" year="1783" invnr="KMS4083">
-      Carl Fredric von Breda: <i>Portræt af Claes Fredrik Horn</i>, 1783, olie på lærred, 64.5 x 54,5 cm.
+      Carl Fredric von Breda: <i>Portræt af Claes Fredrik Horn</i>, 1783, olie på lærred, 64.5 × 54,5 cm.
   </picture>
 </pictures>
     

--- a/fdirs/houghton/portraits.xml
+++ b/fdirs/houghton/portraits.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <pictures>
   <picture src="p1.jpg" square-src="p1-square.jpg" primary="true" objid="mw03265" invnr="NPG 3824" museum="npg" year="1844">
-    George Richmond: <i>Richard Monckton Milnes, 1st Baron Houghton</i>, ca. 1844, kridt, 529x476mm.
+    George Richmond: <i>Richard Monckton Milnes, 1st Baron Houghton</i>, ca. 1844, kridt, 529 × 476 mm.
   </picture>
 </pictures>

--- a/fdirs/howard/portraits.xml
+++ b/fdirs/howard/portraits.xml
@@ -4,7 +4,7 @@
     Hans Holbein: <i>Henry Howard, Earl of Surrey</i>.
   </picture>
   <picture src="p2.jpg" year="1542">
-    Hans Holbein (1497-1543): <i>Henry Howard Earl of Surrey</i>, 1542, 55x44cm, Paulo Assis Chateaubriand
+    Hans Holbein (1497-1543): <i>Henry Howard Earl of Surrey</i>, 1542, 55 × 44 cm, Paulo Assis Chateaubriand
   </picture>
   <picture src="p3.jpg" primary="true" square-src="p3-square.jpg" museum="npg" year="1570">
     <i>Henry Howard, Earl of Surrey</i>, ca. 1570, baseret på et maleri af William Scrots fra 1546.

--- a/fdirs/hunt/portraits.xml
+++ b/fdirs/hunt/portraits.xml
@@ -1,10 +1,10 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <pictures>
   <picture src="p1.jpg" primary="true" square-src="p1-square.jpg" year="1811" objid="mw03305" invnr="NPG 293" museum="npg">
-      Benjamin Robert Haydon: <i>Leigh Hunt</i>, ca. 1811, olie på lærred, 610x502mm.
+      Benjamin Robert Haydon: <i>Leigh Hunt</i>, ca. 1811, olie på lærred, 610 × 502 mm.
   </picture>
   <picture src="p2.jpg" objid="mw03307" invnr="NPG 2508" year="1837" museum="npg">
-      Samuel Laurence: <i>Leigh Hunt</i>, ca. 1837, olie på lærred, 1118x905mm.
+      Samuel Laurence: <i>Leigh Hunt</i>, ca. 1837, olie på lærred, 1118 × 905 mm.
   </picture>
 </pictures>
     

--- a/fdirs/ingemann/1832.xml
+++ b/fdirs/ingemann/1832.xml
@@ -2644,7 +2644,7 @@ Regner det atter idag? fort da mod Solskin og Vaar!
    <source pages="112"/>
    <pictures>
        <picture src="ingemann2017100436-p2.jpg">H.C. Andersen: <i>Landeveien over de Pontinske Sumpe; man seer Circes Ø; nu Circello</i>, tegning, 22. marts 1834. Odense Bys Museer. <!-- http://www.hcandersen-homepage.dk/?page_id=59773 --></picture>
-       <picture src="ingemann2017100436-p1.jpg" objid="958670" museum="smb">August Kopisch (1799-1853): <i>Die Pontinischen Sümpfe bei Sonnenuntergang</i>, 1848, olie på lærred, 62 x 111 cm. Alte Nationalgalerie, Berlin. <!-- Berlin, Staatliche Museen zu Berlin - Preußischer Kulturbesitz, Nationalgalerie, Inventar-Nr. W.S. 118, Zugang: Zusammenführung, 1991 --></picture>
+       <picture src="ingemann2017100436-p1.jpg" objid="958670" museum="smb">August Kopisch (1799-1853): <i>Die Pontinischen Sümpfe bei Sonnenuntergang</i>, 1848, olie på lærred, 62 × 111 cm. Alte Nationalgalerie, Berlin. <!-- Berlin, Staatliche Museen zu Berlin - Preußischer Kulturbesitz, Nationalgalerie, Inventar-Nr. W.S. 118, Zugang: Zusammenführung, 1991 --></picture>
    </pictures>
    <quality>korrektur1,kilde,side</quality>
 </head>

--- a/fdirs/jensenca/artwork.xml
+++ b/fdirs/jensenca/artwork.xml
@@ -34,7 +34,7 @@
       <i>Herman Wilhelm Bissen</i>, 1835, olie på lærred, 25×21 cm. Ny Carlsberg Glyptotek. <!-- invnr. 1734 -->
   </picture>
   <picture id="herholdt-1835" year="1835" museum="smk" invnr="KMS3129">
-    <i>Professor dr. med. J.D. Herholdt</i>, 1835, olie på lærred. 23,5x19 cm.
+    <i>Professor dr. med. J.D. Herholdt</i>, 1835, olie på lærred. 23,5 × 19 cm.
   </picture>
   <picture id="andersen-1836" subject="andersen" year="1836">
     <i>H.C. Andersen</i>, 1836. H.C. Andersen Museet, Odense.

--- a/fdirs/jessen/portraits.xml
+++ b/fdirs/jessen/portraits.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <pictures>
     <picture src="p2-oval.jpg">
-        Christian Hornemann: <i>Juliane Marie von Jessen</i>, u.å., pastel på papir, 39x32cm.
+        Christian Hornemann: <i>Juliane Marie von Jessen</i>, u.å., pastel på papir, 39 × 32 cm.
         <!-- https://bidtoart.com/en/fine-art/portrait-of-juliane-marie-von-jessen/697417 -->
         <!-- https://commons.wikimedia.org/wiki/File:Portrait_of_Juliane_Marie_von_Jessen.jpg -->
     </picture>

--- a/fdirs/jonson/portraits.xml
+++ b/fdirs/jonson/portraits.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <pictures>
   <picture src="p1.jpg" primary="true" square-src="p1-square.jpg" objid="mw03528" invnr="NPG 2752" museum="npg" year="1617">
-      Abraham van Blyenberch: <i>Ben Jonson</i>, ca. 1617, olie på lærred, 47x42cm.
+      Abraham van Blyenberch: <i>Ben Jonson</i>, ca. 1617, olie på lærred, 47 × 42 cm.
   </picture>
 </pictures>
     

--- a/fdirs/juel/artwork.xml
+++ b/fdirs/juel/artwork.xml
@@ -28,7 +28,7 @@
         <i>Emilie Kilde</i>, 1784, olie på lærred, 49×37,5cm. Brandts, Odense.
     </picture>
     <picture id="1784-wessel" year="1784" subject="wessel" museum="smk" invnr="KKS10891">
-        <i>Johan Herman Wessel</i>, 1787, kobberstik, 185x126mm. Kobberstik af J.F. Clemens - efter en nu tabt tegning af Jens Juel fra 1784.
+        <i>Johan Herman Wessel</i>, 1787, kobberstik, 185 × 126 mm. Kobberstik af J.F. Clemens - efter en nu tabt tegning af Jens Juel fra 1784.
     </picture>
     <picture id="1787-louise-augusta" year="1787">
         <i>Prinsesse Louise Augusta af Danmark</i>, 1787, olie på lærred.

--- a/fdirs/keats/post.xml
+++ b/fdirs/keats/post.xml
@@ -364,7 +364,7 @@ And so live ever - or else swoon to death.
       <note>Teksten følger John Keats: <i>Complete Poems</i>, ed. Jack Stillinger, The Belknap Press of Harvard University Press, 1982</note>
    </notes>
    <pictures>
-      <picture src="keats2000012803-p1.jpg">John William Waterhouse (<year>1849</year>-<year>1917</year>): »La Belle Dame Sans Merci« (<year>1893</year>), oliemaleri, 112x81 cm, Hessisches Landesmuseum, Darmstadt.</picture>
+      <picture src="keats2000012803-p1.jpg">John William Waterhouse (<year>1849</year>-<year>1917</year>): »La Belle Dame Sans Merci« (<year>1893</year>), oliemaleri, 112 × 81 cm, Hessisches Landesmuseum, Darmstadt.</picture>
    </pictures>
    <quality>korrektur1,kilde</quality>
 </head>

--- a/fdirs/kellgren/portraits.xml
+++ b/fdirs/kellgren/portraits.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <pictures>
   <picture src="p1.jpg" primary="true" square-src="p1-square.jpg" museum="digitalmuseum.se" objid="011023533471">
-      Julius Alexis Wetterbergh: <i>Johan Henrik Kellgren</i>, olie på papir, 12x8,8cm. Nordiska museet, Stockholm.
+      Julius Alexis Wetterbergh: <i>Johan Henrik Kellgren</i>, olie på papir, 12 × 8,8 cm. Nordiska museet, Stockholm.
   </picture>
 </pictures>

--- a/fdirs/kleiste/portraits.xml
+++ b/fdirs/kleiste/portraits.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <pictures>
     <picture src="p1.jpg" primary="true" square-src="p1-square.jpg" museum="gleimhaus" year="1751" objid="839">
-        Gottfried Hempel: <i>Ewald Christian von Kleist</i>, ca. 1751, olie på lærred, 48,8x39,8cm.
+        Gottfried Hempel: <i>Ewald Christian von Kleist</i>, ca. 1751, olie på lærred, 48,8 × 39,8 cm.
     </picture>
 </pictures>

--- a/fdirs/koebke/artwork.xml
+++ b/fdirs/koebke/artwork.xml
@@ -7,22 +7,22 @@
         <i>Ida Thiele, senere gift Wilde, som barn</i>, 1832, olie på lærred, 22,5×20cm.
     </picture>
     <picture id="1833-christian-petersen" year="1833-05-22" museum="smk" invnr="KMS3159">
-        <i>Urtekræmmer Christian F. Petersen, kunstnerens fætter og svoger</i>, 22/5 1833, olie på lærred,  31,5x27 cm.
+        <i>Urtekræmmer Christian F. Petersen, kunstnerens fætter og svoger</i>, 22/5 1833, olie på lærred,  31,5 × 27 cm.
     </picture>
     <picture id="1833-selvportraet" subject="koebke" year="1833" museum="smk" invnr="KMS3150">
-        <i>Selvportræt</i>, ca. 1833, olie på lærred,  42x35,5cm.
+        <i>Selvportræt</i>, ca. 1833, olie på lærred,  42 × 35,5 cm.
     </picture>
     <picture id="1834-hansenc" subject="hansenc" year="1834" museum="ribe" invnr="RKMm0118">
-        <i>Portræt af maleren Constantin Hansen</i>, 1834-35, olie på lærred, 107,5x87,5cm.
+        <i>Portræt af maleren Constantin Hansen</i>, 1834-35, olie på lærred, 107,5 × 87,5 cm.
     </picture>
     <picture id="1835-grethe-petersen" year="1835" museum="smk" invnr="KMS3160">
-        <i>Cecilie Margrethe Petersen, født Købke, kunstnerens søster</i>, 1835, olie på lærred,  94x74 cm.
+        <i>Cecilie Margrethe Petersen, født Købke, kunstnerens søster</i>, 1835, olie på lærred,  94 × 74 cm.
     </picture>
     <picture id="1836-marstrand" subject="marstrand" year="1836" museum="smk" invnr="KMS1348">
-        <i>Maleren Wilhelm Marstrand</i>, 1836, olie på lærred, 18,5x15cm.
+        <i>Maleren Wilhelm Marstrand</i>, 1836, olie på lærred, 18,5 × 15 cm.
     </picture>
     <picture id="1846-krohn" subject="krohn" year="1846" museum="natmus.se" objid="160037">
-        <i>Skolebestyrer J. Krohn som barn, kunstnerens søstersøn</i>, 1846, olie på lærred, 30x25cm.
+        <i>Skolebestyrer J. Krohn som barn, kunstnerens søstersøn</i>, 1846, olie på lærred, 30 × 25 cm.
     </picture>
 </pictures>
 

--- a/fdirs/koerner/portraits.xml
+++ b/fdirs/koerner/portraits.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <pictures>
   <picture src="p1.jpg" primary="true" square-src="p1-square.jpg" museum="smb" objid="962513" year="1813">
-      Ukendt kunstner (kopi efter Emma Körner): <i>Porträt des Dichters Theodor Körner</i>, 1813/14, olie på lærred, 110x83cm. Alte Nationalgalerie, Berlin.<!-- Tidligere tilskrevet Dorothea Stock (1760-1832) -->
+      Ukendt kunstner (kopi efter Emma Körner): <i>Porträt des Dichters Theodor Körner</i>, 1813/14, olie på lærred, 110 × 83 cm. Alte Nationalgalerie, Berlin.<!-- Tidligere tilskrevet Dorothea Stock (1760-1832) -->
   </picture>
 </pictures>

--- a/fdirs/kroyer/artwork.xml
+++ b/fdirs/kroyer/artwork.xml
@@ -1,31 +1,31 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <pictures>
     <picture id="1879-sardineri" year="1879" museum="smk" invnr="KMS3108">
-        <i>Et sardineri i Concarneau</i>, 1879, olie på lærred, 101,5x140,5cm.
+        <i>Et sardineri i Concarneau</i>, 1879, olie på lærred, 101,5 × 140,5 cm.
     </picture>
     <picture id="1879-franske-arbejdere" year="1879" museum="ribe" invnr="RKMm0492">
-        <i>Franske arbejdere i hulvej</i>, 1879, olie på lærred, 80x100cm.
+        <i>Franske arbejdere i hulvej</i>, 1879, olie på lærred, 80 × 100 cm.
     </picture>
     <picture id="1880-hattemagere" year="1880" museum="hirschsprungske">
-        <i>Italienske landsbyhattemagere. Sora</i>, 1883, olie på lærred, 135,5x10cm.
+        <i>Italienske landsbyhattemagere. Sora</i>, 1883, olie på lærred, 135,5 × 10 cm.
     </picture>
     <picture id="1883-brandes-3" subject="brandes" year="1883">
         <i>Georg Brandes</i>, 1883.
     </picture>
     <picture id="1885-emil-poulsen" year="1885" museum="nivaagaard" objid="p-s-kroeyer-1">
-        <i>Dobbeltportræt af kgl. skuespiller Emil Poulsen (1842-1911) og hustru Anna, f. Næser (1849-1934)</i>, 1885, pastel på papir, 57x68cm.
+        <i>Dobbeltportræt af kgl. skuespiller Emil Poulsen (1842-1911) og hustru Anna, f. Næser (1849-1934)</i>, 1885, pastel på papir, 57 × 68 cm.
     </picture>
     <picture id="1888-hip-hip-hurra" year="1888">
-        <i>Hip, hip, hurra! Kunstnerfest på Skagen</i>, 1888, olie på lærred, 134,5x165,5cm. Göteborgs konstmuseum.
+        <i>Hip, hip, hurra! Kunstnerfest på Skagen</i>, 1888, olie på lærred, 134,5 × 165,5 cm. Göteborgs konstmuseum.
     </picture>
     <picture id="1888-kroyer" subject="kroyer" year="1888" museum="digitalmuseum.no" objid="021045726602">
-        <i>Selvportræt</i>, 1888, olie på lærred, 40x50cm. Stavanger kunstmuseum.
+        <i>Selvportræt</i>, 1888, olie på lærred, 40 × 50 cm. Stavanger kunstmuseum.
     </picture>
     <picture id="1895-fra-koebenhavns-boers" subject="kroyer" year="1895">
-        <i>Fra Københavns Børs</i>, 1895, olie på lærred, 254x409cm. Børsen.
+        <i>Fra Københavns Børs</i>, 1895, olie på lærred, 254 × 409 cm. Børsen.
     </picture>
     <picture id="1900-brandes-2" subject="brandes" year="1900" museum="hirschsprungske">
-        <i>Georg Brandes som foredragsholder</i>, 1900, olie på træ, 42,9x 3,1 cm.
+        <i>Georg Brandes som foredragsholder</i>, 1900, olie på træ, 42,9 × 3,1 cm.
     </picture>
     <picture id="1900-brandes-1" subject="brandes" year="1900" museum="hirschsprungske">
         <i>Kritikeren og forfatteren Georg Brandes</i>, 1900. Skitse til maleri tilhørende Dagbladet Politiken.
@@ -37,7 +37,7 @@
         <i>Drachmann</i>, tegning.
     </picture>
     <picture id="1902-drachmann-5" subject="drachmann" year="1902" museum="hirschsprungske">
-        <i>Digteren Holger Drachmann i Skagens plantage</i>, 1902, 32,5x40,8 cm.
+        <i>Digteren Holger Drachmann i Skagens plantage</i>, 1902, 32,5 × 40,8 cm.
     </picture>
     <picture id="1895-drachmann-7" subject="drachmann" year="1895" museum="hirschsprungske">
         <i>Holger Drachmann</i>, 1895, pastel.

--- a/fdirs/kuchler/artwork.xml
+++ b/fdirs/kuchler/artwork.xml
@@ -14,7 +14,7 @@
         <i>H.C. Andersen</i>, januar 1834, Rom, olie på lærred.
     </picture>
     <picture id="hansenc-1837" year="1837" invnr="KMS4964" museum="smk">
-        <i>Maleren Constantin Hansen</i>, 1837, olie på papir opsat på lærred, 28x20 cm.
+        <i>Maleren Constantin Hansen</i>, 1837, olie på papir opsat på lærred, 28 × 20 cm.
     </picture>
 </pictures>
 

--- a/fdirs/landor/portraits.xml
+++ b/fdirs/landor/portraits.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <pictures>
   <picture src="p1.jpg" primary="true" square-src="p1-square.jpg" objid="mw03735" invnr="NPG 236" museum="npg">
-      William Fisher († 1895): <i>Walter Savage Landor</i>, før 1895, olie på lærred, 89,5x69,9cm. 
+      William Fisher († 1895): <i>Walter Savage Landor</i>, før 1895, olie på lærred, 89,5 × 69,9 cm.
   </picture>
 </pictures>
     

--- a/fdirs/levy/1906.xml
+++ b/fdirs/levy/1906.xml
@@ -443,7 +443,7 @@ og kløver Luften under lette Vinger.
     </notes>
     <pictures>
         <picture src="levy2019031012-p1.jpg">
-            Henri de Toulouse-Lautrec: <i>Yvette Guilbert </i>, 1894, gouache på pap, 57x42cm. Pusjkinmuseet (Музей изобразительных искусств имени А. С. Пушкина), Moskva.
+            Henri de Toulouse-Lautrec: <i>Yvette Guilbert </i>, 1894, gouache på pap, 57 × 42 cm. Pusjkinmuseet (Музей изобразительных искусств имени А. С. Пушкина), Moskva.
         </picture>
     </pictures>
     <quality>korrektur1,kilde,side</quality>

--- a/fdirs/lorentzen/artwork.xml
+++ b/fdirs/lorentzen/artwork.xml
@@ -4,7 +4,7 @@
     <i>Friedrich Johan Struensee</i>, 1771.
   </picture>
   <picture id="179x-frimann-oval" year="1790">
-      <i>Peter Harboe Frimann</i>, 1790erne, olie på lærred, 71x56cm. Nasjonalgalleriet, Oslo. 
+      <i>Peter Harboe Frimann</i>, 1790erne, olie på lærred, 71 × 56 cm. Nasjonalgalleriet, Oslo.
   </picture>
   <picture id="1808-steffens" museum="fnm" invnr="a-7911" year="1808">
     <i>Henrik Steffens</i>, 1808.

--- a/fdirs/lorentzen/portraits.xml
+++ b/fdirs/lorentzen/portraits.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <pictures>
   <picture src="p1.jpg" primary="true" square-src="p1-square.jpg" year="1827" museum="nivaagaard" objid="martinus-roerbye-5">
-      Martinus Rørbye: <i>Portræt af maleren C. A. Lorentzen</i>, 1827, olie på lærred, 95x77cm.
+      Martinus Rørbye: <i>Portræt af maleren C. A. Lorentzen</i>, 1827, olie på lærred, 95 × 77 cm.
   </picture>
 </pictures>

--- a/fdirs/luetken/portraits.xml
+++ b/fdirs/luetken/portraits.xml
@@ -4,7 +4,7 @@
       Signeret fotografi. Ukendt år.
   </picture>
   <picture src="p2.jpg">
-      Søren Hjorth Nielsen (1901-1983): <i>Portræt af forfatter Hulda Lütken</i>, litografi, 33x30cm. Privateje.
+      Søren Hjorth Nielsen (1901-1983): <i>Portræt af forfatter Hulda Lütken</i>, litografi, 33 × 30 cm. Privateje.
       <!-- http://www.lauritz.com/da/auktion/soeren-hjorth-nielsen-1901-1983-og-per-ulrich-1915-1994-2/i2134665/# -->
       <!-- Der er stadig copyright på dette billede -->
   </picture>

--- a/fdirs/lund/artwork.xml
+++ b/fdirs/lund/artwork.xml
@@ -1,26 +1,25 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <pictures>
     <picture id="1803-andromache" year="1803" museum="smk" invnr="KMS7455">
-        <i>Andromache i afmagt ved synet af Hektors lig</i>, 1803/04, olie på lærred, 49,2x62,7cm.
+        <i>Andromache i afmagt ved synet af Hektors lig</i>, 1803/04, olie på lærred, 49,2 × 62,7 cm.
   </picture>
   <picture id="1809-oehlenschlaeger" year="1809" subject="oehlenschlaeger" museum="fnm" invnr="a-50">
     <i>Adam Oehlenschläger</i>, 1809, olie på lærred.
   </picture>
   <picture id="1811-ida-brun" year="1811">
-      <i>Portræt af Ida Brun med udsigt til Rom i baggrunden</i>, 1811, olie på lærred, 151,5x131,5 cm. Brændt i 2013.
+      <i>Portræt af Ida Brun med udsigt til Rom i baggrunden</i>, 1811, olie på lærred, 151,5 × 131,5 cm. Brændt i 2013.
        <!-- https://arkivet.thorvaldsensmuseum.dk/personer/brun-ida -->
   </picture>
   <picture id="1827-selvportraet" year="1827" subject="lund">
-      <i>Selvportræt</i>, 1827, olie på lærred, 45x40cm. 
+      <i>Selvportræt</i>, 1827, olie på lærred, 45 × 40 cm.
       <!-- https://bruun-rasmussen.dk/m/lots/9B2F42BF5C6B -->
   </picture>
   <picture id="1832-thiele" year="1832" subject="thiele">
     <i>Just Mathias Thiele</i>, 1832, olie på lærred. Bakkehusmuseet.
   </picture>
   <picture id="sophienholm" museum="thorvaldsens" invnr="B412">
-    <i>Sophienholm</i>, ukendt år, olie på jern, 26,4x21,3 cm.
+    <i>Sophienholm</i>, ukendt år, olie på jern, 26,4 × 21,3 cm.
   </picture>
 </pictures>
-
 
 

--- a/fdirs/lundbye/artwork.xml
+++ b/fdirs/lundbye/artwork.xml
@@ -1,13 +1,13 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <pictures>
   <picture id="1841-malkescene" year="1841" museum="smk" invnr="KMS431">
-      <i>Malkescene. Fra Christian Winther: Aftenmøde</i>, 1841, olie på lærred, 84.5x95 cm.
+      <i>Malkescene. Fra Christian Winther: Aftenmøde</i>, 1841, olie på lærred, 84.5 × 95 cm.
   </picture>
   <picture id="1841-selvportraet" year="1841" museum="glyptoteket">
       <i>Selvportræt</i>, 1841.
   </picture>
   <picture id="1846-piazza-barberini" museum="thorvaldsens" invnr="D1852" year="1846">
-      <i>Piazza Barberini</i>, 1846, pen, blæk, akvaral på papir, 291x282mm.
+      <i>Piazza Barberini</i>, 1846, pen, blæk, akvaral på papir, 291 × 282 mm.
   </picture>
 </pictures>
 

--- a/fdirs/magnusson/portraits.xml
+++ b/fdirs/magnusson/portraits.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <pictures>
   <picture src="p1.jpg" primary="true" square-src="p1-square.jpg" >
-      Emile Lassalle (litograf): <i>Finn Magnussen</i>, litografi, 40x27,0cm, 1838. [fra <i>Voyage en Islande et au Groënland. Publié par order du Roi sous la direction de M. Paul Gaimard ... Atlas zoologique, médical et géographique.</i>]
+      Emile Lassalle (litograf): <i>Finn Magnussen</i>, litografi, 40 × 27,0 cm, 1838. [fra <i>Voyage en Islande et au Groënland. Publié par order du Roi sous la direction de M. Paul Gaimard ... Atlas zoologique, médical et géographique.</i>]
   <!-- https://jcb.lunaimaging.com/luna/servlet/detail/JCB~1~1~501267~115901884:Finn-Magnussen-# -->
   </picture>
 </pictures>

--- a/fdirs/manzoni/portraits.xml
+++ b/fdirs/manzoni/portraits.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <pictures>
   <picture src="p1.jpg" primary="true" square-src="p1-square.jpg">
-    Francesco Hayez: <i>Portræt af Alessandro Manzoni</i>, 118x92 cm, Brera.
+    Francesco Hayez: <i>Portræt af Alessandro Manzoni</i>, 118 × 92 cm, Brera.
   </picture>
   <picture src="p2.jpg">
   </picture>

--- a/fdirs/matthison/1899.xml
+++ b/fdirs/matthison/1899.xml
@@ -1041,7 +1041,7 @@ sig kun som Blomster om et Gravkors fletter.
     <firstline>Hesperien, hvis Haver er berømte</firstline>
     <source pages="48-49"/>
     <pictures>
-        <picture src="matthison2019051543-p1.jpg">Sir Edward Coley Burne-Jones: <i>The Mirror of Venus</i>, 1898, olie på lærred, 120x200 cm, Gulbenkian Foundation, Lissabon. <a href="https://gulbenkian.pt/museu/en/works_museu/the-mirror-of-venus/">⌘</a></picture><!-- -->
+        <picture src="matthison2019051543-p1.jpg">Sir Edward Coley Burne-Jones: <i>The Mirror of Venus</i>, 1898, olie på lærred, 120 × 200 cm, Gulbenkian Foundation, Lissabon. <a href="https://gulbenkian.pt/museu/en/works_museu/the-mirror-of-venus/">⌘</a></picture><!-- -->
     </pictures>
     <quality>korrektur1,kilde,side</quality>
 </head>

--- a/fdirs/matthison/1915.xml
+++ b/fdirs/matthison/1915.xml
@@ -1422,7 +1422,7 @@ Ypperstepræster.
         <note>Se også Matthison-Hansens <xref poem="matthison2019051632"/>.</note>
     </notes>
     <pictures>
-        <picture src="matthison2019051543-p1.jpg">Sir Edward Coley Burne-Jones: <i>The Mirror of Venus</i>, 1898, olie på lærred, 120x200 cm, Gulbenkian Foundation, Lissabon. <a href="https://gulbenkian.pt/museu/en/works_museu/the-mirror-of-venus/">⌘</a></picture><!-- -->
+        <picture src="matthison2019051543-p1.jpg">Sir Edward Coley Burne-Jones: <i>The Mirror of Venus</i>, 1898, olie på lærred, 120 × 200 cm, Gulbenkian Foundation, Lissabon. <a href="https://gulbenkian.pt/museu/en/works_museu/the-mirror-of-venus/">⌘</a></picture><!-- -->
     </pictures>
     <keywords>sonnet</keywords>
     <quality>korrektur1,kilde,side</quality>

--- a/fdirs/matthisson/portraits.xml
+++ b/fdirs/matthisson/portraits.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <pictures>
   <picture src="p1.jpg" primary="true" square-src="p1-square.jpg" year="1794" museum="gleimhaus" objid="927">
-      Christian Ferdinand Hartmann: <i>Porträt Friedrich von Matthisson</i>, 1794, olie på lærred, 51x42,5cm.
+      Christian Ferdinand Hartmann: <i>Porträt Friedrich von Matthisson</i>, 1794, olie på lærred, 51 × 42,5 cm.
   </picture>
 </pictures>

--- a/fdirs/meyer/portraits.xml
+++ b/fdirs/meyer/portraits.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <pictures>
   <picture src="p1.jpg" primary="true" square-src="p1-square.jpg" invnr="460" year="1900">
-      Franz von Lenbach (1836–1904): <i>Conrad Ferdinand Meyer</i>, München, 1900, olie på lærred, 97x77cm. Zentralbibliothek Zürich.<!-- http://doi.org/10.7891/e-manuscripta-30609 -->
+      Franz von Lenbach (1836–1904): <i>Conrad Ferdinand Meyer</i>, München, 1900, olie på lærred, 97 × 77 cm. Zentralbibliothek Zürich.<!-- http://doi.org/10.7891/e-manuscripta-30609 -->
   </picture>
 </pictures>
     

--- a/fdirs/michaelis/1900.xml
+++ b/fdirs/michaelis/1900.xml
@@ -259,7 +259,7 @@ Det er Slaven, der retter sin trodsige Krop
     <firstline>Milde Kölner-Moder med din lille Mund</firstline>
     <source pages="18-19"/>
     <pictures>
-        <picture src="michaelis201709156-p1.jpg">Stefan Lochner (ca. 1410-1451): <i>Madonna med Violen</i>, før 1450, 121.5x102 cm. Kolumba Museum, Köln.</picture>
+        <picture src="michaelis201709156-p1.jpg">Stefan Lochner (ca. 1410-1451): <i>Madonna med Violen</i>, før 1450, 121.5 × 102 cm. Kolumba Museum, Köln.</picture>
     </pictures>
     <quality>korrektur1,korrektur2,kilde,side</quality>
 </head>
@@ -2029,7 +2029,7 @@ Hjerterne vaagne bag Skærf og bag Panser.
     <firstline>Tæt skal jeg Tonerne slynge</firstline>
     <source pages="91-92"/>
     <pictures>
-        <picture src="michaelis2017091540-p1.jpg">Rembrandt: <i>Saul and David</i>, ca. 1651-1654 og ca. 1655-1658, olie på lærred, 130x165,5cm. Mauritshuis, Den Haag.</picture>
+        <picture src="michaelis2017091540-p1.jpg">Rembrandt: <i>Saul and David</i>, ca. 1651-1654 og ca. 1655-1658, olie på lærred, 130 × 165,5 cm. Mauritshuis, Den Haag.</picture>
     </pictures>
     <quality>korrektur1,kilde,side</quality>
 </head>
@@ -2085,7 +2085,7 @@ i Øjets bundløse Sø.
     <firstline>Den sidste tunge Strid er stridt</firstline>
     <source pages="93-94"/>
     <pictures>
-        <picture src="michaelis2017091542-p1.jpg">Rembrandt: <i>The anatomy lesson of Dr. Joan Deyman</i>, ca. 1666, olie på lærred, 100x134cm. Rijksmuseum, Amsterdam.</picture>
+        <picture src="michaelis2017091542-p1.jpg">Rembrandt: <i>The anatomy lesson of Dr. Joan Deyman</i>, ca. 1666, olie på lærred, 100 × 134 cm. Rijksmuseum, Amsterdam.</picture>
     </pictures>
     <quality>korrektur1,kilde,side</quality>
 </head>
@@ -2141,7 +2141,7 @@ jeg læser alt, hvad du har lidt.
     <firstline>Der aander fra dit Ansigt</firstline>
     <source pages="95-96"/>
     <pictures>
-        <picture src="michaelis2017091544-p1.jpg">Rembrandt: <i>Portrait of Hendrikje Stoffels</i>, c.1654-6, oile på lærred, 101,9x83,7 cm. The National Gallery, London.</picture>
+        <picture src="michaelis2017091544-p1.jpg">Rembrandt: <i>Portrait of Hendrikje Stoffels</i>, c.1654-6, oile på lærred, 101,9 × 83,7 cm. The National Gallery, London.</picture>
     </pictures>
     <quality>korrektur1,kilde,side</quality>
 </head>

--- a/fdirs/moellerpm/andre.xml
+++ b/fdirs/moellerpm/andre.xml
@@ -3152,7 +3152,7 @@ Der næsten over Evne sig maa strække.
       <note>Fra <i>Rosenblade samlede af J.M. Thiele</i>, 1818.</note>
    </notes>
    <pictures>
-       <picture src="moellerpm2001052550-p1.jpg">Vilhelm Hammershøi: <i>Poul Møller. ,,Sonetten til Laura''</i>, 1899, blyant, 52,5x43 cm.</picture>
+       <picture src="moellerpm2001052550-p1.jpg">Vilhelm Hammershøi: <i>Poul Møller. ,,Sonetten til Laura''</i>, 1899, blyant, 52,5 × 43 cm.</picture>
    </pictures>
    <quality>korrektur1</quality>
    <keywords>sonnet</keywords>

--- a/fdirs/musset/portraits.xml
+++ b/fdirs/musset/portraits.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <pictures>
   <picture src="p1-oval.jpg" primary="true" square-src="p1-square.jpg">
-      Charles Landelle (1821-1908): <i>Portrait d'Alfred de Musset</i>, 1854, pastel, 53,5x46cm. Musée d'Orsay.
+      Charles Landelle (1821-1908): <i>Portrait d'Alfred de Musset</i>, 1854, pastel, 53,5 × 46 cm. Musée d'Orsay.
       <!-- http://www.musee-orsay.fr/en/collections/index-of-works/notice.html?nnumid=018083 -->
   </picture>
 </pictures>

--- a/fdirs/nalbandian/1905.xml
+++ b/fdirs/nalbandian/1905.xml
@@ -2612,10 +2612,10 @@ skifter just Ham og samles
     <firstline>Blandt alle de Minder, som ejer</firstline>
     <source pages="120-126"/>
     <pictures>
-        <picture src="nalbandian2019030949-p4.jpg" year="1883">Arnold Böcklin: <i>Frühlingstag (Die drei Lebensalter)</i>, 1883, olie på panel, 103x150cm. Kunstmuseum Bern.</picture><!-- http://www.sikart.ch/werke.aspx?id=10170712 -->
-        <picture src="nalbandian2019030949-p3.jpg" year="1872" objid="962057" museum="smb">Arnold Böcklin: <i>Selbstbildnis mit fiedelndem Tod</i>, 1872, olie på lærred, 75x61cm. Alte Nationalgalerie, Berlin.</picture>
-        <picture src="nalbandian2019030949-p1.jpg" year="1883" objid="967648" museum="smb">Arnold Böcklin: <i>Die Toteninsel</i>, 1883, olie på panel, 80x150cm. Alte Nationalgalerie, Berlin.</picture>
-        <picture src="nalbandian2019030949-p2.jpg" year="1884" objid="962824" museum="smb">Arnold Böcklin: <i>Der Einsiedler</i>, 1884, olie på panel, 90x69cm. Alte Nationalgalerie, Berlin.</picture>
+        <picture src="nalbandian2019030949-p4.jpg" year="1883">Arnold Böcklin: <i>Frühlingstag (Die drei Lebensalter)</i>, 1883, olie på panel, 103 × 150 cm. Kunstmuseum Bern.</picture><!-- http://www.sikart.ch/werke.aspx?id=10170712 -->
+        <picture src="nalbandian2019030949-p3.jpg" year="1872" objid="962057" museum="smb">Arnold Böcklin: <i>Selbstbildnis mit fiedelndem Tod</i>, 1872, olie på lærred, 75 × 61 cm. Alte Nationalgalerie, Berlin.</picture>
+        <picture src="nalbandian2019030949-p1.jpg" year="1883" objid="967648" museum="smb">Arnold Böcklin: <i>Die Toteninsel</i>, 1883, olie på panel, 80 × 150 cm. Alte Nationalgalerie, Berlin.</picture>
+        <picture src="nalbandian2019030949-p2.jpg" year="1884" objid="962824" museum="smb">Arnold Böcklin: <i>Der Einsiedler</i>, 1884, olie på panel, 90 × 69 cm. Alte Nationalgalerie, Berlin.</picture>
     </pictures>
     <quality>korrektur1,kilde,side</quality>
 </head>

--- a/fdirs/oehlenschlaeger/1860-20.xml
+++ b/fdirs/oehlenschlaeger/1860-20.xml
@@ -974,7 +974,7 @@ Og den gode Sag.
        <note>Ove Malling (1747-1829); der alluderes til hans bog, <i>Store og gode Handlinger af Danske, Norske og Holstenere,</i> 1777.</note>
    </notes>
    <pictures>
-       <picture src="oehlen2002011501-p1.jpg" museum="smk" invnr="KKSgb11583">J.F. Clemens (kobberstikker) efter forlæg af C.G. Kratzenstein Stub: <i>Ove Malling</i>, 242x174mm, 1810. Den Kongelige Kobberstiksamling.</picture>
+       <picture src="oehlen2002011501-p1.jpg" museum="smk" invnr="KKSgb11583">J.F. Clemens (kobberstikker) efter forlæg af C.G. Kratzenstein Stub: <i>Ove Malling</i>, 242 × 174 mm, 1810. Den Kongelige Kobberstiksamling.</picture>
    </pictures>
    <source pages="26"/>
    <quality>korrektur1,korrektur2,kilde,side</quality>

--- a/fdirs/oehlenschlaeger/1860-21.xml
+++ b/fdirs/oehlenschlaeger/1860-21.xml
@@ -3207,7 +3207,7 @@ Og lad længe Sundhedsrosen voxe midt i Vintersnee.
     <title>Til en Veninde</title>
     <firstline>Du vil, Veninde! jeg skal prise</firstline>
     <pictures>
-        <picture src="oehlenschlaeger2019021649-p1.jpg">J.P. Møller: <i>Parti ved Ermelundshuset</i>, ukendt år, olie på lærred, 20x26cm. Privateje.<!-- https://bruun-rasmussen.dk/m/lots/ED988D200086 --></picture>
+        <picture src="oehlenschlaeger2019021649-p1.jpg">J.P. Møller: <i>Parti ved Ermelundshuset</i>, ukendt år, olie på lærred, 20 × 26 cm. Privateje.<!-- https://bruun-rasmussen.dk/m/lots/ED988D200086 --></picture>
     </pictures>
     <source pages="82-84"/>
     <quality>korrektur1,korrektur2,kilde,side</quality>
@@ -5552,7 +5552,7 @@ Den nok forbedrer sig med Tiden.
     <subtitle>Den 27de Januar 1829.</subtitle>
     <firstline>See Graveren i aarle Stund</firstline>
     <pictures>
-        <picture src="oehlenschlaeger2019021677-p1.jpg" year="1894" museum="smk" invnr="KMS1500">Carl Thomsen: <i>Rahbek ved sin hustrus dødsleje</i>, 1894, olie på lærred, 65.5 x 80 cm.</picture>
+        <picture src="oehlenschlaeger2019021677-p1.jpg" year="1894" museum="smk" invnr="KMS1500">Carl Thomsen: <i>Rahbek ved sin hustrus dødsleje</i>, 1894, olie på lærred, 65.5 × 80 cm.</picture>
     </pictures>
     <source pages="145-148"/>
     <keywords>rahbekk</keywords>

--- a/fdirs/oehlenschlaeger/1860-22.xml
+++ b/fdirs/oehlenschlaeger/1860-22.xml
@@ -5977,7 +5977,7 @@ Bredfulde Maal.
     </notes>
     <pictures>
         <picture src="oehlenschlaeger2019021873-p1.jpg" year="1832" museum="smk" invnr="KMS1374">
-            Davis Monies: <i>Professor, dr. med. J.D. Herholdt</i>, 1832, olie på lærred, 83x67,5 cm.
+            Davis Monies: <i>Professor, dr. med. J.D. Herholdt</i>, 1832, olie på lærred, 83 × 67,5 cm.
         </picture>
         <picture ref="jensenca/herholdt-1835"/>
     </pictures>
@@ -10069,7 +10069,7 @@ Gud skienker Fremtid Grøde.
     <firstline>Skiøn er den Fest, som Ætten fryder</firstline>
     <pictures>
         <picture src="oehlenschlaeger20190218124-p1.jpg" year="1840-1843" museum="smk" invnr="KMS493">
-            Sophus Schack: <i>Christian VIII og Caroline Amalies salving i Frederiksborg Slotskirke den 28. juni 1840</i>, 1840-1943, olie på lærred, 295x222 cm. Statens Museem for Kunst.
+            Sophus Schack: <i>Christian VIII og Caroline Amalies salving i Frederiksborg Slotskirke den 28. juni 1840</i>, 1840-1943, olie på lærred, 295 × 222 cm. Statens Museem for Kunst.
         </picture>
     </pictures>
     <source pages="267-277"/>

--- a/fdirs/opie/portraits.xml
+++ b/fdirs/opie/portraits.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <pictures>
   <picture src="p1.jpg" primary="true" square-src="p1-square.jpg" museum="npg" objid="mw04749" invnr="NPG 765" year="1798">
-      John Opie: <i>Amelia Opie</i>, 1798, olie på lærred, 743x622mm.
+      John Opie: <i>Amelia Opie</i>, 1798, olie på lærred, 743 × 622 mm.
   </picture>
 </pictures>
     

--- a/fdirs/opitz/portraits.xml
+++ b/fdirs/opitz/portraits.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <pictures>
   <picture src="p1.jpg" primary="true" square-src="p1-square.jpg">
-    Bartholomäus Strobel (1591-1647): <i>Martin Opitz</i>, ml. 1836 og 1837, olie på lærred, 116x93cm. Biblioteka Gdańska.
+    Bartholomäus Strobel (1591-1647): <i>Martin Opitz</i>, ml. 1836 og 1837, olie på lærred, 116 × 93 cm. Biblioteka Gdańska.
   </picture>
   <picture src="p2.jpg">
   </picture>

--- a/fdirs/overbeck/portraits.xml
+++ b/fdirs/overbeck/portraits.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <pictures>
   <picture src="p1.jpg" primary="true" square-src="p1-square.jpg">
-      Rudolph Suhrlandt (1781–1862): <i>Christian Adolph Overbeck</i>, 1818, olie på lærred, 84x67,5 cm. Museum Behnhaus Drägerhaus, Lübeck.
+      Rudolph Suhrlandt (1781–1862): <i>Christian Adolph Overbeck</i>, 1818, olie på lærred, 84 × 67,5 cm. Museum Behnhaus Drägerhaus, Lübeck.
   </picture>
 </pictures>
     

--- a/fdirs/pfeffel/portraits.xml
+++ b/fdirs/pfeffel/portraits.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <pictures>
   <picture src="p1.jpg" square-src="p1-square.jpg" primary="true" year="1809" museum="gleimhaus" objid="955">
-      Georg Friedrich Adolph Schöner: <i>Gottlieb Conrad Pfeffel</i>, 1809, olie på lærred, 65x52 cm.
+      Georg Friedrich Adolph Schöner: <i>Gottlieb Conrad Pfeffel</i>, 1809, olie på lærred, 65 × 52 cm.
   </picture>
 </pictures>

--- a/fdirs/pram/1782.xml
+++ b/fdirs/pram/1782.xml
@@ -75,7 +75,7 @@ Nordens Digtere bebrejdes deres Taushed. Vore afdöde Skialde Tullin, Stenersen,
     <pictures>
         <picture ref="juel/emilie-kilde-1784" />
         <picture src="pram2018071803-p1.jpg">
-            Caspar David Friedrich: <i>Emilias Kilde, 5. Mai 1797</i>, fjer, akvarel, 21,8x16,7 cm. Hamburger Kunsthalle, Kupferstichkabinett.
+            Caspar David Friedrich: <i>Emilias Kilde, 5. Mai 1797</i>, fjer, akvarel, 21,8 × 16,7 cm. Hamburger Kunsthalle, Kupferstichkabinett.
         </picture>
         <picture ref="jensenca/schimmelmann-1827">
             Den 80-årige Schimmelmann lod sig i 1827 male af C.A. Jensen.

--- a/fdirs/ramsay/portraits.xml
+++ b/fdirs/ramsay/portraits.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <pictures>
   <picture src="p1.jpg" primary="true" square-src="p1-square.jpg">
-    William Aikman: <i>Allan Ramsay</i>, 1722, olie på lærred, 75,7x64cm. Scottish National Portrait Gallery.
+    William Aikman: <i>Allan Ramsay</i>, 1722, olie på lærred, 75,7 × 64 cm. Scottish National Portrait Gallery.
   </picture>
 </pictures>
     

--- a/fdirs/richardt/1895-2.xml
+++ b/fdirs/richardt/1895-2.xml
@@ -13275,7 +13275,7 @@ af Aand - og Vid - og Mønt!
     <subtitle>(Til et Billede af Edv. Petersen.)</subtitle>
     <firstline>Ak, Sant' Agate! hvilken Tort!</firstline>
     <pictures>
-        <picture src="richardt20190731161-p1.jpg" museum="smk" invnr="KKS9632h">F. Hendriksen (efter forlæg af Edvard Petersen): <i>Ubudne gæster</i>, efter 1870, xylografi, 205x175mm.</picture>
+        <picture src="richardt20190731161-p1.jpg" museum="smk" invnr="KKS9632h">F. Hendriksen (efter forlæg af Edvard Petersen): <i>Ubudne gæster</i>, efter 1870, xylografi, 205 × 175 mm.</picture>
     </pictures>
     <quality>korrektur1,kilde,side</quality>
     <source pages="390-391"/>

--- a/fdirs/rimestad/1908.xml
+++ b/fdirs/rimestad/1908.xml
@@ -977,7 +977,7 @@ En Hjemvé mod svundne Lyster har fyldt hendes Blik!
     <subtitle>Til Otto Rung</subtitle>
     <firstline>Det Smil blev til i en Mesters Drøm</firstline>
     <pictures>
-        <picture src="rimestad2019030614-p1.jpg">Leonardo da Vinci: <i>Johannes Døberen</i>, 1513-1516, olie på træ, 69x57cm. Louvre.</picture>
+        <picture src="rimestad2019030614-p1.jpg">Leonardo da Vinci: <i>Johannes Døberen</i>, 1513-1516, olie på træ, 69 × 57 cm. Louvre.</picture>
     </pictures>
     <notes>
         <note>Otto Rung (1874-1945), jurist, embedsmands, forfatter og især kendt som produktiv manuskriptforfatter.</note>

--- a/fdirs/rimestad/portraits.xml
+++ b/fdirs/rimestad/portraits.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <pictures>
     <picture src="p1.jpg" primary="true" square-src="p1-square.jpg">
-        Ludvig Peter Karsten (1876-1926): <i>Portrait of the author Christian Rimestad</i>, 1920, olie på lærred på træ, 23x23cm.
+        Ludvig Peter Karsten (1876-1926): <i>Portrait of the author Christian Rimestad</i>, 1920, olie på lærred på træ, 23 × 23 cm.
         <!--  http://bit.ly/2tROzQv -->
     </picture>
     <picture src="p2.jpg">

--- a/fdirs/rodeh/1928.xml
+++ b/fdirs/rodeh/1928.xml
@@ -230,7 +230,7 @@ Naar vi ved Efteraar tænker tilbage paa den svundne Sommer, staar den for os so
     </notes>
    <quality>korrektur1,korrektur2,kilde,side</quality>
    <pictures>
-       <picture src="rodeh201709107-p1.jpg">J.F. Willumsen: <i>Sophus Claussen læser sit digt <a poem="claussen2002090101">,,Imperia''</a> for Helge Rode og J. F. Willumsen</i>, 1915, olie på lærred, 147x187cm, ARoS, Aarhus.</picture>
+       <picture src="rodeh201709107-p1.jpg">J.F. Willumsen: <i>Sophus Claussen læser sit digt <a poem="claussen2002090101">,,Imperia''</a> for Helge Rode og J. F. Willumsen</i>, 1915, olie på lærred, 147 × 187 cm, ARoS, Aarhus.</picture>
    </pictures>
    <keywords>claussen,jensenjv,moellerpm,ewald,heine,byron</keywords>
 </head>

--- a/fdirs/rodeh/portraits.xml
+++ b/fdirs/rodeh/portraits.xml
@@ -1,13 +1,13 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <pictures>
   <picture src="p1.jpg" primary="true" square-src="p1-square.jpg" year="1908">
-      Edvard Munch: <i>Portræt af den danske forfatter Helge Rode</i>, 1908, olie på lærred, 198x96 cm, Moderna Museet, Stockholm.
+      Edvard Munch: <i>Portræt af den danske forfatter Helge Rode</i>, 1908, olie på lærred, 198 × 96 cm, Moderna Museet, Stockholm.
   </picture>
   <picture src="p2.jpg">
       Ebbe Rode: <i>Helge Rode</i>, ukendt år, tegning. Det Kongelige Bibliotek. ,,Skuespilleren Ebbe Rodes (1910-1998) tegning af sin far.''
   </picture>
   <picture src="p4.jpg" year="1919">
-      Ludvig Peter Karsten: <i>Helge Rode</i>, 1919, olie på lærred, 208x85 cm.
+      Ludvig Peter Karsten: <i>Helge Rode</i>, 1919, olie på lærred, 208 × 85 cm.
       <!-- http://www.artnet.com/artists/ludvig-peter-karsten/helge-rode-5jRXhJ8X5BrdTj9K442ZcA2 -->
   </picture>
   <picture src="p3.jpg">

--- a/fdirs/roed/artwork.xml
+++ b/fdirs/roed/artwork.xml
@@ -10,7 +10,7 @@
       <i>Ludvig Holberg</i>, 1847. Kopi af et maleri af Johan Roselius (1725-1803) fra 1752.
   </picture>
   <picture id="kuchler-1862" subject="kuchler" year="1882" museum="thorvaldsens" invnr="B417">
-      <i>Albert Küchler som munk</i>, 1862, olie på lærred, 59,5x46,7cm.
+      <i>Albert Küchler som munk</i>, 1862, olie på lærred, 59,5 × 46,7 cm.
   </picture>
 </pictures>
 

--- a/fdirs/schiller/portraits.xml
+++ b/fdirs/schiller/portraits.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <pictures>
   <picture src="p3.jpg" year="1791">
-      Anton Graff: <i>Portrait Friedrich Schiller</i>, begyndt 1786, færdiggjort 1791, olie på lærred, 71x57cm. Städtische Galerie Dresden.
+      Anton Graff: <i>Portrait Friedrich Schiller</i>, begyndt 1786, færdiggjort 1791, olie på lærred, 71 × 57 cm. Städtische Galerie Dresden.
   </picture>
   <picture src="p1.jpg" primary="true" square-src="p1-square.jpg" year="1793">
     Ludovike Simanowiz (1759-1827): <i>Friedrich Schiller</i>, mellem 1793 og 1794.
@@ -10,7 +10,7 @@
     F.G. Weitsch: <i>Schiller</i>, 1804, tegning. Staatliche Museen, Berlin.
   </picture>
   <picture src="p7.jpg" year="1808">
-      Gerhard von Kügelgen (1772-1820): <i>Friedrich Schiller</i>, 1808-1809, olie på lærred, 73x61cm. Goethe-Haus, Frankfurt-am-Main.
+      Gerhard von Kügelgen (1772-1820): <i>Friedrich Schiller</i>, 1808-1809, olie på lærred, 73 × 61 cm. Goethe-Haus, Frankfurt-am-Main.
   </picture>
   <picture ref="thorvaldsen/1836-schiller"/>
 </pictures>

--- a/fdirs/staffeldt/andre.xml
+++ b/fdirs/staffeldt/andre.xml
@@ -54,7 +54,7 @@ Gierne jeg for Kiephest og for Dukke
       <note>Trykt i Poulsens <i>Nytaarsgave</i> for 1802.</note>
    </notes>
    <pictures>
-      <picture src="staffeldt1999030406.jpg">Vecellio Tiziano (1490-1576): »Venere di Urbino« (1538), oliemaleri, 119 x 165 cm, Galleria degli Uffizi, Firenze.</picture>
+      <picture src="staffeldt1999030406.jpg">Vecellio Tiziano (1490-1576): »Venere di Urbino« (1538), oliemaleri, 119 × 165 cm, Galleria degli Uffizi, Firenze.</picture>
    </pictures>
    <quality>korrektur1</quality>
    <keywords>sonnet</keywords>

--- a/fdirs/tavaststjerna/portraits.xml
+++ b/fdirs/tavaststjerna/portraits.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <pictures>
   <picture src="p1.jpg" primary="true" square-src="p1-square.jpg">
-      Albert Edelfelt (1854–1905): <i>Karl August Tavaststjerna</i>, 1885, pastel, 48,5x32,5 cm. Ateneumin Taidemuseo (Konstmuseet Ateneum), Helsinki.
+      Albert Edelfelt (1854–1905): <i>Karl August Tavaststjerna</i>, 1885, pastel, 48,5 × 32,5 cm. Ateneumin Taidemuseo (Konstmuseet Ateneum), Helsinki.
   </picture>
 </pictures>
     

--- a/fdirs/tennyson/1842.xml
+++ b/fdirs/tennyson/1842.xml
@@ -16,9 +16,9 @@
    <indextitle>The Lady of Shallot</indextitle>
    <firstline>On either side the river lie</firstline>
    <pictures>
-      <picture src="tennyson1999041201-p1.jpg">John William Waterhouse (<year>1849</year>-<year>1917</year>): »The Lady of Shalott (looking at Lancelot)« (<year>1894</year>), oliemaleri, 142x86 cm, City Art Gallery, Leeds.</picture>
-      <picture src="tennyson1999041201-p2.jpg">John William Waterhouse (<year>1849</year>-<year>1917</year>): »The Lady of Shalott (on boat)« (<year>1888</year>), oliemaleri, 153x200 cm, The Tate Gallery, London.</picture>
-      <picture src="tennyson1999041201-p3.jpg">John William Waterhouse (<year>1849</year>-<year>1917</year>): »"I am half sick of shadows," said the Lady of Shalott« (<year>1916</year>), oliemaleri, 100x74 cm, Art Gallery of Ontario, Toronto.</picture>
+      <picture src="tennyson1999041201-p1.jpg">John William Waterhouse (<year>1849</year>-<year>1917</year>): »The Lady of Shalott (looking at Lancelot)« (<year>1894</year>), oliemaleri, 142 × 86 cm, City Art Gallery, Leeds.</picture>
+      <picture src="tennyson1999041201-p2.jpg">John William Waterhouse (<year>1849</year>-<year>1917</year>): »The Lady of Shalott (on boat)« (<year>1888</year>), oliemaleri, 153 × 200 cm, The Tate Gallery, London.</picture>
+      <picture src="tennyson1999041201-p3.jpg">John William Waterhouse (<year>1849</year>-<year>1917</year>): »"I am half sick of shadows," said the Lady of Shalott« (<year>1916</year>), oliemaleri, 100 × 74 cm, Art Gallery of Ontario, Toronto.</picture>
    </pictures>
    <quality>korrektur1</quality>
 </head>

--- a/fdirs/thaarup/andre.xml
+++ b/fdirs/thaarup/andre.xml
@@ -380,7 +380,7 @@ Held være Venskabs Harmoni! :|:
       <note>Skrevet 1788 til indskriften på Frihedsstøtten.</note>
    </notes>
    <pictures>
-       <picture src="thaarup2001120101-p1.jpg" museum="smk" invnr="KKSgb4610">Frederik Ludvig Bradt: <i>Frihedsstøtten set fra Frederiksbergsiden</i>, ca. 1800, blyant, vandfarve, pen og sort blæk, 557x445 mm.</picture>
+       <picture src="thaarup2001120101-p1.jpg" museum="smk" invnr="KKSgb4610">Frederik Ludvig Bradt: <i>Frihedsstøtten set fra Frederiksbergsiden</i>, ca. 1800, blyant, vandfarve, pen og sort blæk, 557 × 445 mm.</picture>
    </pictures>
    <quality>korrektur1</quality>
 </head>

--- a/fdirs/thorvaldsen/artwork.xml
+++ b/fdirs/thorvaldsen/artwork.xml
@@ -49,7 +49,7 @@
       <i>Gratierne og Amor</i>, 1820-23, marmor, 172,7cm.
   </picture>
   <picture id="1824-kaerlighedens-aldre" year="1824" museum="thorvaldsens" invnr="A426" >
-      <i>Kærlighedens aldre</i>, 1824, marmor, 52x148cm.
+      <i>Kærlighedens aldre</i>, 1824, marmor, 52 × 148 cm.
   </picture>
   <picture id="1836-amor-med-lyren" year="1836" museum="thorvaldsens" invnr="A33" >
       <i>Amor med Lyren</i>, 1836, marmor, 58,6 cm.

--- a/fdirs/tiedge/portraits.xml
+++ b/fdirs/tiedge/portraits.xml
@@ -2,6 +2,6 @@
 <pictures>
     <picture ref="thorvaldsen/1805-tiedge" />
     <picture src="p1.jpg" primary="true" square-src="p1-square.jpg" museum="gleimhaus" objid="45498">
-        <i>Christoph August Tiedge</i>, kobberstik, 169x106mm.
+        <i>Christoph August Tiedge</i>, kobberstik, 169 × 106 mm.
     </picture>
 </pictures>

--- a/fdirs/voss/portraits.xml
+++ b/fdirs/voss/portraits.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <pictures>
     <picture src="p1.jpg" primary="true" square-src="p1-square.jpg" museum="gleimhaus" objid="887" year="1797">
-        Georg Friedrich Adolf Schöner: <i>Johann Heinrich Voss</i>, 1797, olie på lærred, 47,5 x 39 cm.
+        Georg Friedrich Adolf Schöner: <i>Johann Heinrich Voss</i>, 1797, olie på lærred, 47,5 × 39 cm.
   </picture>
 </pictures>
     

--- a/fdirs/wied/portraits.xml
+++ b/fdirs/wied/portraits.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <pictures>
   <picture src="p1.jpg" museum="skagen" primary="true" square-src="p1-square.jpg">
-    Valdemar Schønheyder Møller: <i>Gustav Wied</i>, ukendt år, olie på lærred, 32x34,5 cm.
+    Valdemar Schønheyder Møller: <i>Gustav Wied</i>, ukendt år, olie på lærred, 32 × 34,5 cm.
   </picture>
 </pictures>


### PR DESCRIPTION
## Resumé
- erstatter dimensionsseparatoren `x` med `×` i billed- og kunstværksmål
- normaliserer formatet til mellemrum omkring separatoren og før enheden, fx `65 × 80 cm`
- følger SMK-luft i målvisning, men med korrekt gange-tegn

## Test
- `git diff --check`
- `npm run build-static`