### PR TITLE
Bladr mellem værker med piletaster

### DIFF
--- a/common/worksort.js
+++ b/common/worksort.js
@@ -1,0 +1,36 @@
+const sortableYear = (year) => {
+  let result = year.replace('ca.', '').replace('c.', '').trim();
+  if (result[0] === '-') {
+    result = 9999 + parseInt(result); // Sorter omvendt
+    result = '-' + result; // Men før de positive
+  }
+  return result;
+};
+
+const sortWorks = (poet, works) => {
+  if (poet.id === 'bibel') {
+    return [...works];
+  } else {
+    return [...works].sort((a, b) => {
+      if (a.id === 'andre') {
+        return 1;
+      } else if (b.id === 'andre') {
+        return -1;
+      } else {
+        const aKey =
+          a.year == null || a.year === '?'
+            ? a.title
+            : sortableYear(a.year) + a.id;
+        const bKey =
+          b.year == null || b.year === '?'
+            ? b.title
+            : sortableYear(b.year) + b.id;
+        return aKey > bKey ? 1 : -1;
+      }
+    });
+  }
+};
+
+module.exports = {
+  sortWorks,
+};

--- a/components/workslist.js
+++ b/components/workslist.js
@@ -2,6 +2,7 @@ import Link from 'next/link';
 import { Fragment } from 'react';
 import CommonData from '../common/commondata.js';
 import _ from '../common/translations.js';
+import WorkSorting from '../common/worksort.js';
 import { formattedYear } from '../components/formatteddate.js';
 
 const workNameTranslated = (work, lang) => {
@@ -18,43 +19,10 @@ const WorksList = ({ lang, poet, works }) => {
     return null;
   }
 
-  const sortWorks = (works) => {
-    const sortableYear = (year) => {
-      let result = year.replace('ca.', '').replace('c.', '').trim();
-      if (result[0] === '-') {
-        result = 9999 + parseInt(result); // Sorter omvendt
-        result = '-' + result; // Men før de positive
-      }
-      return result;
-    };
-
-    if (poet.id === 'bibel') {
-      return works;
-    } else {
-      return works.sort((a, b) => {
-        if (a.id === 'andre') {
-          return 1;
-        } else if (b.id === 'andre') {
-          return -1;
-        } else {
-          const aKey =
-            a.year == null || a.year === '?'
-              ? a.title
-              : sortableYear(a.year) + a.id;
-          const bKey =
-            b.year == null || b.year === '?'
-              ? b.title
-              : sortableYear(b.year) + b.id;
-          return aKey > bKey ? 1 : -1;
-        }
-      });
-    }
-  };
-
   const anyPrefixes =
     works.filter((work) => work.toctitle.prefix != null).length > 0;
 
-  const rows = sortWorks(works).map((work, i) => {
+  const rows = WorkSorting.sortWorks(poet, works).map((work, i) => {
     const workName = workNameTranslated(work, lang);
 
     const year = work.year;

--- a/pages/work.js
+++ b/pages/work.js
@@ -3,6 +3,7 @@ import * as OpenGraph from '../common/opengraph.js';
 import _ from '../common/translations.js';
 import { workCrumbs } from '../components/breadcrumbs.js';
 import { formattedDate } from '../components/formatteddate.js';
+import * as Links from '../components/links.js';
 import { poetMenu } from '../components/menu.js';
 import Note from '../components/note.js';
 import Page from '../components/page.js';
@@ -20,8 +21,19 @@ import WorkSubtitles from '../components/worksubtitles.js';
 import ErrorPage from './error.js';
 
 const WorkPage = (props) => {
-  const { lang, poet, work, notes, pictures, toc, subworks, modified, error } =
-    props;
+  const {
+    lang,
+    poet,
+    work,
+    notes,
+    pictures,
+    toc,
+    subworks,
+    modified,
+    prev,
+    next,
+    error,
+  } = props;
 
   if (error) {
     return <ErrorPage error={error} lang={lang} message="Ukendt værk" />;
@@ -98,7 +110,19 @@ const WorkPage = (props) => {
     ogDescription = subworks.map((part) => part.toctitle).join(', ');
   }
 
-  let sectixonTitles = null;
+  let paging = {};
+  if (prev != null) {
+    paging.prev = {
+      url: Links.workURL(lang, poet.id, prev.id),
+      title: workTitleString(prev),
+    };
+  }
+  if (next != null) {
+    paging.next = {
+      url: Links.workURL(lang, poet.id, next.id),
+      title: workTitleString(next),
+    };
+  }
 
   return (
     <Page
@@ -114,6 +138,7 @@ const WorkPage = (props) => {
       crumbs={workCrumbs(lang, poet, work)}
       pageTitle={<PoetName poet={poet} includePeriod />}
       pageSubtitle={_('Værker', lang)}
+      paging={paging}
       menuItems={poetMenu(poet)}
       poet={poet}
       selectedMenuItem="works">
@@ -151,6 +176,8 @@ WorkPage.getInitialProps = async ({ query: { lang, poetId, workId } }) => {
     notes: json.notes,
     pictures: json.pictures,
     modified: json.modified,
+    prev: json.prev,
+    next: json.next,
     error: json.error,
   };
 };

--- a/tools/build-static/toc.js
+++ b/tools/build-static/toc.js
@@ -8,6 +8,7 @@ const {
   fileExists,
 } = require('../libs/helpers.js');
 const { extractTitle, get_notes, get_pictures } = require('./parsing.js');
+const { sortWorks } = require('../../common/worksort.js');
 const {
   loadXMLDoc,
   getChildren,
@@ -109,6 +110,32 @@ const collect_git_modified_dates = () => {
 const build_works_toc = async (collected) => {
   const modifiedDates = collect_git_modified_dates();
 
+  const workFilesForPoet = (poetId) => {
+    return collected.workids
+      .get(poetId)
+      .map((workId) => `fdirs/${poetId}/${workId}.xml`)
+      .filter(fileExists);
+  };
+
+  const worksForPaging = (poetId, poet) => {
+    const works = collected.workids
+      .get(poetId)
+      .map((workId) => collected.works.get(`${poetId}/${workId}`))
+      .filter((work) => work != null && work.parent == null)
+      .filter((work) => work.has_content);
+    return sortWorks(poet, works);
+  };
+
+  const resolvePrevNextWork = (works, workId) => {
+    const index = works.findIndex((work) => {
+      return work.id === workId;
+    });
+    return {
+      prev: index > 0 ? works[index - 1] : null,
+      next: index >= 0 && index < works.length - 1 ? works[index + 1] : null,
+    };
+  };
+
   // Returns {toc, subworks, notes, pictures}
   const extract_work_data = async (work) => {
     const type = safeGetAttr(work, 'type');
@@ -144,6 +171,12 @@ const build_works_toc = async (collected) => {
     Array.from(collected.poets.entries()).map(async (entry) => {
       const [poetId, poet] = entry;
       safeMkdir(`public/api/${poetId}`);
+      const workFilenames = workFilesForPoet(poetId);
+      const poetWorksModified = isFileModified(
+        `fdirs/${poetId}/info.xml`,
+        ...workFilenames
+      );
+      const pageWorks = worksForPaging(poetId, poet);
 
       return Promise.all(
         collected.workids.get(poetId).map(async (workId) => {
@@ -151,7 +184,7 @@ const build_works_toc = async (collected) => {
           if (!fileExists(filename)) {
             return;
           }
-          if (!isFileModified(filename)) {
+          if (!poetWorksModified && !isFileModified(filename)) {
             return;
           }
           let doc = loadXMLDoc(filename);
@@ -179,6 +212,7 @@ const build_works_toc = async (collected) => {
           const parentData = collected.works.get(parentId);
 
           if (work_data) {
+            const { prev, next } = resolvePrevNextWork(pageWorks, workId);
             const toc_file_data = {
               poet,
               toc: work_data.toc,
@@ -187,6 +221,8 @@ const build_works_toc = async (collected) => {
               notes: work_data.notes || [],
               pictures: work_data.pictures || [],
               modified: modifiedDates.get(filename),
+              prev,
+              next,
             };
             const tocFilename = `public/api/${poetId}/${workId}-toc.json`;
             console.log(tocFilename);


### PR DESCRIPTION
## Resumé
- tilføjer `prev` og `next` til værkernes toc-JSON under `build-static`
- genbruger samme værksortering i både værklisten og build-processen
- lader værksiden bruge den eksisterende paging-komponent, så venstre/højre-taster virker som på tekster

Fixes #1015

## Test
- `git diff --check`
- `npm run build-static-force-reload`
- `npm test -- --runInBand __tests__/links.test.js`
- `npm run build`