### PR TITLE
Sorter tekstlister efter digterens sprog

### DIFF
--- a/__tests__/sorting.test.js
+++ b/__tests__/sorting.test.js
@@ -29,6 +29,36 @@ describe('sectionsByTitle', () => {
   });
 });
 
+describe('linesPairsByLineForLang', () => {
+  it('sorts Aa as Å in Danish line sorting', () => {
+    const data = ['Ø', 'A', 'Æ', 'B', 'Aa', 'C'].map((x) => {
+      return { sortBy: x };
+    });
+    const sorted = data
+      .sort(Sorting.linesPairsByLineForLang('da'))
+      .map((x) => x.sortBy);
+    expect(sorted).toEqual(['A', 'B', 'C', 'Æ', 'Ø', 'Aa']);
+  });
+
+  it('sorts Tennysons Waäit by English line sorting', () => {
+    const data = [
+      'Wab',
+      'Waäit till our Sally cooms in, fur thou mun a’ sights to tell',
+      'Waz',
+    ].map((x) => {
+      return { sortBy: x };
+    });
+    const sorted = data
+      .sort(Sorting.linesPairsByLineForLang('en'))
+      .map((x) => x.sortBy);
+    expect(sorted).toEqual([
+      'Waäit till our Sally cooms in, fur thou mun a’ sights to tell',
+      'Wab',
+      'Waz',
+    ]);
+  });
+});
+
 describe('poetYearSectionsByTitle', () => {
   it('puts 25-49 first among CE sections and unknown sections last', () => {
     const data = [

--- a/common/sorting.js
+++ b/common/sorting.js
@@ -1,5 +1,19 @@
 const daDK = 'da-DK';
 
+const localesByLang = {
+  da: daDK,
+  de: 'de',
+  en: 'en-GB',
+  es: 'es',
+  fa: 'fa',
+  fr: 'fr-FR',
+  it: 'it-IT',
+  no: 'nb-NO',
+  sv: 'sv-SE',
+};
+
+export const localeForLang = (lang) => localesByLang[lang] || daDK;
+
 const nvl = (x, v) => {
   return x == null ? v : x;
 };
@@ -36,6 +50,15 @@ export const linesPairsByLine = (a, b) => {
   const a1 = a.sortBy;
   const b1 = b.sortBy;
   return a1.localeCompare(b1, daDK);
+};
+
+export const linesPairsByLineForLang = (lang) => {
+  const locale = localeForLang(lang);
+  return (a, b) => {
+    const a1 = a.sortBy;
+    const b1 = b.sortBy;
+    return a1.localeCompare(b1, locale);
+  };
 };
 
 export const keywordsByTitle = (a, b) => {

--- a/fdirs/brunsmand/info.xml
+++ b/fdirs/brunsmand/info.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<person id="brunsmand" country="dk" lang="dk" type="poet">
+<person id="brunsmand" country="dk" lang="da" type="poet">
   <name>
     <firstname>Johannes</firstname>
     <lastname>Brunsmand</lastname>

--- a/fdirs/calderon/info.xml
+++ b/fdirs/calderon/info.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<person id="calderon" country="un" lang="sp" type="poet">
+<person id="calderon" country="un" lang="es" type="poet">
   <name>
     <firstname>Pedro</firstname>
     <lastname>Calderón de la Barca</lastname>

--- a/fdirs/cervantes/info.xml
+++ b/fdirs/cervantes/info.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<person id="cervantes" country="un" lang="sp" type="poet">
+<person id="cervantes" country="un" lang="es" type="poet">
   <name>
     <firstname>Miguel de</firstname>
     <lastname>Cervantes</lastname>

--- a/fdirs/hafez/info.xml
+++ b/fdirs/hafez/info.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<person id="hafez" country="un" lang="pe" type="poet">
+<person id="hafez" country="un" lang="fa" type="poet">
   <name>
     <firstname>Shams al-din</firstname>
     <lastname>Hafez</lastname>

--- a/fdirs/khayyam/info.xml
+++ b/fdirs/khayyam/info.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<person id="khayyam" country="un" lang="pe" type="poet">
+<person id="khayyam" country="un" lang="fa" type="poet">
   <name>
     <firstname>Omar</firstname>
     <lastname>Khayyam</lastname>

--- a/fdirs/saadi/info.xml
+++ b/fdirs/saadi/info.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<person id="saadi" country="un" lang="pe" type="poet">
+<person id="saadi" country="un" lang="fa" type="poet">
   <name>
     <firstname>Saadi</firstname>
     <lastname>Shirazi</lastname>

--- a/pages/texts.js
+++ b/pages/texts.js
@@ -12,7 +12,7 @@ import PoetName from '../components/poetname.js';
 import SectionedList from '../components/sectionedlist.js';
 import ErrorPage from './error.js';
 
-const groupLines = (lines, type) => {
+const groupLines = (lines, type, contentLang) => {
   let groups = new Map();
   lines.forEach((linePair) => {
     let line, alternative;
@@ -29,10 +29,10 @@ const groupLines = (lines, type) => {
     line = line.replace(',', '').replace('!', '');
     linePair['sortBy'] = line + ' [' + alternative + '[' + linePair.id;
     let letter = line[0];
-    if (line.indexOf('Aa') === 0) {
+    if (contentLang === 'da' && line.indexOf('Aa') === 0) {
       letter = 'Å';
     }
-    if (line.indexOf('Ö') === 0) {
+    if (contentLang === 'da' && line.indexOf('Ö') === 0) {
       letter = 'Ø';
     }
     if (line.indexOf('È') === 0) {
@@ -47,7 +47,7 @@ const groupLines = (lines, type) => {
   groups.forEach((group, key) => {
     sortedGroups.push({
       title: key,
-      items: group.sort(Sorting.linesPairsByLine),
+      items: group.sort(Sorting.linesPairsByLineForLang(contentLang)),
     });
   });
   return sortedGroups.sort(Sorting.sectionsByTitle);
@@ -60,7 +60,7 @@ const TextsPage = (props) => {
     return <ErrorPage error={error} lang={lang} message="Ukendt digter" />;
   }
 
-  const groups = groupLines(lines, type);
+  const groups = groupLines(lines, type, poet.lang);
   let sections = [];
   groups.forEach((group) => {
     const items = group.items.map((lines) => {

--- a/tools/build-static/poets.js
+++ b/tools/build-static/poets.js
@@ -125,8 +125,8 @@ const build_poets_first_pass = collected => {
     if (!country.match(/(dk|se|no|gb|de|fr|us|it|un)/)) {
       throw `${id} har ukendt land: ${country}`;
     }
-    if (!lang.match(/(da|sv|no|en|de|fr|la|pe|sp|un|it)/)) {
-      throw `${id} har ukendt sprog: ${country}`;
+    if (!lang.match(/(da|sv|no|en|de|fr|la|fa|es|un|it)/)) {
+      throw `${id} har ukendt sprog: ${lang}`;
     }
 
     let square_portrait = null;


### PR DESCRIPTION
Denne PR retter sorteringen af digterens titel- og førstelinjelister, så de bruger digterens `lang` fra `info.xml` i stedet for altid dansk sortering. Dermed sorteres Tennysons engelske førstelinje `Waäit till our Sally...` korrekt under W.

Fixes #772.

Derudover normaliseres gamle interne `lang`-koder i `info.xml`:

- `dk` -> `da`
- `sp` -> `es`
- `pe` -> `fa`

Valideringen af digtersprog er opdateret tilsvarende.

Testet med:

```sh
npm test -- --runTestsByPath __tests__/sorting.test.js
```