### PR TITLE
Gruppér tekstlister efter sprogregler

### DIFF
--- a/__tests__/sorting.test.js
+++ b/__tests__/sorting.test.js
@@ -57,6 +57,86 @@ describe('linesPairsByLineForLang', () => {
       'Waz',
     ]);
   });
+
+  it('ignores punctuation when sorting French elisions', () => {
+    const data = [
+      "L'Ennemi",
+      'La Beauté',
+      'Le Balcon',
+      'Les Bijoux',
+    ].map((x) => {
+      return { sortBy: x };
+    });
+    const sorted = data
+      .sort(Sorting.linesPairsByLineForLang('fr'))
+      .map((x) => x.sortBy);
+    expect(sorted).toEqual([
+      'La Beauté',
+      'Le Balcon',
+      "L'Ennemi",
+      'Les Bijoux',
+    ]);
+  });
+
+  it('sorts French accented letters as their base letters', () => {
+    const data = ['Effet', 'École', 'Ecologie', 'Économie'].map((x) => {
+      return { sortBy: x };
+    });
+    const sorted = data
+      .sort(Sorting.linesPairsByLineForLang('fr'))
+      .map((x) => x.sortBy);
+    expect(sorted).toEqual(['École', 'Ecologie', 'Économie', 'Effet']);
+  });
+
+  it('sorts French œ as oe', () => {
+    const data = ['coffre', 'cœur', 'coexistence'].map((x) => {
+      return { sortBy: x };
+    });
+    const sorted = data
+      .sort(Sorting.linesPairsByLineForLang('fr'))
+      .map((x) => x.sortBy);
+    expect(sorted).toEqual(['cœur', 'coexistence', 'coffre']);
+  });
+
+  it('sorts Swedish Å, Ä, and Ö after Z', () => {
+    const data = ['Ö', 'Y', 'Ä', 'X', 'Å', 'Z'].map((x) => {
+      return { sortBy: x };
+    });
+    const sorted = data
+      .sort(Sorting.linesPairsByLineForLang('sv'))
+      .map((x) => x.sortBy);
+    expect(sorted).toEqual(['X', 'Y', 'Z', 'Å', 'Ä', 'Ö']);
+  });
+
+  it('sorts German ß as ss', () => {
+    const data = ['Mast', 'Maße', 'Massel', 'Masse'].map((x) => {
+      return { sortBy: x };
+    });
+    const sorted = data
+      .sort(Sorting.linesPairsByLineForLang('de'))
+      .map((x) => x.sortBy);
+    expect(sorted).toEqual(['Masse', 'Maße', 'Massel', 'Mast']);
+  });
+});
+
+describe('lineSectionTitleForLang', () => {
+  it('groups Danish Aa as Å', () => {
+    expect(Sorting.lineSectionTitleForLang('Aarets tider', 'da')).toEqual('Å');
+  });
+
+  it('groups German umlauts by their base letters', () => {
+    expect(Sorting.lineSectionTitleForLang('Äolsharfen', 'de')).toEqual('A');
+    expect(Sorting.lineSectionTitleForLang('Öffnet die Fenster', 'de')).toEqual(
+      'O'
+    );
+    expect(Sorting.lineSectionTitleForLang('Über allen Gipfeln', 'de')).toEqual(
+      'U'
+    );
+  });
+
+  it('groups accented letters by their base letters outside Danish', () => {
+    expect(Sorting.lineSectionTitleForLang('Ève', 'fr')).toEqual('E');
+  });
 });
 
 describe('poetYearSectionsByTitle', () => {

--- a/common/sorting.js
+++ b/common/sorting.js
@@ -12,7 +12,26 @@ const localesByLang = {
   sv: 'sv-SE',
 };
 
+const lineCollatorOptions = {
+  ignorePunctuation: true,
+};
+
 export const localeForLang = (lang) => localesByLang[lang] || daDK;
+
+export const lineSectionTitleForLang = (line, lang) => {
+  if (lang === 'da' && line.indexOf('Aa') === 0) {
+    return 'Å';
+  }
+  if (lang === 'da' && line.indexOf('Ö') === 0) {
+    return 'Ø';
+  }
+
+  const normalizedLetter =
+    lang === 'da'
+      ? line[0]
+      : line[0].normalize('NFD').replace(/[\u0300-\u036f]/g, '');
+  return normalizedLetter.toUpperCase()[0];
+};
 
 const nvl = (x, v) => {
   return x == null ? v : x;
@@ -54,10 +73,11 @@ export const linesPairsByLine = (a, b) => {
 
 export const linesPairsByLineForLang = (lang) => {
   const locale = localeForLang(lang);
+  const collator = new Intl.Collator(locale, lineCollatorOptions);
   return (a, b) => {
     const a1 = a.sortBy;
     const b1 = b.sortBy;
-    return a1.localeCompare(b1, locale);
+    return collator.compare(a1, b1);
   };
 };
 

--- a/pages/texts.js
+++ b/pages/texts.js
@@ -28,17 +28,7 @@ const groupLines = (lines, type, contentLang) => {
     }
     line = line.replace(',', '').replace('!', '');
     linePair['sortBy'] = line + ' [' + alternative + '[' + linePair.id;
-    let letter = line[0];
-    if (contentLang === 'da' && line.indexOf('Aa') === 0) {
-      letter = 'Å';
-    }
-    if (contentLang === 'da' && line.indexOf('Ö') === 0) {
-      letter = 'Ø';
-    }
-    if (line.indexOf('È') === 0) {
-      letter = 'E';
-    }
-    letter = letter.toUpperCase();
+    let letter = Sorting.lineSectionTitleForLang(line, contentLang);
     let array = groups.get(letter) || [];
     array.push(linePair);
     groups.set(letter, array);


### PR DESCRIPTION
Denne PR retter gruppebogstavet i digternes titel- og førstelinjelister, så det følger samme sproglige hensyn som sorteringen.

Ændringen betyder blandt andet:

- tyske `Ä`, `Ö` og `Ü` grupperes under `A`, `O` og `U`
- franske accenter grupperes under grundbogstavet
- franske elisioner sorteres med `ignorePunctuation`, så fx `L'Ennemi` ikke flyttes foran `La...`
- dansk `Aa -> Å` bevares

Der er samtidig tilføjet regressionstests for tysk, fransk og svensk sortering.

Testet med:

```sh
npm test -- --runTestsByPath __tests__/sorting.test.js
```