### PR TITLE
Flyt landevælgeren op i forfatteroversigten

### DIFF
--- a/pages/poets.js
+++ b/pages/poets.js
@@ -171,13 +171,13 @@ const Poets = (props) => {
       selectedMenuItem={groupBy}
       country={country}
       pageTitle={pageTitle}>
-      {renderedGroups}
       <CountryPicker
-        style={{ marginTop: '40px' }}
+        style={{ marginBottom: '60px' }}
         lang={lang}
         countryToURL={countryCodeToURL}
         selectedCountry={country}
       />
+      {renderedGroups}
     </Page>
   );
 };


### PR DESCRIPTION
Denne PR flytter landevælgeren på forfatteroversigten op over selve listen, så man kan skifte land før man scroller gennem forfatterne.

Der er lagt 60px luft under vælgeren ned til listen.