### PR TITLE
Sorter forfattere efter landets regler

### DIFF
--- a/__tests__/sorting.test.js
+++ b/__tests__/sorting.test.js
@@ -29,6 +29,30 @@ describe('sectionsByTitle', () => {
   });
 });
 
+describe('poetsByLastnameForCountry', () => {
+  it('sorts German poet names by German collation', () => {
+    const data = ['Müller', 'Mörike', 'Mozart', 'Meyer'].map((lastname) => {
+      return { name: { lastname } };
+    });
+    const sorted = data
+      .sort(Sorting.poetsByLastnameForCountry('de'))
+      .map((x) => x.name.lastname);
+    expect(sorted).toEqual(['Meyer', 'Mörike', 'Mozart', 'Müller']);
+  });
+
+  it('sorts ungrouped poet names by Danish collation', () => {
+    const data = ['Øster', 'Andersen', 'Aagesen', 'Blicher'].map(
+      (lastname) => {
+        return { name: { lastname } };
+      }
+    );
+    const sorted = data
+      .sort(Sorting.poetsByLastnameForCountry('un'))
+      .map((x) => x.name.lastname);
+    expect(sorted).toEqual(['Andersen', 'Blicher', 'Øster', 'Aagesen']);
+  });
+});
+
 describe('linesPairsByLineForLang', () => {
   it('sorts Aa as Å in Danish line sorting', () => {
     const data = ['Ø', 'A', 'Æ', 'B', 'Aa', 'C'].map((x) => {

--- a/common/sorting.js
+++ b/common/sorting.js
@@ -12,11 +12,24 @@ const localesByLang = {
   sv: 'sv-SE',
 };
 
+const localesByCountry = {
+  de: 'de',
+  dk: daDK,
+  fr: 'fr-FR',
+  gb: 'en-GB',
+  it: 'it-IT',
+  no: 'nb-NO',
+  se: 'sv-SE',
+  un: daDK,
+  us: 'en-US',
+};
+
 const lineCollatorOptions = {
   ignorePunctuation: true,
 };
 
 export const localeForLang = (lang) => localesByLang[lang] || daDK;
+export const localeForCountry = (country) => localesByCountry[country] || daDK;
 
 export const lineSectionTitleForLang = (line, lang) => {
   if (lang === 'da' && line.indexOf('Aa') === 0) {
@@ -37,16 +50,45 @@ const nvl = (x, v) => {
   return x == null ? v : x;
 };
 
+const poetLastnameSortKey = (poet) => {
+  return nvl(
+    poet.name.sortname,
+    nvl(poet.name.lastname, '') + nvl(poet.name.firstname, '')
+  );
+};
+
 export const poetsByLastname = (a, b) => {
-  const ao = nvl(
-    a.name.sortname,
-    nvl(a.name.lastname, '') + nvl(a.name.firstname, '')
-  );
-  const bo = nvl(
-    b.name.sortname,
-    nvl(b.name.lastname, '') + nvl(b.name.firstname, '')
-  );
+  const ao = poetLastnameSortKey(a);
+  const bo = poetLastnameSortKey(b);
   return ao.localeCompare(bo, daDK);
+};
+
+export const poetsByLastnameForCountry = (country) => {
+  const locale = localeForCountry(country);
+  return (a, b) => {
+    const ao = poetLastnameSortKey(a);
+    const bo = poetLastnameSortKey(b);
+    return ao.localeCompare(bo, locale);
+  };
+};
+
+export const poetsByBirthDateForCountry = (country) => {
+  const byLastname = poetsByLastnameForCountry(country);
+  return (a, b) => {
+    if (a.period == null || b.period == null) {
+      return byLastname(a, b);
+    } else if (a.period.born == null || b.period.born == null) {
+      return byLastname(a, b);
+    } else {
+      const a1 = a.period.born.date;
+      const b1 = b.period.born.date;
+      if (a1 === b1) {
+        return byLastname(a, b);
+      } else {
+        return a1 < b1 ? -1 : 1;
+      }
+    }
+  };
 };
 
 export const poetsByBirthDate = (a, b) => {

--- a/pages/poets.js
+++ b/pages/poets.js
@@ -35,7 +35,7 @@ const poetListItem = (poet) => {
   };
 };
 
-const groupsByLetter = (poets, lang) => {
+const groupsByLetter = (poets, lang, country) => {
   let groups = new Map();
 
   poets
@@ -64,7 +64,7 @@ const groupsByLetter = (poets, lang) => {
   groups.forEach((group, key) => {
     sortedGroups.push({
       title: key,
-      items: group.sort(Sorting.poetsByLastname),
+      items: group.sort(Sorting.poetsByLastnameForCountry(country)),
     });
   });
   return sortedGroups.sort(Sorting.sectionsByTitle);
@@ -76,7 +76,7 @@ const poetYearIntervalTitle = (year) => {
   return formatYearInterval(intervalStart, intervalEnd);
 };
 
-const groupsByYear = (poets, lang) => {
+const groupsByYear = (poets, lang, country) => {
   let groups = new Map();
   poets
     .filter((p) => p.type === 'poet')
@@ -100,7 +100,7 @@ const groupsByYear = (poets, lang) => {
   groups.forEach((group, key) => {
     sortedGroups.push({
       title: key,
-      items: group.sort(Sorting.poetsByBirthDate),
+      items: group.sort(Sorting.poetsByBirthDateForCountry(country)),
     });
   });
   return sortedGroups.sort(Sorting.poetYearSectionsByTitle);
@@ -129,8 +129,8 @@ const Poets = (props) => {
   ];
   const groups =
     groupBy === 'name'
-      ? groupsByLetter(poets, lang)
-      : groupsByYear(poets, lang);
+      ? groupsByLetter(poets, lang, country)
+      : groupsByYear(poets, lang, country);
 
   let sections = [];
 


### PR DESCRIPTION
Denne PR retter sorteringen på forfatteroversigterne, så navne sorteres efter landets locale i stedet for altid efter danske regler.

Det betyder blandt andet, at tyske digtere sorteres med tyske regler, så `Mörike` kommer før `Müller` på `/da/poets/de/name`.

`un`-gruppen er eksplicit sat til dansk sortering, da den bruges som opsamlingsgruppe for digtere uden egentlig landegruppe.

Testet med:

```sh
npm test -- --runTestsByPath __tests__/sorting.test.js
```