### PR TITLE
Ret fransk tegnsætningsmellemrum

### DIFF
--- a/__tests__/poem-lines.js
+++ b/__tests__/poem-lines.js
@@ -1,10 +1,4 @@
 import fs from 'fs';
-import {
-  getElementByTagName,
-  loadXMLDoc,
-  safeGetAttr,
-  safeGetText,
-} from '../tools/build-static/xml.js';
 import { fileExists, loadText } from '../tools/libs/helpers.js';
 
 function flatten(arr) {
@@ -59,6 +53,35 @@ function textAliases(data) {
       .filter((alias) => alias.length > 0)
       .map((alias) => ({ id: idMatch[1], alias }));
   });
+}
+
+function firstYear(text) {
+  const match = (text || '').match(/\d{3,4}/);
+  return match == null ? null : parseInt(match[0], 10);
+}
+
+function firstMatch(text, regexp) {
+  const match = text.match(regexp);
+  return match == null ? null : match[1];
+}
+
+function findMissingModernFrenchSpacing(data) {
+  const textData = data
+    .replace(/<!--[\s\S]*?-->/g, '')
+    .replace(/<picture\b[\s\S]*?<\/picture>/g, '');
+  const lines = textData.split('\n');
+  for (let i = 0; i < lines.length; i++) {
+    const text = lines[i].replace(/<[^>]+>/g, '');
+    const match = text.match(/\S([?!;:])/);
+    if (match != null) {
+      return {
+        line: i + 1,
+        sign: match[1],
+        text: lines[i],
+      };
+    }
+  }
+  return null;
 }
 
 function ignoredTestsAtLine(data) {
@@ -148,19 +171,22 @@ describe('Check workfiles', () => {
     .filter((p) => p.indexOf('.') === -1);
 
   let filenameLangs = {};
+  let filenameBornYears = {};
+  let filenameWorkYears = {};
 
   let filenames = allPoetIds.map((poetId) => {
     const infoFilename = `fdirs/${poetId}/info.xml`;
     if (!fs.existsSync(infoFilename)) {
       throw new Error(`Missing info.xml in fdirs/${poetId}.`);
     }
-    const doc = loadXMLDoc(infoFilename);
-    const person = getElementByTagName(doc, 'person');
+    const infoData = loadText(infoFilename);
+    const person = firstMatch(infoData, /(<person\b[^>]*>)/);
     if (person == null) {
       throw new Error(`${infoFilename} is malformed.`);
     }
-    const lang = safeGetAttr(person, 'lang');
-    const workIds = safeGetText(person, 'works');
+    const lang = firstMatch(person, /\slang="([^"]+)"/);
+    const bornYear = firstYear(firstMatch(infoData, /<born>([\s\S]*?)<\/born>/));
+    const workIds = firstMatch(infoData, /<works>([\s\S]*?)<\/works>/);
     let items = workIds
       ? workIds
           .toString()
@@ -174,6 +200,8 @@ describe('Check workfiles', () => {
     return items.map((w) => {
       const filename = `${poetId}/${w}.xml`;
       filenameLangs[filename] = lang;
+      filenameBornYears[filename] = bornYear;
+      filenameWorkYears[filename] = firstYear(w);
       return filename;
     });
   });
@@ -256,6 +284,21 @@ describe('Check workfiles', () => {
           });
         }
       });
+
+      const shouldUseModernFrenchPunctuationSpacing =
+        lang === 'fr' &&
+        ((filenameBornYears[filename] != null &&
+          filenameBornYears[filename] >= 1800) ||
+          (filenameWorkYears[filename] != null &&
+            filenameWorkYears[filename] >= 1800));
+      if (shouldUseModernFrenchPunctuationSpacing) {
+        const missingFrenchSpacing = findMissingModernFrenchSpacing(data);
+        if (missingFrenchSpacing != null) {
+          fail(
+            `French spacing missing before '${missingFrenchSpacing.sign}' in ${filename}:${missingFrenchSpacing.line} [${missingFrenchSpacing.text}]`
+          );
+        }
+      }
     });
   });
 });

--- a/fdirs/baudelaire/1857.xml
+++ b/fdirs/baudelaire/1857.xml
@@ -5,7 +5,7 @@
    <title>Les Fleurs du mal</title>
    <year>1857</year>
    <pictures>
-       <picture type="titlepage" src="1857-p1.jpg">Titelbladet til <i>Les Fleurs du mal</i> (1857). Les / Fleurs du mal / par / Charles Baudelaire // On dit qu’il faut couler les exécrables choses / Dans le puits de l’oubli et au sépulchre encloses, / Et que par les escrits le mal ressuscité / Infectera les mœurs de la postérité; / Mais le vice n’a point pour mère la science, / Et la vertu n’est pas fille de l’ignorance. // (Théodore Agrippa d’Aubigné, Les Tragiques, liv. II.) // Concordiae Fructus / Paris / Poulet-Malassis et De Broise / Libraires - Éditeurs / 4, rue de Buci / 1857</picture>
+       <picture type="titlepage" src="1857-p1.jpg">Titelbladet til <i>Les Fleurs du mal</i> (1857). Les / Fleurs du mal / par / Charles Baudelaire // On dit qu’il faut couler les exécrables choses / Dans le puits de l’oubli et au sépulchre encloses, / Et que par les escrits le mal ressuscité / Infectera les mœurs de la postérité ; / Mais le vice n’a point pour mère la science, / Et la vertu n’est pas fille de l’ignorance. // (Théodore Agrippa d’Aubigné, Les Tragiques, liv. II.) // Concordiae Fructus / Paris / Poulet-Malassis et De Broise / Libraires - Éditeurs / 4, rue de Buci / 1857</picture>
        
    </pictures>
    <quality>korrektur1</quality>
@@ -52,7 +52,7 @@ Occupent nos esprits et travaillent nos corps,
 Et nous alimentons nos aimables remords,
 Comme les mendiants nourrissent leur vermine.
 
-Nos péchés sont têtus, nos repentirs sont lâches;
+Nos péchés sont têtus, nos repentirs sont lâches ;
 Nous nous faisons payer grassement nos aveux,
 Et nous rentrons gaiement dans le chemin bourbeux,
 Croyant par de vils pleurs laver toutes nos taches.
@@ -62,8 +62,8 @@ Qui berce longuement notre esprit enchanté,
 Et le riche métal de notre volonté
 Est tout vaporisé par ce savant chimiste.
 
-C'est le Diable qui tient les fils qui nous remuent!
-Aux objets répugnants nous trouvons des appas;
+C'est le Diable qui tient les fils qui nous remuent !
+Aux objets répugnants nous trouvons des appas ;
 Chaque jour vers l'Enfer nous descendons d'un pas,
 Sans horreur, à travers des ténèbres qui puent.
 
@@ -80,22 +80,22 @@ Descend, fleuve invisible, avec de sourdes plaintes.
 Si le viol, le poison, le poignard, l'incendie,
 N'ont pas encor brodé de leurs plaisants dessins
 Le canevas banal de nos piteux destins,
-C'est que notre âme, hélas! n'est pas assez hardie.
+C'est que notre âme, hélas ! n'est pas assez hardie.
 
 Mais parmi les chacals, les panthères, les lices,
 Les singes, les scorpions, les vautours, les serpents,
 Les monstres glapissants, hurlants, grognants, rampants,
 Dans la ménagerie infâme de nos vices,
 
-Il en est un plus laid, plus méchant, plus immonde!
+Il en est un plus laid, plus méchant, plus immonde !
 Quoiqu'il ne pousse ni grands gestes ni grands cris,
 Il ferait volontiers de la terre un débris
-Et dans un bâillement avalerait le monde;
+Et dans un bâillement avalerait le monde ;
 
-C'est l'Ennui! L'oeil chargé d'un pleur involontaire,
+C'est l'Ennui ! L'oeil chargé d'un pleur involontaire,
 Il rêve d'échafauds en fumant son houka.
 Tu le connais, lecteur, ce monstre délicat,
-- Hypocrite lecteur, - mon semblable, - mon frère!
+- Hypocrite lecteur, - mon semblable, - mon frère !
 </poetry>
 </body>
 </text>
@@ -119,12 +119,12 @@ Tu le connais, lecteur, ce monstre délicat,
 Lorsque, par un décret des puissances suprêmes,
 Le Poète apparaît en ce monde ennuyé,
 Sa mère épouvantée et pleine de blasphèmes
-Crispe ses poings vers Dieu, qui la prend en pitié:
+Crispe ses poings vers Dieu, qui la prend en pitié :
 
--"Ah! que n'ai je mis bas tout un noeud de vipères,
-Plutôt que de nourrir cette dérision!
+-"Ah ! que n'ai je mis bas tout un noeud de vipères,
+Plutôt que de nourrir cette dérision !
 Maudite soit la nuit aux plaisirs éphémères
-Où mon ventre a conçu mon expiation!
+Où mon ventre a conçu mon expiation !
 
 Puisque tu m'as choisie entre toutes les femmes
 Pour être le dégoût de mon triste mari,
@@ -134,7 +134,7 @@ Comme un billet d'amour, ce monstre rabougri,
 Je ferai rejaillir ta haine qui m'accable
 Sur l'instrument maudit de tes méchancetés,
 Et je tordrai si bien cet arbre misérable,
-Qu'il ne pourra pousser ses boutons empestés!"
+Qu'il ne pourra pousser ses boutons empestés !"
 
 Elle ravale ainsi l'écume de sa haine,
 Et, ne comprenant pas les desseins éternels,
@@ -147,7 +147,7 @@ Et dans tout ce qu'il boit et dans tout ce qu'il mange
 Retrouve l'ambroisie et le nectar vermeil.
 
 Il joue avec le vent, cause avec le nuage,
-Et s'enivre en chantant du chemin de la croix;
+Et s'enivre en chantant du chemin de la croix ;
 Et l'Esprit qui le suit dans son pèlerinage
 Pleure de le voir gai comme un oiseau des bois.
 
@@ -157,39 +157,39 @@ Cherchent à qui saura lui tirer une plainte,
 Et font sur lui l'essai de leur férocité.
 
 Dans le pain et le vin destinés à sa bouche
-Ils mêlent de la cendre avec d'impurs crachats;
+Ils mêlent de la cendre avec d'impurs crachats ;
 Avec hypocrisie ils jettent ce qu'il touche,
 Et s'accusent d'avoir mis leurs pieds dans ses pas.
 
-Sa femme va criant sur les places publiques:
+Sa femme va criant sur les places publiques :
 "Puisqu'il me trouve assez belle pour m'adorer,
 Je ferai le métier des idoles antiques,
-Et comme elles je veux me faire redorer;
+Et comme elles je veux me faire redorer ;
 
 Et je me soûlerai de nard, d'encens, de myrrhe,
 De génuflexions, de viandes et de vins,
 Pour savoir si je puis dans un coeur qui m'admire
-Usurper en riant les hommages divins!
+Usurper en riant les hommages divins !
 
 Et, quand je m'ennuierai de ces farces impies,
-Je poserai sur lui ma frêle et forte main;
+Je poserai sur lui ma frêle et forte main ;
 Et mes ongles, pareils aux ongles des harpies,
 Sauront jusqu'à son coeur se frayer un chemin.
 
 Comme un tout jeune oiseau qui tremble et qui palpite,
 J'arracherai ce coeur tout rouge de son sein,
 Et, pour rassasier ma bête favorite
-Je le lui jetterai par terre avec dédain!"
+Je le lui jetterai par terre avec dédain !"
 
 Vers le Ciel, où son oeil voit un trône splendide,
 Le Poète serein lève ses bras pieux
 Et les vastes éclairs de son esprit lucide
-Lui dérobent l'aspect des peuples furieux:
+Lui dérobent l'aspect des peuples furieux :
 
 -"Soyez béni, mon Dieu, qui donnez la souffrance
 Comme un divin remède à nos impuretés
 Et comme la meilleure et la plus pure essence
-Qui prépare les forts aux saintes voluptés!
+Qui prépare les forts aux saintes voluptés !
 
 Je sais que vous gardez une place au Poète
 Dans les rangs bienheureux des saintes Légions,
@@ -204,12 +204,12 @@ Imposer tous les temps et tous les univers.
 Mais les bijoux perdus de l'antique Palmyre,
 Les métaux inconnus, les perles de la mer,
 Par votre main montés, ne pourraient pas suffire
-A ce beau diadème éblouissant et clair;
+A ce beau diadème éblouissant et clair ;
 
 Car il ne sera fait que de pure lumière,
 Puisée au foyer saint des rayons primitifs,
 Et dont les yeux mortels, dans leur splendeur entière,
-Ne sont que des miroirs obscurcis et plaintifs!"
+Ne sont que des miroirs obscurcis et plaintifs !"
 </poetry>
 </body>
 </text>
@@ -234,13 +234,13 @@ Que ces rois de l'azur, maladroits et honteux,
 Laissent piteusement leurs grandes ailes blanches
 Comme des avirons traîner à côté d'eux.
 
-Ce voyageur ailé, comme il est gauche et veule!
-Lui, naguère si beau, qu'il est comique et laid!
+Ce voyageur ailé, comme il est gauche et veule !
+Lui, naguère si beau, qu'il est comique et laid !
 L'un agace son bec avec un brûle-gueule,
-L'autre mime, en boitant, l'infirme qui volait!
+L'autre mime, en boitant, l'infirme qui volait !
 
 Le Poète est semblable au prince des nuées
-Qui hante la tempête et se rit de l'archer;
+Qui hante la tempête et se rit de l'archer ;
 Exilé sur le sol au milieu des huées,
 Ses ailes de géant l'empêchent de marcher.
 </poetry>
@@ -267,7 +267,7 @@ Et, comme un bon nageur qui se pâme dans l'onde,
 Tu sillonnes gaiement l'immensité profonde
 Avec une indicible et mâle volupté.
 
-Envole-toi bien loin de ces miasmes morbides;
+Envole-toi bien loin de ces miasmes morbides ;
 Va te purifier dans l'air supérieur,
 Et bois, comme une pure et divine liqueur,
 Le feu clair qui remplit les espaces limpides.
@@ -275,12 +275,12 @@ Le feu clair qui remplit les espaces limpides.
 Derrière les ennuis et les vastes chagrins
 Qui chargent de leur poids l'existence brumeuse,
 Heureux celui qui peut d'une aile vigoureuse
-S'élancer vers les champs lumineux et sereins;
+S'élancer vers les champs lumineux et sereins ;
 
 Celui dont les pensers, comme des alouettes,
 Vers les cieux le matin prennent un libre essor,
 - Qui plane sur la vie, et comprend sans effort
-Le langage des fleurs et des choses muettes!
+Le langage des fleurs et des choses muettes !
 </poetry>
 </body>
 </text>
@@ -297,7 +297,7 @@ Le langage des fleurs et des choses muettes!
 <body>
 <poetry>
 La Nature est un temple où de vivants piliers
-Laissent parfois sortir de confuses paroles;
+Laissent parfois sortir de confuses paroles ;
 L'homme y passe à travers des forêts de symboles
 Qui l'observent avec des regards familiers.
 
@@ -338,29 +338,29 @@ Ne trouvait point ses fils un poids trop onéreux,
 Mais, louve au coeur gonflé de tendresses communes
 Abreuvait l'univers à ses tétines brunes.
 L'homme, élégant, robuste et fort, avait le droit
-D'être fier des beautés qui le nommaient leur roi;
+D'être fier des beautés qui le nommaient leur roi ;
 Fruits purs de tout outrage et vierges de gerçures,
-Dont la chair lisse et ferme appelait les morsures!
+Dont la chair lisse et ferme appelait les morsures !
 
 Le Poète aujourd'hui, quand il veut concevoir
 Ces natives grandeurs, aux lieux où se font voir
 La nudité de l'homme et celle de la femme,
 Sent un froid ténébreux envelopper son âme
 Devant ce noir tableau plein d'épouvantement.
-O monstruosités pleurant leur vêtement!
-O ridicules troncs! torses dignes des masques!
+O monstruosités pleurant leur vêtement !
+O ridicules troncs ! torses dignes des masques !
 O pauvres corps tordus, maigres, ventrus ou flasques,
 Que le dieu de l'Utile, implacable et serein,
-Enfants, emmaillota dans ses langes d'airain!
-Et vous, femmes, hélas! pâles comme des cierges,
+Enfants, emmaillota dans ses langes d'airain !
+Et vous, femmes, hélas ! pâles comme des cierges,
 Que ronge et que nourrit la débauche, et vous, vierges,
 Du vice maternel traînant l'hérédité
-Et toutes les hideurs de la fécondité!
+Et toutes les hideurs de la fécondité !
 
 Nous avons, il est vrai, nations corrompues,
-Aux peuples anciens des beautés inconnues:
+Aux peuples anciens des beautés inconnues :
 Des visages rongés par les chancres du coeur,
-Et comme qui dirait des beautés de langueur;
+Et comme qui dirait des beautés de langueur ;
 Mais ces inventions de nos muses tardives
 N'empêcheront jamais les races maladives
 De rendre à la jeunesse un hommage profond,
@@ -368,7 +368,7 @@ De rendre à la jeunesse un hommage profond,
 A l'oeil limpide et clair ainsi qu'une eau courante,
 Et qui va répandant sur tout, insouciante
 Comme l'azur du ciel, les oiseaux et les fleurs,
-Ses parfums, ses chansons et ses douces chaleurs!
+Ses parfums, ses chansons et ses douces chaleurs !
 </poetry>
 </body>
 </text>
@@ -386,57 +386,57 @@ Ses parfums, ses chansons et ses douces chaleurs!
 Rubens, fleuve d'oubli, jardin de la paresse,
 Oreiller de chair fraîche où l'on ne peut aimer,
 Mais où la vie afflue et s'agite sans cesse,
-Comme l'air dans le ciel et la mer dans la mer;
+Comme l'air dans le ciel et la mer dans la mer ;
 
 Léonard de Vinci, miroir profond et sombre,
 Où des anges charmants, avec un doux souris
 Tout chargé de mystère, apparaissent à l'ombre
-Des glaciers et des pins qui ferment leur pays;
+Des glaciers et des pins qui ferment leur pays ;
 
 Rembrandt, triste hôpital tout rempli de murmures,
 Et d'un grand crucifix décoré seulement,
 Où la prière en pleurs s'exhale des ordures,
-Et d'un rayon d'hiver traversé brusquement;
+Et d'un rayon d'hiver traversé brusquement ;
 
 Michel-Ange, lieu vague où l'on voit des Hercules
 Se mêler à des Christs, et se lever tout droits
 Des fantômes puissants qui dans les crépuscules
-Déchirent leur suaire en étirant leurs doigts;
+Déchirent leur suaire en étirant leurs doigts ;
 
 Colères de boxeur, impudences de faune,
 Toi qui sus ramasser la beauté des goujats,
 Grand coeur gonflé d'orgueil, homme débile et jaune,
-Puget, mélancolique empereur des forçats;
+Puget, mélancolique empereur des forçats ;
 
 Watteau, ce carnaval où bien des coeurs illustres,
 Comme des papillons, errent en flamboyant,
 Décors frais et légers éclairés par des lustres
-Qui versent la folie à ce bal tournoyant;
+Qui versent la folie à ce bal tournoyant ;
 
 Goya, cauchemar plein de choses inconnues,
 De foetus qu'on fait cuire au milieu des sabbats,
 De vieilles au miroir et d'enfants toutes nues,
-Pour tenter les démons ajustant bien leurs bas;
+Pour tenter les démons ajustant bien leurs bas ;
 
 Delacroix, lac de sang hanté des mauvais anges,
 Ombragé par un bois de sapins toujours vert,
 Où, sous un ciel chagrin, des fanfares étranges
-Passent, comme un soupir étouffé de Weber;
+Passent, comme un soupir étouffé de Weber ;
 
 Ces malédictions, ces blasphèmes, ces plaintes,
 Ces extases, ces cris, ces pleurs, ces Te Deum,
-Sont un écho redit par mille labyrinthes;
-C'est pour les coeurs mortels un divin opium!
+Sont un écho redit par mille labyrinthes ;
+C'est pour les coeurs mortels un divin opium !
 
 C'est un cri répété par mille sentinelles,
-Un ordre renvoyé par mille porte-voix;
+Un ordre renvoyé par mille porte-voix ;
 C'est un phare allumé sur mille citadelles,
-Un appel de chasseurs perdus dans les grands bois!
+Un appel de chasseurs perdus dans les grands bois !
 
 Car c'est vraiment, Seigneur, le meilleur témoignage
 Que nous puissions donner de notre dignité
 Que cet ardent sanglot qui roule d'âge en âge
-Et vient mourir au bord de votre éternité!
+Et vient mourir au bord de votre éternité !
 </poetry>
 </body>
 </text>
@@ -446,21 +446,21 @@ Et vient mourir au bord de votre éternité!
    <title>La Muse malade</title>
    <toctitle>La Muse malade</toctitle>
    <indextitle>La Muse malade</indextitle>
-   <firstline>Ma pauvre muse, hélas! qu'as-tu donc ce matin?</firstline>
+   <firstline>Ma pauvre muse, hélas ! qu'as-tu donc ce matin ?</firstline>
    <quality>korrektur1</quality>
    <keywords>sonnet</keywords>
 </head>
 <body>
 <poetry>
-Ma pauvre muse, hélas! qu'as-tu donc ce matin?
+Ma pauvre muse, hélas ! qu'as-tu donc ce matin ?
 Tes yeux creux sont peuplés de visions nocturnes,
 Et je vois tour à tour réfléchis sur ton teint
 La folie et l'horreur, froides et taciturnes.
 
 Le succube verdâtre et le rose lutin
-T'ont-ils versé la peur et l'amour de leurs urnes?
+T'ont-ils versé la peur et l'amour de leurs urnes ?
 Le cauchemar, d'un poing despotique et mutin
-T'a-t-il noyée au fond d'un fabuleux Minturnes?
+T'a-t-il noyée au fond d'un fabuleux Minturnes ?
 
 Je voudrais qu'exhalant l'odeur de la santé
 Ton sein de pensers forts fût toujours fréquenté,
@@ -487,12 +487,12 @@ Phoebus, et le grand Pan, le seigneur des moissons.
 O muse de mon coeur, amante des palais,
 Auras-tu, quand Janvier lâchera ses Borées,
 Durant les noirs ennuis des neigeuses soirées,
-Un tison pour chauffer tes deux pieds violets?
+Un tison pour chauffer tes deux pieds violets ?
 
 Ranimeras-tu donc tes épaules marbrées
-Aux nocturnes rayons qui percent les volets?
+Aux nocturnes rayons qui percent les volets ?
 Sentant ta bourse à sec autant que ton palais
-Récolteras-tu l'or des voûtes azurées?
+Récolteras-tu l'or des voûtes azurées ?
 
 Il te faut, pour gagner ton pain de chaque soir,
 Comme un enfant de choeur, jouer de l'encensoir,
@@ -527,12 +527,12 @@ Prenant pour atelier le champ des funérailles,
 Glorifiait la Mort avec simplicité.
 
 - Mon âme est un tombeau que, mauvais cénobite,
-Depuis l'éternité je parcours et j'habite;
+Depuis l'éternité je parcours et j'habite ;
 Rien n'embellit les murs de ce cloître odieux.
 
-O moine fainéant! quand saurai-je donc faire
+O moine fainéant ! quand saurai-je donc faire
 Du spectacle vivant de ma triste misère
-Le travail de mes mains et l'amour de mes yeux?
+Le travail de mes mains et l'amour de mes yeux ?
 </poetry>
 </body>
 </text>
@@ -549,7 +549,7 @@ Le travail de mes mains et l'amour de mes yeux?
 <body>
 <poetry>
 Ma jeunesse ne fut qu'un ténébreux orage,
-Traversé çà et là par de brillants soleils;
+Traversé çà et là par de brillants soleils ;
 Le tonnerre et la pluie ont fait un tel ravage,
 Qu'il reste en mon jardin bien peu de fruits vermeils.
 
@@ -560,11 +560,11 @@ Où l'eau creuse des trous grands comme des tombeaux.
 
 Et qui sait si les fleurs nouvelles que je rêve
 Trouveront dans ce sol lavé comme une grève
-Le mystique aliment qui ferait leur vigueur?
+Le mystique aliment qui ferait leur vigueur ?
 
-- O douleur! ô douleur! Le Temps mange la vie,
+- O douleur ! ô douleur ! Le Temps mange la vie,
 Et l'obscur Ennemi qui nous ronge le coeur
-Du sang que nous perdons croît et se fortifie!
+Du sang que nous perdons croît et se fortifie !
 </poetry>
 </body>
 </text>
@@ -581,7 +581,7 @@ Du sang que nous perdons croît et se fortifie!
 <body>
 <poetry>
 Pour soulever un poids si lourd,
-Sisyphe, il faudrait ton courage!
+Sisyphe, il faudrait ton courage !
 Bien qu'on ait du coeur à l'ouvrage,
 L'Art est long et le Temps est court.
 
@@ -592,7 +592,7 @@ Va battant des marches funèbres.
 
 - Maint joyau dort enseveli
 Dans les ténèbres et l'oubli,
-Bien loin des pioches et des sondes;
+Bien loin des pioches et des sondes ;
 
 Mainte fleur épanche à regret
 Son parfum doux comme un secret
@@ -655,7 +655,7 @@ Promenant sur le ciel des yeux appesantis
 Par le morne regret des chimères absentes.
 
 Du fond de son réduit sablonneux, le grillon,
-Les regardant passer, redouble sa chanson;
+Les regardant passer, redouble sa chanson ;
 Cybèle, qui les aime, augmente ses verdures,
 
 Fait couler le rocher et fleurir le désert
@@ -670,30 +670,30 @@ L'empire familier des ténèbres futures.
    <title>L'Homme et la Mer</title>
    <toctitle>L'Homme et la Mer</toctitle>
    <indextitle>L'Homme et la Mer</indextitle>
-   <firstline>Homme libre, toujours tu chériras la mer!</firstline>
+   <firstline>Homme libre, toujours tu chériras la mer !</firstline>
    <quality>korrektur1</quality>
 </head>
 <body>
 <poetry>
-Homme libre, toujours tu chériras la mer!
-La mer est ton miroir; tu contemples ton âme
+Homme libre, toujours tu chériras la mer !
+La mer est ton miroir ; tu contemples ton âme
 Dans le déroulement infini de sa lame,
 Et ton esprit n'est pas un gouffre moins amer.
 
-Tu te plais à plonger au sein de ton image;
+Tu te plais à plonger au sein de ton image ;
 Tu l'embrasses des yeux et des bras, et ton coeur
 Se distrait quelquefois de sa propre rumeur
 Au bruit de cette plainte indomptable et sauvage.
 
-Vous êtes tous les deux ténébreux et discrets:
-Homme, nul n'a sondé le fond de tes abîmes;
+Vous êtes tous les deux ténébreux et discrets :
+Homme, nul n'a sondé le fond de tes abîmes ;
 O mer, nul ne connaît tes richesses intimes,
-Tant vous êtes jaloux de garder vos secrets!
+Tant vous êtes jaloux de garder vos secrets !
 
 Et cependant voilà des siècles innombrables
 Que vous vous combattez sans pitié ni remords,
 Tellement vous aimez le carnage et la mort,
-O lutteurs éternels, ô frères implacables!
+O lutteurs éternels, ô frères implacables !
 </poetry>
 </body>
 </text>
@@ -729,7 +729,7 @@ Semblait lui réclamer un suprême sourire
 Où brillât la douceur de son premier serment.
 
 Tout droit dans son armure, un grand homme de pierre
-Se tenait à la barre et coupait le flot noir;
+Se tenait à la barre et coupait le flot noir ;
 Mais le calme héros, courbé sur sa rapière,
 Regardait le sillage et ne daignait rien voir.
 </poetry>
@@ -749,17 +749,17 @@ Regardait le sillage et ne daignait rien voir.
 En ces temps merveilleux où la Théologie
 Fleurit avec le plus de sève et d'énergie,
 On raconte qu'un jour un docteur des plus grands,
-- Après avoir forcé les coeurs indifférents;
-Les avoir remués dans leurs profondeurs noires;
+- Après avoir forcé les coeurs indifférents ;
+Les avoir remués dans leurs profondeurs noires ;
 Après avoir franchi vers les célestes gloires
 Des chemins singuliers à lui-même inconnus,
 Où les purs Esprits seuls peut-être étaient venus,
 - Comme un homme monté trop haut, pris de panique,
-S'écria, transporté d'un orgueil satanique:
-"Jésus, petit Jésus! je t'ai poussé bien haut!
+S'écria, transporté d'un orgueil satanique :
+"Jésus, petit Jésus ! je t'ai poussé bien haut !
 Mais, si j'avais voulu t'attaquer au défaut
 De l'armure, ta honte égalerait ta gloire,
-Et tu ne serais plus qu'un foetus dérisoire!"
+Et tu ne serais plus qu'un foetus dérisoire !"
 
 Immédiatement sa raison s'en alla.
 L'éclat de ce soleil d'un crêpe se voila
@@ -782,29 +782,29 @@ Il faisait des enfants la joie et la risée.
    <title>La Beauté</title>
    <toctitle>La Beauté</toctitle>
    <indextitle>La Beauté</indextitle>
-   <firstline>Je suis belle, ô mortels! comme un rêve de pierre</firstline>
+   <firstline>Je suis belle, ô mortels ! comme un rêve de pierre</firstline>
    <quality>korrektur1</quality>
    <keywords>sonnet</keywords>
 </head>
 <body>
 <poetry>
-Je suis belle, ô mortels! comme un rêve de pierre,
+Je suis belle, ô mortels ! comme un rêve de pierre,
 Et mon sein, où chacun s'est meurtri tour à tour,
 Est fait pour inspirer au poète un amour
 Eternel et muet ainsi que la matière.
 
-Je trône dans l'azur comme un sphinx incompris;
-J'unis un coeur de neige à la blancheur des cygnes;
+Je trône dans l'azur comme un sphinx incompris ;
+J'unis un coeur de neige à la blancheur des cygnes ;
 Je hais le mouvement qui déplace les lignes,
 Et jamais je ne pleure et jamais je ne ris.
 
 Les poètes, devant mes grandes attitudes,
 Que j'ai l'air d'emprunter aux plus fiers monuments,
-Consumeront leurs jours en d'austères études;
+Consumeront leurs jours en d'austères études ;
 
 Car j'ai, pour fasciner ces dociles amants,
-De purs miroirs qui font toutes choses plus belles:
-Mes yeux, mes larges yeux aux clartés éternelles!
+De purs miroirs qui font toutes choses plus belles :
+Mes yeux, mes larges yeux aux clartés éternelles !
 </poetry>
 </body>
 </text>
@@ -818,7 +818,7 @@ Mes yeux, mes larges yeux aux clartés éternelles!
    <quality>korrektur1</quality>
    <keywords>sonnet</keywords>
    <pictures>
-       <picture src="baudel1999070132-p1.jpg">Michelangelo: <i>Notte</i>, fra gravmælet over Giuliano de' Medici, 1526-31, Medici kapellet, San Lorenzo, Firenze.</picture>
+       <picture src="baudel1999070132-p1.jpg">Michelangelo : <i>Notte</i>, fra gravmælet over Giuliano de' Medici, 1526-31, Medici kapellet, San Lorenzo, Firenze.</picture>
        <!-- Samme billede findes under dam/dam2004111805-p1.jpg -->
    </pictures>
 </head>
@@ -836,11 +836,11 @@ Une fleur qui ressemble à mon rouge idéal.
 
 Ce qu'il faut à ce coeur profond comme un abîme,
 C'est vous, Lady Macbeth, âme puissante au crime,
-Rêve d'Eschyle éclos au climat des autans;
+Rêve d'Eschyle éclos au climat des autans ;
 
 Ou bien toi, grande Nuit, fille de Michel-Ange,
 Qui tors paisiblement dans une pose étrange
-Tes appas façonnés aux bouches des Titans!
+Tes appas façonnés aux bouches des Titans !
 </poetry>
 </body>
 </text>
@@ -862,11 +862,11 @@ J'eusse aimé vivre auprès d'une jeune géante,
 Comme aux pieds d'une reine un chat voluptueux.
 
 J'eusse aimé voir son corps fleurir avec son âme
-Et grandir librement dans ses terribles jeux;
+Et grandir librement dans ses terribles jeux ;
 Deviner si son coeur couve une sombre flamme
-Aux humides brouillards qui nagent dans ses yeux;
+Aux humides brouillards qui nagent dans ses yeux ;
 
-Parcourir à loisir ses magnifiques formes;
+Parcourir à loisir ses magnifiques formes ;
 Ramper sur le versant de ses genoux énormes,
 Et parfois en été, quand les soleils malsains,
 
@@ -891,7 +891,7 @@ Comme un hameau paisible au pied d'une montagne.
 </head>
 <body>
 <poetry>
-Contemplons ce trésor de grâces florentines;
+Contemplons ce trésor de grâces florentines ;
 Dans l'ondulation de ce corps musculeux
 L'Elégance et la Force abondent, soeurs divines.
 Cette femme, morceau vraiment miraculeux,
@@ -900,38 +900,38 @@ Est faite pour trôner sur des lits somptueux
 Et charmer les loisirs d'un pontife ou d'un prince.
 
 - Aussi, vois ce souris fin et voluptueux
-Où la Fatuité promène son extase;
-Ce long regard sournois, langoureux et moqueur;
+Où la Fatuité promène son extase ;
+Ce long regard sournois, langoureux et moqueur ;
 Ce visage mignard, tout encadré de gaze,
-Dont chaque trait nous dit avec un air vainqueur:
-"La Volupté m'appelle et l'Amour me couronne!"
+Dont chaque trait nous dit avec un air vainqueur :
+"La Volupté m'appelle et l'Amour me couronne !"
 A cet être doué de tant de majesté
-Vois quel charme excitant la gentillesse donne!
+Vois quel charme excitant la gentillesse donne !
 Approchons, et tournons autour de sa beauté.
 
-O blasphème de l'art! ô surprise fatale!
+O blasphème de l'art ! ô surprise fatale !
 La femme au corps divin, promettant le bonheur,
-Par le haut se termine en monstre bicéphale!
+Par le haut se termine en monstre bicéphale !
 
-- Mais non! ce n'est qu'un masque, un décor suborneur,
+- Mais non ! ce n'est qu'un masque, un décor suborneur,
 Ce visage éclairé d'une exquise grimace,
 Et, regarde, voici, crispée atrocement,
 La véritable tête, et la sincère face
 Renversée à l'abri de la face qui ment
-Pauvre grande beauté! le magnifique fleuve
+Pauvre grande beauté ! le magnifique fleuve
 De tes pleurs aboutit dans mon coeur soucieux
 Ton mensonge m'enivre, et mon âme s'abreuve
-Aux flots que la Douleur fait jaillir de tes yeux!
+Aux flots que la Douleur fait jaillir de tes yeux !
 
-- Mais pourquoi pleure-t-elle? Elle, beauté parfaite,
+- Mais pourquoi pleure-t-elle ? Elle, beauté parfaite,
 Qui mettrait à ses pieds le genre humain vaincu,
-Quel mal mystérieux ronge son flanc d'athlète?
+Quel mal mystérieux ronge son flanc d'athlète ?
 
-- Elle pleure insensé, parce qu'elle a vécu!
-Et parce qu'elle vit! Mais ce qu'elle déplore
+- Elle pleure insensé, parce qu'elle a vécu !
+Et parce qu'elle vit ! Mais ce qu'elle déplore
 Surtout, ce qui la fait frémir jusqu'aux genoux,
-C'est que demain, hélas! il faudra vivre encore!
-Demain. après-demain et toujours! - comme nous!
+C'est que demain, hélas ! il faudra vivre encore !
+Demain. après-demain et toujours ! - comme nous !
 </poetry>
 </body>
 </text>
@@ -947,39 +947,39 @@ Demain. après-demain et toujours! - comme nous!
 <body>
 <poetry>
 Viens-tu du ciel profond ou sors-tu de l'abîme,
-O Beauté? ton regard, infernal et divin,
+O Beauté ? ton regard, infernal et divin,
 Verse confusément le bienfait et le crime,
 Et l'on peut pour cela te comparer au vin.
 
-Tu contiens dans ton oeil le couchant et l'aurore;
-Tu répands des parfums comme un soir orageux;
+Tu contiens dans ton oeil le couchant et l'aurore ;
+Tu répands des parfums comme un soir orageux ;
 Tes baisers sont un philtre et ta bouche une amphore
 Qui font le héros lâche et l'enfant courageux.
 
-Sors-tu du gouffre noir ou descends-tu des astres?
-Le Destin charmé suit tes jupons comme un chien;
+Sors-tu du gouffre noir ou descends-tu des astres ?
+Le Destin charmé suit tes jupons comme un chien ;
 Tu sèmes au hasard la joie et les désastres,
 Et tu gouvernes tout et ne réponds de rien.
 
-Tu marches sur des morts, Beauté, dont tu te moques;
+Tu marches sur des morts, Beauté, dont tu te moques ;
 De tes bijoux l'Horreur n'est pas le moins charmant,
 Et le Meurtre, parmi tes plus chères breloques,
 Sur ton ventre orgueilleux danse amoureusement.
 
 L'éphémère ébloui vole vers toi, chandelle,
-Crépite, flambe et dit: Bénissons ce flambeau!
+Crépite, flambe et dit : Bénissons ce flambeau !
 L'amoureux pantelant incliné sur sa belle
 A l'air d'un moribond caressant son tombeau.
 
 Que tu viennes du ciel ou de l'enfer, qu'importe,
-O Beauté! monstre énorme, effrayant, ingénu!
+O Beauté ! monstre énorme, effrayant, ingénu !
 Si ton oeil, ton souris, ton pied, m'ouvrent la porte
-D'un Infini que j'aime et n'ai jamais connu?
+D'un Infini que j'aime et n'ai jamais connu ?
 
-De Satan ou de Dieu, qu'importe? Ange ou Sirène,
+De Satan ou de Dieu, qu'importe ? Ange ou Sirène,
 Qu'importe, si tu rends, - fée aux yeux de velours,
-Rythme, parfum, lueur, ô mon unique reine! -
-L'univers moins hideux et les instants moins lourds?
+Rythme, parfum, lueur, ô mon unique reine ! -
+L'univers moins hideux et les instants moins lourds ?
 </poetry>
 </body>
 </text>
@@ -998,10 +998,10 @@ L'univers moins hideux et les instants moins lourds?
 Quand, les deux yeux fermés, en un soir chaud d'automne,
 Je respire l'odeur de ton sein chaleureux,
 Je vois se dérouler des rivages heureux
-Qu'éblouissent les feux d'un soleil monotone;
+Qu'éblouissent les feux d'un soleil monotone ;
 
 Une île paresseuse où la nature donne
-Des arbres singuliers et des fruits savoureux;
+Des arbres singuliers et des fruits savoureux ;
 Des hommes dont le corps est mince et vigoureux,
 Et des femmes dont l'oeil par sa franchise étonne.
 
@@ -1021,28 +1021,28 @@ Se mêle dans mon âme au chant des mariniers.
    <title>La Chevelure</title>
    <toctitle>La Chevelure</toctitle>
    <indextitle>La Chevelure</indextitle>
-   <firstline>O toison, moutonnant jusque sur l'encolure!</firstline>
+   <firstline>O toison, moutonnant jusque sur l'encolure !</firstline>
    <quality>korrektur1</quality>
 </head>
 <body>
 <poetry>
-O toison, moutonnant jusque sur l'encolure!
-O boucles! O parfum chargé de nonchaloir!
-Extase! Pour peupler ce soir l'alcôve obscure
+O toison, moutonnant jusque sur l'encolure !
+O boucles ! O parfum chargé de nonchaloir !
+Extase ! Pour peupler ce soir l'alcôve obscure
 Des souvenirs dormant dans cette chevelure,
-Je la veux agiter dans l'air comme un mouchoir!
+Je la veux agiter dans l'air comme un mouchoir !
 
 La langoureuse Asie et la brûlante Afrique,
 Tout un monde lointain, absent, presque défunt,
-Vit dans tes profondeurs, forêt aromatique!
+Vit dans tes profondeurs, forêt aromatique !
 Comme d'autres esprits voguent sur la musique,
-Le mien, ô mon amour! nage sur ton parfum.
+Le mien, ô mon amour ! nage sur ton parfum.
 
 J'irai là-bas où l'arbre et l'homme, pleins de sève,
-Se pâment longuement sous l'ardeur des climats;
-Fortes tresses, soyez la houle qui m'enlève!
+Se pâment longuement sous l'ardeur des climats ;
+Fortes tresses, soyez la houle qui m'enlève !
 Tu contiens, mer d'ébène, un éblouissant rêve
-De voiles, de rameurs, de flammes et de mâts:
+De voiles, de rameurs, de flammes et de mâts :
 
 Un port retentissant où mon âme peut boire
 A grands flots le parfum, le son et la couleur
@@ -1051,22 +1051,22 @@ Ouvrent leurs vastes bras pour embrasser la gloire
 D'un ciel pur où frémit l'éternelle chaleur.
 
 Je plongerai ma tête amoureuse d'ivresse
-Dans ce noir océan où l'autre est enfermé;
+Dans ce noir océan où l'autre est enfermé ;
 Et mon esprit subtil que le roulis caresse
 Saura vous retrouver, ô féconde paresse,
-Infinis bercements du loisir embaumé!
+Infinis bercements du loisir embaumé !
 
 Cheveux bleus, pavillon de ténèbres tendues
-Vous me rendez l'azur du ciel immense et rond;
+Vous me rendez l'azur du ciel immense et rond ;
 Sur les bords duvetés de vos mèches tordues
 Je m'enivre ardemment des senteurs confondues
 De l'huile de coco, du musc et du goudron.
 
-Longtemps! toujours! ma main dans ta crinière lourde
+Longtemps ! toujours ! ma main dans ta crinière lourde
 Sèmera le rubis, la perle et le saphir,
-Afin qu'à mon désir tu ne sois jamais sourde!
+Afin qu'à mon désir tu ne sois jamais sourde !
 N'es-tu pas l'oasis où je rêve, et la gourde
-Où je hume à longs traits le vin du souvenir?
+Où je hume à longs traits le vin du souvenir ?
 </poetry>
 </body>
 </text>
@@ -1090,8 +1090,8 @@ Qui séparent mes bras des immensités bleues.
 
 Je m'avance à l'attaque, et je grimpe aux assauts,
 Comme après un cadavre un choeur de vermisseaux,
-Et je chéris, ô bête implacable et cruelle!
-Jusqu'à cette froideur par où tu m'es plus belle!
+Et je chéris, ô bête implacable et cruelle !
+Jusqu'à cette froideur par où tu m'es plus belle !
 </poetry>
 </body>
 </text>
@@ -1107,7 +1107,7 @@ Jusqu'à cette froideur par où tu m'es plus belle!
 <body>
 <poetry>
 Tu mettrais l'univers entier dans ta ruelle,
-Femme impure! L'ennui rend ton âme cruelle.
+Femme impure ! L'ennui rend ton âme cruelle.
 Pour exercer tes dents à ce jeu singulier,
 Il te faut chaque jour un coeur au râtelier.
 Tes yeux, illuminés ainsi que des boutiques
@@ -1115,17 +1115,17 @@ Et des ifs flamboyants dans les fêtes publiques,
 Usent insolemment d'un pouvoir emprunté,
 Sans connaître jamais la loi de leur beauté.
 
-Machine aveugle et sourde, en cruautés féconde!
+Machine aveugle et sourde, en cruautés féconde !
 Salutaire instrument, buveur du sang du monde,
 Comment n'as-tu pas honte et comment n'as-tu pas
-Devant tous les miroirs vu pâlir tes appas?
+Devant tous les miroirs vu pâlir tes appas ?
 La grandeur de ce mal où tu te crois savante
 Ne t'a donc jamais fait reculer d'épouvante,
 Quand la nature, grande en ses desseins cachés
 De toi se sert, ô femme, ô reine des péchés,
-- De toi, vil animal, - pour pétrir un génie?
+- De toi, vil animal, - pour pétrir un génie ?
 
-O fangeuse grandeur! sublime ignominie!
+O fangeuse grandeur ! sublime ignominie !
 </poetry>
 </body>
 </text>
@@ -1147,17 +1147,17 @@ Oeuvre de quelque obi, le Faust de la savane,
 Sorcière au flanc d'ébène, enfant des noirs minuits,
 
 Je préfère au constance, à l'opium, au nuits,
-L'élixir de ta bouche où l'amour se pavane;
+L'élixir de ta bouche où l'amour se pavane ;
 Quand vers toi mes désirs partent en caravane,
 Tes yeux sont la citerne où boivent mes ennuis.
 
 Par ces deux grands yeux noirs, soupiraux de ton âme,
-O démon sans pitié! verse-moi moins de flamme;
+O démon sans pitié ! verse-moi moins de flamme ;
 Je ne suis pas le Styx pour t'embrasser neuf fois,
 
-Hélas! et je ne puis, Mégère libertine,
+Hélas ! et je ne puis, Mégère libertine,
 Pour briser ton courage et te mettre aux abois,
-Dans l'enfer de ton lit devenir Proserpine!
+Dans l'enfer de ton lit devenir Proserpine !
 </poetry>
 </body>
 </text>
@@ -1207,7 +1207,7 @@ La froide majesté de la femme stérile.
 Que j'aime voir, chère indolente,
 De ton corps si beau,
 Comme une étoffe vacillante,
-Miroiter la peau!
+Miroiter la peau !
 
 Sur ta chevelure profonde
 Aux âcres parfums,
@@ -1247,7 +1247,7 @@ Au bord de tes dents,
 Je crois boire un vin de Bohême,
 Amer et vainqueur,
 Un ciel liquide qui parsème
-D'étoiles mon coeur!
+D'étoiles mon coeur !
 </poetry>
 </body>
 </text>
@@ -1263,7 +1263,7 @@ D'étoiles mon coeur!
 <body>
 <poetry>
 Rappelez-vous l'objet que nous vîmes, mon âme,
-Ce beau matin d'été si doux:
+Ce beau matin d'été si doux :
 Au détour d'un sentier une charogne infâme
 Sur un lit semé de cailloux,
 
@@ -1275,7 +1275,7 @@ Son ventre plein d'exhalaisons.
 Le soleil rayonnait sur cette pourriture,
 Comme afin de la cuire à point,
 Et de rendre au centuple à la grande Nature
-Tout ce qu'ensemble elle avait joint;
+Tout ce qu'ensemble elle avait joint ;
 
 Et le ciel regardait la carcasse superbe
 Comme une fleur s'épanouir.
@@ -1310,17 +1310,17 @@ Le morceau qu'elle avait lâché.
 - Et pourtant vous serez semblable à cette ordure,
 A cette horrible infection,
 Etoile de mes yeux, soleil de ma nature,
-Vous, mon ange et ma passion!
+Vous, mon ange et ma passion !
 
-Oui! telle vous serez, ô la reine des grâces,
+Oui ! telle vous serez, ô la reine des grâces,
 Apres les derniers sacrements,
 Quand vous irez, sous l'herbe et les floraisons grasses,
 Moisir parmi les ossements.
 
-Alors, ô ma beauté! dites à la vermine
+Alors, ô ma beauté ! dites à la vermine
 Qui vous mangera de baisers,
 Que j'ai gardé la forme et l'essence divine
-De mes amours décomposés!
+De mes amours décomposés !
 </poetry>
 </body>
 </text>
@@ -1342,20 +1342,20 @@ De mes amours décomposés!
 J'implore ta pitié, Toi, l'unique que j'aime,
 Du fond du gouffre obscur où mon coeur est tombé.
 C'est un univers morne à l'horizon plombé,
-Où nagent dans la nuit l'horreur et le blasphème;
+Où nagent dans la nuit l'horreur et le blasphème ;
 
 Un soleil sans chaleur plane au-dessus six mois,
-Et les six autres mois la nuit couvre la terre;
+Et les six autres mois la nuit couvre la terre ;
 C'est un pays plus nu que la terre polaire
-- Ni bêtes, ni ruisseaux, ni verdure, ni bois!
+- Ni bêtes, ni ruisseaux, ni verdure, ni bois !
 
 Or il n'est pas d'horreur au monde qui surpasse
 La froide cruauté de ce soleil de glace
-Et cette immense nuit semblable au vieux Chaos;
+Et cette immense nuit semblable au vieux Chaos ;
 
 Je jalouse le sort des plus vils animaux
 Qui peuvent se plonger dans un sommeil stupide,
-Tant l'écheveau du temps lentement se dévide!
+Tant l'écheveau du temps lentement se dévide !
 </poetry>
 </body>
 </text>
@@ -1371,34 +1371,34 @@ Tant l'écheveau du temps lentement se dévide!
 <body>
 <poetry>
 Toi qui, comme un coup de couteau,
-Dans mon coeur plaintif es entrée;
+Dans mon coeur plaintif es entrée ;
 Toi qui, forte comme un troupeau
 De démons, vins, folle et parée,
 
 De mon esprit humilié
-Faire ton lit et ton domaine;
+Faire ton lit et ton domaine ;
 - Infâme à qui je suis lié
 Comme le forçat à la chaîne,
 
 Comme au jeu le joueur têtu,
 Comme à la bouteille l'ivrogne,
 Comme aux vermines la charogne
-- Maudite, maudite sois-tu!
+- Maudite, maudite sois-tu !
 
 J'ai prié le glaive rapide
 De conquérir ma liberté,
 Et j'ai dit au poison perfide
 De secourir ma lâcheté.
 
-Hélas! le poison et le glaive
-M'ont pris en dédain et m'ont dit:
+Hélas ! le poison et le glaive
+M'ont pris en dédain et m'ont dit :
 "Tu n'es pas digne qu'on t'enlève
 A ton esclavage maudit,
 
-Imbécile! - de son empire
+Imbécile ! - de son empire
 Si nos efforts te délivraient,
 Tes baisers ressusciteraient
-Le cadavre de ton vampire!"
+Le cadavre de ton vampire !"
 </poetry>
 </body>
 </text>
@@ -1429,7 +1429,7 @@ Et depuis tes pieds frais jusqu'à tes noires tresses
 Déroulé le trésor des profondes caresses,
 
 Si, quelque soir, d'un pleur obtenu sans effort
-Tu pouvais seulement, ô reine des cruelles!
+Tu pouvais seulement, ô reine des cruelles !
 Obscurcir la splendeur de tes froides prunelles.
 </poetry>
 </body>
@@ -1449,7 +1449,7 @@ Obscurcir la splendeur de tes froides prunelles.
 Lorsque tu dormiras, ma belle ténébreuse,
 Au fond d'un monument construit en marbre noir,
 Et lorsque tu n'auras pour alcôve et manoir
-Qu'un caveau pluvieux et qu'une fosse creuse;
+Qu'un caveau pluvieux et qu'une fosse creuse ;
 
 Quand la pierre, opprimant ta poitrine peureuse
 Et tes flancs qu'assouplit un charmant nonchaloir,
@@ -1460,8 +1460,8 @@ Le tombeau, confident de mon rêve infini
 (Car le tombeau toujours comprendra le poète),
 Durant ces grandes nuits d'où le somme est banni,
 
-Te dira: "Que vous sert, courtisane imparfaite,
-De n'avoir pas connu ce que pleurent les morts?"
+Te dira : "Que vous sert, courtisane imparfaite,
+De n'avoir pas connu ce que pleurent les morts ?"
 - Et le vers rongera ta peau comme un remords.
 </poetry>
 </body>
@@ -1478,7 +1478,7 @@ De n'avoir pas connu ce que pleurent les morts?"
 </head>
 <body>
 <poetry>
-Viens, mon beau chat, sur mon coeur amoureux;
+Viens, mon beau chat, sur mon coeur amoureux ;
 Retiens les griffes de ta patte,
 Et laisse-moi plonger dans tes beaux yeux,
 Mêlés de métal et d'agate.
@@ -1515,18 +1515,18 @@ Ont éclaboussé l'air de lueurs et de sang.
 Ces jeux, ces cliquetis du fer sont les vacarmes
 D'une jeunesse en proie à l'amour vagissant.
 
-Les glaives sont brisés! comme notre jeunesse,
-Ma chère! Mais les dents, les ongles acérés,
+Les glaives sont brisés ! comme notre jeunesse,
+Ma chère ! Mais les dents, les ongles acérés,
 Vengent bientôt l'épée et la dague traîtresse.
-- O fureur des coeurs mûrs par l'amour ulcérés!
+- O fureur des coeurs mûrs par l'amour ulcérés !
 
 Dans le ravin hanté des chats-pards et des onces
 Nos héros, s'étreignant méchamment, ont roulé,
 Et leur peau fleurira l'aridité des ronces.
 
-- Ce gouffre, c'est l'enfer, de nos amis peuplé!
+- Ce gouffre, c'est l'enfer, de nos amis peuplé !
 Roulons-y sans remords, amazone inhumaine,
-Afin d'éterniser l'ardeur de notre haine!
+Afin d'éterniser l'ardeur de notre haine !
 </poetry>
 </body>
 </text>
@@ -1542,40 +1542,40 @@ Afin d'éterniser l'ardeur de notre haine!
 <body>
 <poetry>
 Mère des souvenirs, maîtresse des maîtresses,
-O toi, tous mes plaisirs! ô toi, tous mes devoirs!
+O toi, tous mes plaisirs ! ô toi, tous mes devoirs !
 Tu te rappelleras la beauté des caresses,
 La douceur du foyer et le charme des soirs,
-Mère des souvenirs, maîtresse des maîtresses!
+Mère des souvenirs, maîtresse des maîtresses !
 
 Les soirs illuminés par l'ardeur du charbon,
 Et les soirs au balcon, voilés de vapeurs roses.
-Que ton sein m'était doux! que ton coeur m'était bon!
+Que ton sein m'était doux ! que ton coeur m'était bon !
 Nous avons dit souvent d'impérissables choses
 Les soirs illumines par l'ardeur du charbon.
 
-Que les soleils sont beaux dans les chaudes soirées!
-Que l'espace est profond! que le coeur est puissant!
+Que les soleils sont beaux dans les chaudes soirées !
+Que l'espace est profond ! que le coeur est puissant !
 En me penchant vers toi, reine des adorées,
 Je croyais respirer le parfum de ton sang.
-Que les soleils sont beaux dans les chaudes soirées!
+Que les soleils sont beaux dans les chaudes soirées !
 
 La nuit s'épaississait ainsi qu'une cloison,
 Et mes yeux dans le noir devinaient tes prunelles,
-Et je buvais ton souffle, ô douceur! ô poison!
+Et je buvais ton souffle, ô douceur ! ô poison !
 Et tes pieds s'endormaient dans mes mains fraternelles.
 La nuit s'épaississait ainsi qu'une cloison.
 
 Je sais l'art d'évoquer les minutes heureuses,
 Et revis mon passé blotti dans tes genoux.
 Car à quoi bon chercher tes beautés langoureuses
-Ailleurs qu'en ton cher corps et qu'en ton coeur si doux?
-Je sais l'art d'évoquer les minutes heureuses!
+Ailleurs qu'en ton cher corps et qu'en ton coeur si doux ?
+Je sais l'art d'évoquer les minutes heureuses !
 
 Ces serments, ces parfums, ces baisers infinis,
 Renaîtront-ils d'un gouffre interdit à nos sondes,
 Comme montent au ciel les soleils rajeunis
-Après s'être lavés au fond des mers profondes?
-- O serments! ô parfums! ô baisers infinis!
+Après s'être lavés au fond des mers profondes ?
+- O serments ! ô parfums ! ô baisers infinis !
 </poetry>
 </body>
 </text>
@@ -1592,22 +1592,22 @@ Après s'être lavés au fond des mers profondes?
 <body>
 <poetry>
 Le soleil s'est couvert d'un crêpe. Comme lui,
-O Lune de ma vie! emmitoufle-toi d'ombre
-Dors ou fume à ton gré; sois muette, sois sombre,
-Et plonge tout entière au gouffre de l'Ennui;
+O Lune de ma vie ! emmitoufle-toi d'ombre
+Dors ou fume à ton gré ; sois muette, sois sombre,
+Et plonge tout entière au gouffre de l'Ennui ;
 
-Je t'aime ainsi! Pourtant, si tu veux aujourd'hui,
+Je t'aime ainsi ! Pourtant, si tu veux aujourd'hui,
 Comme un astre éclipsé qui sort de la pénombre,
 Te pavaner aux lieux que la Folie encombre
-C'est bien! Charmant poignard, jaillis de ton étui!
+C'est bien ! Charmant poignard, jaillis de ton étui !
 
-Allume ta prunelle à la flamme des lustres!
-Allume le désir dans les regards des rustres!
-Tout de toi m'est plaisir, morbide ou pétulant;
+Allume ta prunelle à la flamme des lustres !
+Allume le désir dans les regards des rustres !
+Tout de toi m'est plaisir, morbide ou pétulant ;
 
-Sois ce que tu voudras, nuit noire, rouge aurore;
+Sois ce que tu voudras, nuit noire, rouge aurore ;
 Il n'est pas une fibre en tout mon corps tremblant
-Qui ne crie: O mon cher Belzébuth, je t'adore!
+Qui ne crie : O mon cher Belzébuth, je t'adore !
 </poetry>
 </body>
 </text>
@@ -1624,12 +1624,12 @@ Qui ne crie: O mon cher Belzébuth, je t'adore!
 <body>
 <poetry>
 Dans les caveaux d'insondable tristesse
-Où le Destin m'a déjà relégué;
-Où jamais n'entre un rayon rose et gai;
+Où le Destin m'a déjà relégué ;
+Où jamais n'entre un rayon rose et gai ;
 Où, seul avec la Nuit, maussade hôtesse,
 
 Je suis comme un peintre qu'un Dieu moqueur
-Condamne à peindre, hélas! sur les ténèbres;
+Condamne à peindre, hélas ! sur les ténèbres ;
 Où, cuisinier aux appétits funèbres,
 Je fais bouillir et je mange mon coeur,
 
@@ -1637,9 +1637,9 @@ Par instants brille, et s'allonge, et s'étale
 Un spectre fait de grâce et de splendeur.
 A sa rêveuse allure orientale,
 Quand il atteint sa totale grandeur,
-Je reconnais ma belle visiteuse:
+Je reconnais ma belle visiteuse :
 
-C'est Elle! noire et pourtant lumineuse.
+C'est Elle ! noire et pourtant lumineuse.
 </poetry>
 </body>
 </text>
@@ -1658,10 +1658,10 @@ C'est Elle! noire et pourtant lumineuse.
 Lecteur, as-tu quelquefois respiré
 Avec ivresse et lente gourmandise
 Ce grain d'encens qui remplit une église,
-Ou d'un sachet le musc invétéré?
+Ou d'un sachet le musc invétéré ?
 
 Charme profond, magique, dont nous grise
-Dans le présent le passé restauré!
+Dans le présent le passé restauré !
 Ainsi l'amant sur un corps adoré
 Du souvenir cueille la fleur exquise.
 
@@ -1693,12 +1693,12 @@ Je ne sais quoi d'étrange et d'enchanté
 En l'isolant de l'immense nature,
 
 Ainsi bijoux, meubles, métaux, dorure,
-S'adaptaient juste à sa rare beauté;
+S'adaptaient juste à sa rare beauté ;
 Rien n'offusquait sa parfaite clarté,
 Et tout semblait lui servir de bordure.
 
 Même on eût dit parfois qu'elle croyait
-Que tout voulait l'aimer; elle noyait
+Que tout voulait l'aimer ; elle noyait
 Sa nudité voluptueusement
 
 Dans les baisers du satin et du linge,
@@ -1726,7 +1726,7 @@ De cette bouche où mon coeur se noya,
 
 De ces baisers puissants comme un dictame,
 De ces transports plus vifs que des rayons,
-Que reste-t-il? C'est affreux, ô mon âme!
+Que reste-t-il ? C'est affreux, ô mon âme !
 Rien qu'un dessin fort pâle, aux trois crayons,
 
 Qui, comme moi, meurt dans la solitude
@@ -1735,7 +1735,7 @@ Chaque jour frotte avec son aile rude...
 
 Noir assassin de la Vie et de l'Art,
 Tu ne tueras jamais dans ma mémoire
-Celle qui fut mon plaisir et ma gloire!
+Celle qui fut mon plaisir et ma gloire !
 </poetry>
 </body>
 </text>
@@ -1759,15 +1759,15 @@ Vaisseau favorisé par un grand aquilon,
 Ta mémoire, pareille aux fables incertaines,
 Fatigue le lecteur ainsi qu'un tympanon,
 Et par un fraternel et mystique chaînon
-Reste comme pendue à mes rimes hautaines;
+Reste comme pendue à mes rimes hautaines ;
 
 Etre maudit à qui, de l'abîme profond
-Jusqu'au plus haut du ciel, rien, hors moi, ne répond!
+Jusqu'au plus haut du ciel, rien, hors moi, ne répond !
 - O toi qui, comme une ombre à la trace éphémère,
 
 Foules d'un pied léger et d'un regard serein
 Les stupides mortels qui t'ont jugée amère,
-Statue aux yeux de jais, grand ange au front d'airain!
+Statue aux yeux de jais, grand ange au front d'airain !
 </poetry>
 </body>
 </text>
@@ -1784,22 +1784,22 @@ Statue aux yeux de jais, grand ange au front d'airain!
 <body>
 <poetry>
 "D'où vous vient, disiez-vous, cette tristesse étrange,
-Montant comme la mer sur le roc noir et nu?"
+Montant comme la mer sur le roc noir et nu ?"
 - Quand notre coeur a fait une fois sa vendange
 Vivre est un mal. C'est un secret de tous connu,
 
 Une douleur très simple et non mystérieuse
 Et, comme votre joie, éclatante pour tous.
-Cessez donc de chercher, ô belle curieuse!
-Et, bien que votre voix soit douce, taisez-vous!
+Cessez donc de chercher, ô belle curieuse !
+Et, bien que votre voix soit douce, taisez-vous !
 
-Taisez-vous, ignorante! âme toujours ravie!
-Bouche au rire enfantin! Plus encor que la Vie,
+Taisez-vous, ignorante ! âme toujours ravie !
+Bouche au rire enfantin ! Plus encor que la Vie,
 La Mort nous tient souvent par des liens subtils.
 
 Laissez, laissez mon coeur s'enivrer d'un mensonge,
 Plonger dans vos beaux yeux comme dans un beau songe
-Et sommeiller longtemps à l'ombre de vos cils!
+Et sommeiller longtemps à l'ombre de vos cils !
 </poetry>
 </body>
 </text>
@@ -1817,22 +1817,22 @@ Et sommeiller longtemps à l'ombre de vos cils!
 Le Démon, dans ma chambre haute
 Ce matin est venu me voir,
 Et, tâchant à me prendre en faute
-Me dit: "Je voudrais bien savoir
+Me dit : "Je voudrais bien savoir
 
 Parmi toutes les belles choses
 Dont est fait son enchantement,
 Parmi les objets noirs ou roses
 Qui composent son corps charmant,
 
-Quel est le plus doux."- O mon âme!
-Tu répondis à l'Abhorré:
+Quel est le plus doux."- O mon âme !
+Tu répondis à l'Abhorré :
 "Puisqu'en Elle tout est dictame
 Rien ne peut être préféré.
 
 Lorsque tout me ravit, j'ignore
 Si quelque chose me séduit.
 Elle éblouit comme l'Aurore
-Et console comme la Nuit;
+Et console comme la Nuit ;
 
 Et l'harmonie est trop exquise,
 Qui gouverne tout son beau corps,
@@ -1840,9 +1840,9 @@ Pour que l'impuissante analyse
 En note les nombreux accords.
 
 O métamorphose mystique
-De tous mes sens fondus en un!
+De tous mes sens fondus en un !
 Son haleine fait la musique,
-Comme sa voix fait le parfum!"
+Comme sa voix fait le parfum !"
 </poetry>
 </body>
 </text>
@@ -1861,9 +1861,9 @@ Comme sa voix fait le parfum!"
 Que diras-tu ce soir, pauvre âme solitaire,
 Que diras-tu, mon coeur, coeur autrefois flétri,
 A la très belle, à la très bonne, à la très chère,
-Dont le regard divin t'a soudain refleuri?
+Dont le regard divin t'a soudain refleuri ?
 
-- Nous mettrons notre orgueil à chanter ses louanges:
+- Nous mettrons notre orgueil à chanter ses louanges :
 Rien ne vaut la douceur de son autorité
 Sa chair spirituelle a le parfum des Anges
 Et son oeil nous revêt d'un habit de clarté.
@@ -1872,8 +1872,8 @@ Que ce soit dans la nuit et dans la solitude
 Que ce soit dans la rue et dans la multitude
 Son fantôme dans l'air danse comme un flambeau.
 
-Parfois il parle et dit: "Je suis belle, et j'ordonne
-Que pour l'amour de moi vous n'aimiez que le Beau;
+Parfois il parle et dit : "Je suis belle, et j'ordonne
+Que pour l'amour de moi vous n'aimiez que le Beau ;
 Je suis l'Ange gardien, la Muse et la Madone."
 </poetry>
 </body>
@@ -1901,12 +1901,12 @@ Ils sont mes serviteurs et je suis leur esclave
 Tout mon être obéit à ce vivant flambeau.
 
 Charmants Yeux, vous brillez de la clarté mystique
-Qu'ont les cierges brûlant en plein jour; le soleil
-Rougit, mais n'éteint pas leur flamme fantastique;
+Qu'ont les cierges brûlant en plein jour ; le soleil
+Rougit, mais n'éteint pas leur flamme fantastique ;
 
 Ils célèbrent la Mort, vous chantez le Réveil
 Vous marchez en chantant le réveil de mon âme,
-Astres dont nul soleil ne peut flétrir la flamme!
+Astres dont nul soleil ne peut flétrir la flamme !
 </poetry>
 </body>
 </text>
@@ -1924,32 +1924,32 @@ Astres dont nul soleil ne peut flétrir la flamme!
 Ange plein de gaieté, connaissez-vous l'angoisse,
 La honte, les remords, les sanglots, les ennuis,
 Et les vagues terreurs de ces affreuses nuits
-Qui compriment le coeur comme un papier qu'on froisse?
-Ange plein de gaieté, connaissez-vous l'angoisse?
+Qui compriment le coeur comme un papier qu'on froisse ?
+Ange plein de gaieté, connaissez-vous l'angoisse ?
 
 Ange plein de bonté, connaissez-vous la haine,
 Les poings crispés dans l'ombre et les larmes de fiel,
 Quand la Vengeance bat son infernal rappel,
-Et de nos facultés se fait le capitaine?
-Ange plein de bonté connaissez-vous la haine?
+Et de nos facultés se fait le capitaine ?
+Ange plein de bonté connaissez-vous la haine ?
 
 Ange plein de santé, connaissez-vous les Fièvres,
 Qui, le long des grands murs de l'hospice blafard,
 Comme des exilés, s'en vont d'un pied traînard,
-Cherchant le soleil rare et remuant les lèvres?
-Ange plein de santé, connaissez-vous les Fièvres?
+Cherchant le soleil rare et remuant les lèvres ?
+Ange plein de santé, connaissez-vous les Fièvres ?
 
 Ange plein de beauté, connaissez-vous les rides,
 Et la peur de vieillir, et ce hideux tourment
 De lire la secrète horreur du dévouement
-Dans des yeux où longtemps burent nos yeux avide!
-Ange plein de beauté, connaissez-vous les rides?
+Dans des yeux où longtemps burent nos yeux avide !
+Ange plein de beauté, connaissez-vous les rides ?
 
 Ange plein de bonheur, de joie et de lumières,
 David mourant aurait demandé la santé
-Aux émanations de ton corps enchanté;
+Aux émanations de ton corps enchanté ;
 Mais de toi je n'implore, ange, que tes prières,
-Ange plein de bonheur, de joie et de lumières!
+Ange plein de bonheur, de joie et de lumières !
 </poetry>
 </body>
 </text>
@@ -1967,9 +1967,9 @@ Ange plein de bonheur, de joie et de lumières!
 Une fois, une seule, aimable et douce femme,
 A mon bras votre bras poli
 S'appuya (sur le fond ténébreux de mon âme
-Ce souvenir n'est point pâli);
+Ce souvenir n'est point pâli) ;
 
-Il était tard; ainsi qu'une médaille neuve
+Il était tard ; ainsi qu'une médaille neuve
 La pleine lune s'étalait,
 Et la solennité de la nuit, comme un fleuve,
 Sur Paris dormant ruisselait.
@@ -1994,20 +1994,20 @@ Dont sa famille rougirait,
 Et qu'elle aurait longtemps, pour la cacher au monde,
 Dans un caveau mise au secret.
 
-Pauvre ange, elle chantait, votre note criarde:
+Pauvre ange, elle chantait, votre note criarde :
 "Que rien ici-bas n'est certain,
 Et que toujours, avec quelque soin qu'il se farde,
-Se trahit l'égoïsme humain;
+Se trahit l'égoïsme humain ;
 
 Que c'est un dur métier que d'être belle femme,
 Et que c'est le travail banal
 De la danseuse folle et froide qui se pâme
-Dans son sourire machinal;
+Dans son sourire machinal ;
 
-Que bâtir sur les coeurs est une chose sotte;
+Que bâtir sur les coeurs est une chose sotte ;
 Que tout craque, amour et beauté,
 Jusqu'à ce que l'Oubli les jette dans sa hotte
-Pour les rendre à l'Eternité!"
+Pour les rendre à l'Eternité !"
 
 J'ai souvent évoqué cette lune enchantée,
 Ce silence et cette langueur,
@@ -2042,9 +2042,9 @@ Sur les débris fumeux des stupides orgies
 Ton souvenir plus clair, plus rose, plus charmant,
 A mes yeux agrandis voltige incessamment.
 
-Le soleil a noirci la flamme des bougies;
+Le soleil a noirci la flamme des bougies ;
 Ainsi, toujours vainqueur, ton fantôme est pareil,
-Ame resplendissante, à l'immortel soleil!
+Ame resplendissante, à l'immortel soleil !
 </poetry>
 </body>
 </text>
@@ -2060,24 +2060,24 @@ Ame resplendissante, à l'immortel soleil!
 <body>
 <poetry>
 Voici venir les temps où vibrant sur sa tige
-Chaque fleur s'évapore ainsi qu'un encensoir;
-Les sons et les parfums tournent dans l'air du soir;
-Valse mélancolique et langoureux vertige!
+Chaque fleur s'évapore ainsi qu'un encensoir ;
+Les sons et les parfums tournent dans l'air du soir ;
+Valse mélancolique et langoureux vertige !
 
-Chaque fleur s'évapore ainsi qu'un encensoir;
-Le violon frémit comme un coeur qu'on afflige;
-Valse mélancolique et langoureux vertige!
+Chaque fleur s'évapore ainsi qu'un encensoir ;
+Le violon frémit comme un coeur qu'on afflige ;
+Valse mélancolique et langoureux vertige !
 Le ciel est triste et beau comme un grand reposoir.
 
 Le violon frémit comme un coeur qu'on afflige,
-Un coeur tendre, qui hait le néant vaste et noir!
-Le ciel est triste et beau comme un grand reposoir;
+Un coeur tendre, qui hait le néant vaste et noir !
+Le ciel est triste et beau comme un grand reposoir ;
 Le soleil s'est noyé dans son sang qui se fige.
 
 Un coeur tendre, qui hait le néant vaste et noir,
-Du passé lumineux recueille tout vestige!
+Du passé lumineux recueille tout vestige !
 Le soleil s'est noyé dans son sang qui se fige...
-Ton souvenir en moi luit comme un ostensoir!
+Ton souvenir en moi luit comme un ostensoir !
 </poetry>
 </body>
 </text>
@@ -2108,9 +2108,9 @@ Qui dégagent leur aile et prennent leur essor,
 Teintés d'azur, glacés de rose, lamés d'or.
 
 Voilà le souvenir enivrant qui voltige
-Dans l'air troublé; les yeux se ferment; le Vertige
+Dans l'air troublé ; les yeux se ferment ; le Vertige
 Saisit l'âme vaincue et la pousse à deux mains
-Vers un gouffre obscurci de miasmes humains;
+Vers un gouffre obscurci de miasmes humains ;
 
 Il la terrasse au bord d'un gouffre séculaire,
 Où, Lazare odorant déchirant son suaire,
@@ -2122,10 +2122,10 @@ Des hommes, dans le coin d'une sinistre armoire
 Quand on m'aura jeté, vieux flacon désolé,
 Décrépit, poudreux, sale, abject, visqueux, fêlé,
 
-Je serai ton cercueil, aimable pestilence!
+Je serai ton cercueil, aimable pestilence !
 Le témoin de ta force et de ta virulence,
-Cher poison préparé par les anges! liqueur
-Qui me ronge, ô la vie et la mort de mon coeur!
+Cher poison préparé par les anges ! liqueur
+Qui me ronge, ô la vie et la mort de mon coeur !
 </poetry>
 </body>
 </text>
@@ -2162,7 +2162,7 @@ Tout cela ne vaut pas le terrible prodige
 De ta salive qui mord,
 Qui plonge dans l'oubli mon âme sans remords,
 Et charriant le vertige,
-La roule défaillante aux rives de la mort!
+La roule défaillante aux rives de la mort !
 </poetry>
 </body>
 </text>
@@ -2177,8 +2177,8 @@ La roule défaillante aux rives de la mort!
 </head>
 <body>
 <poetry>
-On dirait ton regard d'une vapeur couvert;
-Ton oeil mystérieux (est-il bleu, gris ou vert?)
+On dirait ton regard d'une vapeur couvert ;
+Ton oeil mystérieux (est-il bleu, gris ou vert ?)
 Alternativement tendre, rêveur, cruel,
 Réfléchit l'indolence et la pâleur du ciel.
 
@@ -2190,12 +2190,12 @@ Les nerfs trop éveillés raillent l'esprit qui dort.
 Tu ressembles parfois à ces beaux horizons
 Qu'allument les soleils des brumeuses saisons...
 Comme tu resplendis, paysage mouillé
-Qu'enflamment les rayons tombant d'un ciel brouillé!
+Qu'enflamment les rayons tombant d'un ciel brouillé !
 
-O femme dangereuse, ô séduisants climats!
+O femme dangereuse, ô séduisants climats !
 Adorerai-je aussi ta neige et vos frimas,
 Et saurai-je tirer de l'implacable hiver
-Des plaisirs plus aigus que la glace et le fer?
+Des plaisirs plus aigus que la glace et le fer ?
 </poetry>
 </body>
 </text>
@@ -2217,7 +2217,7 @@ Ainsi qu'en son appartement,
 Un beau chat, fort, doux et charmant.
 Quand il miaule, on l'entend à peine,
 
-Tant son timbre est tendre et discret;
+Tant son timbre est tendre et discret ;
 Mais que sa voix s'apaise ou gronde,
 Elle est toujours riche et profonde.
 C'est là son charme et son secret.
@@ -2228,7 +2228,7 @@ Me remplit comme un vers nombreux
 Et me réjouit comme un philtre.
 
 Elle endort les plus cruels maux
-Et contient toutes les extases;
+Et contient toutes les extases ;
 Pour dire les plus longues phrases,
 Elle n'a pas besoin de mots.
 
@@ -2240,7 +2240,7 @@ Chanter sa plus vibrante corde,
 Que ta voix, chat mystérieux,
 Chat séraphique, chat étrange,
 En qui tout est, comme en un ange,
-Aussi subtil qu'harmonieux!
+Aussi subtil qu'harmonieux !
 
      II
 
@@ -2249,10 +2249,10 @@ Sort un parfum si doux, qu'un soir
 J'en fus embaumé, pour l'avoir
 Caressée une fois, rien qu'une.
 
-C'est l'esprit familier du lieu;
+C'est l'esprit familier du lieu ;
 Il juge, il préside, il inspire
-Toutes choses dans son empire;
-Peut-être est-il fée, est-il dieu?
+Toutes choses dans son empire ;
+Peut-être est-il fée, est-il dieu ?
 
 Quand mes yeux, vers ce chat que j'aime
 Tirés comme par un aimant,
@@ -2272,13 +2272,13 @@ Qui me contemplent fixement.
    <title>Le Beau Navire</title>
    <toctitle>Le Beau Navire</toctitle>
    <indextitle>Le Beau Navire</indextitle>
-   <firstline>Je veux te raconter, ô molle enchanteresse!</firstline>
+   <firstline>Je veux te raconter, ô molle enchanteresse !</firstline>
    <quality>korrektur1</quality>
 </head>
 <body>
 <poetry>
-Je veux te raconter, ô molle enchanteresse!
-Les diverses beautés qui parent ta jeunesse;
+Je veux te raconter, ô molle enchanteresse !
+Les diverses beautés qui parent ta jeunesse ;
 Je veux te peindre ta beauté,
 Où l'enfance s'allie à la maturité.
 
@@ -2288,24 +2288,24 @@ Chargé de toile, et va roulant
 Suivant un rhythme doux, et paresseux, et lent.
 
 Sur ton cou large et rond, sur tes épaules grasses,
-Ta tête se pavane avec d'étranges grâces;
+Ta tête se pavane avec d'étranges grâces ;
 D'un air placide et triomphant
 Tu passes ton chemin, majestueuse enfant.
 
-Je veux te raconter, ô molle enchanteresse!
-Les diverses beautés qui parent ta jeunesse;
+Je veux te raconter, ô molle enchanteresse !
+Les diverses beautés qui parent ta jeunesse ;
 Je veux te peindre ta beauté,
 Où l'enfance s'allie à la maturité.
 
 Ta gorge qui s'avance et qui pousse la moire,
 Ta gorge triomphante est une belle armoire
 Dont les panneaux bombés et clairs
-Comme les boucliers accrochent des éclairs;
+Comme les boucliers accrochent des éclairs ;
 
-Boucliers provoquants, armés de pointes roses!
+Boucliers provoquants, armés de pointes roses !
 Armoire à doux secrets, pleine de bonnes choses,
 De vins, de parfums, de liqueurs
-Qui feraient délirer les cerveaux et les coeurs!
+Qui feraient délirer les cerveaux et les coeurs !
 
 Quand tu vas balayant l'air de ta jupe large
 Tu fais l'effet d'un beau vaisseau qui prend le large,
@@ -2323,7 +2323,7 @@ Faits pour serrer obstinément,
 Comme pour l'imprimer dans ton coeur, ton amant.
 
 Sur ton cou large et rond, sur tes épaules grasses,
-Ta tête se pavane avec d'étranges grâces;
+Ta tête se pavane avec d'étranges grâces ;
 D'un air placide et triomphant
 Tu passes ton chemin, majestueuse enfant.
 </poetry>
@@ -2343,10 +2343,10 @@ Tu passes ton chemin, majestueuse enfant.
 Mon enfant, ma soeur,
 Songe à la douceur
 D'aller là-bas
-vivre ensemble!
+vivre ensemble !
 Aimer à loisir,
 Aimer et mourir
-Au pays qui te ressemble!
+Au pays qui te ressemble !
 Les soleils mouillés
 De ces ciels brouillés
 Pour mon esprit ont les charmes
@@ -2359,7 +2359,7 @@ Luxe, calme et volupté.
 
 Des meubles luisants,
 Polis par les ans,
-Décoreraient notre chambre;
+Décoreraient notre chambre ;
 Les plus rares fleurs
 Mêlant leurs odeurs
 Aux vagues senteurs de l'ambre,
@@ -2375,14 +2375,14 @@ Luxe, calme et volupté.
 
 Vois sur ces canaux
 Dormir ces vaisseaux
-Dont l'humeur est vagabonde;
+Dont l'humeur est vagabonde ;
 C'est pour assouvir
 Ton moindre désir
 Qu'ils viennent du bout du monde.
 Les soleils couchants
 Revêtent les champs,
 Les canaux, la ville entière,
-D'hyacinthe et d'or;
+D'hyacinthe et d'or ;
 Le monde s'endort
 Dans une chaude lumière.
 
@@ -2405,62 +2405,62 @@ Luxe, calme et volupté.
 Pouvons-nous étouffer le vieux, le long Remords,
 Qui vit, s'agite et se tortille
 Et se nourrit de nous comme le ver des morts,
-Comme du chêne la chenille?
-Pouvons-nous étouffer l'implacable Remords?
+Comme du chêne la chenille ?
+Pouvons-nous étouffer l'implacable Remords ?
 
 Dans quel philtre, dans quel vin, dans quelle tisane,
 Noierons-nous ce vieil ennemi,
 Destructeur et gourmand comme la courtisane,
-Patient comme la fourmi?
-Dans quel philtre? - dans quel vin? - dans quelle tisane?
+Patient comme la fourmi ?
+Dans quel philtre ? - dans quel vin ? - dans quelle tisane ?
 
-Dis-le, belle sorcière, oh! dis, si tu le sais,
+Dis-le, belle sorcière, oh ! dis, si tu le sais,
 A cet esprit comblé d'angoisse
 Et pareil au mourant qu'écrasent les blessés,
 Que le sabot du cheval froisse,
-Dis-le, belle sorcière, oh! dis, si tu le sais,
+Dis-le, belle sorcière, oh ! dis, si tu le sais,
 
 A cet agonisant que le loup déjà flaire
 Et que surveille le corbeau,
-A ce soldat brisé! s'il faut qu'il désespère
-D'avoir sa croix et son tombeau;
-Ce pauvre agonisant que déjà le loup flaire!
+A ce soldat brisé ! s'il faut qu'il désespère
+D'avoir sa croix et son tombeau ;
+Ce pauvre agonisant que déjà le loup flaire !
 
-Peut-on illuminer un ciel bourbeux et noir?
+Peut-on illuminer un ciel bourbeux et noir ?
 Peut-on déchirer des ténèbres
 Plus denses que la poix, sans matin et sans soir,
-Sans astres, sans éclairs funèbres?
-Peut-on illuminer un ciel bourbeux et noir?
+Sans astres, sans éclairs funèbres ?
+Peut-on illuminer un ciel bourbeux et noir ?
 
 L'Espérance qui brille aux carreaux de l'Auberge
-Est soufflée, est morte à jamais!
+Est soufflée, est morte à jamais !
 Sans lune et sans rayons, trouver où l'on héberge
-Les martyrs d'un chemin mauvais!
-Le Diable a tout éteint aux carreaux de l'Auberge!
+Les martyrs d'un chemin mauvais !
+Le Diable a tout éteint aux carreaux de l'Auberge !
 
-Adorable sorcière, aimes-tu les damnés?
-Dis, connais-tu l'irrémissible?
+Adorable sorcière, aimes-tu les damnés ?
+Dis, connais-tu l'irrémissible ?
 Connais-tu le Remords, aux traits empoisonnés,
-A qui notre coeur sert de cible?
-Adorable sorcière, aimes-tu les damnés?
+A qui notre coeur sert de cible ?
+Adorable sorcière, aimes-tu les damnés ?
 
 L'Irréparable ronge avec sa dent maudite
 Notre âme, piteux monument,
 Et souvent il attaque ainsi que le termite,
 Par la base le bâtiment.
-L'Irréparable ronge avec sa dent maudite!
+L'Irréparable ronge avec sa dent maudite !
 
 - J'ai vu parfois, au fond d'un théâtre banal
 Qu'enflammait l'orchestre sonore,
 Une fée allumer dans un ciel infernal
-Une miraculeuse aurore;
+Une miraculeuse aurore ;
 J'ai vu parfois au fond d'un théâtre banal
 
 Un être, qui n'était que lumière, or et gaze,
-Terrasser l'énorme Satan;
+Terrasser l'énorme Satan ;
 Mais mon coeur, que jamais ne visite l'extase,
 Est un théâtre où l'on attend
-Toujours. toujours en vain, l'Etre aux ailes de gaze!
+Toujours. toujours en vain, l'Etre aux ailes de gaze !
 </poetry>
 </body>
 </text>
@@ -2470,29 +2470,29 @@ Toujours. toujours en vain, l'Etre aux ailes de gaze!
    <title>Causerie</title>
    <toctitle>Causerie</toctitle>
    <indextitle>Causerie</indextitle>
-   <firstline>Vous êtes un beau ciel d'automne, clair et rose!</firstline>
+   <firstline>Vous êtes un beau ciel d'automne, clair et rose !</firstline>
    <quality>korrektur1</quality>
    <keywords>sonnet</keywords>
 </head>
 <body>
 <poetry>
-Vous êtes un beau ciel d'automne, clair et rose!
+Vous êtes un beau ciel d'automne, clair et rose !
 Mais la tristesse en moi monte comme la mer,
 Et laisse, en refluant, sur ma lèvre morose
 Le souvenir cuisant de son limon amer.
 
-- Ta main se glisse en vain sur mon sein qui se pâme;
+- Ta main se glisse en vain sur mon sein qui se pâme ;
 Ce qu'elle cherche, amie, est un lieu saccagé
 Par la griffe et la dent féroce de la femme.
-Ne cherchez plus mon coeur; les bêtes l'ont mangé.
+Ne cherchez plus mon coeur ; les bêtes l'ont mangé.
 
-Mon coeur est un palais flétri par la cohue;
-On s'y soûle, on s'y tue, on s'y prend aux cheveux!
-- Un parfum nage autour de votre gorge nue!...
+Mon coeur est un palais flétri par la cohue ;
+On s'y soûle, on s'y tue, on s'y prend aux cheveux !
+- Un parfum nage autour de votre gorge nue !...
 
-O Beauté, dur fléau des âmes, tu le veux!
+O Beauté, dur fléau des âmes, tu le veux !
 Avec tes yeux de feu, brillants comme des fêtes,
-Calcine ces lambeaux qu'ont épargnés les bêtes!
+Calcine ces lambeaux qu'ont épargnés les bêtes !
 </poetry>
 </body>
 </text>
@@ -2509,12 +2509,12 @@ Calcine ces lambeaux qu'ont épargnés les bêtes!
 <poetry>
       I
 
-Bientôt nous plongerons dans les froides ténèbres;
-Adieu, vive clarté de nos étés trop courts!
+Bientôt nous plongerons dans les froides ténèbres ;
+Adieu, vive clarté de nos étés trop courts !
 J'entends déjà tomber avec des chocs funèbres
 Le bois retentissant sur le pavé des cours.
 
-Tout l'hiver va rentrer dans mon être: colère,
+Tout l'hiver va rentrer dans mon être : colère,
 Haine, frissons, horreur, labeur dur et forcé,
 Et, comme le soleil dans son enfer polaire,
 Mon coeur ne sera plus qu'un bloc rouge et glacé.
@@ -2526,7 +2526,7 @@ Sous les coups du bélier infatigable et lourd.
 
 Il me semble, bercé par ce choc monotone,
 Qu'on cloue en grande hâte un cercueil quelque part.
-Pour qui? - C'était hier l'été; voici l'automne!
+Pour qui ? - C'était hier l'été ; voici l'automne !
 Ce bruit mystérieux sonne comme un départ.
 
      II
@@ -2536,15 +2536,15 @@ Douce beauté, mais tout aujourd'hui m'est amer,
 Et rien, ni votre amour, ni le boudoir, ni l'âtre,
 Ne me vaut le soleil rayonnant sur la mer.
 
-Et pourtant aimez-moi, tendre coeur! soyez mère,
-Même pour un ingrat, même pour un méchant;
+Et pourtant aimez-moi, tendre coeur ! soyez mère,
+Même pour un ingrat, même pour un méchant ;
 Amante ou soeur, soyez la douceur éphémère
 D'un glorieux automne ou d'un soleil couchant.
 
-Courte tâche! La tombe attend - elle est avide!
-Ah! laissez-moi, mon front posé sur vos genoux,
+Courte tâche ! La tombe attend - elle est avide !
+Ah ! laissez-moi, mon front posé sur vos genoux,
 Goûter, en regrettant l'été blanc et torride,
-De l'arrière-saison le rayon jaune et doux!
+De l'arrière-saison le rayon jaune et doux !
 </poetry>
 </body>
 </text>
@@ -2568,12 +2568,12 @@ Une niche, d'azur et d'or tout émaillée,
 Où tu te dresseras, Statue émerveillée.
 Avec mes Vers polis, treillis d'un pur métal
 Savamment constellé de rimes de cristal
-Je ferai pour ta tête une énorme Couronne;
+Je ferai pour ta tête une énorme Couronne ;
 Et dans ma Jalousie, ô mortelle Madone
 Je saurai te tailler un Manteau, de façon
 Barbare, roide et lourd, et doublé de soupçon,
 Qui, comme une guérite, enfermera tes charmes,
-Non de Perles brodé, mais de toutes mes Larmes!
+Non de Perles brodé, mais de toutes mes Larmes !
 Ta Robe, ce sera mon Désir, frémissant,
 Onduleux, mon Désir qui monte et qui descend,
 Aux pointes se balance, aux vallons se repose,
@@ -2591,7 +2591,7 @@ Ce monstre tout gonflé de haine et de crachats.
 Tu verras mes Pensers, rangés comme les Cierges
 Devant l'autel fleuri de la Reine des Vierges
 Etoilant de reflets le plafond peint en bleu,
-Te regarder toujours avec des yeux de feu;
+Te regarder toujours avec des yeux de feu ;
 Et comme tout en moi te chérit et t'admire,
 Tout se fera Benjoin, Encens, Oliban, Myrrhe,
 Et sans cesse vers toi, sommet blanc et neigeux,
@@ -2599,12 +2599,12 @@ En Vapeurs montera mon Esprit orageux.
 
 Enfin, pour compléter ton rôle de Marie,
 Et pour mêler l'amour avec la barbarie,
-Volupté noire! des sept Péchés capitaux,
+Volupté noire ! des sept Péchés capitaux,
 Bourreau plein de remords, je ferai sept Couteaux
 Bien affilés, et comme un jongleur insensible,
 Prenant le plus profond de ton amour pour cible,
 Je les planterai tous dans ton Coeur pantelant,
-Dans ton Coeur sanglotant, dans ton Coeur ruisselant!
+Dans ton Coeur sanglotant, dans ton Coeur ruisselant !
 </poetry>
 </body>
 </text>
@@ -2625,7 +2625,7 @@ Qui n'est pas celui d'un ange,
 Sorcière aux yeux alléchants,
 
 Je t'adore, ô ma frivole,
-Ma terrible passion!
+Ma terrible passion !
 Avec la dévotion
 Du prêtre pour son idole.
 
@@ -2635,14 +2635,14 @@ Ta tête a les attitudes
 De l'énigme et du secret.
 
 Sur ta chair le parfum rôde
-Comme autour d'un encensoir;
+Comme autour d'un encensoir ;
 Tu charmes comme le soir
 Nymphe ténébreuse et chaude.
 
-Ah! les philtres les plus forts
+Ah ! les philtres les plus forts
 Ne valent pas ta paresse,
 Et tu connais la caresse
-Ou fait revivre les morts!
+Ou fait revivre les morts !
 
 Tes hanches sont amoureuses
 De ton dos et de tes seins,
@@ -2652,7 +2652,7 @@ Par tes poses langoureuses.
 Quelquefois, pour apaiser
 Ta rage mystérieuse,
 Tu prodigues, sérieuse,
-La morsure et le baiser;
+La morsure et le baiser ;
 
 Tu me déchires, ma brune,
 Avec un rire moqueur,
@@ -2665,9 +2665,9 @@ Moi, je mets ma grande joie,
 Mon génie et mon destin,
 
 Mon âme par toi guérie,
-Par toi, lumière et couleur!
+Par toi, lumière et couleur !
 Explosion de chaleur
-Dans ma noire Sibérie!
+Dans ma noire Sibérie !
 </poetry>
 </body>
 </text>
@@ -2686,15 +2686,15 @@ Dans ma noire Sibérie!
 Imaginez Diane en galant équipage,
 Parcourant les forêts ou battant les halliers,
 Cheveux et gorge au vent, s'enivrant de tapage,
-Superbe et défiant les meilleurs cavaliers!
+Superbe et défiant les meilleurs cavaliers !
 
 Avez-vous vu Théroigne, amante du carnage,
 Excitant à l'assaut un peuple sans souliers,
 La joue et l'oeil en feu, jouant son personnage,
-Et montant, sabre au poing, les royaux escaliers?
+Et montant, sabre au poing, les royaux escaliers ?
 
-Telle la Sisina! Mais la douce guerrière
-A l'âme charitable autant que meurtrière;
+Telle la Sisina ! Mais la douce guerrière
+A l'âme charitable autant que meurtrière ;
 Son courage, affolé de poudre et de tambours,
 
 Devant les suppliants sait mettre bas les armes,
@@ -2720,7 +2720,7 @@ In solitudine cordis.
 
 Esto sertis implicata,
 O femina delicata
-Per quam solvuntur peccata!
+Per quam solvuntur peccata !
 
 Sicut beneficum Lethe,
 Hauriam oscula de te,
@@ -2732,14 +2732,14 @@ Apparuisti, Deitas,
 
 Velut stella salutaris
 In naufragiis amaris.....
-Suspendam cor tuis aris!
+Suspendam cor tuis aris !
 
 Piscina plena virtutis,
 Fons æternæ juventutis
-Labris vocem redde mutis!
+Labris vocem redde mutis !
 
-Quod erat spurcum, cremasti;
-Quod rudius, exaequasti;
+Quod erat spurcum, cremasti ;
+Quod rudius, exaequasti ;
 Quod debile, confirmasti.
 
 In fame mea taberna
@@ -2748,15 +2748,15 @@ Recte me semper guberna.
 
 Adde nunc vires viribus,
 Dulce balneum suavibus
-Unguentatum odoribus!
+Unguentatum odoribus !
 
 Meos circa lumbos mica,
 O castitatis lorica,
-Aqua tincta seraphica;
+Aqua tincta seraphica ;
 
 Patera gemmis corusca,
 Panis salsus, mollis esca,
-Divinum vinum, Francisca!
+Divinum vinum, Francisca !
 </poetry>
 </body>
 </text>
@@ -2777,8 +2777,8 @@ J'ai connu, sous un dais d'arbres tout empourprés
 Et de palmiers d'où pleut sur les yeux la paresse,
 Une dame créole aux charmes ignorés.
 
-Son teint est pâle et chaud; la brune enchanteresse
-A dans le cou des airs noblement maniérés;
+Son teint est pâle et chaud ; la brune enchanteresse
+A dans le cou des airs noblement maniérés ;
 Grande et svelte en marchant comme une chasseresse,
 Son sourire est tranquille et ses yeux assurés.
 
@@ -2806,26 +2806,26 @@ Que vos grands yeux rendraient plus soumis que vos noirs.
 Dis-moi ton coeur parfois s'envole-t-il, Agathe,
 Loin du noir océan de l'immonde cité
 Vers un autre océan où la splendeur éclate,
-Bleu, clair, profond, ainsi que la virginité?
-Dis-moi, ton coeur parfois s'envole-t-il, Agathe?
+Bleu, clair, profond, ainsi que la virginité ?
+Dis-moi, ton coeur parfois s'envole-t-il, Agathe ?
 
-La mer la vaste mer, console nos labeurs!
+La mer la vaste mer, console nos labeurs !
 Quel démon a doté la mer, rauque chanteuse
 Qu'accompagne l'immense orgue des vents grondeurs,
-De cette fonction sublime de berceuse?
-La mer, la vaste mer, console nos labeurs!
+De cette fonction sublime de berceuse ?
+La mer, la vaste mer, console nos labeurs !
 
-Emporte-moi wagon! enlève-moi, frégate!
-Loin! loin! ici la boue est faite de nos pleurs!
+Emporte-moi wagon ! enlève-moi, frégate !
+Loin ! loin ! ici la boue est faite de nos pleurs !
 - Est-il vrai que parfois le triste coeur d'Agathe
-Dise: Loin des remords, des crimes, des douleurs,
-Emporte-moi, wagon, enlève-moi, frégate?
+Dise : Loin des remords, des crimes, des douleurs,
+Emporte-moi, wagon, enlève-moi, frégate ?
 
 Comme vous êtes loin, paradis parfumé,
 Où sous un clair azur tout n'est qu'amour et joie,
 Où tout ce que l'on aime est digne d'être aimé,
-Où dans la volupté pure le coeur se noie!
-Comme vous êtes loin, paradis parfumé!
+Où dans la volupté pure le coeur se noie !
+Comme vous êtes loin, paradis parfumé !
 
 Mais le vert paradis des amours enfantines,
 Les courses, les chansons, les baisers, les bouquets,
@@ -2834,10 +2834,10 @@ Avec les brocs de vin, le soir, dans les bosquets,
 - Mais le vert paradis des amours enfantines,
 
 L'innocent paradis, plein de plaisirs furtifs,
-Est-il déjà plus loin que l'Inde et que la Chine?
+Est-il déjà plus loin que l'Inde et que la Chine ?
 Peut-on le rappeler avec des cris plaintifs,
 Et l'animer encor d'une voix argentine,
-L'innocent paradis plein de plaisirs furtifs?
+L'innocent paradis plein de plaisirs furtifs ?
 </poetry>
 </body>
 </text>
@@ -2855,7 +2855,7 @@ L'innocent paradis plein de plaisirs furtifs?
 Comme les anges à l'oeil fauve,
 Je reviendrai dans ton alcôve
 Et vers toi glisserai sans bruit
-Avec les ombres de la nuit;
+Avec les ombres de la nuit ;
 
 Et je te donnerai, ma brune,
 Des baisers froids comme la lune
@@ -2884,23 +2884,23 @@ Moi, je veux régner par l'effroi.
 </head>
 <body>
 <poetry>
-Ils me disent, tes yeux, clairs comme le cristal:
-"Pour toi, bizarre amant, quel est donc mon mérite?"
-- Sois charmante et tais-toi! Mon coeur, que tout irrite,
+Ils me disent, tes yeux, clairs comme le cristal :
+"Pour toi, bizarre amant, quel est donc mon mérite ?"
+- Sois charmante et tais-toi ! Mon coeur, que tout irrite,
 Excepté la candeur de l'antique animal,
 
 Ne veut pas te montrer son secret infernal,
 Berceuse dont la main aux longs sommeils m'invite,
 Ni sa noire légende avec la flamme écrite.
-Je hais la passion et l'esprit me fait mal!
+Je hais la passion et l'esprit me fait mal !
 
 Aimons-nous doucement. L'Amour dans sa guérite,
 Ténébreux, embusqué, bande son arc fatal.
-Je connais les engins de son vieil arsenal:
+Je connais les engins de son vieil arsenal :
 
-Crime, horreur et folie! - O pâle marguerite!
+Crime, horreur et folie ! - O pâle marguerite !
 Comme moi n'es-tu pas un soleil automnal,
-O ma si blanche, ô ma si froide Marguerite?
+O ma si blanche, ô ma si froide Marguerite ?
 </poetry>
 </body>
 </text>
@@ -2916,7 +2916,7 @@ O ma si blanche, ô ma si froide Marguerite?
 </head>
 <body>
 <poetry>
-Ce soir, la lune rêve avec plus de paresse;
+Ce soir, la lune rêve avec plus de paresse ;
 Ainsi qu'une beauté, sur de nombreux coussins,
 Qui d'une main distraite et légère caresse
 Avant de s'endormir le contour de ses seins,
@@ -2954,13 +2954,13 @@ Les chats puissants et doux, orgueil de la maison,
 Qui comme eux sont frileux et comme eux sédentaires.
 
 Amis de la science et de la volupté
-Ils cherchent le silence et l'horreur des ténèbres;
+Ils cherchent le silence et l'horreur des ténèbres ;
 L'Erèbe les eût pris pour ses coursiers funèbres,
 S'ils pouvaient au servage incliner leur fierté.
 
 Ils prennent en songeant les nobles attitudes
 Des grands sphinx allongés au fond des solitudes,
-Qui semblent s'endormir dans un rêve sans fin;
+Qui semblent s'endormir dans un rêve sans fin ;
 
 Leurs reins féconds sont pleins d'étincelles magiques,
 Et des parcelles d'or, ainsi qu'un sable fin,
@@ -2991,7 +2991,7 @@ Les ténèbres s'établiront.
 
 Leur attitude au sage enseigne
 Qu'il faut en ce monde qu'il craigne
-Le tumulte et le mouvement;
+Le tumulte et le mouvement ;
 
 L'homme ivre d'une ombre qui passe
 Porte toujours le châtiment
@@ -3010,7 +3010,7 @@ D'avoir voulu changer de place.
 </head>
 <body>
 <poetry>
-Je suis la pipe d'un auteur;
+Je suis la pipe d'un auteur ;
 On voit, à contempler ma mine
 D'Abyssinienne ou de Cafrine,
 Que mon maître est un grand fumeur.
@@ -3036,28 +3036,28 @@ De ses fatigues son esprit.
    <title>La Musique</title>
    <toctitle>La Musique</toctitle>
    <indextitle>La Musique</indextitle>
-   <firstline>La musique souvent me prend comme une mer!</firstline>
+   <firstline>La musique souvent me prend comme une mer !</firstline>
    <quality>korrektur1</quality>
 </head>
 <body>
 <poetry>
-La musique souvent me prend comme une mer!
+La musique souvent me prend comme une mer !
 Vers ma pâle étoile,
 Sous un plafond de brume ou dans un vaste éther,
-Je mets à la voile;
+Je mets à la voile ;
 
 La poitrine en avant et les poumons gonflés
 Comme de la toile
 J'escalade le dos des flots amoncelés
-Que la nuit me voile;
+Que la nuit me voile ;
 
 Je sens vibrer en moi toutes les passions
-D'un vaisseau qui souffre;
+D'un vaisseau qui souffre ;
 Le bon vent, la tempête et ses convulsions
 
 Sur l'immense gouffre
 Me bercent. D'autres fois, calme plat, grand miroir
-De mon désespoir!
+De mon désespoir !
 </poetry>
 </body>
 </text>
@@ -3081,7 +3081,7 @@ Enterre votre corps vanté,
 A l'heure où les chastes étoiles
 Ferment leurs yeux appesantis,
 L'araignée y fera ses toiles,
-Et la vipère ses petits;
+Et la vipère ses petits ;
 
 Vous entendrez toute l'année
 Sur votre tête condamnée
@@ -3138,18 +3138,18 @@ Je veux creuser moi-même une fosse profonde,
 Où je puisse à loisir étaler mes vieux os
 Et dormir dans l'oubli comme un requin dans l'onde.
 
-Je hais les testaments et je hais les tombeaux;
+Je hais les testaments et je hais les tombeaux ;
 Plutôt que d'implorer une larme du monde,
 Vivant, j'aimerais mieux inviter les corbeaux
 A saigner tous les bouts de ma carcasse immonde.
 
-O vers! noirs compagnons sans oreille et sans yeux,
-Voyez venir à vous un mort libre et joyeux;
+O vers ! noirs compagnons sans oreille et sans yeux,
+Voyez venir à vous un mort libre et joyeux ;
 Philosophes viveurs, fils de la pourriture,
 
 A travers ma ruine allez donc sans remords,
 Et dites-moi s'il est encor quelque torture
-Pour ce vieux corps sans âme et mort parmi les morts!
+Pour ce vieux corps sans âme et mort parmi les morts !
 </poetry>
 </body>
 </text>
@@ -3165,7 +3165,7 @@ Pour ce vieux corps sans âme et mort parmi les morts!
 </head>
 <body>
 <poetry>
-La Haine est le tonneau des pâles Danaïdes;
+La Haine est le tonneau des pâles Danaïdes ;
 La Vengeance éperdue aux bras rouges et forts
 A beau précipiter dans ses ténèbres vides
 De grands seaux pleins du sang et des larmes des morts,
@@ -3205,7 +3205,7 @@ Au bruit des carillons qui chantent dans la brume.
 Bienheureuse la cloche au gosier vigoureux
 Qui, malgré sa vieillesse, alerte et bien portante,
 Jette fidèlement son cri religieux,
-Ainsi qu'un vieux soldat qui veille sous la tente!
+Ainsi qu'un vieux soldat qui veille sous la tente !
 
 Moi, mon âme est fêlée, et lorsqu'en ses ennuis
 Elle veut de ses chants peupler l'air froid des nuits,
@@ -3235,7 +3235,7 @@ Aux pâles habitants du voisin cimetière
 Et la mortalité sur les faubourgs brumeux.
 
 Mon chat sur le carreau cherchant une litière
-Agite sans repos son corps maigre et galeux;
+Agite sans repos son corps maigre et galeux ;
 L'âme d'un vieux poète erre dans la gouttière
 Avec la triste voix d'un fantôme frileux.
 
@@ -3280,7 +3280,7 @@ Rien n'égale en longueur les boiteuses journées,
 Quand sous les lourds flocons des neigeuses années
 L'ennui, fruit de la morne incuriosité
 Prend les proportions de l'immortalité.
-- Désormais tu n'es plus, ô matière vivante!
+- Désormais tu n'es plus, ô matière vivante !
 Qu'un granit entouré d'une vague épouvante,
 Assoupi dans le fond d'un Sahara brumeux
 Un vieux sphinx ignoré du monde insoucieux,
@@ -3307,7 +3307,7 @@ S'ennuie avec ses chiens comme avec d'autres bêtes.
 Rien ne peut l'égayer, ni gibier, ni faucon,
 Ni son peuple mourant en face du balcon.
 Du bouffon favori la grotesque ballade
-Ne distrait plus le front de ce cruel malade;
+Ne distrait plus le front de ce cruel malade ;
 Son lit fleurdelisé se transforme en tombeau,
 Et les dames d'atour, pour qui tout prince est beau,
 Ne savent plus trouver d'impudique toilette
@@ -3335,12 +3335,12 @@ Où coule au lieu de sang l'eau verte du Léthé
 Quand le ciel bas et lourd pèse comme un couvercle
 Sur l'esprit gémissant en proie aux longs ennuis,
 Et que de l'horizon embrassant tout le cercle
-Il nous verse un jour noir plus triste que les nuits;
+Il nous verse un jour noir plus triste que les nuits ;
 
 Quand la terre est changée en un cachot humide,
 Où l'Espérance, comme une chauve-souris,
 S'en va battant les murs de son aile timide
-Et se cognant la tête à des plafonds pourris;
+Et se cognant la tête à des plafonds pourris ;
 
 Quand la pluie étalant ses immenses traînées
 D'une vaste prison imite les barreaux,
@@ -3353,7 +3353,7 @@ Ainsi que des esprits errants et sans patrie
 Qui se mettent à geindre opiniâtrement.
 
 - Et de longs corbillards, sans tambours ni musique,
-Défilent lentement dans mon âme; l'Espoir,
+Défilent lentement dans mon âme ; l'Espoir,
 Vaincu, pleure, et l'Angoisse atroce, despotique,
 Sur mon crâne incliné plante son drapeau noir.
 </poetry>
@@ -3371,19 +3371,19 @@ Sur mon crâne incliné plante son drapeau noir.
 </head>
 <body>
 <poetry>
-Grands bois, vous m'effrayez comme des cathédrales;
-Vous hurlez comme l'orgue; et dans nos coeurs maudits,
+Grands bois, vous m'effrayez comme des cathédrales ;
+Vous hurlez comme l'orgue ; et dans nos coeurs maudits,
 Chambres d'éternel deuil où vibrent de vieux râles,
 Répondent les échos de vos De profundis.
 
-Je te hais, Océan! tes bonds et tes tumultes,
-Mon esprit les retrouve en lui; ce rire amer
+Je te hais, Océan ! tes bonds et tes tumultes,
+Mon esprit les retrouve en lui ; ce rire amer
 De l'homme vaincu, plein de sanglots et d'insultes,
 Je l'entends dans le rire énorme de la mer
 
-Comme tu me plairais, ô nuit! sans ces étoiles
-Dont la lumière parle un langage connu!
-Car je cherche le vide, et le noir, et le nu!
+Comme tu me plairais, ô nuit ! sans ces étoiles
+Dont la lumière parle un langage connu !
+Car je cherche le vide, et le noir, et le nu !
 
 Mais les ténèbres sont elles-mêmes des toiles
 Où vivent, jaillissant de mon oeil par milliers,
@@ -3404,24 +3404,24 @@ Des êtres disparus aux regards familiers.
 <poetry>
 Morne esprit, autrefois amoureux de la lutte,
 L'Espoir, dont l'éperon attisait ton ardeur
-Ne veut plus t'enfourcher! Couche-toi sans pudeur
+Ne veut plus t'enfourcher ! Couche-toi sans pudeur
 Vieux cheval dont le pied à chaque obstacle butte.
 
-Résigne-toi, mon coeur; dors ton sommeil de brute.
+Résigne-toi, mon coeur ; dors ton sommeil de brute.
 
-Esprit vaincu, fourbu! Pour toi, vieux maraudeur,
+Esprit vaincu, fourbu ! Pour toi, vieux maraudeur,
 L'amour n'a plus de goût, non plus que la dispute
-Adieu donc, chants du cuivre et soupirs de la flûte!
-Plaisirs, ne tentez plus un coeur sombre et boudeur!
+Adieu donc, chants du cuivre et soupirs de la flûte !
+Plaisirs, ne tentez plus un coeur sombre et boudeur !
 
-Le Printemps adorable a perdu son odeur!
+Le Printemps adorable a perdu son odeur !
 
 Et le Temps m'engloutit minute par minute
 Comme la neige immense un corps pris de roideur
 - Je contemple d'en haut le globe en sa rondeur
 Et je n'y cherche plus l'abri d'une cahute.
 
-Avalanche, veux-tu m'emporter dans ta chute?
+Avalanche, veux-tu m'emporter dans ta chute ?
 </poetry>
 </body>
 </text>
@@ -3437,17 +3437,17 @@ Avalanche, veux-tu m'emporter dans ta chute?
 <body>
 <poetry>
 L'un t'éclaire avec son ardeur,
-L'autre en toi met son deuil, Nature!
-Ce qui dit à l'un: Sépulture!
-Dit à l'autre: Vie et splendeur!
+L'autre en toi met son deuil, Nature !
+Ce qui dit à l'un : Sépulture !
+Dit à l'autre : Vie et splendeur !
 
 Hermès inconnu qui m'assistes
 Et qui toujours m'intimidas,
 Tu me rends l'égal de Midas,
-Le plus triste des alchimistes;
+Le plus triste des alchimistes ;
 
 Par toi je change l'or en fer
-Et le paradis en enfer;
+Et le paradis en enfer ;
 Dans le suaire des nuages
 
 Je découvre un cadavre cher,
@@ -3471,7 +3471,7 @@ Je bâtis de grands sarcophages.
 De ce ciel bizarre et livide,
 Tourmenté comme ton destin,
 Quels pensers dans ton âme vide
-Descendent? réponds, libertin.
+Descendent ? réponds, libertin.
 
 - Insatiablement avide
 De l'obscur et de l'incertain,
@@ -3479,7 +3479,7 @@ Je ne geindrai pas comme Ovide
 Chassé du paradis latin.
 
 Cieux déchirés comme des grèves
-En vous se mire mon orgueil;
+En vous se mire mon orgueil ;
 Vos vastes nuages en deuil
 
 Sont les corbillards de mes rêves,
@@ -3513,27 +3513,27 @@ Sur tes pleurs salés nagera
 Comme un vaisseau qui prend le large,
 Et dans mon coeur qu'ils soûleront
 Tes chers sanglots retentiront
-Comme un tambour qui bat la charge!
+Comme un tambour qui bat la charge !
 
 Ne suis-je pas un faux accord
 Dans la divine symphonie,
 Grâce à la vorace Ironie
 Qui me secoue et qui me mord
 
-Elle est dans ma voix, la criarde!
-C'est tout mon sang ce poison noir!
+Elle est dans ma voix, la criarde !
+C'est tout mon sang ce poison noir !
 Je suis le sinistre miroir
 Où la mégère se regarde.
 
-Je suis la plaie et le couteau!
-Je suis le soufflet et la joue!
+Je suis la plaie et le couteau !
+Je suis le soufflet et la joue !
 Je suis les membres et la roue,
-Et la victime et le bourreau!
+Et la victime et le bourreau !
 
 Je suis de mon coeur le vampire,
 - Un de ces grands abandonnés
 Au rire éternel condamnés
-Et qui ne peuvent plus sourire!
+Et qui ne peuvent plus sourire !
 </poetry>
 </body>
 </text>
@@ -3553,22 +3553,22 @@ Et qui ne peuvent plus sourire!
 Une Idée, une Forme, un Etre
 Parti de l'azur et tombé
 Dans un Styx bourbeux et plombé
-Où nul oeil du Ciel ne pénètre;
+Où nul oeil du Ciel ne pénètre ;
 
 Un Ange, imprudent voyageur
 Qu'a tenté l'amour du difforme,
 Au fond d'un cauchemar énorme
 Se débattant comme un nageur,
 
-Et luttant, angoisses funèbres!
+Et luttant, angoisses funèbres !
 Contre un gigantesque remous
 Qui va chantant comme les fous
-Et pirouettant dans les ténèbres;
+Et pirouettant dans les ténèbres ;
 
 Un malheureux ensorcelé
 Dans ses tâtonnements futiles
 Pour fuir d'un lieu plein de reptiles,
-Cherchant la lumière et la clé;
+Cherchant la lumière et la clé ;
 
 Un damné descendant sans lampe
 Au bord d'un gouffre dont l'odeur
@@ -3578,29 +3578,29 @@ D'éternels escaliers sans rampe,
 Où veillent des monstres visqueux
 Dont les larges yeux de phosphore
 Font une nuit plus noire encore
-Et ne rendent visibles qu'eux;
+Et ne rendent visibles qu'eux ;
 
 Un navire pris dans le pôle
 Comme en un piège de cristal,
 Cherchant par quel détroit fatal
-Il est tombé dans cette geôle;
+Il est tombé dans cette geôle ;
 
 - Emblèmes nets, tableau parfait
 D'une fortune irrémédiable
 Qui donne à penser que le Diable
-Fait toujours bien tout ce qu'il fait!
+Fait toujours bien tout ce qu'il fait !
 
      II
 
 Tête-à-tête sombre et limpide
-Qu'un coeur devenu son miroir!
+Qu'un coeur devenu son miroir !
 Puits de Vérité, clair et noir
 Où tremble une étoile livide,
 
 Un phare ironique, infernal
 Flambeau des grâces sataniques,
 Soulagement et gloire uniques,
-- La conscience dans le Mal!
+- La conscience dans le Mal !
 </poetry>
 </body>
 </text>
@@ -3610,40 +3610,40 @@ Soulagement et gloire uniques,
    <title>L'Horloge</title>
    <toctitle>L'Horloge</toctitle>
    <indextitle>L'Horloge</indextitle>
-   <firstline>Horloge! dieu sinistre, effrayant, impassible</firstline>
+   <firstline>Horloge ! dieu sinistre, effrayant, impassible</firstline>
    <quality>korrektur1</quality>
 </head>
 <body>
 <poetry>
-Horloge! dieu sinistre, effrayant, impassible,
-Dont le doigt nous menace et nous dit: Souviens-toi!
+Horloge ! dieu sinistre, effrayant, impassible,
+Dont le doigt nous menace et nous dit : Souviens-toi !
 Les vibrantes Douleurs dans ton coeur plein d'effroi
-Se planteront bientôt comme dans une cible;
+Se planteront bientôt comme dans une cible ;
 
 Le Plaisir vaporeux fuira vers l'horizon
-Ainsi qu'une sylphide au fond de la coulisse;
+Ainsi qu'une sylphide au fond de la coulisse ;
 Chaque instant te dévore un morceau du délice
 A chaque homme accordé pour toute sa saison.
 
 Trois mille six cents fois par heure, la Seconde
-Chuchote Souviens-toi! - Rapide, avec sa voix
+Chuchote Souviens-toi ! - Rapide, avec sa voix
 D'insecte, Maintenant dit Je suis Autrefois,
-Et j'ai pompé ta vie avec ma trompe immonde!
+Et j'ai pompé ta vie avec ma trompe immonde !
 
-Remember! Souviens-toi! prodigue! Esto memor!
+Remember ! Souviens-toi ! prodigue ! Esto memor !
 (Mon gosier de métal parle toutes les langues)
 Les minutes, mortel folâtre, sont des gangues
-Qu'il ne faut pas lâcher sans en extraire l'or!
+Qu'il ne faut pas lâcher sans en extraire l'or !
 
 Souviens-toi que le Temps est un joueur avide
-Qui gagne sans tricher, à tout coup! c'est la loi
-Le jour décroît; la nuit augmente, souviens-toi!
-Le gouffre a toujours soif; la clepsydre se vide.
+Qui gagne sans tricher, à tout coup ! c'est la loi
+Le jour décroît ; la nuit augmente, souviens-toi !
+Le gouffre a toujours soif ; la clepsydre se vide.
 
 Tantôt sonnera l'heure où le divin Hasard,
 Où l'auguste Vertu, ton épouse encor vierge,
-Où le Repentir même (oh! la dernière auberge!),
-Où tout te dira Meurs, vieux lâche! il est trop tard!
+Où le Repentir même (oh ! la dernière auberge !),
+Où tout te dira Meurs, vieux lâche ! il est trop tard !
 </poetry>
 </body>
 </text>
@@ -3671,7 +3671,7 @@ Coucher auprès du ciel, comme les astrologues,
 Et, voisin des clochers écouter en rêvant
 Leurs hymnes solennels emportés par le vent.
 Les deux mains au menton, du haut de ma mansarde,
-Je verrai l'atelier qui chante et qui bavarde;
+Je verrai l'atelier qui chante et qui bavarde ;
 Les tuyaux, les clochers, ces mâts de la cité,
 Et les grands ciels qui font rêver d'éternité.
 
@@ -3679,7 +3679,7 @@ Il est doux, à travers les brumes, de voir naître
 L'étoile dans l'azur, la lampe à la fenêtre
 Les fleuves de charbon monter au firmament
 Et la lune verser son pâle enchantement.
-Je verrai les printemps, les étés, les automnes;
+Je verrai les printemps, les étés, les automnes ;
 Et quand viendra l'hiver aux neiges monotones,
 Je fermerai partout portières et volets
 Pour bâtir dans la nuit mes féeriques palais.
@@ -3689,7 +3689,7 @@ Des jardins, des jets d'eau pleurant dans les albâtres,
 Des baisers, des oiseaux chantant soir et matin,
 Et tout ce que l'Idylle a de plus enfantin.
 L'Emeute, tempêtant vainement à ma vitre,
-Ne fera pas lever mon front de mon pupitre;
+Ne fera pas lever mon front de mon pupitre ;
 Car je serai plongé dans cette volupté
 D'évoquer le Printemps avec ma volonté,
 De tirer un soleil de mon coeur, et de faire
@@ -3718,13 +3718,13 @@ Trébuchant sur les mots comme sur les pavés
 Heurtant parfois des vers depuis longtemps rêvés.
 
 Ce père nourricier, ennemi des chloroses,
-Eveille dans les champs les vers comme les roses;
+Eveille dans les champs les vers comme les roses ;
 Il fait s'évaporer les soucis vers le ciel,
 Et remplit les cerveaux et les ruches le miel.
 C'est lui qui rajeunit les porteurs de béquilles
 Et les rend gais et doux comme des jeunes filles,
 Et commande aux moissons de croître et de mûrir
-Dans le coeur immortel qui toujours veut fleurir!
+Dans le coeur immortel qui toujours veut fleurir !
 
 Quand, ainsi qu'un poète, il descend dans les villes,
 Il ennoblit le sort des choses les plus viles,
@@ -3762,17 +3762,17 @@ Tes sabots lourds.
 Au lieu d'un haillon trop court,
 Qu'un superbe habit de cour
 Traîne à plis bruyants et longs
-Sur tes talons;
+Sur tes talons ;
 
 En place de bas troués
 Que pour les yeux des roués
 Sur ta jambe un poignard d'or
-Reluise encor;
+Reluise encor ;
 
 Que des noeuds mal attachés
 Dévoilent pour nos péchés
 Tes deux beaux seins, radieux
-Comme des yeux;
+Comme des yeux ;
 
 Que pour te déshabiller
 Tes bras se fassent prier
@@ -3792,27 +3792,27 @@ Sous l'escalier,
 Maint page épris du hasard,
 Maint seigneur et maint Ronsard
 Epieraient pour le déduit
-Ton frais réduit!
+Ton frais réduit !
 
 Tu compterais dans tes lits
 Plus de baisers que de lis
 Et rangerais sous tes lois
-Plus d'un Valois!
+Plus d'un Valois !
 
 - Cependant tu vas gueusant
 Quelque vieux débris gisant
 Au seuil de quelque Véfour
-De carrefour;
+De carrefour ;
 
 Tu vas lorgnant en dessous
 Des bijoux de vingt-neuf sous
-Dont je ne puis, oh! Pardon!
+Dont je ne puis, oh ! Pardon !
 Te faire don.
 
 Va donc, sans autre ornement,
 Parfum, perles, diamant,
 Que ta maigre nudité,
-O ma beauté!
+O ma beauté !
 </poetry>
 </body>
 </text>
@@ -3823,14 +3823,14 @@ O ma beauté!
    <subtitle>A Victor Hugo</subtitle>
    <toctitle>Le Cygne</toctitle>
    <indextitle>Le Cygne</indextitle>
-   <firstline>Andromaque, je pense à vous! Ce petit fleuve</firstline>
+   <firstline>Andromaque, je pense à vous ! Ce petit fleuve</firstline>
    <quality>korrektur1</quality>
 </head>
 <body>
 <poetry>
       I
 
-Andromaque, je pense à vous! Ce petit fleuve,
+Andromaque, je pense à vous ! Ce petit fleuve,
 Pauvre et triste miroir où jadis resplendit
 L'immense majesté de vos douleurs de veuve,
 Ce Simoïs menteur qui par vos pleurs grandit,
@@ -3838,14 +3838,14 @@ Ce Simoïs menteur qui par vos pleurs grandit,
 A fécondé soudain ma mémoire fertile,
 Comme je traversais le nouveau Carrousel.
 Le vieux Paris n'est plus (la forme d'une ville
-Change plus vite, hélas! que le coeur d'un mortel);
+Change plus vite, hélas ! que le coeur d'un mortel) ;
 
 Je ne vois qu'en esprit tout ce camp de baraques,
 Ces tas de chapiteaux ébauchés et de fûts,
 Les herbes, les gros blocs verdis par l'eau des flaques,
 Et, brillant aux carreaux, le bric-à-brac confus.
 
-Là s'étalait jadis une ménagerie;
+Là s'étalait jadis une ménagerie ;
 Là je vis, un matin, à l'heure où sous les cieux
 Froids et clairs le Travail s'éveille, où la voirie
 Pousse un sombre ouragan dans l'air silencieux,
@@ -3856,46 +3856,46 @@ Sur le sol raboteux traînait son blanc plumage.
 Près d'un ruisseau sans eau la bête ouvrant le bec
 
 Baignait nerveusement ses ailes dans la poudre,
-Et disait, le coeur plein de son beau lac natal:
-"Eau, quand donc pleuvras-tu? quand tonneras-tu, foudre?"
+Et disait, le coeur plein de son beau lac natal :
+"Eau, quand donc pleuvras-tu ? quand tonneras-tu, foudre ?"
 Je vois ce malheureux, mythe étrange et fatal,
 
 Vers le ciel quelquefois, comme l'homme d'Ovide,
 Vers le ciel ironique et cruellement bleu,
 Sur son cou convulsif tendant sa tête avide
-Comme s'il adressait des reproches à Dieu!
+Comme s'il adressait des reproches à Dieu !
 
      II
 
-Paris change! mais rien dans ma mélancolie
-N'a bougé! palais neufs, échafaudages, blocs,
+Paris change ! mais rien dans ma mélancolie
+N'a bougé ! palais neufs, échafaudages, blocs,
 Vieux faubourgs, tout pour moi devient allégorie
 Et mes chers souvenirs sont plus lourds que des rocs.
 
-Aussi devant ce Louvre une image m'opprime:
+Aussi devant ce Louvre une image m'opprime :
 Je pense à mon grand cygne, avec ses gestes fous,
 Comme les exilés, ridicule et sublime
-Et rongé d'un désir sans trêve! et puis à vous,
+Et rongé d'un désir sans trêve ! et puis à vous,
 
 Andromaque, des bras d'un grand époux tombée,
 Vil bétail, sous la main du superbe Pyrrhus,
 Auprès d'un tombeau vide en extase courbée
-Veuve d'Hector, hélas! et femme d'Hélénus!
+Veuve d'Hector, hélas ! et femme d'Hélénus !
 
 Je pense à la négresse, amaigrie et phtisique
 Piétinant dans la boue, et cherchant, l'oeil hagard,
 Les cocotiers absents de la superbe Afrique
-Derrière la muraille immense du brouillard;
+Derrière la muraille immense du brouillard ;
 
 A quiconque a perdu ce qui ne se retrouve
-Jamais, jamais! à ceux qui s'abreuvent de pleurs
-Et tètent la Douleur comme une bonne louve!
-Aux maigres orphelins séchant comme des fleurs!
+Jamais, jamais ! à ceux qui s'abreuvent de pleurs
+Et tètent la Douleur comme une bonne louve !
+Aux maigres orphelins séchant comme des fleurs !
 
 Ainsi dans la forêt où mon esprit s'exile
-Un vieux Souvenir sonne à plein souffle du cor!
+Un vieux Souvenir sonne à plein souffle du cor !
 Je pense aux matelots oubliés dans une île,
-Aux captifs, aux vaincus!... à bien d'autres encor!
+Aux captifs, aux vaincus !... à bien d'autres encor !
 </poetry>
 </body>
 </text>
@@ -3912,7 +3912,7 @@ Aux captifs, aux vaincus!... à bien d'autres encor!
 <body>
 <poetry>
 Fourmillante cité, cité pleine de rêves,
-Où le spectre en plein jour raccroche le passant!
+Où le spectre en plein jour raccroche le passant !
 Les mystères partout coulent comme des sèves
 Dans les canaux étroits du colosse puissant.
 
@@ -3932,7 +3932,7 @@ Et dont l'aspect aurait fait pleuvoir les aumônes,
 Sans la méchanceté qui luisait dans ses yeux,
 
 M'apparut. On eût dit sa prunelle trempée
-Dans le fiel; son regard aiguisait les frimas,
+Dans le fiel ; son regard aiguisait les frimas,
 Et sa barbe à longs poils, roide comme une épée,
 Se projetait, pareille à celle de Judas.
 
@@ -3946,35 +3946,35 @@ Dans la neige et la boue il allait s'empêtrant,
 Comme s'il écrasait des morts sous ses savates,
 Hostile à l'univers plutôt qu'indifférent.
 
-Son pareil le suivait: barbe, oeil, dos, bâton, loques,
+Son pareil le suivait : barbe, oeil, dos, bâton, loques,
 Nul trait ne distinguait, du même enfer venu,
 Ce jumeau centenaire, et ces spectres baroques
 Marchaient du même pas vers un but inconnu.
 
 A quel complot infâme étais-je donc en butte,
-Ou quel méchant hasard ainsi m'humiliait?
+Ou quel méchant hasard ainsi m'humiliait ?
 Car je comptai sept fois, de minute en minute,
-Ce sinistre vieillard qui se multipliait!
+Ce sinistre vieillard qui se multipliait !
 
 Que celui-là qui rit de mon inquiétude
 Et qui n'est pas saisi d'un frisson fraternel
 Songe bien que malgré tant de décrépitude
-Ces sept monstres hideux avaient l'air éternel!
+Ces sept monstres hideux avaient l'air éternel !
 
 Aurais je, sans mourir, contemplé le huitième,
 Sosie inexorable, ironique et fatal
-Dégoûtant Phénix, fils et père de lui-même?
+Dégoûtant Phénix, fils et père de lui-même ?
 - Mais je tournai le dos au cortège infernal.
 
 Exaspéré comme un ivrogne qui voit double,
 Je rentrai, je fermai ma porte, épouvanté,
 Malade et morfondu, l'esprit fiévreux et trouble,
-Blessé par le mystère et par l'absurdité!
+Blessé par le mystère et par l'absurdité !
 
-Vainement ma raison voulait prendre la barre;
+Vainement ma raison voulait prendre la barre ;
 La tempête en jouant déroutait ses efforts,
 Et mon âme dansait, dansait, vieille gabarre
-Sans mâts, sur une mer monstrueuse et sans bords!
+Sans mâts, sur une mer monstrueuse et sans bords !
 </poetry>
 </body>
 </text>
@@ -3998,34 +3998,34 @@ Je guette, obéissant à mes humeurs fatales,
 Des êtres singuliers, décrépits et charmants.
 
 Ces monstres disloqués furent jadis des femmes,
-Eponine ou Laïs! Monstres brisés, bossus
-Ou tordus, aimons-les! ce sont encor des âmes.
+Eponine ou Laïs ! Monstres brisés, bossus
+Ou tordus, aimons-les ! ce sont encor des âmes.
 Sous des jupons troués et sous de froids tissus
 
 Ils rampent, flagellés par les bises iniques,
 Frémissant au fracas roulant des omnibus,
 Et serrant sur leur flanc, ainsi que des reliques,
-Un petit sac brodé de fleurs ou de rébus;
+Un petit sac brodé de fleurs ou de rébus ;
 
-Ils trottent, tout pareils à des marionnettes;
+Ils trottent, tout pareils à des marionnettes ;
 Se traînent, comme font les animaux blessés,
 Ou dansent, sans vouloir danser, pauvres sonnettes
-Où se pend un Démon sans pitié! Tout cassés
+Où se pend un Démon sans pitié ! Tout cassés
 
 Qu'ils sont, ils ont des yeux perçants comme une vrille,
-Luisants comme ces trous où l'eau dort dans la nuit;
+Luisants comme ces trous où l'eau dort dans la nuit ;
 Ils ont les yeux divins de la petite fille
 Qui s'étonne et qui rit à tout ce qui reluit.
 
 - Avez-vous observé que maints cercueils de vieilles
-Sont presque aussi petits que celui d'un enfant?
+Sont presque aussi petits que celui d'un enfant ?
 La Mort savante met dans ces bières pareilles
 Un symbole d'un goût bizarre et captivant,
 
 Et lorsque j'entrevois un fantôme débile
 Traversant de Paris le fourmillant tableau,
 Il me semble toujours que cet être fragile
-S'en va tout doucement vers un nouveau berceau;
+S'en va tout doucement vers un nouveau berceau ;
 
 A moins que, méditant sur la géométrie,
 Je ne cherche, à l'aspect de ces membres discords,
@@ -4035,28 +4035,28 @@ La forme de la boîte où l'on met tous ces corps.
 - Ces yeux sont des puits faits d'un million de larmes,
 Des creusets qu'un métal refroidi pailleta...
 Ces yeux mystérieux ont d'invincibles charmes
-Pour celui que l'austère Infortune allaita!
+Pour celui que l'austère Infortune allaita !
 
      II
 
-De Frascati défunt Vestale enamourée;
-Prêtresse de Thalie, hélas! dont le souffleur
-Enterré sait le nom; célèbre évaporée
+De Frascati défunt Vestale enamourée ;
+Prêtresse de Thalie, hélas ! dont le souffleur
+Enterré sait le nom ; célèbre évaporée
 Que Tivoli jadis ombragea dans sa fleur,
 
-Toutes m'enivrent; mais parmi ces êtres frêles
+Toutes m'enivrent ; mais parmi ces êtres frêles
 Il en est qui, faisant de la douleur un miel,
-Ont dit au Dévouement qui leur prêtait ses ailes:
-Hippogriffe puissant, mène-moi jusqu'au ciel!
+Ont dit au Dévouement qui leur prêtait ses ailes :
+Hippogriffe puissant, mène-moi jusqu'au ciel !
 
 L'une, par sa patrie au malheur exercée,
 L'autre, que son époux surchargea de douleurs,
 L'autre, par son enfant Madone transpercée,
-Toutes auraient pu faire un fleuve avec leurs pleurs!
+Toutes auraient pu faire un fleuve avec leurs pleurs !
 
      III
 
-Ah! que j'en ai suivi de ces petites vieilles!
+Ah ! que j'en ai suivi de ces petites vieilles !
 Une, entre autres, à l'heure où le soleil tombant
 Ensanglante le ciel de blessures vermeilles,
 Pensive, s'asseyait à l'écart sur un banc,
@@ -4067,9 +4067,9 @@ Et qui, dans ces soirs d'or où l'on se sent revivre,
 Versent quelque héroïsme au coeur des citadins.
 
 Celle-là, droite encor, fière et sentant la règle,
-Humait avidement ce chant vif et guerrier;
-Son oeil parfois s'ouvrait comme l'oeil d'un vieil aigle;
-Son front de marbre avait l'air fait pour le laurier!
+Humait avidement ce chant vif et guerrier ;
+Son oeil parfois s'ouvrait comme l'oeil d'un vieil aigle ;
+Son front de marbre avait l'air fait pour le laurier !
 
      IV
 
@@ -4079,29 +4079,29 @@ Mères au coeur saignant, courtisanes ou saintes,
 Dont autrefois les noms par tous étaient cités.
 
 Vous qui fûtes la grâce ou qui fûtes la gloires,
-Nul ne vous reconnaît! un ivrogne incivil
-Vous insulte en passant d'un amour dérisoire;
+Nul ne vous reconnaît ! un ivrogne incivil
+Vous insulte en passant d'un amour dérisoire ;
 Sur vos talons gambade un enfant lâche et vil.
 
 Honteuses d'exister, ombres ratatinées,
-Peureuses, le dos bas, vous côtoyez les murs;
-Et nul ne vous salue, étranges destinées!
-Débris d'humanité pour l'éternité mûrs!
+Peureuses, le dos bas, vous côtoyez les murs ;
+Et nul ne vous salue, étranges destinées !
+Débris d'humanité pour l'éternité mûrs !
 
 Mais moi, moi qui de loin tendrement vous surveille,
 L'oeil inquiet, fixé sur vos pas incertains,
-Tout comme si j'étais votre père, ô merveille!
-Je goûte à votre insu des plaisirs clandestins:
+Tout comme si j'étais votre père, ô merveille !
+Je goûte à votre insu des plaisirs clandestins :
 
-Je vois s'épanouir vos passions novices;
-Sombres ou lumineux, je vis vos jours perdus;
-Mon coeur multiplié jouit de tous vos vices!
-Mon âme resplendit de toutes vos vertus!
+Je vois s'épanouir vos passions novices ;
+Sombres ou lumineux, je vis vos jours perdus ;
+Mon coeur multiplié jouit de tous vos vices !
+Mon âme resplendit de toutes vos vertus !
 
-Ruines! ma famille! ô cerveaux congénères!
-Je vous fais chaque soir un solennel adieu!
+Ruines ! ma famille ! ô cerveaux congénères !
+Je vous fais chaque soir un solennel adieu !
 Où serez-vous demain, Eves octogénaires,
-Sur qui pèse la griffe effroyable de Dieu?
+Sur qui pèse la griffe effroyable de Dieu ?
 </poetry>
 </body>
 </text>
@@ -4111,29 +4111,29 @@ Sur qui pèse la griffe effroyable de Dieu?
    <title>Les Aveugles</title>
    <toctitle>Les Aveugles</toctitle>
    <indextitle>Les Aveugles</indextitle>
-   <firstline>Contemple-les, mon âme; ils sont vraiment affreux!</firstline>
+   <firstline>Contemple-les, mon âme ; ils sont vraiment affreux !</firstline>
    <quality>korrektur1</quality>
    <keywords>sonnet</keywords>
 </head>
 <body>
 <poetry>
-Contemple-les, mon âme; ils sont vraiment affreux!
-Pareils aux mannequins; vaguement ridicules;
-Terribles, singuliers comme les somnambules;
+Contemple-les, mon âme ; ils sont vraiment affreux !
+Pareils aux mannequins ; vaguement ridicules ;
+Terribles, singuliers comme les somnambules ;
 Dardant on ne sait où leurs globes ténébreux.
 
 Leurs yeux, d'où la divine étincelle est partie,
 Comme s'ils regardaient au loin, restent levés
-Au ciel; on ne les voit jamais vers les pavés
+Au ciel ; on ne les voit jamais vers les pavés
 Pencher rêveusement leur tête appesantie.
 
 Ils traversent ainsi le noir illimité,
-Ce frère du silence éternel. O cité!
+Ce frère du silence éternel. O cité !
 Pendant qu'autour de nous tu chantes, ris et beugles,
 
 Eprise du plaisir jusqu'à l'atrocité,
-Vois! je me traîne aussi! mais, plus qu'eux hébété,
-Je dis: Que cherchent-ils au Ciel, tous ces aveugles?
+Vois ! je me traîne aussi ! mais, plus qu'eux hébété,
+Je dis : Que cherchent-ils au Ciel, tous ces aveugles ?
 </poetry>
 </body>
 </text>
@@ -4152,20 +4152,20 @@ Je dis: Que cherchent-ils au Ciel, tous ces aveugles?
 La rue assourdissante autour de moi hurlait.
 Longue, mince, en grand deuil, douleur majestueuse,
 Une femme passa, d'une main fastueuse
-Soulevant, balançant le feston et l'ourlet;
+Soulevant, balançant le feston et l'ourlet ;
 
 Agile et noble, avec sa jambe de statue.
 Moi, je buvais, crispé comme un extravagant,
 Dans son oeil, ciel livide où germe l'ouragan,
 La douceur qui fascine et le plaisir qui tue.
 
-Un éclair... puis la nuit! - Fugitive beauté
+Un éclair... puis la nuit ! - Fugitive beauté
 Dont le regard m'a fait soudainement renaître,
-Ne te verrai-je plus que dans l'éternité?
+Ne te verrai-je plus que dans l'éternité ?
 
-Ailleurs, bien loin d'ici! trop tard! jamais peut-être!
+Ailleurs, bien loin d'ici ! trop tard ! jamais peut-être !
 Car j'ignore où tu fuis, tu ne sais où je vais,
-O toi que j'eusse aimée, ô toi qui le savais!
+O toi que j'eusse aimée, ô toi qui le savais !
 </poetry>
 </body>
 </text>
@@ -4207,22 +4207,22 @@ Ou de vos muscles dépouillés,
 Dites, quelle moisson étrange,
 Forçats arrachés au charnier,
 Tirez-vous, et de quel fermier
-Avez-vous à remplir la grange?
+Avez-vous à remplir la grange ?
 
 Voulez-vous (d'un destin trop dur
-Epouvantable et clair emblème!)
+Epouvantable et clair emblème !)
 Montrer que dans la fosse même
-Le sommeil promis n'est pas sûr;
+Le sommeil promis n'est pas sûr ;
 
-Qu'envers nous le Néant est traître;
+Qu'envers nous le Néant est traître ;
 Que tout, même la Mort, nous ment,
 Et que sempiternellement
-Hélas! il nous faudra peut-être
+Hélas ! il nous faudra peut-être
 
 Dans quelque pays inconnu
 Ecorcher la terre revêche
 Et pousser une lourde bêche
-Sous notre pied sanglant et nu?
+Sous notre pied sanglant et nu ?
 </poetry>
 </body>
 </text>
@@ -4237,14 +4237,14 @@ Sous notre pied sanglant et nu?
 </head>
 <body>
 <poetry>
-Voici le soir charmant, ami du criminel;
-Il vient comme un complice, à pas de loup; le ciel
+Voici le soir charmant, ami du criminel ;
+Il vient comme un complice, à pas de loup ; le ciel
 Se ferme lentement comme une grande alcôve,
 Et l'homme impatient se change en bête fauve.
 
 O soir, aimable soir, désiré par celui
-Dont les bras, sans mentir, peuvent dire: Aujourd'hui
-Nous avons travaillé! - C'est le soir qui soulage
+Dont les bras, sans mentir, peuvent dire : Aujourd'hui
+Nous avons travaillé ! - C'est le soir qui soulage
 Les esprits que dévore une douleur sauvage,
 Le savant obstiné dont le front s'alourdit,
 Et l'ouvrier courbé qui regagne son lit.
@@ -4252,14 +4252,14 @@ Cependant des démons malsains dans l'atmosphère
 S'éveillent lourdement, comme des gens d'affaire,
 Et cognent en volant les volets et l'auvent.
 A travers les lueurs que tourmente le vent
-La Prostitution s'allume dans les rues;
-Comme une fourmilière elle ouvre ses issues;
+La Prostitution s'allume dans les rues ;
+Comme une fourmilière elle ouvre ses issues ;
 Partout elle se fraye un occulte chemin,
-Ainsi que l'ennemi qui tente un coup de main;
+Ainsi que l'ennemi qui tente un coup de main ;
 Elle remue au sein de la cité de fange
 Comme un ver qui dérobe à l'Homme ce qu'il mange.
 On entend çà et là les cuisines siffler,
-Les théâtres glapir, les orchestres ronfler;
+Les théâtres glapir, les orchestres ronfler ;
 Les tables d'hôte, dont le jeu fait les délices,
 S'emplissent de catins et d'escrocs, leurs complices,
 Et les voleurs, qui n'ont ni trêve ni merci,
@@ -4269,15 +4269,15 @@ Pour vivre quelques jours et vêtir leurs maîtresses.
 
 Recueille-toi, mon âme, en ce grave moment,
 Et ferme ton oreille à ce rugissement.
-C'est l'heure où les douleurs des malades s'aigrissent!
-La sombre Nuit les prend à la gorge; ils finissent
-Leur destinée et vont vers le gouffre commun;
+C'est l'heure où les douleurs des malades s'aigrissent !
+La sombre Nuit les prend à la gorge ; ils finissent
+Leur destinée et vont vers le gouffre commun ;
 L'hôpital se remplit de leurs soupirs. - Plus d'un
 Ne viendra plus chercher la soupe parfumée,
 Au coin du feu, le soir, auprès d'une âme aimée.
 
 Encore la plupart n'ont-ils jamais connu
-La douceur du foyer et n'ont jamais vécu!
+La douceur du foyer et n'ont jamais vécu !
 </poetry>
 </body>
 </text>
@@ -4295,17 +4295,17 @@ La douceur du foyer et n'ont jamais vécu!
 Dans des fauteuils fanés des courtisanes vieilles,
 Pâles, le sourcil peint, l'oeil câlin et fatal,
 Minaudant, et faisant de leurs maigres oreilles
-Tomber un cliquetis de pierre et de métal;
+Tomber un cliquetis de pierre et de métal ;
 
 Autour des verts tapis des visages sans lèvre,
 Des lèvres sans couleur, des mâchoires sans dent,
 Et des doigts convulsés d'une infernale fièvre,
-Fouillant la poche vide ou le sein palpitant;
+Fouillant la poche vide ou le sein palpitant ;
 
 Sous de sales plafonds un rang de pâles lustres
 Et d'énormes quinquets projetant leurs lueurs
 Sur des fronts ténébreux de poètes illustres
-Qui viennent gaspiller leurs sanglantes sueurs;
+Qui viennent gaspiller leurs sanglantes sueurs ;
 
 Voilà le noir tableau qu'en un rêve nocturne
 Je vis se dérouler sous mon oeil clairvoyant.
@@ -4315,12 +4315,12 @@ Je me vis accoudé, froid, muet, enviant,
 Enviant de ces gens la passion tenace,
 De ces vieilles putains la funèbre gaieté,
 Et tous gaillardement trafiquant à ma face,
-L'un de son vieil honneur, l'autre de sa beauté!
+L'un de son vieil honneur, l'autre de sa beauté !
 
 Et mon coeur s'effraya d'envier maint pauvre homme
 Courant avec ferveur à l'abîme béant,
 Et qui, soûl de son sang, préférerait en somme
-La douleur à la mort et l'enfer au néant!
+La douleur à la mort et l'enfer au néant !
 </poetry>
 </body>
 </text>
@@ -4341,7 +4341,7 @@ Avec son gros bouquet, son mouchoir et ses gants
 Elle a la nonchalance et la désinvolture
 D'une coquette maigre aux airs extravagants.
 
-Vit-on jamais au bal une taille plus mince?
+Vit-on jamais au bal une taille plus mince ?
 Sa robe exagérée, en sa royale ampleur,
 S'écroule abondamment sur un pied sec que pince
 Un soulier pomponné, joli comme une fleur.
@@ -4359,27 +4359,27 @@ O charme d'un néant follement attifé.
 Aucuns t'appelleront une caricature,
 Qui ne comprennent pas, amants ivres de chair,
 L'élégance sans nom de l'humaine armature.
-Tu réponds, grand squelette, à mon goût le plus cher!
+Tu réponds, grand squelette, à mon goût le plus cher !
 
 Viens-tu troubler, avec ta puissante grimace,
-La fête de la Vie? ou quelque vieux désir,
+La fête de la Vie ? ou quelque vieux désir,
 Eperonnant encor ta vivante carcasse,
-Te pousse-t-il, crédule, au sabbat du Plaisir?
+Te pousse-t-il, crédule, au sabbat du Plaisir ?
 
 Au chant des violons, aux flammes des bougies,
 Espères-tu chasser ton cauchemar moqueur,
 Et viens-tu demander au torrent des orgies
-De rafraîchir l'enfer allumé dans ton coeur?
+De rafraîchir l'enfer allumé dans ton coeur ?
 
-Inépuisable puits de sottise et de fautes!
-De l'antique douleur éternel alambic!
+Inépuisable puits de sottise et de fautes !
+De l'antique douleur éternel alambic !
 A travers le treillis recourbé de tes côtes
 Je vois, errant encor, l'insatiable aspic.
 
 Pour dire vrai, je crains que ta coquetterie
 Ne trouve pas un prix digne de ses efforts
-Qui, de ces coeurs mortels, entend la raillerie?
-Les charmes de l'horreur n'enivrent que les forts!
+Qui, de ces coeurs mortels, entend la raillerie ?
+Les charmes de l'horreur n'enivrent que les forts !
 
 Le gouffre de tes yeux, plein d'horribles pensées,
 Exhale le vertige, et les danseurs prudents
@@ -4387,19 +4387,19 @@ Ne contempleront pas sans d'amères nausées
 Le sourire éternel de tes trente-deux dents.
 
 Pourtant, qui n'a serré dans ses bras un squelette,
-Et qui ne s'est nourri des choses du tombeau?
-Qu'importe le parfum, l'habit ou la toilette?
+Et qui ne s'est nourri des choses du tombeau ?
+Qu'importe le parfum, l'habit ou la toilette ?
 Qui fait le dégoûté montre qu'il se croit beau.
 
 Bayadère sans nez, irrésistible gouge,
-Dis donc à ces danseurs qui font les offusqués:
+Dis donc à ces danseurs qui font les offusqués :
 "Fiers mignons, malgré l'art des poudres et du rouge
-Vous sentez tous la mort! O squelettes musqués,
+Vous sentez tous la mort ! O squelettes musqués,
 
 Antinoüs flétris, dandys à face glabre,
 Cadavres vernissés, lovelaces chenus,
 Le branle universel de la danse macabre
-Vous entraîne en des lieux qui ne sont pas connus!
+Vous entraîne en des lieux qui ne sont pas connus !
 
 Des quais froids de la Seine aux bords brûlants du Gange,
 Le troupeau mortel saute et se pâme, sans voir
@@ -4409,7 +4409,7 @@ Sinistrement béante ainsi qu'un tromblon noir.
 En tout climat, sous tout soleil, la Mort t'admire
 En tes contorsions, risible Humanité
 Et souvent, comme toi, se parfumant de myrrhe,
-Mêle son ironie à ton insanité!"
+Mêle son ironie à ton insanité !"
 </poetry>
 </body>
 </text>
@@ -4427,32 +4427,32 @@ Mêle son ironie à ton insanité!"
 Quand je te vois passer, ô ma chère indolente,
 Au chant des instruments qui se brise au plafond
 Suspendant ton allure harmonieuse et lente,
-Et promenant l'ennui de ton regard profond;
+Et promenant l'ennui de ton regard profond ;
 
 Quand je contemple, aux feux du gaz qui le colore,
 Ton front pâle, embelli par un morbide attrait,
 Où les torches du soir allument une aurore,
 Et tes yeux attirants comme ceux d'un portrait,
 
-Je me dis: Qu'elle est belle! et bizarrement fraîche!
+Je me dis : Qu'elle est belle ! et bizarrement fraîche !
 Le souvenir massif, royale et lourde tour,
 La couronne, et son coeur, meurtri comme une pêche,
 Est mûr, comme son corps, pour le savant amour.
 
-Es-tu le fruit d'automne aux saveurs souveraines?
+Es-tu le fruit d'automne aux saveurs souveraines ?
 Es-tu vase funèbre attendant quelques pleurs,
 Parfum qui fait rêver aux oasis lointaines,
-Oreiller caressant, ou corbeille de fleurs?
+Oreiller caressant, ou corbeille de fleurs ?
 
 Je sais qu'il est des yeux, des plus mélancoliques,
-Qui ne recèlent point de secrets précieux;
+Qui ne recèlent point de secrets précieux ;
 Beaux écrins sans joyaux, médaillons sans reliques,
-Plus vides, plus profonds que vous-mêmes, ô Cieux!
+Plus vides, plus profonds que vous-mêmes, ô Cieux !
 
 Mais ne suffit-il pas que tu sois l'apparence,
-Pour réjouir un coeur qui fuit la vérité?
-Qu'importe ta bêtise ou ton indifférence?
-Masque ou décor. salut! T'adore ta beauté.
+Pour réjouir un coeur qui fuit la vérité ?
+Qu'importe ta bêtise ou ton indifférence ?
+Masque ou décor. salut ! T'adore ta beauté.
 </poetry>
 </body>
 </text>
@@ -4468,7 +4468,7 @@ Masque ou décor. salut! T'adore ta beauté.
 <body>
 <poetry>
 Je n'ai pas oublié, voisine de la ville,
-Notre blanche maison, petite mais tranquille;
+Notre blanche maison, petite mais tranquille ;
 Sa Pomone de plâtre et sa vieille Vénus
 Dans un bosquet chétif cachant leurs membres nus,
 Et le soleil, le soir, ruisselant et superbe,
@@ -4512,7 +4512,7 @@ Je la trouvais tapie en un coin de ma chambre,
 Grave, et venant du fond de son lit éternel
 Couver l'enfant grandi de son oeil maternel,
 Que pourrais-je répondre à cette âme pieuse,
-Voyant tomber des pleurs de sa paupière creuse?
+Voyant tomber des pleurs de sa paupière creuse ?
 </poetry>
 </body>
 </text>
@@ -4529,7 +4529,7 @@ Voyant tomber des pleurs de sa paupière creuse?
 <body>
 <poetry>
 O fins d'automne, hivers, printemps trempés de boue,
-Endormeuses saisons! je vous aime et vous loue
+Endormeuses saisons ! je vous aime et vous loue
 D'envelopper ainsi mon coeur et mon cerveau
 D'un linceul vaporeux et d'un vague tombeau.
 
@@ -4567,7 +4567,7 @@ Tel que jamais mortel n'en vit,
 Ce matin encore l'image,
 Vague et lointaine, me ravit.
 
-Le sommeil est plein de miracles!
+Le sommeil est plein de miracles !
 Par un caprice singulier
 J'avais banni de ces spectacles
 Le végétal irrégulier,
@@ -4580,7 +4580,7 @@ Du métal, du marbre et de l'eau.
 Babel d'escaliers et d'arcades,
 C'était un palais infini
 Plein de bassins et de cascades
-Tombant dans l'or mat ou bruni;
+Tombant dans l'or mat ou bruni ;
 
 Et des cataractes pesantes,
 Comme des rideaux de cristal
@@ -4595,12 +4595,12 @@ Comme des femmes, se miraient.
 Des nappes d'eau s'épanchaient, bleues,
 Entre des quais roses et verts,
 Pendant des millions de lieues,
-Vers les confins de l'univers:
+Vers les confins de l'univers :
 
 C'étaient des pierres inouïes
 Et des flots magiques, c'étaient
 D'immenses glaces éblouies
-Par tout ce qu'elles reflétaient!
+Par tout ce qu'elles reflétaient !
 
 Insouciants et taciturnes,
 Des Ganges, dans le firmament,
@@ -4610,21 +4610,21 @@ Dans des gouffres de diamant.
 Architecte de mes féeries,
 Je faisais, à ma volonté,
 Sous un tunnel de pierreries
-Passer un océan dompté;
+Passer un océan dompté ;
 
 Et tout, même la couleur noire,
-Semblait fourbi, clair, irisé;
+Semblait fourbi, clair, irisé ;
 Le liquide enchâssait sa gloire
 Dans le rayon cristallisé.
 
 Nul astre d'ailleurs, nuls vestiges
 De soleil, même au bas du ciel,
 Pour illuminer ces prodiges,
-Qui brillaient d'un feu personnel!
+Qui brillaient d'un feu personnel !
 
 Et sur ces mouvantes merveilles
-Planait (terrible nouveauté!
-Tout pour l'oeil, rien pour les oreilles!)
+Planait (terrible nouveauté !
+Tout pour l'oeil, rien pour les oreilles !)
 Un silence d'éternité.
 
      II
@@ -4632,7 +4632,7 @@ Un silence d'éternité.
 En rouvrant mes yeux pleins de flamme
 J'ai vu l'horreur de mon taudis,
 Et senti, rentrant dans mon âme,
-La pointe des soucis maudits;
+La pointe des soucis maudits ;
 
 La pendule aux accents funèbres
 Sonnait brutalement midi,
@@ -4656,9 +4656,9 @@ La diane chantait dans les cours des casernes,
 Et le vent du matin soufflait sur les lanternes.
 
 C'était l'heure où l'essaim des rêves malfaisants
-Tord sur leurs oreillers les bruns adolescents;
+Tord sur leurs oreillers les bruns adolescents ;
 Où, comme un oeil sanglant qui palpite et qui bouge,
-La lampe sur le jour fait une tache rouge;
+La lampe sur le jour fait une tache rouge ;
 Où l'âme, sous le poids du corps revêche et lourd,
 Imite les combats de la lampe et du jour.
 Comme un visage en pleurs que les brises essuient,
@@ -4667,11 +4667,11 @@ Et l'homme est las d'écrire et la femme d'aimer.
 
 Les maisons çà et là commençaient à fumer.
 Les femmes de plaisir, la paupière livide,
-Bouche ouverte, dormaient de leur sommeil stupide;
+Bouche ouverte, dormaient de leur sommeil stupide ;
 Les pauvresses, traînant leurs seins maigres et froids,
 Soufflaient sur leurs tisons et soufflaient sur leurs doigts.
 C'était l'heure où parmi le froid et la lésine
-S'aggravent les douleurs des femmes en gésine;
+S'aggravent les douleurs des femmes en gésine ;
 Comme un sanglot coupé par un sang écumeux
 Le chant du coq au loin déchirait l'air brumeux
 Une mer de brouillards baignait les édifices,
@@ -4705,14 +4705,14 @@ Empoignait ses outils, vieillard laborieux.
 </head>
 <body>
 <poetry>
-Un soir, l'âme du vin chantait dans les bouteilles:
+Un soir, l'âme du vin chantait dans les bouteilles :
 "Homme, vers toi je pousse, ô cher déshérité,
 Sous ma prison de verre et mes cires vermeilles,
-Un chant plein de lumière et de fraternité!
+Un chant plein de lumière et de fraternité !
 
 Je sais combien il faut, sur la colline en flamme,
 De peine, de sueur et de soleil cuisant
-Pour engendrer ma vie et pour me donner l'âme;
+Pour engendrer ma vie et pour me donner l'âme ;
 Mais je ne serai point ingrat ni malfaisant,
 
 Car j'éprouve une joie immense quand je tombe
@@ -4721,11 +4721,11 @@ Et sa chaude poitrine est une douce tombe
 Où je me plais bien mieux que dans mes froids caveaux.
 
 Entends-tu retentir les refrains des dimanches
-Et l'espoir qui gazouille en mon sein palpitant?
+Et l'espoir qui gazouille en mon sein palpitant ?
 Les coudes sur la table et retroussant tes manches,
-Tu me glorifieras et tu seras content;
+Tu me glorifieras et tu seras content ;
 
-J'allumerai les yeux de ta femme ravie;
+J'allumerai les yeux de ta femme ravie ;
 A ton fils je rendrai sa force et ses couleurs
 Et serai pour ce frêle athlète de la vie
 L'huile qui raffermit les muscles des lutteurs.
@@ -4733,7 +4733,7 @@ L'huile qui raffermit les muscles des lutteurs.
 En toi je tomberai, végétale ambroisie,
 Grain précieux jeté par l'éternel Semeur,
 Pour que de notre amour naisse la poésie
-Qui jaillira vers Dieu comme une rare fleur!"
+Qui jaillira vers Dieu comme une rare fleur !"
 </poetry>
 </body>
 </text>
@@ -4773,20 +4773,20 @@ Suivis de compagnons, blanchis dans les batailles,
 Dont la moustache pend comme les vieux drapeaux.
 Les bannières, les fleurs et les arcs triomphaux
 
-Se dressent devant eux, solennelle magie!
+Se dressent devant eux, solennelle magie !
 Et dans l'étourdissante et lumineuse orgie
 Des clairons, du soleil, des cris et du tambour,
-Ils apportent la gloire au peuple ivre d'amour!
+Ils apportent la gloire au peuple ivre d'amour !
 
 C'est ainsi qu'à travers l'Humanité frivole
-Le vin roule de l'or, éblouissant Pactole;
+Le vin roule de l'or, éblouissant Pactole ;
 Par le gosier de l'homme il chante ses exploits
 Et règne par ses dons ainsi que les vrais rois.
 
 Pour noyer la rancoeur et bercer l'indolence
 De tous ces vieux maudits qui meurent en silence,
-Dieu, touché de remords, avait fait le sommeil;
-L'Homme ajouta le Vin, fils sacré du Soleil!
+Dieu, touché de remords, avait fait le sommeil ;
+L'Homme ajouta le Vin, fils sacré du Soleil !
 </poetry>
 </body>
 </text>
@@ -4796,30 +4796,30 @@ L'Homme ajouta le Vin, fils sacré du Soleil!
    <title>Le Vin de l'Assassin</title>
    <toctitle>Le Vin de l'Assassin</toctitle>
    <indextitle>Le Vin de l'Assassin</indextitle>
-   <firstline>Ma femme est morte, je suis libre!</firstline>
+   <firstline>Ma femme est morte, je suis libre !</firstline>
    <quality>korrektur1</quality>
 </head>
 <body>
 <poetry>
-Ma femme est morte, je suis libre!
+Ma femme est morte, je suis libre !
 Je puis donc boire tout mon soûl.
 Lorsque je rentrais sans un sou,
 Ses cris me déchiraient la fibre.
 
-Autant qu'un roi je suis heureux;
+Autant qu'un roi je suis heureux ;
 L'air est pur, le ciel admirable...
 Nous avions un été semblable
-Lorsque j'en devins amoureux!
+Lorsque j'en devins amoureux !
 
 L'horrible soif qui me déchire
 Aurait besoin pour s'assouvir
 D'autant de vin qu'en peut tenir
-Son tombeau; - ce n'est pas peu dire:
+Son tombeau ; - ce n'est pas peu dire :
 
 Je l'ai jetée au fond d'un puits,
 Et j'ai même poussé sur elle
 Tous les pavés de la margelle.
-- Je l'oublierai si je le puis!
+- Je l'oublierai si je le puis !
 
 Au nom des serments de tendresse,
 Dont rien ne peut nous délier,
@@ -4828,18 +4828,18 @@ Comme au beau temps de notre ivresse,
 
 J'implorai d'elle un rendez-vous,
 Le soir, sur une route obscure.
-Elle y vint - folle créature!
-Nous sommes tous plus ou moins fous!
+Elle y vint - folle créature !
+Nous sommes tous plus ou moins fous !
 
 Elle était encore jolie,
-Quoique bien fatiguée! et moi,
-Je l'aimais trop! voilà pourquoi
-Je lui dis: Sors de cette vie!
+Quoique bien fatiguée ! et moi,
+Je l'aimais trop ! voilà pourquoi
+Je lui dis : Sors de cette vie !
 
 Nul ne peut me comprendre. Un seul
 Parmi ces ivrognes stupides
 Songea-t-il dans ses nuits morbides
-A faire du vin un linceul?
+A faire du vin un linceul ?
 
 Cette crapule invulnérable
 Comme les machines de fer
@@ -4849,14 +4849,14 @@ N'a connu l'amour véritable,
 Avec ses noirs enchantements,
 Son cortège infernal d'alarmes,
 Ses fioles de poison, ses larmes,
-Ses bruits de chaîne et d'ossements!
+Ses bruits de chaîne et d'ossements !
 
-- Me voilà libre et solitaire!
-Je serai ce soir ivre mort;
+- Me voilà libre et solitaire !
+Je serai ce soir ivre mort ;
 Alors, sans peur et sans remords,
 Je me coucherai sur la terre,
 
-Et je dormirai comme un chien!
+Et je dormirai comme un chien !
 Le chariot aux lourdes roues
 Chargé de pierres et de boues,
 Le wagon enragé peut bien
@@ -4864,7 +4864,7 @@ Le wagon enragé peut bien
 Ecraser ma tête coupable
 Ou me couper par le milieu,
 Je m'en moque comme de Dieu,
-Du Diable ou de la Sainte Table!
+Du Diable ou de la Sainte Table !
 </poetry>
 </body>
 </text>
@@ -4883,20 +4883,20 @@ Du Diable ou de la Sainte Table!
 Le regard singulier d'une femme galante
 Qui se glisse vers nous comme le rayon blanc
 Que la lune onduleuse envoie au lac tremblant,
-Quand elle y veut baigner sa beauté nonchalante;
+Quand elle y veut baigner sa beauté nonchalante ;
 
-Le dernier sac d'écus dans les doigts d'un joueur;
-Un baiser libertin de la maigre Adeline;
+Le dernier sac d'écus dans les doigts d'un joueur ;
+Un baiser libertin de la maigre Adeline ;
 Les sons d'une musique énervante et câline,
 Semblable au cri lointain de l'humaine douleur,
 
 Tout cela ne vaut pas, ô bouteille profonde,
 Les baumes pénétrants que ta panse féconde
-Garde au coeur altéré du poète pieux;
+Garde au coeur altéré du poète pieux ;
 
 Tu lui verses l'espoir, la jeunesse et la vie,
 - Et l'orgueil, ce trésor de toute gueuserie,
-Qui nous rend triomphants et semblables aux Dieux!
+Qui nous rend triomphants et semblables aux Dieux !
 </poetry>
 </body>
 </text>
@@ -4906,21 +4906,21 @@ Qui nous rend triomphants et semblables aux Dieux!
    <title>Le Vin des Amants</title>
    <toctitle>Le Vin des Amants</toctitle>
    <indextitle>Le Vin des Amants</indextitle>
-   <firstline>Aujourd'hui l'espace est splendide!</firstline>
+   <firstline>Aujourd'hui l'espace est splendide !</firstline>
    <quality>korrektur1</quality>
    <keywords>sonnet</keywords>
 </head>
 <body>
 <poetry>
-Aujourd'hui l'espace est splendide!
+Aujourd'hui l'espace est splendide !
 Sans mors, sans éperons, sans bride,
 Partons à cheval sur le vin
-Pour un ciel féerique et divin!
+Pour un ciel féerique et divin !
 
 Comme deux anges que torture
 Une implacable calenture,
 Dans le bleu cristal du matin
-Suivons le mirage lointain!
+Suivons le mirage lointain !
 
 Mollement balancés sur l'aile
 Du tourbillon intelligent,
@@ -4928,7 +4928,7 @@ Dans un délire parallèle,
 
 Ma soeur, côte à côte nageant,
 Nous fuirons sans repos ni trêves
-Vers le paradis de mes rêves!
+Vers le paradis de mes rêves !
 </poetry>
 </body>
 </text>
@@ -4952,8 +4952,8 @@ Vers le paradis de mes rêves!
 </head>
 <body>
 <poetry>
-Sans cesse à mes côtés s'agite le Démon;
-Il nage autour de moi comme un air impalpable;
+Sans cesse à mes côtés s'agite le Démon ;
+Il nage autour de moi comme un air impalpable ;
 Je l'avale et le sens qui brûle mon poumon
 Et l'emplit d'un désir éternel et coupable.
 
@@ -4968,7 +4968,7 @@ Des plaines de l'Ennui, profondes et désertes,
 
 Et jette dans mes yeux pleins de confusion
 Des vêtements souillés, des blessures ouvertes,
-Et l'appareil sanglant de la Destruction!
+Et l'appareil sanglant de la Destruction !
 </poetry>
 </body>
 </text>
@@ -5005,17 +5005,17 @@ La tête, avec l'amas de sa crinière sombre
 Et de ses bijoux précieux,
 
 Sur la table de nuit, comme une renoncule,
-Repose; et, vide de pensers,
+Repose ; et, vide de pensers,
 Un regard vague et blanc comme le crépuscule
 S'échappe des yeux révulsés.
 
 Sur le lit, le tronc nu sans scrupules étale
 Dans le plus complet abandon
 La secrète splendeur et la beauté fatale
-Dont la nature lui fit don;
+Dont la nature lui fit don ;
 
 Un bas rosâtre, orné de coins d'or, à la jambe,
-Comme un souvenir est resté;
+Comme un souvenir est resté ;
 La jarretière, ainsi qu'un oeil secret qui flambe,
 Darde un regard diamanté.
 
@@ -5027,35 +5027,35 @@ Révèle un amour ténébreux,
 Une coupable joie et des fêtes étranges
 Pleines de baisers infernaux,
 Dont se réjouissait l'essaim des mauvais anges
-Nageant dans les plis des rideaux;
+Nageant dans les plis des rideaux ;
 
 Et cependant, à voir la maigreur élégante
 De l'épaule au contour heurté,
 La hanche un peu pointue et la taille fringante
 Ainsi qu'un reptile irrité,
 
-Elle est bien jeune encor! - Son âme exaspérée
+Elle est bien jeune encor ! - Son âme exaspérée
 Et ses sens par l'ennui mordus
 S'étaient-ils entr'ouverts à la meute altérée
-Des désirs errants et perdus?
+Des désirs errants et perdus ?
 
 L'homme vindicatif que tu n'as pu, vivante,
 Malgré tant d'amour, assouvir,
 Combla-t-il sur ta chair inerte et complaisante
-L'immensité de son désir?
+L'immensité de son désir ?
 
-Réponds, cadavre impur! et par tes tresses roides
+Réponds, cadavre impur ! et par tes tresses roides
 Te soulevant d'un bras fiévreux,
 Dis-moi, tête effrayante, a-t-il sur tes dents froides
-Collé les suprêmes adieux?
+Collé les suprêmes adieux ?
 
 - Loin du monde railleur, loin de la foule impure,
 Loin des magistrats curieux,
 Dors en paix, dors en paix, étrange créature,
-Dans ton tombeau mystérieux;
+Dans ton tombeau mystérieux ;
 
 Ton époux court le monde, et ta forme immortelle
-Veille près de lui quand il dort;
+Veille près de lui quand il dort ;
 Autant que toi sans doute il te sera fidèle,
 Et constant jusques à la mort.
 </poetry>
@@ -5080,17 +5080,17 @@ Ont de douces langueurs et des frissons amers.
 Les unes, coeurs épris des longues confidences,
 Dans le fond des bosquets où jasent les ruisseaux,
 Vont épelant l'amour des craintives enfances
-Et creusent le bois vert des jeunes arbrisseaux;
+Et creusent le bois vert des jeunes arbrisseaux ;
 
 D'autres, comme des soeurs, marchent lentes et graves
 A travers les rochers pleins d'apparitions,
 Où saint Antoine a vu surgir comme des laves
-Les seins nus et pourprés de ses tentations;
+Les seins nus et pourprés de ses tentations ;
 
 Il en est, aux lueurs des résines croulantes,
 Qui dans le creux muet des vieux antres païens
 T'appellent au secours de leurs fièvres hurlantes,
-O Bacchus, endormeur des remords anciens!
+O Bacchus, endormeur des remords anciens !
 
 Et d'autres, dont la gorge aime les scapulaires,
 Qui, recélant un fouet sous leurs longs vêtements,
@@ -5135,9 +5135,9 @@ Et la bière et l'alcôve en blasphèmes fécondes
 Nous offrent tour à tour, comme deux bonnes soeurs,
 De terribles plaisirs et d'affreuses douceurs.
 
-Quand veux-tu m'enterrer, Débauche aux bras immondes?
+Quand veux-tu m'enterrer, Débauche aux bras immondes ?
 O Mort, quand viendras-tu, sa rivale en attraits,
-Sur ses myrtes infects enter tes noirs cyprès?
+Sur ses myrtes infects enter tes noirs cyprès ?
 </poetry>
 </body>
 </text>
@@ -5164,12 +5164,12 @@ Désaltérant la soif de chaque créature,
 Et partout colorant en rouge la nature.
 
 J'ai demandé souvent à des vins captieux
-D'endormir pour un jour la terreur qui me mine;
-Le vin rend l'oeil plus clair et l'oreille plus fine!
+D'endormir pour un jour la terreur qui me mine ;
+Le vin rend l'oeil plus clair et l'oreille plus fine !
 
-J'ai cherché dans l'amour un sommeil oublieux;
+J'ai cherché dans l'amour un sommeil oublieux ;
 Mais l'amour n'est pour moi qu'un matelas d'aiguilles
-Fait pour donner à boire à ces cruelles filles!
+Fait pour donner à boire à ces cruelles filles !
 </poetry>
 </body>
 </text>
@@ -5192,7 +5192,7 @@ Elle rit à la Mort et nargue la Débauche,
 Ces monstres dont la main, qui toujours gratte et fauche,
 Dans ses jeux destructeurs a pourtant respecté
 De ce corps ferme et droit la rude majesté.
-Elle marche en déesse et repose en sultane;
+Elle marche en déesse et repose en sultane ;
 Elle a dans le plaisir la foi mahométane,
 Et dans ses bras ouverts, que remplissent ses seins,
 Elle appelle des yeux la race des humains.
@@ -5229,7 +5229,7 @@ Semblables à des nains cruels et curieux.
 A me considérer froidement ils se mirent,
 Et, comme des passants sur un fou qu'ils admirent,
 Je les entendis rire et chuchoter entre eux,
-En échangeant maint signe et maint clignement d'yeux:
+En échangeant maint signe et maint clignement d'yeux :
 
 - "Contemplons à loisir cette caricature
 Et cette ombre d'Hamlet imitant sa posture,
@@ -5240,13 +5240,13 @@ Parce qu'il sait jouer artistement son rôle,
 Vouloir intéresser au chant de ses douleurs
 Les aigles, les grillons, les ruisseaux et les fleurs,
 Et même à nous, auteurs de ces vieilles rubriques,
-Réciter en hurlant ses tirades publiques?"
+Réciter en hurlant ses tirades publiques ?"
 
 J'aurais pu (mon orgueil aussi haut que les monts
 Domine la nuée et le cri des démons)
 Détourner simplement ma tête souveraine,
 Si je n'eusse pas vu parmi leur troupe obscène,
-Crime qui n'a pas fait chanceler le soleil!
+Crime qui n'a pas fait chanceler le soleil !
 La reine de mon coeur au regard nonpareil
 Qui riait avec eux de ma sombre détresse
 Et leur versait parfois quelque sale caresse.
@@ -5265,16 +5265,16 @@ Et leur versait parfois quelque sale caresse.
 <body>
 <poetry>
 Mon coeur, comme un oiseau, voltigeait tout joyeux
-Et planait librement à l'entour des cordages;
-Le navire roulait sous un ciel sans nuages;
+Et planait librement à l'entour des cordages ;
+Le navire roulait sous un ciel sans nuages ;
 Comme un ange enivré d'un soleil radieux.
 
-Quelle est cette île triste et noire? - C'est Cythère,
+Quelle est cette île triste et noire ? - C'est Cythère,
 Nous dit-on, un pays fameux dans les chansons
 Eldorado banal de tous les vieux garçons.
 Regardez, après tout, c'est une pauvre terre.
 
-- Ile des doux secrets et des fêtes du coeur!
+- Ile des doux secrets et des fêtes du coeur !
 De l'antique Vénus le superbe fantôme
 Au-dessus de tes mers plane comme un arôme
 Et charge les esprits d'amour et de langueur.
@@ -5284,15 +5284,15 @@ Vénérée à jamais par toute nation,
 Où les soupirs des coeurs en adoration
 Roulent comme l'encens sur un jardin de roses
 
-Ou le roucoulement éternel d'un ramier!
+Ou le roucoulement éternel d'un ramier !
 - Cythère n'était plus qu'un terrain des plus maigres,
 Un désert rocailleux troublé par des cris aigres.
-J'entrevoyais pourtant un objet singulier!
+J'entrevoyais pourtant un objet singulier !
 
 Ce n'était pas un temple aux ombres bocagères,
 Où la jeune prêtresse, amoureuse des fleurs,
 Allait, le corps brûlé de secrètes chaleurs,
-Entre-bâillant sa robe aux brises passagères;
+Entre-bâillant sa robe aux brises passagères ;
 
 Mais voilà qu'en rasant la côte d'assez près
 Pour troubler les oiseaux avec nos voiles blanches,
@@ -5302,7 +5302,7 @@ Du ciel se détachant en noir, comme un cyprès.
 De féroces oiseaux perchés sur leur pâture
 Détruisaient avec rage un pendu déjà mûr,
 Chacun plantant, comme un outil, son bec impur
-Dans tous les coins saignants de cette pourriture;
+Dans tous les coins saignants de cette pourriture ;
 
 Les yeux étaient deux trous, et du ventre effondré
 Les intestins pesants lui coulaient sur les cuisses,
@@ -5310,7 +5310,7 @@ Et ses bourreaux, gorgés de hideuses délices,
 L'avaient à coups de bec absolument châtré.
 
 Sous les pieds, un troupeau de jaloux quadrupèdes,
-Le museau relevé, tournoyait et rôdait;
+Le museau relevé, tournoyait et rôdait ;
 Une plus grande bête au milieu s'agitait
 Comme un exécuteur entouré de ses aides.
 
@@ -5319,25 +5319,25 @@ Silencieusement tu souffrais ces insultes
 En expiation de tes infâmes cultes
 Et des péchés qui t'ont interdit le tombeau.
 
-Ridicule pendu, tes douleurs sont les miennes!
+Ridicule pendu, tes douleurs sont les miennes !
 Je sentis, à l'aspect de tes membres flottants,
 Comme un vomissement, remonter vers mes dents
-Le long fleuve de fiel des douleurs anciennes;
+Le long fleuve de fiel des douleurs anciennes ;
 
 Devant toi, pauvre diable au souvenir si cher,
 J'ai senti tous les becs et toutes les mâchoires
 Des corbeaux lancinants et des panthères noires
 Qui jadis aimaient tant à triturer ma chair.
 
-- Le ciel était charmant, la mer était unie;
+- Le ciel était charmant, la mer était unie ;
 Pour moi tout était noir et sanglant désormais,
-Hélas! et j'avais, comme en un suaire épais,
+Hélas ! et j'avais, comme en un suaire épais,
 Le coeur enseveli dans cette allégorie.
 
-Dans ton île, ô Vénus! je n'ai trouvé debout
+Dans ton île, ô Vénus ! je n'ai trouvé debout
 Qu'un gibet symbolique où pendait mon image...
-- Ah! Seigneur! donnez-moi la force et le courage
-De contempler mon coeur et mon corps sans dégoût!
+- Ah ! Seigneur ! donnez-moi la force et le courage
+De contempler mon coeur et mon corps sans dégoût !
 </poetry>
 </body>
 </text>
@@ -5369,14 +5369,14 @@ Crève et crache son âme grêle
 Comme un songe d'or.
 
 J'entends le crâne à chaque bulle
-Prier et gémir:
+Prier et gémir :
 - "Ce jeu féroce et ridicule,
-Quand doit-il finir?
+Quand doit-il finir ?
 
 Car ce que ta bouche cruelle
 Eparpille en l'air,
 Monstre assassin, c'est ma cervelle,
-Mon sang et ma chair!"
+Mon sang et ma chair !"
 </poetry>
 </body>
 </text>
@@ -5400,16 +5400,16 @@ Mon sang et ma chair!"
 <body>
 <poetry>
 Qu'est-ce que Dieu fait donc de ce flot d'anathèmes
-Qui monte tous les jours vers ses chers Séraphins?
+Qui monte tous les jours vers ses chers Séraphins ?
 Comme un tyran gorgé de viande et de vins,
 Il s'endort au doux bruit de nos affreux blasphèmes.
 
 Les sanglots des martyrs et des suppliciés
 Sont une symphonie enivrante sans doute,
 Puisque, malgré le sang que leur volupté coûte,
-Les cieux ne s'en sont point encore rassasiés!
+Les cieux ne s'en sont point encore rassasiés !
 
-- Ah! Jésus, souviens-toi du Jardin des Olives!
+- Ah ! Jésus, souviens-toi du Jardin des Olives !
 Dans ta simplicité tu priais à genoux
 Celui qui dans son ciel riait au bruit des clous
 Que d'ignobles bourreaux plantaient dans tes chairs vives,
@@ -5417,7 +5417,7 @@ Que d'ignobles bourreaux plantaient dans tes chairs vives,
 Lorsque tu vis cracher sur ta divinité
 La crapule du corps de garde et des cuisines,
 Et lorsque tu sentis s'enfoncer les épines
-Dans ton crâne où vivait l'immense Humanité;
+Dans ton crâne où vivait l'immense Humanité ;
 
 Quand de ton corps brisé la pesanteur horrible
 Allongeait tes deux bras distendus, que ton sang
@@ -5431,13 +5431,13 @@ Des chemins tout jonchés de fleurs et de rameaux,
 
 Où, le coeur tout gonflé d'espoir et de vaillance,
 Tu fouettais tous ces vils marchands à tour de bras,
-Où tu fus maître enfin? Le remords n'a-t-il pas
-Pénétré dans ton flanc plus avant que la lance?
+Où tu fus maître enfin ? Le remords n'a-t-il pas
+Pénétré dans ton flanc plus avant que la lance ?
 
 - Certes, je sortirai, quant à moi, satisfait
-D'un monde où l'action n'est pas la soeur du rêve;
-Puissé-je user du glaive et périr par le glaive!
-Saint Pierre a renié Jésus... il a bien fait!
+D'un monde où l'action n'est pas la soeur du rêve ;
+Puissé-je user du glaive et périr par le glaive !
+Saint Pierre a renié Jésus... il a bien fait !
 </poetry>
 </body>
 </text>
@@ -5454,55 +5454,55 @@ Saint Pierre a renié Jésus... il a bien fait!
 <poetry>
       I
 
-Race d'Abel, dors, bois et mange;
+Race d'Abel, dors, bois et mange ;
 Dieu te sourit complaisamment.
 
 Race de Caïn, dans la fange
 Rampe et meurs misérablement.
 
 Race d'Abel, ton sacrifice
-Flatte le nez du Séraphin!
+Flatte le nez du Séraphin !
 
 Race de Caïn, ton supplice
-Aura-t-il jamais une fin?
+Aura-t-il jamais une fin ?
 
 Race d'Abel, vois tes semailles
-Et ton bétail venir à bien;
+Et ton bétail venir à bien ;
 
 Race de Caïn, tes entrailles
 Hurlent la faim comme un vieux chien.
 
 Race d'Abel, chauffe ton ventre
-A ton foyer patriarcal;
+A ton foyer patriarcal ;
 
 Race de Caïn, dans ton antre
-Tremble de froid, pauvre chacal!
+Tremble de froid, pauvre chacal !
 
-Race d'Abel, aime et pullule!
+Race d'Abel, aime et pullule !
 Ton or fait aussi des petits.
 
 Race de Caïn, coeur qui brûle,
 Prends garde à ces grands appétits.
 
 Race d'Abel, tu croîs et broutes
-Comme les punaises des bois!
+Comme les punaises des bois !
 
 Race de Caïn, sur les routes
 Traîne ta famille aux abois.
 
      II
 
-Ah! race d'Abel, ta charogne
-Engraissera le sol fumant!
+Ah ! race d'Abel, ta charogne
+Engraissera le sol fumant !
 
 Race de Caïn, ta besogne
-N'est pas faite suffisamment;
+N'est pas faite suffisamment ;
 
-Race d'Abel, voici ta honte:
-Le fer est vaincu par l'épieu!
+Race d'Abel, voici ta honte :
+Le fer est vaincu par l'épieu !
 
 Race de Caïn, au ciel monte,
-Et sur la terre jette Dieu!
+Et sur la terre jette Dieu !
 </poetry>
 </body>
 </text>
@@ -5520,77 +5520,77 @@ Et sur la terre jette Dieu!
 O toi, le plus savant et le plus beau des Anges,
 Dieu trahi par le sort et privé de louanges,
 
-O Satan, prends pitié de ma longue misère!
+O Satan, prends pitié de ma longue misère !
 
 O Prince de l'exil, à qui l'on a fait tort
 Et qui, vaincu, toujours te redresses plus fort,
 
-O Satan, prends pitié de ma longue misère!
+O Satan, prends pitié de ma longue misère !
 
 Toi qui sais tout, grand roi des choses souterraines,
 Guérisseur familier des angoisses humaines,
 
-O Satan, prends pitié de ma longue misère!
+O Satan, prends pitié de ma longue misère !
 
 Toi qui, même aux lépreux, aux parias maudits,
 Enseignes par l'amour le goût du Paradis,
 
-O Satan, prends pitié de ma longue misère!
+O Satan, prends pitié de ma longue misère !
 
 O toi qui de la Mort, ta vieille et forte amante,
-Engendras l'Espérance, - une folle charmante!
+Engendras l'Espérance, - une folle charmante !
 
-O Satan, prends pitié de ma longue misère!
+O Satan, prends pitié de ma longue misère !
 
 Toi qui fais au proscrit ce regard calme et haut
 Qui damne tout un peuple autour d'un échafaud.
 
-O Satan, prends pitié de ma longue misère!
+O Satan, prends pitié de ma longue misère !
 
 Toi qui sais en quels coins des terres envieuses
 Le Dieu jaloux cacha les pierres précieuses,
 
-O Satan, prends pitié de ma longue misère!
+O Satan, prends pitié de ma longue misère !
 
 Toi dont l'oeil clair connaît les profonds arsenaux
 Où dort enseveli le peuple des métaux,
 
-O Satan, prends pitié de ma longue misère!
+O Satan, prends pitié de ma longue misère !
 
 Toi dont la large main cache les précipices
 Au somnambule errant au bord des édifices,
 
-O Satan, prends pitié de ma longue misère!
+O Satan, prends pitié de ma longue misère !
 
 Toi qui, magiquement, assouplis les vieux os
 De l'ivrogne attardé foulé par les chevaux,
 
-O Satan, prends pitié de ma longue misère!
+O Satan, prends pitié de ma longue misère !
 
 Toi qui, pour consoler l'homme frêle qui souffre,
 Nous appris à mêler le salpêtre et le soufre,
 
-O Satan, prends pitié de ma longue misère!
+O Satan, prends pitié de ma longue misère !
 
 Toi qui poses ta marque, ô complice subtil,
 Sur le front du Crésus impitoyable et vil,
 
-O Satan, prends pitié de ma longue misère!
+O Satan, prends pitié de ma longue misère !
 
 Toi qui mets dans les yeux et dans le coeur des filles
 Le culte de la plaie et l'amour des guenilles,
 
-O Satan, prends pitié de ma longue misère!
+O Satan, prends pitié de ma longue misère !
 
 Bâton des exilés, lampe des inventeurs,
 Confesseur des pendus et des conspirateurs,
 
-O Satan, prends pitié de ma longue misère!
+O Satan, prends pitié de ma longue misère !
 
 Père adoptif de ceux qu'en sa noire colère
 Du paradis terrestre a chassés Dieu le Père,
 
-O Satan, prends pitié de ma longue misère!
+O Satan, prends pitié de ma longue misère !
 </poetry>
 </body>
 </text>
@@ -5607,10 +5607,10 @@ O Satan, prends pitié de ma longue misère!
 <poetry>
 Gloire et louange à toi, Satan, dans les hauteurs
 Du Ciel, où tu régnas, et dans les profondeurs
-De l'Enfer, où, vaincu, tu rêves en silence!
+De l'Enfer, où, vaincu, tu rêves en silence !
 Fais que mon âme un jour, sous l'Arbre de Science,
 Près de toi se repose, à l'heure où sur ton front
-Comme un Temple nouveau ses rameaux s'épandront!
+Comme un Temple nouveau ses rameaux s'épandront !
 </poetry>
 </body>
 </text>
@@ -5646,7 +5646,7 @@ Dans nos deux esprits, ces miroirs jumeaux.
 
 Un soir fait de rose et de bleu mystique,
 Nous échangerons un éclair unique,
-Comme un long sanglot, tout chargé d'adieux;
+Comme un long sanglot, tout chargé d'adieux ;
 
 Et plus tard un Ange, entr'ouvrant les portes,
 Viendra ranimer, fidèle et joyeux,
@@ -5660,29 +5660,29 @@ Les miroirs ternis et les flammes mortes.
    <title>La Mort des Pauvres</title>
    <toctitle>La Mort des Pauvres</toctitle>
    <indextitle>La Mort des Pauvres</indextitle>
-   <firstline>C'est la Mort qui console, hélas! et qui fait vivre</firstline>
+   <firstline>C'est la Mort qui console, hélas ! et qui fait vivre</firstline>
    <quality>korrektur1</quality>
    <keywords>sonnet</keywords>
 </head>
 <body>
 <poetry>
-C'est la Mort qui console, hélas! et qui fait vivre;
+C'est la Mort qui console, hélas ! et qui fait vivre ;
 C'est le but de la vie - et c'est le seul espoir
 Qui, comme un élixir, nous monte et nous enivre,
-Et nous donne le coeur de marcher jusqu'au soir;
+Et nous donne le coeur de marcher jusqu'au soir ;
 
 A travers la tempête, et la neige, et le givre,
 C'est la clarté vibrante à notre horizon noir
 C'est l'auberge fameuse inscrite sur le livre,
-Où l'on pourra manger, et dormir, et s'asseoir;
+Où l'on pourra manger, et dormir, et s'asseoir ;
 
 C'est un Ange qui tient dans ses doigts magnétiques
 Le sommeil et le don des rêves extatiques,
-Et qui refait le lit des gens pauvres et nus;
+Et qui refait le lit des gens pauvres et nus ;
 
 C'est la gloire des Dieux, c'est le grenier mystique,
 C'est la bourse du pauvre et sa patrie antique,
-C'est le portique ouvert sur les Cieux inconnus!
+C'est le portique ouvert sur les Cieux inconnus !
 </poetry>
 </body>
 </text>
@@ -5699,22 +5699,22 @@ C'est le portique ouvert sur les Cieux inconnus!
 <body>
 <poetry>
 Combien faut-il de fois secouer mes grelots
-Et baiser ton front bas, morne caricature?
+Et baiser ton front bas, morne caricature ?
 Pour piquer dans le but, de mystique nature,
-Combien, ô mon carquois, perdre de javelots?
+Combien, ô mon carquois, perdre de javelots ?
 
 Nous userons notre âme en de subtils complots,
 Et nous démolirons mainte lourde armature,
 Avant de contempler la grande Créature
-Dont l'infernal désir nous remplit de sanglots!
+Dont l'infernal désir nous remplit de sanglots !
 
 Il en est qui jamais n'ont connu leur Idole,
 Et ces sculpteurs damnés et marqués d'un affront,
 Qui vont se martelant la poitrine et le front,
 
-N'ont qu'un espoir, étrange et sombre Capitole!
+N'ont qu'un espoir, étrange et sombre Capitole !
 C'est que la Mort, planant comme un soleil nouveau,
-Fera s'épanouir les fleurs de leur cerveau!
+Fera s'épanouir les fleurs de leur cerveau !
 </poetry>
 </body>
 </text>
@@ -5737,15 +5737,15 @@ Aussi, sitôt qu'à l'horizon
 La nuit voluptueuse monte,
 Apaisant tout, même la faim,
 Effaçant tout, même la honte,
-Le Poète se dit: "Enfin!
+Le Poète se dit : "Enfin !
 
 Mon esprit, comme mes vertèbres,
-Invoque ardemment le repos;
+Invoque ardemment le repos ;
 Le coeur plein de songes funèbres,
 
 Je vais me coucher sur le dos
 Et me rouler dans vos rideaux,
-O rafraîchissantes ténèbres!"
+O rafraîchissantes ténèbres !"
 </poetry>
 </body>
 </text>
@@ -5763,21 +5763,21 @@ O rafraîchissantes ténèbres!"
 <body>
 <poetry>
 Connais-tu, comme moi, la douleur savoureuse
-Et de toi fais-tu dire: "Oh! l'homme singulier!"
+Et de toi fais-tu dire : "Oh ! l'homme singulier !"
 - J'allais mourir. C'était dans mon âme amoureuse
-Désir mêlé d'horreur, un mal particulier;
+Désir mêlé d'horreur, un mal particulier ;
 
 Angoisse et vif espoir, sans humeur factieuse.
 Plus allait se vidant le fatal sablier,
-Plus ma torture était âpre et délicieuse;
+Plus ma torture était âpre et délicieuse ;
 Tout mon coeur s'arrachait au monde familier.
 
 J'étais comme l'enfant avide du spectacle,
 Haïssant le rideau comme on hait un obstacle...
-Enfin la vérité froide se révéla:
+Enfin la vérité froide se révéla :
 
 J'étais mort sans surprise, et la terrible aurore
-M'enveloppait. - Eh quoi! n'est-ce donc que cela?
+M'enveloppait. - Eh quoi ! n'est-ce donc que cela ?
 La toile était levée et j'attendais encore.
 </poetry>
 </body>
@@ -5796,84 +5796,84 @@ La toile était levée et j'attendais encore.
 <poetry>
 Pour l'enfant, amoureux de cartes et d'estampes,
 L'univers est égal à son vaste appétit.
-Ah! que le monde est grand à la clarté des lampes!
-Aux yeux du souvenir que le monde est petit!
+Ah ! que le monde est grand à la clarté des lampes !
+Aux yeux du souvenir que le monde est petit !
 
 Un matin nous partons, le cerveau plein de flamme,
 Le coeur gros de rancune et de désirs amers,
 Et nous allons, suivant le rythme de la lame,
-Berçant notre infini sur le fini des mers:
+Berçant notre infini sur le fini des mers :
 
-Les uns, joyeux de fuir une patrie infâme;
+Les uns, joyeux de fuir une patrie infâme ;
 D'autres, l'horreur de leurs berceaux, et quelques-uns,
 Astrologues noyés dans les yeux d'une femme,
 La Circé tyrannique aux dangereux parfums.
 
 Pour n'être pas changés en bêtes, ils s'enivrent
-D'espace et de lumière et de cieux embrasés;
+D'espace et de lumière et de cieux embrasés ;
 La glace qui les mord, les soleils qui les cuivrent,
 Effacent lentement la marque des baisers.
 
 Mais les vrais voyageurs sont ceux-là seuls qui partent
-Pour partir; coeurs légers, semblables aux ballons,
+Pour partir ; coeurs légers, semblables aux ballons,
 De leur fatalité jamais ils ne s'écartent,
-Et, sans savoir pourquoi, disent toujours: Allons!
+Et, sans savoir pourquoi, disent toujours : Allons !
 
 Ceux-là dont les désirs ont la forme des nues,
 Et qui rêvent, ainsi qu'un conscrit le canon,
 De vastes voluptés, changeantes, inconnues,
-Et dont l'esprit humain n'a jamais su le nom!
+Et dont l'esprit humain n'a jamais su le nom !
 
 	 II
 
-Nous imitons, horreur! la toupie et la boule
-Dans leur valse et leurs bonds; même dans nos sommeils
+Nous imitons, horreur ! la toupie et la boule
+Dans leur valse et leurs bonds ; même dans nos sommeils
 La Curiosité nous tourmente et nous roule
 Comme un Ange cruel qui fouette des soleils.
 
 Singulière fortune où le but se déplace,
-Et, n'étant nulle part, peut être n'importe où!
+Et, n'étant nulle part, peut être n'importe où !
 Où l'Homme, dont jamais l'espérance n'est lasse,
-Pour trouver le repos court toujours comme un fou!
+Pour trouver le repos court toujours comme un fou !
 
-Notre âme est un trois-mâts cherchant son Icarie;
-Une voix retentit sur le pont: "Ouvre l'oeil!"
-Une voix de la hune, ardente et folle, crie:
-"Amour... gloire... bonheur!" Enfer! c'est un écueil!
+Notre âme est un trois-mâts cherchant son Icarie ;
+Une voix retentit sur le pont : "Ouvre l'oeil !"
+Une voix de la hune, ardente et folle, crie :
+"Amour... gloire... bonheur !" Enfer ! c'est un écueil !
 
 Chaque îlot signalé par l'homme de vigie
-Est un Eldorado promis par le Destin;
+Est un Eldorado promis par le Destin ;
 L'Imagination qui dresse son orgie
 Ne trouve qu'un récif aux clartés du matin.
 
-O le pauvre amoureux des pays chimériques!
+O le pauvre amoureux des pays chimériques !
 Faut-il le mettre aux fers, le jeter à la mer,
 Ce matelot ivrogne, inventeur d'Amériques
-Dont le mirage rend le gouffre plus amer?
+Dont le mirage rend le gouffre plus amer ?
 
 Tel le vieux vagabond, piétinant dans la boue,
-Rêve, le nez en l'air, de brillants paradis;
+Rêve, le nez en l'air, de brillants paradis ;
 Son oeil ensorcelé découvre une Capoue
 Partout où la chandelle illumine un taudis.
 
 	 III
 
-Etonnants voyageurs! quelles nobles histoires
-Nous lisons dans vos yeux profonds comme les mers!
+Etonnants voyageurs ! quelles nobles histoires
+Nous lisons dans vos yeux profonds comme les mers !
 Montrez-nous les écrins de vos riches mémoires,
 Ces bijoux merveilleux, faits d'astres et d'éthers.
 
-Nous voulons voyager sans vapeur et sans voile!
+Nous voulons voyager sans vapeur et sans voile !
 Faites, pour égayer l'ennui de nos prisons,
 Passer sur nos esprits, tendus comme une toile,
 Vos souvenirs avec leurs cadres d'horizons.
 
-Dites, qu'avez-vous vu?
+Dites, qu'avez-vous vu ?
 
 	 IV
 
 "Nous avons vu des astres
-Et des flots, nous avons vu des sables aussi;
+Et des flots, nous avons vu des sables aussi ;
 Et, malgré bien des chocs et d'imprévus désastres,
 Nous nous sommes souvent ennuyés, comme ici.
 
@@ -5885,113 +5885,113 @@ De plonger dans un ciel au reflet alléchant.
 Les plus riches cités, les plus grands paysages,
 Jamais ne contenaient l'attrait mystérieux
 De ceux que le hasard fait avec les nuages.
-Et toujours le désir nous rendait soucieux!
+Et toujours le désir nous rendait soucieux !
 
 - La jouissance ajoute au désir de la force.
 Désir, vieil arbre à qui le plaisir sert d'engrais,
 Cependant que grossit et durcit ton écorce,
-Tes branches veulent voir le soleil de plus près!
+Tes branches veulent voir le soleil de plus près !
 
 Grandiras-tu toujours, grand arbre plus vivace
-Que le cyprès? - Pourtant nous avons, avec soin,
+Que le cyprès ? - Pourtant nous avons, avec soin,
 Cueilli quelques croquis pour votre album vorace
-Frères qui trouvez beau tout ce qui vient de loin!
+Frères qui trouvez beau tout ce qui vient de loin !
 
-Nous avons salué des idoles à trompe;
-Des trônes constellés de joyaux lumineux;
+Nous avons salué des idoles à trompe ;
+Des trônes constellés de joyaux lumineux ;
 Des palais ouvragés dont la féerique pompe
-Serait pour vos banquiers un rêve ruineux;
+Serait pour vos banquiers un rêve ruineux ;
 
-Des costumes qui sont pour les yeux une ivresse;
+Des costumes qui sont pour les yeux une ivresse ;
 Des femmes dont les dents et les ongles sont teints,
 Et des jongleurs savants que le serpent caresse."
 
 	  V
 
-Et puis, et puis encore?
+Et puis, et puis encore ?
 
 	 VI
 
-"O cerveaux enfantins!
+"O cerveaux enfantins !
 
 Pour ne pas oublier la chose capitale,
 Nous avons vu partout, et sans l'avoir cherché,
 Du haut jusques en bas de l'échelle fatale,
-Le spectacle ennuyeux de l'immortel péché:
+Le spectacle ennuyeux de l'immortel péché :
 
 La femme, esclave vile, orgueilleuse et stupide,
-Sans rire s'adorant et s'aimant sans dégoût;
+Sans rire s'adorant et s'aimant sans dégoût ;
 L'homme, tyran goulu, paillard, dur et cupide,
-Esclave de l'esclave et ruisseau dans l'égout;
+Esclave de l'esclave et ruisseau dans l'égout ;
 
-Le bourreau qui jouit, le martyr qui sanglote;
-La fête qu'assaisonne et parfume le sang;
+Le bourreau qui jouit, le martyr qui sanglote ;
+La fête qu'assaisonne et parfume le sang ;
 Le poison du pouvoir énervant le despote,
-Et le peuple amoureux du fouet abrutissant;
+Et le peuple amoureux du fouet abrutissant ;
 
 Plusieurs religions semblables à la nôtre,
-Toutes escaladant le ciel; la Sainteté,
+Toutes escaladant le ciel ; la Sainteté,
 Comme en un lit de plume un délicat se vautre,
-Dans les clous et le crin cherchant la volupté;
+Dans les clous et le crin cherchant la volupté ;
 
 L'Humanité bavarde, ivre de son génie,
 Et, folle maintenant comme elle était jadis,
-Criant à Dieu, dans sa furibonde agonie:
-"O mon semblable, mon maître, je te maudis!"
+Criant à Dieu, dans sa furibonde agonie :
+"O mon semblable, mon maître, je te maudis !"
 
 Et les moins sots, hardis amants de la Démence,
 Fuyant le grand troupeau parqué par le Destin,
-Et se réfugiant dans l'opium immense!
+Et se réfugiant dans l'opium immense !
 - Tel est du globe entier l'éternel bulletin."
 
 	 VII
 
-Amer savoir, celui qu'on tire du voyage!
+Amer savoir, celui qu'on tire du voyage !
 Le monde, monotone et petit, aujourd'hui,
-Hier, demain, toujours, nous fait voir notre image:
-Une oasis d'horreur dans un désert d'ennui!
+Hier, demain, toujours, nous fait voir notre image :
+Une oasis d'horreur dans un désert d'ennui !
 
-Faut-il partir? rester? Si tu peux rester, reste;
+Faut-il partir ? rester ? Si tu peux rester, reste ;
 Pars, s'il le faut. L'un court, et l'autre se tapit
 Pour tromper l'ennemi vigilant et funeste,
-Le Temps! Il est, hélas! des coureurs sans répit,
+Le Temps ! Il est, hélas ! des coureurs sans répit,
 
 Comme le Juif errant et comme les apôtres,
 A qui rien ne suffit, ni wagon ni vaisseau,
-Pour fuir ce rétiaire infâme; il en est d'autres
+Pour fuir ce rétiaire infâme ; il en est d'autres
 Qui savent le tuer sans quitter leur berceau.
 
 Lorsque enfin il mettra le pied sur notre échine,
-Nous pourrons espérer et crier: En avant!
+Nous pourrons espérer et crier : En avant !
 De même qu'autrefois nous partions pour la Chine,
 Les yeux fixés au large et les cheveux au vent,
 
 Nous nous embarquerons sur la mer des Ténèbres
 Avec le coeur joyeux d'un jeune passager.
 Entendez-vous ces voix charmantes et funèbres,
-Qui chantent: "Par ici vous qui voulez manger
+Qui chantent : "Par ici vous qui voulez manger
 
-Le Lotus parfumé! c'est ici qu'on vendange
-Les fruits miraculeux dont votre coeur a faim;
+Le Lotus parfumé ! c'est ici qu'on vendange
+Les fruits miraculeux dont votre coeur a faim ;
 Venez vous enivrer de la douceur étrange
-De cette après-midi qui n'a jamais de fin!"
+De cette après-midi qui n'a jamais de fin !"
 
-A l'accent familier nous devinons le spectre;
+A l'accent familier nous devinons le spectre ;
 Nos Pylades là-bas tendent leurs bras vers nous.
-"Pour rafraîchir ton coeur nage vers ton Electre!"
+"Pour rafraîchir ton coeur nage vers ton Electre !"
 Dit celle dont jadis nous baisions les genoux.
 
      VIII
 
-O Mort, vieux capitaine, il est temps! levons l'ancre!
-Ce pays nous ennuie, ô Mort! Appareillons!
+O Mort, vieux capitaine, il est temps ! levons l'ancre !
+Ce pays nous ennuie, ô Mort ! Appareillons !
 Si le ciel et la mer sont noirs comme de l'encre,
-Nos coeurs que tu connais sont remplis de rayons!
+Nos coeurs que tu connais sont remplis de rayons !
 
-Verse-nous ton poison pour qu'il nous réconforte!
+Verse-nous ton poison pour qu'il nous réconforte !
 Nous voulons, tant ce feu nous brûle le cerveau,
-Plonger au fond du gouffre, Enfer ou Ciel, qu'importe?
-Au fond de l'Inconnu pour trouver du nouveau!
+Plonger au fond du gouffre, Enfer ou Ciel, qu'importe ?
+Au fond de l'Inconnu pour trouver du nouveau !
 </poetry>
 </body>
 </text>

--- a/fdirs/baudelaire/1866.xml
+++ b/fdirs/baudelaire/1866.xml
@@ -28,18 +28,18 @@
 <body>
 <poetry>
 Que le Soleil est beau quand tout frais il se lève,
-Comme une explosion nous lançant son bonjour!
+Comme une explosion nous lançant son bonjour !
 - Bienheureux celui-là qui peut avec amour
-Saluer son coucher plus glorieux qu'un rêve!
+Saluer son coucher plus glorieux qu'un rêve !
 
-Je me souviens!... J'ai vu tout, fleur, source, sillon,
+Je me souviens !... J'ai vu tout, fleur, source, sillon,
 Se pâmer sous son oeil comme un coeur qui palpite...
 - Courons vers l'horizon, il est tard, courons vite,
-Pour attraper au moins un oblique rayon!
+Pour attraper au moins un oblique rayon !
 
-Mais je poursuis en vain le Dieu qui se retire;
+Mais je poursuis en vain le Dieu qui se retire ;
 L'irrésistible Nuit établit son empire,
-Noire, humide, funeste et pleine de frissons;
+Noire, humide, funeste et pleine de frissons ;
 
 Une odeur de tombeau dans les ténèbres nage,
 Et mon pied peureux froisse, au bord du marécage,
@@ -69,28 +69,28 @@ Des crapauds imprévus et de froids limaçons.
 Mère des jeux latins et des voluptés grecques,
 Lesbos, où les baisers, languissants ou joyeux,
 Chauds comme les soleils, frais comme les pastèques,
-Font l'ornement des nuits et des jours glorieux;
+Font l'ornement des nuits et des jours glorieux ;
 Mère des jeux latins et des voluptés grecques,
 
 Lesbos, où les baisers sont comme les cascades
 Qui se jettent sans peur dans les gouffres sans fonds,
 Et courent, sanglotant et gloussant par saccades,
-Orageux et secrets, fourmillants et profonds;
-Lesbos, ou les baisers sont comme les cascades!
+Orageux et secrets, fourmillants et profonds ;
+Lesbos, ou les baisers sont comme les cascades !
 
 Lesbos, où les Phrynés l'une l'autre s'attirent,
 Où jamais un soupir ne resta sans écho,
 A l'égal de Paphos les étoiles t'atdmirent,
-Et Vénus à bon droit peut jalouser Sapho!
+Et Vénus à bon droit peut jalouser Sapho !
 Lesbos, où les Phrynés l'une l'autre s'attirent,
 
 Lesbos, terre des nuits chaudes et langoureuses,
-Qui font qu'à leurs miroirs, stérile volupté!
+Qui font qu'à leurs miroirs, stérile volupté !
 Les filles aux yeux creux, de leurs corps amoureuses,
-Caressent les fruits mûrs de leur nubilité;
+Caressent les fruits mûrs de leur nubilité ;
 Lesbos, terre des nuits chaudes et langoureuses,
 
-Laisse du vieux Platon se froncer l'oeil austère;
+Laisse du vieux Platon se froncer l'oeil austère ;
 Tu tires ton pardon de l'excès des baisers,
 Reine du doux empire, aimable et noble terre,
 Et des raffinements toujours inépuisés
@@ -99,50 +99,50 @@ Laisse du vieux Platon se froncer l'oeil austère.
 Tu tires ton pardon de l'éternel martyre,
 Infligé sans relâche aux coeurs ambitieux,
 Qu'attire loin de nous le radieux sourire
-Entrevu vaguement au bord des autres cieux!
-Tu tires ton pardon de l'éternel martyre!
+Entrevu vaguement au bord des autres cieux !
+Tu tires ton pardon de l'éternel martyre !
 
 Qui des Dieux osera, Lesbos, être ton juge
 Et condamner ton front pâli dans les travaux,
 Si ses balances d'or n'ont pesé le déluge
-De larmes qu'à la mer ont versé tes ruisseaux?
-Qui des Dieux osera, Lesbos, être ton juge?
+De larmes qu'à la mer ont versé tes ruisseaux ?
+Qui des Dieux osera, Lesbos, être ton juge ?
 
-Que nous veulent les lois du juste et de l'injuste?
+Que nous veulent les lois du juste et de l'injuste ?
 Vierges au coeur sublime, honneur de l'archipel,
 Votre religion comme une autre est auguste,
-Et l'amour se rira de l'Enfer et du Ciel!
-Que nous veulent les lois de juste et de l'injuste?
+Et l'amour se rira de l'Enfer et du Ciel !
+Que nous veulent les lois de juste et de l'injuste ?
 
 Car Lesbos entre tous m'a choisi sur la terre
 Pour chanter le secret de ses vierges en fleurs,
 Et je fus dès l'enfance admis au noir mystère
-Des rires effrénés mêlés aux sombres pleurs;
+Des rires effrénés mêlés aux sombres pleurs ;
 Car Lesbos entre tous m'a choisi sur la terre.
 
 Et depuis lors je veille au sommet de Leucate,
 Comme une sentinelle à l'oeil perçant et sûr,
 Qui guette nuit et jour brick, tartane ou frégate,
-Dont les formes au loin frissonnent dans l'azur;
+Dont les formes au loin frissonnent dans l'azur ;
 Et depuis lors je veille au sommet de Leucate
 
 Pour savoir si la mer est indulgente et bonne,
 Et parmi les sanglots dont le roc retentit
 Un soir ramènera vers Lesbos, qui pardonne,
 Le cadavre adoré de Sapho, qui partit
-Pour savoir si la mer est indulgente et bonne!
+Pour savoir si la mer est indulgente et bonne !
 
 De la mâle Sapho, l'amante et le poëte,
-Plus belle que Vénus par ses mornes pâleurs!
+Plus belle que Vénus par ses mornes pâleurs !
 - L'oeil d'azur est vaincu par l'oeil noir que tachète
 Le cercle ténébreux tracé par les douleurs
-De la mâle Sapho, l'amante et le poëte!
+De la mâle Sapho, l'amante et le poëte !
 
 - Plus belle que Vénus se dressant sur le monde
 Et versant les trésors de sa sérénité
 Et le rayonnement de sa jeunesse blonde
-Sur le vieil Océan de sa fille enchanté;
-Plus belle que Vénus se dressant sur le monde!
+Sur le vieil Océan de sa fille enchanté ;
+Plus belle que Vénus se dressant sur le monde !
 
 - De Sapho qui mourut le jour de son blasphème,
 Quand, insultant le rite et le culte inventé,
@@ -153,8 +153,8 @@ De celle qui mourut le jour de son blasphème.
 Et c'est depuis ce temps que Lesbos se lamente,
 Et, malgré les honneurs que lui rend l'univers,
 S'enivre chaque nuit du cri de la tourmente
-Que poussent vers les cieux ses rivages déserts!
-Et c'est depuis ce temps que Lesbos se lamente!
+Que poussent vers les cieux ses rivages déserts !
+Et c'est depuis ce temps que Lesbos se lamente !
 </poetry>
 </body>
 </text>
@@ -200,27 +200,27 @@ Le cantique muet que chante le plaisir,
 Et cette gratitude infinie et sublime
 Qui sort de la paupière ainsi qu'un long soupir.
 
-- «Hippolyte, cher coeur, que dis-tu de ces choses?
+- «Hippolyte, cher coeur, que dis-tu de ces choses ?
 Comprends-tu maintenant qu'il ne faut pas offrir
 L'holocauste sacré de tes premières roses
-Aux souffles violents qui pourraient les flétrir?
+Aux souffles violents qui pourraient les flétrir ?
 
 Mes baisers sont légers comme ces éphémères
 Qui caressent le soir les grands lacs transparents,
 Et ceux de ton amant creuseront leurs ornières
-Comme des chariots ou des socs déchirants;
+Comme des chariots ou des socs déchirants ;
 
 Ils passeront sur toi comme un lourd attelage
 De chevaux et de boeufs aux sabots sans pitié...
-Hippolyte, ô ma soeur! tourne donc ton visage,
+Hippolyte, ô ma soeur ! tourne donc ton visage,
 Toi, mon âme et mon coeur, mon tout et ma moitié,
 
-Tourne vers moi tes yeux pleins d'azur et d'étoiles!
+Tourne vers moi tes yeux pleins d'azur et d'étoiles !
 Pour un de ces regards charmants, baume divin,
 Des plaisirs plus obscurs je lèverai les voiles
-Et je t'endormirai dans un rêve sans fin!»
+Et je t'endormirai dans un rêve sans fin !»
 
-Mais Hippolyte alors, levant sa jeune tête:
+Mais Hippolyte alors, levant sa jeune tête :
 - «Je ne suis point ingrate et ne me repens pas,
 Ma Delphine, je souffre et je suis inquiète,
 Comme après un nocturne et terrible repas.
@@ -230,62 +230,62 @@ Et de noirs bataillons de fantômes épars,
 Qui veulent me conduire en des routes mouvantes
 Qu'un horizon sanglant ferme de toutes parts.
 
-Avons-nous donc commis une action étrange?
-Explique, si tu peux, mon trouble et mon effroi:
-Je frissonne de peur quand tu me dis: «Mon ange!»
+Avons-nous donc commis une action étrange ?
+Explique, si tu peux, mon trouble et mon effroi :
+Je frissonne de peur quand tu me dis : «Mon ange !»
 Et cependant je sens ma bouche aller vers toi.
 
-Ne me regarde pas ainsi, toi, ma pensée!
+Ne me regarde pas ainsi, toi, ma pensée !
 Toi que j'aime à jamais, ma soeur d'élection,
 Quand même tu serais une embûche dressée
-Et le commencement de ma perdition!»
+Et le commencement de ma perdition !»
 
 Delphine secouant sa crinière tragique,
 Et comme trépignant sur le trépied de fer,
-L'oeil fatal, répondit d'une voix despotique:
-- «Qui donc devant l'amour ose parler d'enfer?
+L'oeil fatal, répondit d'une voix despotique :
+- «Qui donc devant l'amour ose parler d'enfer ?
 
 Maudit soit à jamais le rêveur inutile
 Qui voulut le premier, dans sa stupidité,
 S'éprenant d'un problème insoluble et stérile,
-Aux choses de l'amour mêler l'honnêteté!
+Aux choses de l'amour mêler l'honnêteté !
 
 Celui qui veut unir dans un accord mystique
 L'ombre avec la chaleur, la nuit avec le jour,
 Ne chauffera jamais son corps paralytique
-A ce rouge soleil que l'on nomme l'amour!
+A ce rouge soleil que l'on nomme l'amour !
 
-Va, si tu veux, chercher un fiancé stupide;
-Cours offrir un coeur vierge à ses cruels baisers;
+Va, si tu veux, chercher un fiancé stupide ;
+Cours offrir un coeur vierge à ses cruels baisers ;
 Et, pleine de remords et d'horreur, et livide,
 Tu me rapporteras tes seins stigmatisés...
 
-On ne peut ici-bas contenter qu'un seul maître!»
+On ne peut ici-bas contenter qu'un seul maître !»
 Mais l'enfant, épanchant une immense douleur,
-Cria soudain: «- Je sens s'élargir dans mon être
-Un abîme béant; cet abîme est mon coeur!
+Cria soudain : «- Je sens s'élargir dans mon être
+Un abîme béant ; cet abîme est mon coeur !
 
-Brûlant comme un volcan, profond comme le vide!
+Brûlant comme un volcan, profond comme le vide !
 Rien ne rassasiera ce monstre gémissant
 Et ne rafraîchira la soif de l'Euménide
 Qui, la torche à la main, le brûle jusqu'au sang.
 
 Que nos rideaux fermés nous séparent du monde,
-Et que la lassitude amène le repos!
+Et que la lassitude amène le repos !
 Je veux m'anéantir dans ta gorge profonde
-Et trouver sur ton sein la fraîcheur des tombeaux!»
+Et trouver sur ton sein la fraîcheur des tombeaux !»
 
 - Descendez, descendez, lamentables victimes,
-Descendez le chemin de l'enfer éternel!
+Descendez le chemin de l'enfer éternel !
 Plongez au plus profond du gouffre, où tous les crimes,
 Flagellés par un vent qui ne vient pas du ciel,
 
 Bouillonnent pêle-mêle avec un bruit d'orage.
-Ombres folles, courez au but de vos désirs;
+Ombres folles, courez au but de vos désirs ;
 Jamais vous ne pourrez assouvir votre rage,
 Et votre châtiment naîtra de vos plaisirs.
 
-Jamais un rayon frais n'éclaira vos cavernes;
+Jamais un rayon frais n'éclaira vos cavernes ;
 Par les fentes des murs des miasmes fiévreux
 Filtrent en s'enflammant ainsi que des lanternes
 Et pénètrent vos corps de leurs parfums affreux.
@@ -296,9 +296,9 @@ Et le vent furibond de la concupiscence
 Fait claquer votre chair ainsi qu'un vieux drapeau.
 
 Loin des peuples vivants, errantes, condamnées,
-A travers les déserts courez comme les loups;
+A travers les déserts courez comme les loups ;
 Faites votre destin, âmes désordonnées,
-Et fuyez l'infini que vous portez en vous!
+Et fuyez l'infini que vous portez en vous !
 </poetry>
 </body>
 </text>
@@ -314,27 +314,27 @@ Et fuyez l'infini que vous portez en vous!
 <body>
 <poetry>
 Viens sur mon coeur, âme cruelle et sourde,
-Tigre adoré, monstre aux airs indolents;
+Tigre adoré, monstre aux airs indolents ;
 Je veux longtemps plonger mes doigts tremblants
-Dans l'épaisseur de ta crinière lourde;
+Dans l'épaisseur de ta crinière lourde ;
 
 Dans tes jupons remplis de ton parfum
 Ensevelir ma tête endolorie,
 Et respirer, comme une fleur flétrie,
 Le doux relent de mon amour défunt.
 
-Je veux dormir! dormir plutôt que vivre!
+Je veux dormir ! dormir plutôt que vivre !
 Dans un sommeil aussi doux que la mort,
 J'étalerai mes baisers sans remord
 Sur ton beau corps poli comme le cuivre.
 
 Pour engloutir mes sanglots apaisés
-Rien ne me vaut l'abîme de ta couche;
+Rien ne me vaut l'abîme de ta couche ;
 L'oubli puissant habite sur ta bouche,
 Et le Léthé coule dans tes baisers.
 
 A mon destin, désormais mon délice,
-J'obéirai comme un prédestiné;
+J'obéirai comme un prédestiné ;
 Martyr docile, innocent condamné,
 Dont la ferveur attise le supplice,
 
@@ -357,7 +357,7 @@ Qui n'a jamais emprisonné de coeur.
 <body>
 <poetry>
 Ta tête, ton geste, ton air
-Sont beaux comme un beau paysage;
+Sont beaux comme un beau paysage ;
 Le rire joue en ton visage
 Comme un vent frais dans un ciel clair.
 
@@ -372,14 +372,14 @@ Jettent dans l'esprit des poëtes
 L'image d'un ballet de fleurs.
 
 Ces robes folles sont l'emblème
-De ton esprit bariolé;
+De ton esprit bariolé ;
 Folle dont je suis affolé,
-Je te hais autant que je t'aime!
+Je te hais autant que je t'aime !
 
 Quelquefois dans un beau jardin
 Où je traînais mon atonie,
 J'ai senti, comme une ironie,
-Le soleil déchirer mon sein;
+Le soleil déchirer mon sein ;
 
 Et le printemps et la verdure
 Ont tant humilié mon coeur,
@@ -396,10 +396,10 @@ Pour meurtrir ton sein pardonné,
 Et faire à ton flanc étonné
 Une blessure large et creuse,
 
-Et, vertigineuse douceur!
+Et, vertigineuse douceur !
 A travers ces lèvres nouvelles,
 Plus éclatantes et plus belles,
-T'infuser mon venin, ma soeur!
+T'infuser mon venin, ma soeur !
 </poetry>
 </body>
 </text>
@@ -432,11 +432,11 @@ Qui vers elle montait comme vers sa falaise.
 Les yeux fixés sur moi, comme un tigre dompté,
 D'un air vague et rêveur elle essayait des poses,
 Et la candeur unie à la lubricité
-Donnait un charme neuf à ses métamorphoses;
+Donnait un charme neuf à ses métamorphoses ;
 
 Et son bras et sa jambe, et sa cuisse et ses reins,
 Polis comme de l'huile, onduleux comme un cygne,
-Passaient devant mes yeux clairvoyants et sereins;
+Passaient devant mes yeux clairvoyants et sereins ;
 Et son ventre et ses seins, ces grappes de ma vigne,
 
 S'avançaient, plus câlins que les Anges du mal,
@@ -447,12 +447,12 @@ Où, calme et solitaire, elle s'était assise.
 Je croyais voir unis par un nouveau dessin
 Les hanches de l'Antiope au buste d'un imberbe,
 Tant sa taille faisait ressortir son bassin.
-Sur ce teint fauve et brun le fard était superbe!
+Sur ce teint fauve et brun le fard était superbe !
 
 - Et la lampe s'étant résignée à mourir,
 Comme le foyer seul illuminait la chambre,
 Chaque fois qu'il poussait un flamboyant soupir,
-Il inondait de sang cette peau couleur d'ambre!
+Il inondait de sang cette peau couleur d'ambre !
 </poetry>
 </body>
 </text>
@@ -470,24 +470,24 @@ Il inondait de sang cette peau couleur d'ambre!
 La femme cependant, de sa bouche de fraise,
 En se tordant ainsi qu'un serpent sur la braise,
 Et pétrissant ses seins sur le fer de son busc,
-Laissait couler ces mots tout imprégnés de musc:
+Laissait couler ces mots tout imprégnés de musc :
 - «Moi, j'ai la lèvre humide, et je sais la science
 De perdre au fond d'un lit l'antique conscience.
 Je sèche tous les pleurs sur mes seins triomphants,
 Et fais rire les vieux du rire des enfants.
 Je remplace, pour qui me voit nue et sans voiles,
-La lune, le soleil, le ciel et les étoiles!
+La lune, le soleil, le ciel et les étoiles !
 Je suis, mon cher savant, si docte aux voluptés,
 Lorsque j'étouffe un homme en mes bras redoutés,
 Ou lorsque j'abandonne aux morsures mon buste,
 Timide et libertine, et fragile et robuste,
 Que sur ces matelas qui se pâment d'émoi,
-Les anges impuissants se damneraient pour moi!»
+Les anges impuissants se damneraient pour moi !»
 
 Quand elle eut de mes os sucé toute la moelle,
 Et que languissamment je me tournai vers elle
 Pour lui rendre un baiser d'amour, je ne vis plus
-Qu'une outre aux flancs gluants, toute pleine de pus!
+Qu'une outre aux flancs gluants, toute pleine de pus !
 Je fermai les deux yeux, dans ma froide épouvante,
 Et quand je les rouvris à la clarté vivante,
 A mes côtés, au lieu du mannequin puissant
@@ -513,12 +513,12 @@ Que balance le vent pendant les nuits d'hiver.
    <title>Le jet d'eau</title>
    <toctitle><num>VIII.</num>Le jet d'eau</toctitle>
    <indextitle>Le jet d'eau</indextitle>
-   <firstline>Tes beaux yeux sont las, pauvre amante!</firstline>
+   <firstline>Tes beaux yeux sont las, pauvre amante !</firstline>
    <quality>korrektur1</quality>
 </head>
 <body>
 <poetry>
-Tes beaux yeux sont las, pauvre amante!
+Tes beaux yeux sont las, pauvre amante !
 Reste longtemps, sans les rouvrir,
 Dans cette pose nonchalante
 Où t'a surprise le plaisir.
@@ -554,7 +554,7 @@ Descend jusqu'au fond de mon coeur.
 O toi, que la nuit rend si belle,
 Qu'il m'est doux, penché vers tes seins,
 D'écouter la plainte éternelle
-Qui sanglote dans les bassins!
+Qui sanglote dans les bassins !
 Lune, eau sonore, nuit bénie,
 Arbres qui frissonnez autour,
 Votre pure mélancolie
@@ -582,16 +582,16 @@ Est le miroir de mon amour.
 <poetry>
 Vous pouvez mépriser les yeux les plus célèbres,
 Beaux yeux de mon enfant, par où filtre et s'enfuit
-Je ne sais quoi de bon, de doux comme la Nuit!
-Beaux yeux, versez sur moi vos charmantes ténèbres!
+Je ne sais quoi de bon, de doux comme la Nuit !
+Beaux yeux, versez sur moi vos charmantes ténèbres !
 
 Grands yeux de mon enfant, arcanes adorés,
 Vous ressemblez beaucoup à ces grottes magiques
 Où, derrière l'amas des ombres léthargiques,
-Scintillent vaguement des trésors ignorés!
+Scintillent vaguement des trésors ignorés !
 
 Mon enfant a des yeux obscurs, profonds et vastes,
-Comme toi, Nuit immense, éclairés comme toi!
+Comme toi, Nuit immense, éclairés comme toi !
 Leurs feux sont ces pensers d'Amour, mêlés de Foi,
 Qui pétillent au fond, voluptueux ou chastes.
 </poetry>
@@ -611,7 +611,7 @@ Qui pétillent au fond, voluptueux ou chastes.
 A la très-chère, à la très-belle
 Qui remplit mon coeur de clarté,
 A l'ange, à l'idole immortelle,
-Salut en l'immortalité!
+Salut en l'immortalité !
 
 Elle se répand dans ma vie
 Comme un air imprégné de sel,
@@ -624,14 +624,14 @@ Encensoir oublié qui fume
 En secret à travers la nuit,
 
 Comment, amour incorruptible,
-T'exprimer avec vérité?
+T'exprimer avec vérité ?
 Grain de musc qui gis, invisible,
-Au fond de mon éternité!
+Au fond de mon éternité !
 
 A la très-bonne, à la très-belle,
 Qui fait ma joie et ma santé,
 A l'ange, à l'idole immortelle,
-Salut en l'immortalité!
+Salut en l'immortalité !
 </poetry>
 </body>
 </text>
@@ -647,19 +647,19 @@ Salut en l'immortalité!
 <body>
 <poetry>
 J'aime, ô pâle beauté, tes sourcils surbaissés,
-   D'où semblent couler des ténèbres;
+   D'où semblent couler des ténèbres ;
 Tes yeux, quoique très-noirs, m'inspirent des pensers
    Qui ne sont pas du tout funèbres.
 
 Tes yeux, qui sont d'accord avec tes noirs cheveux,
    Avec ta crinière élastique,
-Tes yeux, languissamment, me disent: «Si tu veux,
+Tes yeux, languissamment, me disent : «Si tu veux,
    Amant de la muse plastique,
 
 Suivre l'espoir qu'en toi nous avons excité,
    Et tous les goûts que tu professes,
 Tu pourras constater notre véracité
-   Depuis le nombril jusqu'aux fesses;
+   Depuis le nombril jusqu'aux fesses ;
 
 Tu trouveras au bout de deux beaux seins bien lourds,
    Deux larges médailles de bronze,
@@ -669,7 +669,7 @@ Et sous un ventre uni, doux comme du velours,
 Une riche toison qui, vraiment, est la soeur
    De cette énorme chevelure,
 Souple et frisée, et qui t'égale en épaisseur,
-   Nuit sans étoiles, Nuit obscure!»
+   Nuit sans étoiles, Nuit obscure !»
 </poetry>
 </body>
 </text>
@@ -693,32 +693,32 @@ I
 Tu n'es certes pas, ma très-chère,
 Ce que Veuillot nomme un tendron.
 Le jeu, l'amour, la bonne chère,
-Bouillonnent en toi, vieux chaudron!
+Bouillonnent en toi, vieux chaudron !
 Tu n'es plus fraîche, ma très-chère,
 
-Ma vieille infante! Et cependant
+Ma vieille infante ! Et cependant
 Tes caravanes insensées
 T'ont donné ce lustre abondant
 Des choses qui sont très-usées,
 Mais qui séduisent cependant.
 
 Je ne trouve pas monotone
-La verdeur de tes quarante ans;
+La verdeur de tes quarante ans ;
 Je préfère tes fruits, Automne,
-Aux fleurs banales du Printemps!
-Non! tu n'es jamais monotone!
+Aux fleurs banales du Printemps !
+Non ! tu n'es jamais monotone !
 
 Ta carcasse a des agréments
-Et des grâces particulières;
+Et des grâces particulières ;
 Je trouve d'étranges piments
-Dans le creux de tes deux salières;
-Ta carcasse a des agréments!
+Dans le creux de tes deux salières ;
+Ta carcasse a des agréments !
 
 Nargue des amants ridicules
-Du melon et du giraumont!
+Du melon et du giraumont !
 Je préfère tes clavicules
 A celles du roi Salomon (1),
-Et je plains ces gens ridicules!
+Et je plains ces gens ridicules !
 
 Tes cheveux, comme un casque bleu,
 Ombragent ton front de guerrière,
@@ -729,59 +729,59 @@ Comme les crins d'un casque bleu.
 Tes yeux qui semblent de la boue,
 Où scintille quelque fanal,
 Ravivés au fard de ta joue,
-Lancent un éclair infernal!
-Tes yeux sont noirs comme la boue!
+Lancent un éclair infernal !
+Tes yeux sont noirs comme la boue !
 
 Par sa luxure et son dédain
-Ta lèvre amère nous provoque;
+Ta lèvre amère nous provoque ;
 Cette lèvre, c'est un Eden
 Qui nous attire et qui nous choque.
-Quelle luxure! et quel dédain!
+Quelle luxure ! et quel dédain !
 
 Ta jambe musculeuse et sèche
 Sait gravir au haut des volcans,
 Et malgré la neige et la dèche
 Danser les plus fougueux cancans.
-Ta jambe est musculeuse et sèche;
+Ta jambe est musculeuse et sèche ;
 
 Ta peau brûlante et sans douceur,
 Comme celle des vieux gendarmes,
 Ne connaît pas plus la sueur
 Que ton oeil ne connaît les larmes.
-(Et pourtant elle a sa douceur!)
+(Et pourtant elle a sa douceur !)
 
 
 II
 
-Sotte, tu t'en vas droit au Diable!
+Sotte, tu t'en vas droit au Diable !
 Volontiers j'irais avec toi,
 Si cette vitesse effroyable
 Ne me causait pas quelque émoi.
-Va-t-en donc, toute seule, au Diable!
+Va-t-en donc, toute seule, au Diable !
 
 Mon rein, mon poumon, mon jarret
 Ne me laissent plus rendre hommage
 A ce Seigneur, comme il faudrait.
-«Hélas! c'est vraiment bien dommage!»
+«Hélas ! c'est vraiment bien dommage !»
 Disent mon rein et mon jarret.
 
-Oh! très-sincèrement je souffre
+Oh ! très-sincèrement je souffre
 De ne pas aller aux sabbats,
 Pour voir, quand il pète du soufre,
-Comment tu lui baises son cas (1)!
-Oh! très-sincèrement je souffre!
+Comment tu lui baises son cas (1) !
+Oh ! très-sincèrement je souffre !
 
 Je suis diablement affligé
 De ne pas être ta torchère,
 Et de te demander congé,
-Flambeau d'enfer! Juge, ma chère,
+Flambeau d'enfer ! Juge, ma chère,
 Combien je dois être affligé,
 
 Puisque depuis longtemps je t'aime,
-Etant très-logique! En effet,
+Etant très-logique ! En effet,
 Voulant du Mal chercher la crème
 Et n'aimer qu'un monstre parfait,
-Vraiment oui! vieux monstre, je t'aime!
+Vraiment oui ! vieux monstre, je t'aime !
 </poetry>
 </body>
 </text>
@@ -794,7 +794,7 @@ Vraiment oui! vieux monstre, je t'aime!
    <indextitle>Franciscae meae laudes</indextitle>
    <firstline>Novis te cantabo chordis</firstline>
    <notes>
-      <note>«Ne semble-t-il pas au lecteur, comme à moi, que la langue de la dernière décadence latine, - suprême soupir d'une personne robuste, déjà transformée et préparée pour la vie spirituelle, - est singulièrement propre à exprimer la passion, telle que l'a comprise et sentie le monde poëtique moderne? La mysticité est l'autre pôle de cet aimant, dont Catulle et sa bande, poëtes brutaux et purement épidermiques, n'ont connu que le pôle sensualité. Dans cette merveilleuse langue, le solécisme et le barbarisme me paraissent rendre les négligences forcées d'une passion qui s'oublie et se moque des règles. Les mots, pris dans une acception nouvelle, révèlent la maladresse charmante du barbare du Nord, agenouillé devant la beauté romaine. Le calembour lui-même, quand il traverse ces pédantesques bégaiements, ne joue-t-t-il pas la grâce sauvage et baroque de l'enfance?» - C. B.</note>
+      <note>«Ne semble-t-il pas au lecteur, comme à moi, que la langue de la dernière décadence latine, - suprême soupir d'une personne robuste, déjà transformée et préparée pour la vie spirituelle, - est singulièrement propre à exprimer la passion, telle que l'a comprise et sentie le monde poëtique moderne ? La mysticité est l'autre pôle de cet aimant, dont Catulle et sa bande, poëtes brutaux et purement épidermiques, n'ont connu que le pôle sensualité. Dans cette merveilleuse langue, le solécisme et le barbarisme me paraissent rendre les négligences forcées d'une passion qui s'oublie et se moque des règles. Les mots, pris dans une acception nouvelle, révèlent la maladresse charmante du barbare du Nord, agenouillé devant la beauté romaine. Le calembour lui-même, quand il traverse ces pédantesques bégaiements, ne joue-t-t-il pas la grâce sauvage et baroque de l'enfance ?» - C. B.</note>
    </notes>
    <quality>korrektur1</quality>
 </head>
@@ -806,7 +806,7 @@ In solitudine cordis.
 
 Esto sertis implicata,
 O femina delicata,
-Per quam solvuntur peccata!
+Per quam solvuntur peccata !
 
 Sicut beneficum Lethe,
 Hauriam oscula de te,
@@ -818,15 +818,15 @@ Apparuisti, deitas,
 
 Velut stella salutaris
 In naufragiis amaris.
-- Suspendam cor tuis aris!
+- Suspendam cor tuis aris !
 
 Piscina plena virtutis,
 Fons aeternae juventutis,
-Labris vocem redde mutis!
+Labris vocem redde mutis !
 
-Quod erat spurcum, cremasti;
-Quod rudius, exaequasti;
-Quod debile, confirmasti!
+Quod erat spurcum, cremasti ;
+Quod rudius, exaequasti ;
+Quod debile, confirmasti !
 
 In fame mea taberna,
 In nocte mea lucerna,
@@ -834,15 +834,15 @@ Recte me semper guberna.
 
 Adde nunc viris viribus,
 Dulce balneum suavibus
-Unguentatum odoribus!
+Unguentatum odoribus !
 
 Meos circa lumbos mica,
 O castitatis lorica,
-Aqua tincta seraphica;
+Aqua tincta seraphica ;
 
 Patera gemmis corusca,
 Panis salsus, mollis esca,
-Divinum vinum Francisca!
+Divinum vinum Francisca !
 </poetry>
 </body>
 </text>
@@ -870,7 +870,7 @@ Et dont l'art, subtil entre tous,
 Nous enseigne à rire de nous,
 Celui-là, lecteur, est un sage.
 
-C'est un satirique, un moqueur;
+C'est un satirique, un moqueur ;
 Mais l'énergie avec laquelle
 Il peint le Mal et sa séquelle,
 Prouve la beauté de son coeur.
@@ -880,10 +880,10 @@ De Melmoth ou de Méphisto
 Sous la torche de l'Alecto
 Qui les brûle, mais qui nous glace.
 
-Leur rire, hélas! de la gaîté
-N'est que la douloureuse charge;
+Leur rire, hélas ! de la gaîté
+N'est que la douloureuse charge ;
 Le sien rayonne, franc et large,
-Comme un signe de sa bonté!
+Comme un signe de sa bonté !
 </poetry>
 </body>
 </text>
@@ -899,7 +899,7 @@ Comme un signe de sa bonté!
 <body>
 <poetry>
 Entre tant de beautés que partout on peut voir,
-Je comprends bien, amis, que le désir balance;
+Je comprends bien, amis, que le désir balance ;
 Mais on voit scintiller en Lola de Valence
 Le charme inattendu d'un bijou rose et noir.
 </poetry>
@@ -926,7 +926,7 @@ Mesure d'un regard que la terreur enflamme
 L'escalier de vertige où s'abîme son âme.
 
 Les rires enivrants dont s'emplit la prison
-Vers l'étrange et l'absurde invitent sa raison;
+Vers l'étrange et l'absurde invitent sa raison ;
 Le Doute l'environne, et la Peur ridicule,
 Hideuse et multiforme, autour de lui circule.
 
@@ -936,7 +936,7 @@ Tourbillonne, ameuté derrière son oreille,
 
 Ce rêveur que l'horreur de son logis réveille,
 Voilà bien ton emblême, Ame aux songes obscurs,
-Que le Réel étouffe entre ses quatre murs!
+Que le Réel étouffe entre ses quatre murs !
                                   1842.
 </poetry>
 </body>
@@ -965,29 +965,29 @@ Babel sombre, où roman, science, fabliau,
 Tout, la cendre latine et la poussière grecque,
 Se mêlaient. J'étais haut comme un in-folio.
 Deux voix me parlaient. L'une, insidieuse et ferme,
-Disait: «La Terre est un gâteau plein de douceur;
-Je puis (et ton plaisir serait alors sans terme!)
+Disait : «La Terre est un gâteau plein de douceur ;
+Je puis (et ton plaisir serait alors sans terme !)
 Te faire un appétit d'une égale grosseur.»
-Et l'autre: «Viens! oh! viens voyager dans les rêves,
-Au delà du possible, au delà du connu!»
+Et l'autre : «Viens ! oh ! viens voyager dans les rêves,
+Au delà du possible, au delà du connu !»
 Et celle-là chantait comme le vent des grèves,
 Fantôme vagissant, on ne sait d'où venu,
 Qui caresse l'oreille et cependant l'effraie.
-Je te répondis: «Oui! douce voix!» C'est d'alors
-Que date ce qu'on peut, hélas! nommer ma plaie
+Je te répondis : «Oui ! douce voix !» C'est d'alors
+Que date ce qu'on peut, hélas ! nommer ma plaie
 Et ma fatalité. Derrière les décors
 De l'existence immense, au plus noir de l'abîme,
 Je vois distinctement des mondes singuliers,
 Et, de ma clairvoyance extatique victime,
 Je traîne des serpents qui mordent mes souliers.
 Et c'est depuis ce temps que, pareil aux prophètes,
-J'aime si tendrement le désert et la mer;
+J'aime si tendrement le désert et la mer ;
 Que je ris dans les deuils et pleure dans les fêtes,
-Et trouve un goût suave au vin le plus amer;
+Et trouve un goût suave au vin le plus amer ;
 Que je prends très-souvent les faits pour des mensonges,
 Et que, les yeux au ciel, je tombe dans des trous.
-Mais la Voix me console et dit: «Garde tes songes;
-Le sages n'en ont pas d'aussi beaux que les fous!»
+Mais la Voix me console et dit : «Garde tes songes ;
+Le sages n'en ont pas d'aussi beaux que les fous !»
 </poetry>
 </body>
 </text>
@@ -1003,44 +1003,44 @@ Le sages n'en ont pas d'aussi beaux que les fous!»
 <body>
 <poetry>
 Harpagon, qui veillait son père agonisant,
-Se dit, rêveur, devant ces lèvres déjà blanches:
+Se dit, rêveur, devant ces lèvres déjà blanches :
 «Nous avons au grenier un nombre suffisant,
-   Ce me semble, de vieilles planches?»
+   Ce me semble, de vieilles planches ?»
 
-Célimène roucoule et dit: «Mon coeur est bon,
+Célimène roucoule et dit : «Mon coeur est bon,
 Et naturellement, Dieu m'a faite très-belle.»
-- Son coeur! coeur racorni, fumé comme un jambon,
-   Recuit à la flamme éternelle!
+- Son coeur ! coeur racorni, fumé comme un jambon,
+   Recuit à la flamme éternelle !
 
 Un gazetier fumeux, qui se croit un flambeau,
-Dit au pauvre, qu'il a noyé dans les ténèbres:
+Dit au pauvre, qu'il a noyé dans les ténèbres :
 «Où donc l'aperçois-tu, ce créateur du Beau,
-   Ce Redresseur que tu célèbres?»
+   Ce Redresseur que tu célèbres ?»
 
 Mieux que tous, je connais certain voluptueux
 Qui bâille nuit et jour, et se lamente et pleure,
-Répétant, l'impuissant et le fat: «Oui, je veux
-   Etre vertueux, dans une heure!»
+Répétant, l'impuissant et le fat : «Oui, je veux
+   Etre vertueux, dans une heure !»
 
-L'horloge, à son tour, dit à voix basse: «Il est mûr,
-Le damné! J'avertis en vain la chair infecte.
+L'horloge, à son tour, dit à voix basse : «Il est mûr,
+Le damné ! J'avertis en vain la chair infecte.
 L'homme est aveugle, sourd, fragile, comme un mur
-   Qu'habite et que ronge un insecte!»
+   Qu'habite et que ronge un insecte !»
 
 Et puis, Quelqu'un paraît, que tous avaient nié,
-Et qui leur dit, railleur et fier: «Dans mon ciboire,
+Et qui leur dit, railleur et fier : «Dans mon ciboire,
 Vous avez, que je crois, assez communié,
-   A la joyeuse Messe noire?
+   A la joyeuse Messe noire ?
 
-Chacun de vous m'a fait un temple dans son coeur;
-Vous avez, en secret, baisé ma fesse immonde (2)!
+Chacun de vous m'a fait un temple dans son coeur ;
+Vous avez, en secret, baisé ma fesse immonde (2) !
 Reconnaissez Satan à son rire vainqueur,
-   Enorme et laid comme le monde!
+   Enorme et laid comme le monde !
 
 Avez-vous donc pu croire, hypocrites surpris,
 Qu'on se moque du maître, et qu'avec lui l'on triche,
 Et qu'il soit naturel de recevoir deux prix,
-   D'aller au Ciel et d'être riche?
+   D'aller au Ciel et d'être riche ?
 
 Il faut que le gibier paye le vieux chasseur
 Qui se morfond longtemps à l'affût de la proie.
@@ -1050,15 +1050,15 @@ Je vais vous emporter à travers l'épaisseur,
 A travers l'épaisseur de la terre et du roc,
 A travers les amas confus de votre cendre,
 Dans un palais aussi grand que moi, d'un seul bloc,
-   Et qui n'est pas de pierre tendre;
+   Et qui n'est pas de pierre tendre ;
 
 Car il est fait avec l'universel Péché,
-Et contient mon orgeuil,[!] ma douleur et ma gloire!»
+Et contient mon orgeuil,[ !] ma douleur et ma gloire !»
 - Cependant, tout en haut de l'univers juché,
    Un Ange sonne la victoire
 
-De ceux dont le coeur dit: «Que béni soit ton fouet,
-Seigneur! que la douleur, ô Père, soit bénie!
+De ceux dont le coeur dit : «Que béni soit ton fouet,
+Seigneur ! que la douleur, ô Père, soit bénie !
 Mon âme dans tes mains n'est pas un vain jouet,
    Et ta prudence est infinie.»
 
@@ -1083,7 +1083,7 @@ Qu'il s'infiltre comme une extase dans tous ceux
 L'homme a, pour payer sa rançon,
 Deux champs au tuf profond et riche,
 Qu'il faut qu'il remue et défriche
-Avec le fer de la raison;
+Avec le fer de la raison ;
 
 Pour obtenir la moindre rose,
 Pour extorquer quelques épis,
@@ -1114,8 +1114,8 @@ Gagnent le suffrage des Anges.
 <body>
 <poetry>
 Tes pieds sont aussi fins que tes mains, et ta hanche
-Est large à faire envie à la plus belle blanche;
-A l'artiste pensif ton corps est doux et cher;
+Est large à faire envie à la plus belle blanche ;
+A l'artiste pensif ton corps est doux et cher ;
 Tes grands yeux de velours sont plus noirs que ta chair,
 Aux pays chauds et bleus où ton Dieu t'a fait naître,
 Ta tâche est d'allumer la pipe de ton maître,
@@ -1124,7 +1124,7 @@ De chasser loin du lit les moustiques rôdeurs,
 Et, dès que le matin fait chanter les platanes,
 D'acheter au bazar ananas et bananes.
 Tout le jour, où tu veux, tu mènes tes pieds nus,
-Et fredonnes tout bas de vieux airs inconnus;
+Et fredonnes tout bas de vieux airs inconnus ;
 Et quand descend le soir au manteau d'écarlate,
 Tu poses doucement ton corps sur une natte,
 Où tes rêves flottants sont pleins de colibris,
@@ -1132,7 +1132,7 @@ Et toujours, comme toi, gracieux et fleuris.
 Pourquoi, l'heureuse enfant, veux-tu voir notre France,
 Ce pays trop peuplé que fauche la souffrance,
 Et, confiant ta vie aux bras forts des marins,
-Faire de grands adieux à tes chers tamarins?
+Faire de grands adieux à tes chers tamarins ?
 Toi, vêtue à moitié de mousselines frêles,
 Frissonnant là-bas sous la neige et les grêles,
 Comme tu pleurerais tes loisirs doux et francs,
@@ -1140,7 +1140,7 @@ Si, le corset brutal emprisonnant tes flancs,
 Il te fallait glaner ton souper dans nos fanges
 Et vendre le parfum de tes charmes étranges,
 L'oeil pensif, et suivant, dans nos sales brouillards,
-Des cocotiers absents les fantômes épars!
+Des cocotiers absents les fantômes épars !
 
                                   1840.
 </poetry>
@@ -1166,23 +1166,23 @@ Des cocotiers absents les fantômes épars!
 </head>
 <body>
 <poetry>
-Amina bondit, - fuit, - puis voltige et sourit;
-Le Welche dit: «Tout ça, pour moi, c'est du prâcrit;
+Amina bondit, - fuit, - puis voltige et sourit ;
+Le Welche dit : «Tout ça, pour moi, c'est du prâcrit ;
 Je ne connais, en fait de nymphes bocagères,
 Que celles de Montagne-aux-Herbes-Potagères.»
 
 Du bout de son pied fin et de son oeil qui rit,
-Amina verse à flots le délire et l'esprit;
-Le Welche dit: «Fuyez, délices mensongères!
+Amina verse à flots le délire et l'esprit ;
+Le Welche dit : «Fuyez, délices mensongères !
 Mon épouse n'a pas ces allures légères.»
 
 Vous ignorez, sylphide au jarret triomphant,
 Qui voulez enseigner la walse à l'éléphant,
 Au hibou la gaîté, le rire à la cigogne,
 
-Que sur la grâce en feu le Welche dit: «Haro!»
+Que sur la grâce en feu le Welche dit : «Haro !»
 Et que le doux Bacchus lui versant du bourgogne,
-Le monstre répondrait: «J'aime mieux le faro!»
+Le monstre répondrait : «J'aime mieux le faro !»
 
                                   1864.
 </poetry>
@@ -1204,34 +1204,34 @@ Le monstre répondrait: «J'aime mieux le faro!»
 <body>
 <poetry>
 Il me dit qu'il était très-riche,
-Mais qu'il craignait le choléra;
+Mais qu'il craignait le choléra ;
 - Que de son or il était chiche,
-Mais qu'il goûtait fort l'Opéra;
+Mais qu'il goûtait fort l'Opéra ;
 
 - Qu'il raffolait de la nature,
-Ayant connu monsieur Corot;
+Ayant connu monsieur Corot ;
 - Qu'il n'avait pas encor voiture,
-Mais que cela viendrait bientôt;
+Mais que cela viendrait bientôt ;
 
 - Qu'il aimait le marbre et la brique,
-Les bois noirs et les bois dorés;
+Les bois noirs et les bois dorés ;
 - Qu'il possédait dans sa fabrique
-Trois contre-maîtres décorés;
+Trois contre-maîtres décorés ;
 
 - Qu'il avait, sans compter le reste,
-Vingt mille actions sur le Nord;
+Vingt mille actions sur le Nord ;
 - Qu'il avait trouvé, pour un zeste,
-Des encadrements d'Oppenord;
+Des encadrements d'Oppenord ;
 
-- Qu'il donnerait (fût-ce à Luzarches!)
+- Qu'il donnerait (fût-ce à Luzarches !)
 Dans le bric-à-brac jusqu'au cou,
 Et qu'au Marché des Patriarches
-Il avait fait plus d'un bon coup;
+Il avait fait plus d'un bon coup ;
 
 - Qu'il n'aimait pas beaucoup sa femme,
-Ni sa mère; - mais qu'il croyait
+Ni sa mère ; - mais qu'il croyait
 A l'immortalité de l'âme,
-Et qu'il avait lu Niboyet!
+Et qu'il avait lu Niboyet !
 
 - Qu'il penchait pour l'amour physique,
 Et qu'à Rome, séjour d'ennui,
@@ -1240,20 +1240,20 @@ Etait morte d'amour pour lui.
 
 Pendant trois heures et demie,
 Ce bavard, venu de Tournai,
-M'a dégoisé toute sa vie;
+M'a dégoisé toute sa vie ;
 J'en ai le cerveau consterné.
 
 S'il fallait décrire ma peine,
-Ce serait à n'en plus finir;
-Je me disais, domptant ma haine:
-«Au moins, si je pouvais dormir!»
+Ce serait à n'en plus finir ;
+Je me disais, domptant ma haine :
+«Au moins, si je pouvais dormir !»
 
 Comme un qui n'est pas à son aise,
 Et qui n'ose pas s'en aller,
 Je frottais de mon cul ma chaise,
 Rêvant de le faire empaler.
 
-Ce monstre se nomme Bastogne;
+Ce monstre se nomme Bastogne ;
 Il fuyait devant le fléau.
 Moi, je fuirai jusqu'en Gascogne,
 Ou j'irai me jeter à l'eau,
@@ -1282,12 +1282,12 @@ Ce fléau, natif de Tournai.
 Vous qui raffolez des squelettes
 Et des emblêmes détestés,
 Pour épicer les voluptés,
-(Fût-ce de simples omelettes!)
+(Fût-ce de simples omelettes !)
 
-Vieux Pharaon, ô Monselet!
+Vieux Pharaon, ô Monselet !
 Devant cette enseigne imprévue,
-J'ai rêvé de vous: A la vue
-Du Cimetière, Estaminet!
+J'ai rêvé de vous : A la vue
+Du Cimetière, Estaminet !
 </poetry>
 </body>
 </text>

--- a/fdirs/beranger/andre.xml
+++ b/fdirs/beranger/andre.xml
@@ -11,53 +11,53 @@
 <text id="beranger2001081901">
 <head>
    <title>Mon Habit</title>
-   <firstline>Sois-moi fidèle, ô pauvre habit que j'aime!</firstline>
+   <firstline>Sois-moi fidèle, ô pauvre habit que j'aime !</firstline>
 </head>
 <body>
 <poetry>
-Sois-moi fidèle, ô pauvre habit que j'aime!
+Sois-moi fidèle, ô pauvre habit que j'aime !
 Ensemble nous devenons vieux.
 Depuis dix ans, je te brosse moi-même,
 Et Socrate n'eut pas fait mieux.
 Quand le sort à ta mince étoffe
 Livrerait de nouveaux combats,
-Imite-moi, résiste en philosophe:
+Imite-moi, résiste en philosophe :
 Mon vieil ami, ne nous séparons pas.
 
 Je me souviens, car j'ai bonne mémoire,
 Du premier jour où je te mis.
 C'était ma fête, et pour comble de gloire,
-Tu fus chanté par mes amis;
+Tu fus chanté par mes amis ;
 Ton indigence, qui m'honore,
 Ne m'a point banni de leurs bras.
-Tous ils sont prêts à nous fêter encore:
+Tous ils sont prêts à nous fêter encore :
 Mon vieil ami, ne nous séparons pas.
 
-A ton revers, j'admire une reprise:
+A ton revers, j'admire une reprise :
 C'est encore un doux souvenir.
 Feignant un soir de fuir la tendre Lise,
 Je sens sa main me retenir.
 On te déchire, et cet outrage
 Auprès d'elle enchaîne mes pas.
-Lisette a mis deux jours à tant d'ouvrage:
+Lisette a mis deux jours à tant d'ouvrage :
 Mon vieil ami, ne nous séparons pas.
 
 Y'ai-je imprégné des flots de musc et d'ambre
-Qu'un fat exhale en se mirant!
+Qu'un fat exhale en se mirant !
 M'a-t-on jamais vu dans une antichambre
-T'exposer au mépris d'un grand?
+T'exposer au mépris d'un grand ?
 Pour des rubans, la France entière
 Fut en proie à de longs débats.
-La fleur des champs brille à ta boutonnière:
+La fleur des champs brille à ta boutonnière :
 Mon vieil ami, ne nous séparons pas.
 
 Ne crains plus tant ces jours de courses vaines
-Où notre destin fut pareil:
+Où notre destin fut pareil :
 Ces jours mêlés de plaisirs et de peines,
 Mêlés de pluie et de soleil.
 Je dois bientôt, il me le semble,
 Mettre pour jamais habit bas.
-Attends un peu ; nous finirons ensemble:
+Attends un peu ; nous finirons ensemble :
 Mon vieil ami, ne nous séparons pas.
 </poetry>
 </body>

--- a/fdirs/delavigne/andre.xml
+++ b/fdirs/delavigne/andre.xml
@@ -24,54 +24,54 @@ Qui va tourner
 Roule et s'incline
 Pour m'entraîner.
 O Vierge Marie,
-Pour moi priez Dieu!
-Adieu, patrie!
-Provence, adieu!
+Pour moi priez Dieu !
+Adieu, patrie !
+Provence, adieu !
 
 Mon pauvre père
 Verra souvent
 Pâlir ma mère
 Au bruit du vent.
 O Vierge Marie,
-Pour moi priez Dieu!
-Adieu, patrie!
-Mon père, adieu!
+Pour moi priez Dieu !
+Adieu, patrie !
+Mon père, adieu !
 
 La vieille Hélène
 Se confîra
 Dans sa neuvaine,
 Et dormira.
 O Vierge Marie,
-Pour moi priez Dieu!
-Adieu, patrie!
-Hélène, adieu!
+Pour moi priez Dieu !
+Adieu, patrie !
+Hélène, adieu !
 
 Ma soeur se lève,
-Et dit déjà:
-`J'ai fait un rêve;
+Et dit déjà :
+`J'ai fait un rêve ;
 Il reviendra.'
 O Vierge Marie,
 Pour moi priez Dieu
-Adieu, patrie!
-Ma soeur, adieu!
+Adieu, patrie !
+Ma soeur, adieu !
 
 De mon Isaure
 Le mouchoir blanc
 S'agite encore
 En m'appellant.
 O Vierge Marie,
-Pour moi priez Dieu!
-Adieu, patrie!
-Isaure, adieu!
+Pour moi priez Dieu !
+Adieu, patrie !
+Isaure, adieu !
 
 Brise ennemie,
 Pourquoi souffler,
 Quand mon amie
-Veut me parler?
+Veut me parler ?
 O Vierge Marie,
-Pour moi priez Dieu!
-Adieu, patrie!
-Bonheur, adieu!
+Pour moi priez Dieu !
+Adieu, patrie !
+Bonheur, adieu !
 </poetry>
 </body>
 </text>

--- a/fdirs/gautier/andre.xml
+++ b/fdirs/gautier/andre.xml
@@ -24,7 +24,7 @@ D'une forme au travail
 Rebelle,
 Vers, marbre, onyx, émail.
 
-Point de contraintes fausses!
+Point de contraintes fausses !
 Mais que pour marcher droit
 Tu chausses,
 Muse, un cothurne étroit.
@@ -32,22 +32,22 @@ Muse, un cothurne étroit.
 Fi du rythme commode,
 Comme un soulier trop grand,
 Du mode
-Que tout pied quitte et prend!
+Que tout pied quitte et prend !
 
 Statuaire, repousse
 L'argile que pétrit
 Le pouce,
-Quand flotte ailleurs l'esprit;
+Quand flotte ailleurs l'esprit ;
 
 Lutte avec le carrare,
 Avec le paros dur
 Et rare,
-Gardiens de contour pur;
+Gardiens de contour pur ;
 
 Emprunte à Syracuse
 Son bronze où fermement
 S'accuse
-Le trait fier et charmant;
+Le trait fier et charmant ;
 
 D'une main délicate
 Poursuit dans un filon
@@ -62,7 +62,7 @@ Au four de l'émailleur.
 Fais les sirènes bleues,
 Tordant de cent façons
 Leurs queues,
-Les montres des blasons;
+Les montres des blasons ;
 
 Dans son nimbe trilobe
 La Vierge et son Jésus,
@@ -70,7 +70,7 @@ Le globe
 Avec la croix dessus.
 
 Tout passe. - L'art robuste
-Seul a l'éternité;
+Seul a l'éternité ;
 Le buste
 Survit à la cité.
 
@@ -84,10 +84,10 @@ Mais les vers souverains
 Demeurent
 Plus forts que les airains.
 
-Sculpte, lime, cisèle;
+Sculpte, lime, cisèle ;
 Que ton rêve flottant
 Se scelle
-Dans le bloc résistant!
+Dans le bloc résistant !
 </poetry>
 </body>
 </text>

--- a/fdirs/hugo/1829.xml
+++ b/fdirs/hugo/1829.xml
@@ -47,7 +47,7 @@ Dans la galère capitane
 Nous étions quatrevingts rameurs.
 
 Elle veut fuir vers sa chapelle.
-— Osez-vous bien, fils de Satan?
+— Osez-vous bien, fils de Satan ?
 — Nous osons, dit le capitan.
 Elle pleure, supplie, appelle.
 Malgré sa plainte et ses clameurs,
@@ -213,7 +213,7 @@ Il faut des perles au poignard !
     <title><num>XXVI.</num>Les Tronçons du serpent</title>
     <firstline>Je veille, et nuit et jour mon front rêve enflammé</firstline>
     <notes>
-        <note>Mottoet stammer fra en fransk oversættelse af persiske <a poet="saadi">Saadi</a>: <i>Gulistan</i> (1258).</note>
+        <note>Mottoet stammer fra en fransk oversættelse af persiske <a poet="saadi">Saadi</a> : <i>Gulistan</i> (1258).</note>
         </notes>
     <pictures>
         <picture src="hugo2018111003-p1.jpg">

--- a/fdirs/hugo/1837.xml
+++ b/fdirs/hugo/1837.xml
@@ -49,12 +49,12 @@ V. H.
 <body>
 <poetry>
 Ce siècle est grand et fort. Un noble instinct le mène.
-Partout on voit marcher l'Idée en mission;
+Partout on voit marcher l'Idée en mission ;
 Et le bruit du travail, plein de parole humaine,
 Se mêle au bruit divin de la création.
 
 Partout, dans les cités et dans les solitudes,
-L'homme est fidèle au lait dont nous le nourrissions;
+L'homme est fidèle au lait dont nous le nourrissions ;
 Et dans l'informe bloc des sombres multitudes
 La pensée en rêvant sculpte des nations.
 
@@ -83,15 +83,15 @@ Tout verbe est déchiffré. Notre esprit éperdu,
 Chaque jour, en lisant dans le livre des choses,
 Découvre à l'univers un sens inattendu.
 
-O poètes! le fer et la vapeur ardente
+O poètes ! le fer et la vapeur ardente
 Effacent de la terre, à l'heure où vous rêvez,
 L'antique pesanteur, à tout objet pendante,
 Qui sous les lourds essieux broyait les durs pavés.
 
 L'homme se fait servir par l'aveugle matière.
-Il pense, il cherche, il crée! A son souffle vivant
+Il pense, il cherche, il crée ! A son souffle vivant
 Les germes dispersés dans la nature entière
-Tremblent comme frissonne une forêt au vent!
+Tremblent comme frissonne une forêt au vent !
 
 Oui, tout va, tout s'accroît. Les heures fugitives
 Laissent toutes leur trace. Un grand siècle a surgi.
@@ -131,15 +131,15 @@ Aucun signe n'a lui. Rien n'a changé l'aspect
 De ce siècle orageux, mer de récifs bordée,
 Où le fait, ce flot sombre, écume sur l'idée.
 Nul temple n'a gémi dans nos villes. Nul glas
-N'a passé sur nos fronts criant: Hélas! hélas!
+N'a passé sur nos fronts criant : Hélas ! hélas !
 La presse aux mille voix, cette louve hargneuse,
-A peine a retourné sa tête dédaigneuse;
+A peine a retourné sa tête dédaigneuse ;
 Nous ne l'avons pas vue, irritée et grondant,
 Donner à cette pourpre un dernier coup de dent.
 Et chacun vers son but, la marée à la grève,
 La foule vers l'argent, la penseur vers son rêve,
 Tout a continué de marcher, de courir,
-Et rien n'a dit au monde: Un roi vient de mourir!
+Et rien n'a dit au monde : Un roi vient de mourir !
 </poetry>
 </body>
 </text>
@@ -159,21 +159,21 @@ Comme des sphinx au pied des grandes pyramides,
 Dragons d'airain, hideux, verts, énormes, béants,
 Gardiens de ce palais, bâti pour des géants,
 Qui dresse et fait au loin reliure à la lumière
-Un casque monstrueux sur sa tête de pierre!
+Un casque monstrueux sur sa tête de pierre !
 A ce bruit qui jadis vous eût fait rugir tous,
-- Le roi de France est mort! - d'où vient qu'aucun de vous,
+- Le roi de France est mort ! - d'où vient qu'aucun de vous,
 Comme un lion captif qui secouerait sa chaîne,
 Aucun n'a tressailli sur sa base de chêne,
 Et n'a, se réveillant par un subit effort,
-Dit à son noir voisin: - Le roi de France est mort! -
+Dit à son noir voisin : - Le roi de France est mort ! -
 D'où vient qu'il s'est fermé sans vos salves funèbres,
-Ce cercueil qu'on clouait là-bas dans les ténèbres?
+Ce cercueil qu'on clouait là-bas dans les ténèbres ?
 Et que rien n'est sorti de vos mornes affûts,
 Pas même, ô canons sourds, ce murmure confus
 Qu'au vague battement de ses ailes livides
-le vent des nuits arrache à des armures vides?
+le vent des nuits arrache à des armures vides ?
 C'est que, prostitués dans nos troubles civils,
-Vous êtes comme nous fiers, sonores et vils!
+Vous êtes comme nous fiers, sonores et vils !
 C'est que, rouillés, vieillis, rivés à votre place,
 Toujours agenouillés devant tout ce qui passe,
 Retirés des combats, et dans ce coin obscur
@@ -181,22 +181,22 @@ Par des soldats boiteux gardés sous un vieux mur,
 Vains foudres de parade oubliés de l'armée,
 Autour de tout vainqueur faisant de la fumée,
 Réservés pour la pompe et la solennité,
-Vous avez pris racine en cette lâcheté!
-Soyez flétris! canons que la guerre repousse,
+Vous avez pris racine en cette lâcheté !
+Soyez flétris ! canons que la guerre repousse,
 Dont la voix sans terreur dans les fêtes s'émousse,
 Vous qui glorifiez de votre cri profond
-ceux qui viennent, toujours, jamais ceux qui s'en vont!
+ceux qui viennent, toujours, jamais ceux qui s'en vont !
 Vous qui, depuis trente ans, noirs courtisans de bronze,
 Avez, comme Henri Quatre adorant Louis Onze,
 Toujours tout applaudi, toujours tout salué,
-Vous taisant seulement quand le peuple a hué!
-Lâches, vous préférez ceux que le sort préfère!
+Vous taisant seulement quand le peuple a hué !
+Lâches, vous préférez ceux que le sort préfère !
 Dans le moule brûlant le fondeur pour vous faire
-Mit l'étain et le cuivre et l'oubli du vaincu;
+Mit l'étain et le cuivre et l'oubli du vaincu ;
 Car qui meurt exilé pour vous n'a pas vécu,
 Car vos poumons de fer, où gronde une âpre haleine,
-Sont muets pour Goritz, comme pour Sainte-Hélène!
-   Soyez flétris!
+Sont muets pour Goritz, comme pour Sainte-Hélène !
+   Soyez flétris !
 
 Mais non. C'est à nous, insensés,
 Que le mépris revient. Vous nous obéissez.
@@ -205,19 +205,19 @@ La guerre qui vous fit de ses bouillantes laves
 Vous fit pour la bataille, et nous vous avons pris
 Pour vous éclabousser des fanges de Paris,
 Pour vous sceller au seuil d'un palais centenaire,
-Et pour vous mettre au ventre un éclair sans tonnerre!
+Et pour vous mettre au ventre un éclair sans tonnerre !
 C'est nous qu'il faut flétrir, nous qui, déshonorés,
 Donnons notre âme abjecte à ces bronzes sacrés.
-Nous passons dans l'opprobre! hélas! ils y demeurent.
-Mornes captifs! le jour où des rois proscrits meurent,
+Nous passons dans l'opprobre ! hélas ! ils y demeurent.
+Mornes captifs ! le jour où des rois proscrits meurent,
 Vous ne pouvez, jetant votre fumée à flots,
 Prolonger sur Paris vos éclatants sanglots,
 Et, pareils à des chiens liés à des murailles,
-D'un hurlement plaintif suivre leurs funérailles!
+D'un hurlement plaintif suivre leurs funérailles !
 Muets, et vos longs cous baissés vers les pavés,
 Vous restez là pensifs, et, tristes, vous rêvez
 Aux hommes, froids esprits, coeurs bas, âmes douteuses,
-Qui font faire à l'airain tant de choses honteuses!
+Qui font faire à l'airain tant de choses honteuses !
 </poetry>
 </body>
 </text>
@@ -237,11 +237,11 @@ Se refuse à l'aurore et jamais au couchant,
 Moi que jadis à Reims Charle admit comme un hôte,
 Moi qui plaignis ses maux, moi qui blâmai sa faute,
 Je ne me tairai pas. Je descendrai, courbé,
-Jusqu'au caveau profond, où dort ce roi tombé;
-Je suspendrai ma lampe à cette voûte noire;
+Jusqu'au caveau profond, où dort ce roi tombé ;
+Je suspendrai ma lampe à cette voûte noire ;
 Et sans cesse, à côté de sa triste mémoire,
 Mon esprit, dans ces temps d'oubli contagieux,
-Fera veiller dans l'ombre un vers religieux!
+Fera veiller dans l'ombre un vers religieux !
 
 Et que m'importe à moi qui, déployant mon aile,
 Touche parfois d'en bas à la lyre éternelle,
@@ -254,53 +254,53 @@ De la sueur du peuple à la sueur des rois,
 Que m'importe après tout que depuis six années
 Ce roi fût retranché des têtes couronnées,
 Froide ruine au bord de nos flots écumants,
-Vain fantôme penché sur les événements!
+Vain fantôme penché sur les événements !
 Qu'il ne changeât de rien ni le poids ni le nombre,
 Que, rasé dès longtemps, son front plongeât dans l'ombre,
 Et que déjà, vieillard sans trône et sans pavois,
-Il eût subi l'exil, première mort des rois!
+Il eût subi l'exil, première mort des rois !
 Je le dirai, sans peur que la haine renaisse,
-Son avènement pur eut pour soeur ma jeunesse;
+Son avènement pur eut pour soeur ma jeunesse ;
 Saint Rémi nous reçut sous son mur triomphant
-Tous deux le même jour, lui vieux, moi presque enfant;
+Tous deux le même jour, lui vieux, moi presque enfant ;
 Et moi je ne veux pas, harpe qu'il a connue,
-Qu'on mette mon roi mort dans une bière nue!
+Qu'on mette mon roi mort dans une bière nue !
 Tandis qu'au loin la foule emplit l'air de ses cris,
 L'auguste piété, servante des proscrits,
 Qui les ensevelit dans sa plus blanche toile,
 N'aura pas, dans la nuit que son regard étoile,
 Demandé vainement à ma pensée en deuil
-Un lambeau de velours pour couvrir ce cercueil!
+Un lambeau de velours pour couvrir ce cercueil !
 </poetry>
 </body>
 </text>
 
 <text id="hugo1999070306">
 <head>
-   <title>Oh! que Versailles était superbe</title>
-   <toctitle>Oh! que Versailles était superbe</toctitle>
-   <indextitle>Oh! que Versailles était superbe</indextitle>
-   <firstline>Oh! que Versailles était superbe</firstline>
+   <title>Oh ! que Versailles était superbe</title>
+   <toctitle>Oh ! que Versailles était superbe</toctitle>
+   <indextitle>Oh ! que Versailles était superbe</indextitle>
+   <firstline>Oh ! que Versailles était superbe</firstline>
    <quality>korrektur1</quality>
 </head>
 <body>
 <poetry>
-Oh! que Versailles était superbe
+Oh ! que Versailles était superbe
 Dans ces jours purs de tout affront
 Où les prospérités en gerbe
-S'épanouissaient sur son front!
-Là, tout faste était sans mesure;
-Là, tout arbre avait sa parure;
-Là, tout homme avait sa dorure;
+S'épanouissaient sur son front !
+Là, tout faste était sans mesure ;
+Là, tout arbre avait sa parure ;
+Là, tout homme avait sa dorure ;
 Tout du maître suivait la loi.
 Comme au même but vont cent routes,
-Là les grandeurs abondaient toutes;
+Là les grandeurs abondaient toutes ;
 L'olympe ne pendait aux voûtes
-Que pour compléter le grand roi!
+Que pour compléter le grand roi !
 
 Vers le temps où naissaient nos pères
 Versailles rayonnait encor.
-Les lions ont de grands repaires;
+Les lions ont de grands repaires ;
 Les princes ont des palais d'or.
 Chaque fois que, foule asservie,
 Le peuple au coeur rongé d'envie
@@ -309,7 +309,7 @@ Ce fier château si radieux,
 Rentrant dans sa nuit plus livide,
 Il emportait dans son oeil vide
 Un éblouissement splendide
-De rois, de femmes et de dieux!
+De rois, de femmes et de dieux !
 Alors riaient dans l'espérance
 Trois enfants sous ces nobles toits,
 Les deux Louis, aînés de France,
@@ -318,44 +318,44 @@ Tous trois nés sous les dais de soie,
 Frêles enfants, mais pleins de joie
 Comme ceux qu'un chaud soleil noie
 De rayons purs sous le ciel bleu.
-Oh! d'un beau sort quelle semence!
+Oh ! d'un beau sort quelle semence !
 Près d'eux le roi d'où tout commence,
 Au-dessous d'eux le peuple immense,
-Au-dessus la bonté de Dieu!
+Au-dessus la bonté de Dieu !
 </poetry>
 </body>
 </text>
 
 <text id="hugo1999070307">
 <head>
-   <title>Qui leur eût dit alors l'austère destinée?</title>
-   <toctitle>Qui leur eût dit alors l'austère destinée?</toctitle>
-   <indextitle>Qui leur eût dit alors l'austère destinée?</indextitle>
-   <firstline>Qui leur eût dit alors l'austère destinée?</firstline>
+   <title>Qui leur eût dit alors l'austère destinée ?</title>
+   <toctitle>Qui leur eût dit alors l'austère destinée ?</toctitle>
+   <indextitle>Qui leur eût dit alors l'austère destinée ?</indextitle>
+   <firstline>Qui leur eût dit alors l'austère destinée ?</firstline>
    <quality>korrektur1</quality>
 </head>
 <body>
 <poetry>
-Qui leur eût dit alors l'austère destinée?
+Qui leur eût dit alors l'austère destinée ?
 Qui leur eût dit qu'un jour cette France, inclinée
 Sous leurs fronts de fleurons chargés,
 Ne se souviendrait d'eux ni de leur morne histoire,
 Pas plus que l'océan sans fond et sans mémoire
-Ne se souvient des naufragés!
+Ne se souvient des naufragés !
 
 Que, chaînes, lys, dauphins, un jour les Tuileries
 Verraient l'illustre amas des vieilles armoires
 S'écrouler de leur plafond nu,
 Et qu'en ces temps lointains que le mystère couvre,
 Un Corse, encore à naître, au noir fronton du Louvre
-Sculpterait un aigle inconnu!
+Sculpterait un aigle inconnu !
 
 Que leur royal Saint-Cloud se meublait pour un autre,
 Et qu'en ces fiers jardins du rigide Lenôtre,
 Amour de leurs yeux éblouis,
 Beaux parcs où dans les jeux croissait leur jeune force,
 Les chevaux de Crimée un jour mordraient l'écorce
-Des vieux arbres du grand Louis!
+Des vieux arbres du grand Louis !
 </poetry>
 </body>
 </text>
@@ -371,23 +371,23 @@ Des vieux arbres du grand Louis!
 <body>
 <poetry>
 Dans ces temps radieux, dans cette aube enchantée
-Dieu! comme avec terreur leur mère épouvantée
+Dieu ! comme avec terreur leur mère épouvantée
 Les eût contre son coeur pressés, pâle et sans voix,
 Si quelque vision, troublant ces jours de fêtes,
 Eût jeté tout à coup sur ces fragiles têtes
-Ce cri terrible: - Enfants! vous serez rois tous trois!
+Ce cri terrible : - Enfants ! vous serez rois tous trois !
 
-Et la voix prophétique aurait pu dire encore:
-" - Enfants, que votre aurore est une triste aurore!
-Que les sceptres pour vous sont d'odieux présents!
+Et la voix prophétique aurait pu dire encore :
+" - Enfants, que votre aurore est une triste aurore !
+Que les sceptres pour vous sont d'odieux présents !
 D'où vient donc que le Dieu qui punit Babylone
-Vous fait à pareille heure éclore au pied du trône?
-Et qu'avez-vous donc fait, ô pauvres innocents?
+Vous fait à pareille heure éclore au pied du trône ?
+Et qu'avez-vous donc fait, ô pauvres innocents ?
 
 Beaux enfants qu'on berce et qu'on flatte,
 Tout surpris, vous si purs, si doux,
 Que des vieux en robe écarlate
-Viennent vous parler à genoux!
+Viennent vous parler à genoux !
 Quand les sévères Malesherbes
 Ont relevé leurs fronts superbes,
 Vous courez jouer dans les herbes,
@@ -395,12 +395,12 @@ Sans savoir que tout doit finir,
 Et que votre race qui sombre
 Porte à ses deux bouts couverts d'ombre
 Ravaillac dans le passé sombre,
-Robespierre dans l'avenir!
+Robespierre dans l'avenir !
 
 Dans ce Louvre où de vieux murs gardent
 Les portraits des rois hasardeux,
 Allez voir comme vous regardent
-Charles premier et Jacques deux!
+Charles premier et Jacques deux !
 Sur vous un nuage s'étale.
 Sol étranger, terre natale,
 L'émeute, la guerre fatale,
@@ -408,59 +408,59 @@ Dévoreront vos jours maudits.
 De vous trois, enfants sur qui pèse
 L'antique masure française,
 Le premier sera Louis seize,
-Le dernier sera Charles dix!
+Le dernier sera Charles dix !
 
 Que l'aîné, peu crédule à la vie, à la gloire,
 Au peuple ivre d'amour, sache d'une nuit noire
-D'avance emplir son coeur de courage pourvu;
+D'avance emplir son coeur de courage pourvu ;
 Qu'il rêve un ciel de pluie, un tombereau qui roule,
 Et là-bas, tout au fond, au-dessus de la foule,
-Quelque étrange échafaud dans la brume entrevu!
+Quelque étrange échafaud dans la brume entrevu !
 
 Frères par la naissance et par le malheur frères,
 Les deux autres fuiront, battus des vents contraires.
 Le règne de Louis, roi de quelques bannis,
 Commence dans l'exil, celui de Charle y tombe.
 L'un n'aura pas de sacre et l'autre pas de tombe.
-A l'un Reims doit manquer, à l'autre Saint-Denisl!"
+A l'un Reims doit manquer, à l'autre Saint-Denisl !"
 </poetry>
 </body>
 </text>
 
 <text id="hugo1999070309">
 <head>
-   <title>Quel rêve horrible! - C'est l'histoire</title>
-   <toctitle>Quel rêve horrible! - C'est l'histoire</toctitle>
-   <indextitle>Quel rêve horrible! - C'est l'histoire</indextitle>
-   <firstline>Quel rêve horrible! - C'est l'histoire</firstline>
+   <title>Quel rêve horrible ! - C'est l'histoire</title>
+   <toctitle>Quel rêve horrible ! - C'est l'histoire</toctitle>
+   <indextitle>Quel rêve horrible ! - C'est l'histoire</indextitle>
+   <firstline>Quel rêve horrible ! - C'est l'histoire</firstline>
    <quality>korrektur1</quality>
 </head>
 <body>
 <poetry>
-Quel rêve horrible! - C'est l'histoire.
+Quel rêve horrible ! - C'est l'histoire.
 De nos pères couchés dans les tombeaux profonds
 Ce qu'aucun n'aurait voulu croire,
-Nous l'avons vu, nous qui vivons!
+Nous l'avons vu, nous qui vivons !
 
 Tous ces maux, et d'autres encore,
 Sont tombés sur ces fronts de la main du Seigneur.
-Maintenant croyez à l'aurore!
-Maintenant croyez au bonheur!
+Maintenant croyez à l'aurore !
+Maintenant croyez au bonheur !
 
-Croyez au ciel pur et sans rides!
-Saluez l'avenir qui vous flatte si bien!
+Croyez au ciel pur et sans rides !
+Saluez l'avenir qui vous flatte si bien !
 L'avenir, fantôme aux mains vides,
-Qui promet tout et qui n'a rien!
+Qui promet tout et qui n'a rien !
 
-O rois! ô familles tronquées!
-Brusques écroulements des vieilles majestés!
+O rois ! ô familles tronquées !
+Brusques écroulements des vieilles majestés !
 O calamités embusquées
-Au tournant des prospérités!
+Au tournant des prospérités !
 
 Tout colosse a des pieds de sable.
 Votre abîme est, Seigneur, un abîme infini.
 Louis quinze fut le coupable,
-Louis seize fut le puni!
+Louis seize fut le puni !
 
 La peine se trompe et dévie.
 Celui qui fit le mal, c'est la loi du Très-Haut,
@@ -468,30 +468,30 @@ A le trône et la longue vie,
 Et l'innocent a l'échafaud.
 
 Les fautes que l'aïeul peut faire
-Te poursuivront, ô fils! en vain tu t'en défends.
+Te poursuivront, ô fils ! en vain tu t'en défends.
 Quand il a neigé sous le père,
-L'avalanche est pour les enfants!
+L'avalanche est pour les enfants !
 
-Révolutions! mer profonde!
-Que de choses, hélas! pleines d'enseignement,
+Révolutions ! mer profonde !
+Que de choses, hélas ! pleines d'enseignement,
 Dans les ténèbres de votre onde
-On voit flotter confusément!
+On voit flotter confusément !
 </poetry>
 </body>
 </text>
 
 <text id="hugo1999070310">
 <head>
-   <title>Charles Dix! - Oh! le Dieu qui retire et qui donne</title>
-   <toctitle>Charles Dix! - Oh! le Dieu qui retire et qui donne</toctitle>
-   <indextitle>Charles Dix! - Oh! le Dieu qui retire et qui donne</indextitle>
-   <firstline>Charles Dix! - Oh! le Dieu qui retire et qui donne</firstline>
+   <title>Charles Dix ! - Oh ! le Dieu qui retire et qui donne</title>
+   <toctitle>Charles Dix ! - Oh ! le Dieu qui retire et qui donne</toctitle>
+   <indextitle>Charles Dix ! - Oh ! le Dieu qui retire et qui donne</indextitle>
+   <firstline>Charles Dix ! - Oh ! le Dieu qui retire et qui donne</firstline>
    <quality>korrektur1</quality>
 </head>
 <body>
 <poetry>
-Charles Dix! - Oh! le Dieu qui retire et qui donne
-Forgea pour cette tête une lourde couronne!
+Charles Dix ! - Oh ! le Dieu qui retire et qui donne
+Forgea pour cette tête une lourde couronne !
 L'empire était penchant et les temps étaient durs.
 Une ombre quand il vint couvrait encor nos murs,
 L'ombre de l'empereur, figure colossale.
@@ -504,10 +504,10 @@ Charles ne fut qu'un homme. A ce faîte il eut peur.
 Le gouffre attire. Pris d'un vertige trompeur,
 Dans l'abîme, fermant les yeux à la lumière,
 Il se précipita la tête la première.
-Silence à son tombeau! car tout vient de finir.
+Silence à son tombeau ! car tout vient de finir.
 A peine il aura teint d'un vague souvenir
 Le peuple à l'eau pareil, qui passe, clair ou sombre,
-Près de tout sans en prendre autre chose que l'ombre!
+Près de tout sans en prendre autre chose que l'ombre !
 
 Je n'aurai pas pour lui de reproches amers.
 Je ne suis pas l'oiseau qui crie au bord des mers
@@ -520,39 +520,39 @@ La popularité, cette grande menteuse.
 Aussi n'attendez pas que j'achète aujourd'hui
 Des louanges pour moi par des affronts pour lui.
 Qu'un autre, aux rois déchus donnant un nom sévère
-Fasse un vil pilori de leur fatal calvaire;
+Fasse un vil pilori de leur fatal calvaire ;
 Moi je n'affligerai pas plus, ô Charles dix,
-Ton cercueil maintenant que ton exil jadis!
+Ton cercueil maintenant que ton exil jadis !
 </poetry>
 </body>
 </text>
 
 <text id="hugo1999070311">
 <head>
-   <title>Repose, fils de France, en ta tombe exilée!</title>
-   <toctitle>Repose, fils de France, en ta tombe exilée!</toctitle>
-   <indextitle>Repose, fils de France, en ta tombe exilée!</indextitle>
-   <firstline>Repose, fils de France, en ta tombe exilée!</firstline>
+   <title>Repose, fils de France, en ta tombe exilée !</title>
+   <toctitle>Repose, fils de France, en ta tombe exilée !</toctitle>
+   <indextitle>Repose, fils de France, en ta tombe exilée !</indextitle>
+   <firstline>Repose, fils de France, en ta tombe exilée !</firstline>
    <quality>korrektur1</quality>
 </head>
 <body>
 <poetry>
-Repose, fils de France, en ta tombe exilée!
-Dormez, sire! - Il convient que cette ombre voilée,
+Repose, fils de France, en ta tombe exilée !
+Dormez, sire ! - Il convient que cette ombre voilée,
 Que ce vieux pasteur mort sans peuple et sans troupeaux,
 Roi presque séculaire, ait au moins le repos,
 Qu'il ait au moins la paix où la mort nous convie,
-Puisqu'il eut le travail d'une si dure vie!
-Peuple! soyons cléments! soyons forts! oublions!
+Puisqu'il eut le travail d'une si dure vie !
+Peuple ! soyons cléments ! soyons forts ! oublions !
 Jamais l'odeur des morts n'attire les lions.
 La haine d'un grand peuple est une haine grande
 Qui veut que le pardon au sépulcre descende
 Et n'a pour ennemis que ceux qui sont debout.
-Hélas! quel poids encor pourrions-nous après tout
+Hélas ! quel poids encor pourrions-nous après tout
 Jeter sur ce vieillard cassé par la misère,
-Qui dort sous le fardeau de la terre étrangère!
+Qui dort sous le fardeau de la terre étrangère !
 
-Roi, puissant, vous l'avez brisé; c'est un grand pas.
+Roi, puissant, vous l'avez brisé ; c'est un grand pas.
 Il faut l'épargner mort. Et moi, je ne crois pas
 Qu'il soit digne du peuple en qui Dieu se reflète
 De joindre au bras qui tue une main qui soufflette.
@@ -573,13 +573,13 @@ De joindre au bras qui tue une main qui soufflette.
 Nous, pasteurs des esprits, qui, du bord du chemin
 Regardons tous les pas que fait le genre humain,
 Poètes, par nos chants, penseurs, par nos idées,
-Hâtons vers la raison les âmes attardées!
+Hâtons vers la raison les âmes attardées !
 Hâtons l'ère où viendront s'unir d'un noeud loyal
-Le travail populaire et le labeur royal;
-Où colère et puissance auront fait leur divorce;
+Le travail populaire et le labeur royal ;
+Où colère et puissance auront fait leur divorce ;
 Où tous ceux qui sont forts auront peur de leur force,
 Et d'un saint tremblement frémiront à la fois,
-Rois, devant leurs devoirs, peuples, devant leurs droits!
+Rois, devant leurs devoirs, peuples, devant leurs droits !
 Aidons tous ces grands faits que le Seigneur envoie
 Pour ouvrir une route ou pour clore une voie,
 Les révolutions dont la surface bout,
@@ -587,28 +587,28 @@ Les changements soudains qui font vaciller tout,
 A dégager du fond des nuages de l'âme,
 A poser au-dessus des lois comme une flamme
 Ce sentiment profond en nous tous replié
-Que l'homme appelle doute et la femme pitié!
+Que l'homme appelle doute et la femme pitié !
 Expliquons au profit de la sainte clémence
 Ces hauts événements où l'état recommence,
 Et qui font, quand l'oeil va des vaincus aux vainqueurs,
-Trembler la certitude humaine au fond des coeurs!
+Trembler la certitude humaine au fond des coeurs !
 Faisons venir bientôt l'heure où l'on pourra dire
 Que sur le froid sépulcre on ne doit rien écrire
-Hors des mots de pardon, d'espérance et de paix;
+Hors des mots de pardon, d'espérance et de paix ;
 Et que, l'empereur mort comme les vieux Capets,
 On a tort d'exiler, lorsque rien ne bouillonne,
 Eux de leur Saint-Denis et lui de sa colonne.
-A quoi sert, Dieu clément, cette vaine action?
+A quoi sert, Dieu clément, cette vaine action ?
 Et comment se fait-il que la Proscription
-Ne brise pas ses dents au marbre de la tombe?
+Ne brise pas ses dents au marbre de la tombe ?
 N'est-ce donc pas assez que, cygne, aigle ou colombe,
 Dès qu'un vent de malheur lui jette un nid de rois,
 Sortant de ce bois noir qu'on appelle les lois,
 Cette hyène, acharnée aux grandes races mortes,
-Vienne, là, sous nos murs, les ronger à nos portes!
+Vienne, là, sous nos murs, les ronger à nos portes !
 
 Un jour, - mais nous serons couchés sous le gazon
-Quand cette aube de Dieu blanchira l'horizon! -
+Quand cette aube de Dieu blanchira l'horizon ! -
 - Un jour on comprendra, même en changeant de règne,
 Qu'aucune loi ne peut, sans que l'équité saigne,
 Faire expier à tous ce qu'a commis un seul,
@@ -621,57 +621,57 @@ De mettre le pouvoir sur un front comme un signe
 Et de donner le trône et le Louvre au plus digne,
 Un grand peuple pourra, sans être épouvanté,
 Voir un enfant de plus jouer dans la cité.
-Car tous les coeurs diront: C'est une juste aumône
-De laisser la patrie à qui n'a plus le trône!
+Car tous les coeurs diront : C'est une juste aumône
+De laisser la patrie à qui n'a plus le trône !
 Alors, jetant enfin l'ancre dans un port sûr,
 Ayant les biens germés sur nos maux, et l'azur
 Du ciel nouveau dont Dieu nous donne la tempête,
-Proscription! nos fils broieront du pied ta tête!
-Démon qui tiens du tigre et qui tiens du serpent!
+Proscription ! nos fils broieront du pied ta tête !
+Démon qui tiens du tigre et qui tiens du serpent !
 Dans les prospérités invisible et rampant,
 Qui, lâche et patient, épiant en silence
 Ce que dans son palais le roi dit, rêve, ou pense,
 Horrible, en attendant l'heure d'être lâché,
-Vis, monstre ténébreux, sous le trône caché!
-O poésie! au ciel ton vol se réfugie
+Vis, monstre ténébreux, sous le trône caché !
+O poésie ! au ciel ton vol se réfugie
 Quand les partis hurlants luttent à pleine orgie,
 Quand la nécessité sous son code étouffant
-Brise le fort, le faible, hélas! l'innocent même,
+Brise le fort, le faible, hélas ! l'innocent même,
 Et sourde et sans pitié promène l'anathème
-Du front blanc du vieillard au front pur de l'enfant!
+Du front blanc du vieillard au front pur de l'enfant !
 
 Tu fuis alors à tire-d'aile
 Vers le ciel éternel et pur,
 Vers la lumière à tous fidèle,
-Vers l'innocence, vers l'azur!
+Vers l'innocence, vers l'azur !
 Afin que ta pureté fière
 N'ait pas la fange et la poussière
 Des vils chemins par nous frayés,
 Et que, nuages et tempêtes,
 Tout ce qui passe sur nos têtes
-Ne puisse passer qu'à tes pieds!
+Ne puisse passer qu'à tes pieds !
 
 Tu sais qu'étoile sans orbite,
-L'homme erre au gré de tous les vents;
+L'homme erre au gré de tous les vents ;
 Tu sais que l'injustice habite
-Dans la demeure des vivants;
+Dans la demeure des vivants ;
 Et que nos coeurs sont des arènes
 Où les passions souveraines,
 Groupe horrible en vain combattu,
 Lionnes, louves affamées,
 Tigresses de taches semées,
-Dévorent la chaste vertu!
+Dévorent la chaste vertu !
 
 Tout ce qui souffre est plein de haine.
 Tout ce qui vit traîne un remords.
 Les morts seuls ont rompu leur chaîne.
-Tout est méchant, hormis les morts!
+Tout est méchant, hormis les morts !
 Aussi, voyant partout la vie
 Palpiter de rage et d'envie,
 Et que parmi nous rien n'est beau,
 Si parfois, oiseau solitaire,
 Tu redescends sur cette terre,
-Tu te poses sur un tombeau!
+Tu te poses sur un tombeau !
 
      15 mai 1837
 </poetry>
@@ -682,27 +682,27 @@ Tu te poses sur un tombeau!
 
 <text id="hugo1999070313">
 <head>
-   <title>Quelle est la fin de tout? la vie, ou bien la tombe?</title>
-   <toctitle>Quelle est la fin de tout? la vie, ou bien la tombe?</toctitle>
-   <indextitle>Quelle est la fin de tout? la vie, ou bien la tombe?</indextitle>
-   <firstline>Quelle est la fin de tout? la vie, ou bien la tombe?</firstline>
+   <title>Quelle est la fin de tout ? la vie, ou bien la tombe ?</title>
+   <toctitle>Quelle est la fin de tout ? la vie, ou bien la tombe ?</toctitle>
+   <indextitle>Quelle est la fin de tout ? la vie, ou bien la tombe ?</indextitle>
+   <firstline>Quelle est la fin de tout ? la vie, ou bien la tombe ?</firstline>
    <quality>korrektur1</quality>
 </head>
 <body>
 <poetry>
-Quelle est la fin de tout? la vie, ou bien la tombe?
-Est-ce l'onde où l'on flotte? est-ce l'onde où l'on tombe?
-De tant de pas croisés quel est le but lointain?
-Le berceau contient-il l'homme ou bien le destin?
+Quelle est la fin de tout ? la vie, ou bien la tombe ?
+Est-ce l'onde où l'on flotte ? est-ce l'onde où l'on tombe ?
+De tant de pas croisés quel est le but lointain ?
+Le berceau contient-il l'homme ou bien le destin ?
 Sommes-nous ici-bas, dans nos maux, dans nos joies,
-Des rois prédestinés ou de fatales proies?
+Des rois prédestinés ou de fatales proies ?
 
 O seigneur, dites-nous, dites-nous, ô Dieu fort,
-Si vous n'avez créé l'homme que pour le sort?
+Si vous n'avez créé l'homme que pour le sort ?
 Si déjà le calvaire est caché dans la crèche
 Et si les nids soyeux, dorés par l'aube fraîche,
 Où la plume naissante éclôt parmi des fleurs,
-Sont faits pour les oiseaux ou pour les oiseleurs?
+Sont faits pour les oiseaux ou pour les oiseleurs ?
 
 		24 mars 1837
 </poetry>
@@ -730,46 +730,46 @@ S'emplit d'azur céleste, arche démesurée
 Toi qui lèves si haut ton front large et serein
 Fait pour changer sous lui la campagne en abîme,
 Et pour servir de base à quelque aigle sublime
-Qui viendra s'y poser et qui sera d'airain!
+Qui viendra s'y poser et qui sera d'airain !
 
-O vaste entassement ciselé par l'histoire!
-Monceau de pierre assis sur un monceau de gloire!
-Edifice inouï!
+O vaste entassement ciselé par l'histoire !
+Monceau de pierre assis sur un monceau de gloire !
+Edifice inouï !
 Toi que l'homme par qui notre siècle commence,
 De loin, dans les rayons de l'avenir immense,
-Voyait, tout ébloui!
+Voyait, tout ébloui !
 
-Non, tu n'es pas fini quoique tu sois superbe!
-Non; puisque aucun passant, dans l'ombre assis sur l'herbe,
+Non, tu n'es pas fini quoique tu sois superbe !
+Non ; puisque aucun passant, dans l'ombre assis sur l'herbe,
 Ne fixe un oeil rêveur à ton mur triomphant,
 Tandis que triviale, errante et vagabonde,
 Entre tes quatre pieds toute la ville abonde
-Comme une fourmilière aux pieds d'un éléphant!
+Comme une fourmilière aux pieds d'un éléphant !
 
 A ta beauté royale il manque quelque chose.
 Les siècles vont venir pour ton apothéose
 Qui te l'apporteront.
 Il manque sur ta tête un sombre amas d'années
 Qui pendent pêle-mêle et toutes ruinées
-Aux brèches de ton front!
+Aux brèches de ton front !
 
 Il te manque la ride et l'antiquité fière,
 Le passé, pyramide où tout siècle a sa pierre,
-Les chapiteaux brisés, l'herbe sur les vieux fûts;
+Les chapiteaux brisés, l'herbe sur les vieux fûts ;
 Il manque sous ta voûte où notre orgueil s'élance
 Ce bruit mystérieux qui se mêle au silence,
-Le sourd chuchotement des souvenirs confus!
+Le sourd chuchotement des souvenirs confus !
 
 La vieillesse couronne et la ruine achève.
 Il faut à l'édifice un passé dont on rêve,
 Deuil, triomphe ou remords.
 Nous voulons, en foulant son enceinte pavée,
 Sentir dans la poussière à nos pieds soulevée
-De la cendre des morts!
+De la cendre des morts !
 
 Il faut que le fronton s'effeuille comme un arbre.
 Il faut que le lichen, cette rouille du marbre,
-De sa lèpre dorée au loin couvre le mur;
+De sa lèpre dorée au loin couvre le mur ;
 Et que la vétusté, par qui tout art s'efface,
 Prenne chaque sculpture et la ronge à la face,
 Comme un avide oiseau qui dévore un fruit mûr.
@@ -779,54 +779,54 @@ Que le lierre vivant grimpe aux acanthes mortes,
 Que l'eau dorme aux fossés,
 Que la cariatide, en sa lente révolte,
 Se refuse, enfin lasse, à porter l'archivolte,
-Et dise: C'est assez!
+Et dise : C'est assez !
 
 Ce n'est pas, ce n'est pas entre des pierres neuves
 Que la bise et la nuit pleurent comme des veuves.
-Hélas! d'un beau palais le débris est plus beau.
+Hélas ! d'un beau palais le débris est plus beau.
 Pour que la lune émousse à travers la nuit sombre
 L'ombre par le rayon et le rayon par l'ombre,
-Il lui faut la ruine à défaut du tombeau!
+Il lui faut la ruine à défaut du tombeau !
 
 Voulez-vous qu'une tour, voulez-vous qu'une église
 Soient de ces monuments dont l'âme idéalise
 La forme et la hauteur,
 Attendez que de mousse elles soient revêtues,
 Et laissez travailler à toutes les statues
-Le temps, ce grand sculpteur!
+Le temps, ce grand sculpteur !
 
 Il faut que le vieillard, chargé de jours sans nombre,
 Menant son jeune fils sous l'arche pleine d'ombre,
 Nomme Napoléon comme on nomme Cyrus,
-Et dise en la montrant de ses mains décharnées:
-"Vois cette porte énorme! elle a trois mille années.
-C'est par là qu'ont passé des hommes disparus!"
+Et dise en la montrant de ses mains décharnées :
+"Vois cette porte énorme ! elle a trois mille années.
+C'est par là qu'ont passé des hommes disparus !"
 </poetry>
 </body>
 </text>
 
 <text id="hugo1999070315">
 <head>
-   <title>Oh! Paris est la cité mère!</title>
-   <toctitle>Oh! Paris est la cité mère!</toctitle>
-   <indextitle>Oh! Paris est la cité mère!</indextitle>
-   <firstline>Oh! Paris est la cité mère!</firstline>
+   <title>Oh ! Paris est la cité mère !</title>
+   <toctitle>Oh ! Paris est la cité mère !</toctitle>
+   <indextitle>Oh ! Paris est la cité mère !</indextitle>
+   <firstline>Oh ! Paris est la cité mère !</firstline>
    <quality>korrektur1</quality>
 </head>
 <body>
 <poetry>
-Oh! Paris est la cité mère!
+Oh ! Paris est la cité mère !
 Paris est le lieu solennel
 Où le tourbillon éphémère
-Tourne sur un centre éternel!
-Paris! feu sombre ou pure étoile!
-Morne Isis couverte d'un voile!
+Tourne sur un centre éternel !
+Paris ! feu sombre ou pure étoile !
+Morne Isis couverte d'un voile !
 Araignée à l'immense toile
-Où se prennent les nations!
-Fontaine d'urnes obsédée!
+Où se prennent les nations !
+Fontaine d'urnes obsédée !
 Mamelle sans cesse inondée
 Où pour se nourrir de l'idée
-Viennent les générations!
+Viennent les générations !
 
 Quand Paris se met à l'ouvrage
 Dans sa forge aux mille clameurs,
@@ -835,70 +835,70 @@ Il prend ses lois, ses dieux, ses moeurs.
 Dans sa fournaise, pêle-mêle,
 Il fond, transforme et renouvelle
 Cette science universelle
-Qu'il emprunte à tous les humains;
+Qu'il emprunte à tous les humains ;
 Puis il rejette aux peuples blêmes
 Leurs sceptres et leurs diadèmes,
 Leurs préjugés et leurs systèmes,
-Tout tordus par ses fortes mains!
+Tout tordus par ses fortes mains !
 
 Paris, qui garde, sans y croire,
 Les faisceaux et les encensoirs,
 Tous les matins dresse une gloire,
-Eteint un soleil tous les soirs;
+Eteint un soleil tous les soirs ;
 Avec l'idée, avec le glaive,
 Avec la chose, avec le rêve,
 Il refait, recloue et relève
-L'échelle de la terre aux cieux;
+L'échelle de la terre aux cieux ;
 Frère des Memphis et des Romes,
 Il bâtit au siècle où nous sommes
 Une Babel pour tous les hommes,
-Un Panthéon pour tous les dieux!
+Un Panthéon pour tous les dieux !
 
-Ville qu'un orage enveloppe!
-C'est elle, hélas! qui, nuit et jour,
+Ville qu'un orage enveloppe !
+C'est elle, hélas ! qui, nuit et jour,
 Réveille le géant Europe
-Avec sa cloche et son tambour!
+Avec sa cloche et son tambour !
 Sans cesse, qu'il veille ou qu'il dorme,
 Il entend la cité difforme
 Bourdonner sur sa tête énorme
 Comme un essaim dans la forêt.
 Toujours Paris s'écrie et gronde.
-Nul ne sait, question profonde!
+Nul ne sait, question profonde !
 Ce que perdrait le bruit du monde
-Le jour où Paris se tairait!
+Le jour où Paris se tairait !
 </poetry>
 </body>
 </text>
 
 <text id="hugo1999070316">
 <head>
-   <title>Il se taira pourtant! - Après bien des aurores</title>
-   <toctitle>Il se taira pourtant! - Après bien des aurores</toctitle>
-   <indextitle>Il se taira pourtant! - Après bien des aurores</indextitle>
-   <firstline>Il se taira pourtant! - Après bien des aurores</firstline>
+   <title>Il se taira pourtant ! - Après bien des aurores</title>
+   <toctitle>Il se taira pourtant ! - Après bien des aurores</toctitle>
+   <indextitle>Il se taira pourtant ! - Après bien des aurores</indextitle>
+   <firstline>Il se taira pourtant ! - Après bien des aurores</firstline>
    <quality>korrektur1</quality>
 </head>
 <body>
 <poetry>
-Il se taira pourtant! - Après bien des aurores,
+Il se taira pourtant ! - Après bien des aurores,
 Bien des mois, bien des ans, bien des siècles couchés,
 Quand cette rive où l'eau se brise aux ponts sonores
-Sera rendue aux joncs murmurants et penchés;
+Sera rendue aux joncs murmurants et penchés ;
 
 Quand la Seine fuira de pierres obstruée,
 Usant quelque vieux dôme écroulé dans ses eaux,
 Attentive au doux vent qui porte à la nuée
-Le frisson du feuillage et le chant des oiseaux;
+Le frisson du feuillage et le chant des oiseaux ;
 
 Lorsqu'elle coulera, la nuit, blanche dans l'ombre,
 Heureuse, en endormant son flot longtemps troublé,
 De pouvoir écouter enfin ces voix sans nombre
-Qui passent vaguement sous le ciel étoilé;
+Qui passent vaguement sous le ciel étoilé ;
 
 Quand de cette cité, folle et rude ouvrière,
 Qui, hâtant les destins à ses murs réservés,
 Sous son propre marteau s'en allant en poussière,
-Met son bronze en monnaie et son marbre en pavés;
+Met son bronze en monnaie et son marbre en pavés ;
 
 Quand, des toits des clochers, des ruches tortueuses,
 Des porches, des frontons, des dômes pleins d'orgueil
@@ -908,12 +908,12 @@ Touffue, inextricable et fourmillante à l'oeil,
 Il ne restera plus dans l'immense campagne,
 Pour toute pyramide et pour tout panthéon,
 Que deux tours de granit faites par Charlemagne,
-Et qu'un pilier d'airain fait par Napoléon;
+Et qu'un pilier d'airain fait par Napoléon ;
 
-Toi, tu compléteras le triangle sublime!
-L'airain sera la gloire et le granit la foi;
+Toi, tu compléteras le triangle sublime !
+L'airain sera la gloire et le granit la foi ;
 Toi, tu seras la porte ouverte sur la cime
-Qui dit: il faut monter pour venir jusqu'à moi!
+Qui dit : il faut monter pour venir jusqu'à moi !
 
 Tu salueras là-bas cette église si vieille,
 Cette colonne altière au nom toujours accru,
@@ -923,53 +923,53 @@ Au clairon monstrueux d'un Titan disparu.
 Et sur ces deux débris que les destins rassemblent,
 Pour toi l'aube fera resplendir à la fois
 Deux signes triomphants qui de loin se ressemblent.
-De près l'un est un glaive et l'autre est une croix!
+De près l'un est un glaive et l'autre est une croix !
 
 Sur vous trois poseront mille ans de notre France.
 La colonne est le chant d'un règne à peine ouvert,
 C'est toi qui finiras l'hymne qu'elle commence.
-Elle dit: Austerlitz! tu diras: Champaubert!
+Elle dit : Austerlitz ! tu diras : Champaubert !
 </poetry>
 </body>
 </text>
 
 <text id="hugo1999070317">
 <head>
-   <title>Arche! alors tu seras éternelle et complète</title>
-   <toctitle>Arche! alors tu seras éternelle et complète</toctitle>
-   <indextitle>Arche! alors tu seras éternelle et complète</indextitle>
-   <firstline>Arche! alors tu seras éternelle et complète</firstline>
+   <title>Arche ! alors tu seras éternelle et complète</title>
+   <toctitle>Arche ! alors tu seras éternelle et complète</toctitle>
+   <indextitle>Arche ! alors tu seras éternelle et complète</indextitle>
+   <firstline>Arche ! alors tu seras éternelle et complète</firstline>
    <quality>korrektur1</quality>
 </head>
 <body>
 <poetry>
-Arche! alors tu seras éternelle et complète,
+Arche ! alors tu seras éternelle et complète,
 Quand tout ce que la Seine en son onde reflète
 Aura fui pour jamais,
 Quand de cette cité qui fut égale à Rome
 Il ne restera plus qu'un ange, un aigle, un homme,
-Debout sur trois sommets!
+Debout sur trois sommets !
 
 C'est alors que le roi, le sage, le poète,
 Tous ceux dont le passé presse l'âme inquiète,
-T'admireront vivante auprès de Paris mort;
+T'admireront vivante auprès de Paris mort ;
 Et, pour mieux voir ta face où flotte un sombre rêve,
 Lèveront à demi ton lierre, ainsi qu'on lève
-Un voile sur le front d'une aïeule qui dort!
+Un voile sur le front d'une aïeule qui dort !
 
 Sur ton mur qui pour eux n'aura rien de vulgaire,
 Ils chercheront nos moeurs, nos héros, notre guerre,
-Tous pensifs à tes pieds;
+Tous pensifs à tes pieds ;
 Ils croiront vous voir, le long de ta frise animée,
-Revivre le grand peuple avec la grande armée!
--"Oh! diront-ils, voyez!
+Revivre le grand peuple avec la grande armée !
+-"Oh ! diront-ils, voyez !
 
 Là, c'est le régiment, ce serpent des batailles,
 Traînant sur mille pieds ses luisantes écailles,
 Qui tantôt, furieux, se roule au pied des tours,
 Tantôt, d'un mouvement formidable et tranquille,
 Troue un rempart de pierre et traverse une ville
-Avec son front sonore où battent vingt tambours!
+Avec son front sonore où battent vingt tambours !
 
 Là-haut, c'est l'empereur avec ses capitaines,
 Qui songe s'il ira vers ces terres lointaines
@@ -983,21 +983,21 @@ D'où la fumée à flots monte, tombe et remonte,
 Qui broie une cité, détruit les garnisons,
 Ruine par la brèche incessamment accrue
 Tours, dômes, ponts, clochers, et, comme une charrue,
-Creuse une horrible rue à travers les maisons!"
+Creuse une horrible rue à travers les maisons !"
 
 Et tous les souvenirs qu'à ton front taciturne
 Chaque siècle en passant versera de son urne
 Leur reviendront au coeur.
 Ils feront de ton mur jaillir ta vieille histoire,
 Et diront, en posant un panache de gloire
-Sur ton cimier vainqueur:
+Sur ton cimier vainqueur :
 
--"Oh! que tout était grand dans cette époque antique!
+-"Oh ! que tout était grand dans cette époque antique !
 Si les ans n'avaient pas dévasté ce portique,
-Nous en retrouverions encor les lambeaux!
+Nous en retrouverions encor les lambeaux !
 Mais le temps, grand semeur de la ronce et du lierre,
 Touche les monuments d'une main familière,
-Et déchire le livre aux endroits les plus beaux!"
+Et déchire le livre aux endroits les plus beaux !"
 </poetry>
 </body>
 </text>
@@ -1024,22 +1024,22 @@ La robe dont il les dépouille
 Ne vaut celle qu'il leur revêt.
 
 C'est le temps qui creuse une ride
-Dans un claveau trop indigent;
+Dans un claveau trop indigent ;
 Qui sur l'ange d'un marbre aride
-Passe son pouce intelligent;
+Passe son pouce intelligent ;
 C'est lui qui, pour corriger l'oeuvre,
 Mêle une vivante couleuvre
 Aux noeuds d'une hydre de granit.
 Je cois voir rire un toit gothique
 Quand le temps dans la frise antique
-Ote une pierre et met un nid!
+Ote une pierre et met un nid !
 
-Aussi, quand vous venez, c'est lui qui vous accueille;
+Aussi, quand vous venez, c'est lui qui vous accueille ;
 Lui qui verse l'odeur du vague chèvrefeuille
-Sur ce pavé souillé peut-être d'ossements;
+Sur ce pavé souillé peut-être d'ossements ;
 Lui qui remplit d'oiseaux les sculptures farouches,
 Met la vie en leurs flancs, et de leurs mornes bouches
-Fait sortir mille cris charmants!
+Fait sortir mille cris charmants !
 
 Si quelque Vénus toute nue
 Gémit, pauvre marbre désert,
@@ -1047,10 +1047,10 @@ C'est lui, dans la verte avenue,
 Qui la caresse et qui la sert.
 A l'abri d'un porche héraldique
 Sous un beau feuillage pudique
-Il la cache jusqu'au nombril;
+Il la cache jusqu'au nombril ;
 Et sous son pied blanc et superbe
 Etend les mille fleurs de l'herbe,
-Cette mosaïque d'avril!
+Cette mosaïque d'avril !
 
 La mémoire des morts demeure
 Dans les monuments ruinés.
@@ -1061,46 +1061,46 @@ Filtrant de pensée en pensée,
 Comme une nymphe au front dormant
 Qui, seule sous l'obscure voûte
 D'où son eau suinte goutte à goutte,
-Penche son vase tristement!
+Penche son vase tristement !
 </poetry>
 </body>
 </text>
 
 <text id="hugo1999070319">
 <head>
-   <title>Mais, hélas! hélas! dit l'histoire</title>
-   <toctitle>Mais, hélas! hélas! dit l'histoire</toctitle>
-   <indextitle>Mais, hélas! hélas! dit l'histoire</indextitle>
-   <firstline>Mais, hélas! hélas! dit l'histoire</firstline>
+   <title>Mais, hélas ! hélas ! dit l'histoire</title>
+   <toctitle>Mais, hélas ! hélas ! dit l'histoire</toctitle>
+   <indextitle>Mais, hélas ! hélas ! dit l'histoire</indextitle>
+   <firstline>Mais, hélas ! hélas ! dit l'histoire</firstline>
    <quality>korrektur1</quality>
 </head>
 <body>
 <poetry>
-Mais, hélas! hélas! dit l'histoire,
+Mais, hélas ! hélas ! dit l'histoire,
 Bien souvent le passé couvre plus d'un secret
-Dont sur un mur vieilli la tache reparaît!
-Toute ancienne muraille est noire!
+Dont sur un mur vieilli la tache reparaît !
+Toute ancienne muraille est noire !
 
 Souvent, par le désert et par l'ombre absorbé,
 L'édifice déchu ressemble au roi tombé.
-Plus de gloire où n'est plus la foule!
+Plus de gloire où n'est plus la foule !
 Rome est humiliée et Venise est en deuil.
-La ruine de tout commence par l'orgueil;
-C'est le premier fronton qui croule!
+La ruine de tout commence par l'orgueil ;
+C'est le premier fronton qui croule !
 
 Athène est triste, et cache au front du Parthénon
 Les traces de l'Anglais et celles du canon,
 Et, pleurant ses tours mutilées,
 Rêve à l'artiste grec qui versa de sa main
 Quelque chose de beau comme un sourire humain
-Sur le profil des propylées!
+Sur le profil des propylées !
 
 Thèbe a des temples morts où rampe en serpentant
 La vipère au front plat, au regard éclatant,
-Autour de la colonne torse;
+Autour de la colonne torse ;
 Et, seul, quelque grand aigle habite en souverain
 Les piliers de Rhamsès d'où les lames d'airain
-S'en vont comme une vieille écorce!
+S'en vont comme une vieille écorce !
 
 Dans les débris de Gur, pleins du cri des hiboux,
 Le tigre en marchant ploie et casse les bambous,
@@ -1114,14 +1114,14 @@ A peine entre ses blocs d'herbe haute couverts
 Entend-on le lézard qui bouge.
 Ses murs sont obstrués d'arbres au fruit vermeil
 Où volent, tout moirés par l'ombre et le soleil,
-De beaux oiseaux de cuivre rouge!
+De beaux oiseaux de cuivre rouge !
 
 Muette en la douleur, Jumièges gravement
 Etouffe un triste écho sous son portail normand,
 Et laisse chanter sur ses tombes
 Tous ces nids dans ses tours abrités et couvés
 D'où le souffle du soir fait sur les noirs pavés
-Neiger des plumes de colombes!
+Neiger des plumes de colombes !
 
 Comme une mère sombre, et qui, dans sa fierté,
 Cache sous son manteau son enfant souffleté,
@@ -1131,77 +1131,77 @@ Ses colosses camards à la face frappés
 Par le pied brutal de Cambyse.
 
 C'est que toujours les ans contiennent quelque affront.
-Toute ruine, hélas! pleure et penche le front!
+Toute ruine, hélas ! pleure et penche le front !
 </poetry>
 </body>
 </text>
 
 <text id="hugo1999070320">
 <head>
-   <title>Mais toi! rien s'atteindra ta majesté pudique</title>
-   <toctitle>Mais toi! rien s'atteindra ta majesté pudique</toctitle>
-   <indextitle>Mais toi! rien s'atteindra ta majesté pudique</indextitle>
-   <firstline>Mais toi! rien s'atteindra ta majesté pudique</firstline>
+   <title>Mais toi ! rien s'atteindra ta majesté pudique</title>
+   <toctitle>Mais toi ! rien s'atteindra ta majesté pudique</toctitle>
+   <indextitle>Mais toi ! rien s'atteindra ta majesté pudique</indextitle>
+   <firstline>Mais toi ! rien s'atteindra ta majesté pudique</firstline>
    <quality>korrektur1</quality>
 </head>
 <body>
 <poetry>
-Mais toi! rien s'atteindra ta majesté pudique,
-Porte sainte! jamais ton marbre véridique
+Mais toi ! rien s'atteindra ta majesté pudique,
+Porte sainte ! jamais ton marbre véridique
 Ne sera profané.
-Ton cintre virginal sera pur sous la nue;
+Ton cintre virginal sera pur sous la nue ;
 Et les peuples à naître accourront tête nue
-Vers ton front couronné!
+Vers ton front couronné !
 
 Toujours le pâtre, au loin accroupi dans les seigles,
 Verra sur ton sommeil planer un cercle d'aigles.
 Les chênes à tes blocs noueront leur large tronc.
 La gloire sur ta cime allumera son phare.
 Ce n'est qu'en te chantant une haute fanfare
-Que sous ton arc altier le siècles passeront!
+Que sous ton arc altier le siècles passeront !
 
 Jamais rien qui ressemble à quelque ancienne honte
 N'osera sur ton mur où le flot des ans monte
 Répandre sa noirceur.
 Tu pourras, dans ces champs où vous resterez seules,
 Contempler fièrement les deux tours tes aïeules,
-Ne mêle à tes lauriers son feuillage hideux!
+Ne mêle à tes lauriers son feuillage hideux !
 
 Tandis que ces cités, dans leurs cendres enfouies,
 Furent pleines jadis d'actions inouïes,
 Ivres de sang versé,
-Si bien que le seigneur a dit à la nature:
+Si bien que le seigneur a dit à la nature :
 Refais-toi des palais dans cette architecture
-Dont l'homme a mal usé!
+Dont l'homme a mal usé !
 
-Aussi tout est fini. Le chacal les visite;
-Les murs vont décroissant sous l'herbe parasite;
-L'étang s'installe et dort sous le dôme brisé;
-Sur les Nérons sculptés marche la bête fauve;
+Aussi tout est fini. Le chacal les visite ;
+Les murs vont décroissant sous l'herbe parasite ;
+L'étang s'installe et dort sous le dôme brisé ;
+Sur les Nérons sculptés marche la bête fauve ;
 L'antre se creuse où fut l'incestueuse alcôve.
-Le tigre peut venir où le crime a passé!
+Le tigre peut venir où le crime a passé !
 </poetry>
 </body>
 </text>
 
 <text id="hugo1999070321">
 <head>
-   <title>Oh! dans ces jours lointains où l'on n'ose descendre</title>
-   <toctitle>Oh! dans ces jours lointains où l'on n'ose descendre</toctitle>
-   <indextitle>Oh! dans ces jours lointains où l'on n'ose descendre</indextitle>
-   <firstline>Oh! dans ces jours lointains où l'on n'ose descendre</firstline>
+   <title>Oh ! dans ces jours lointains où l'on n'ose descendre</title>
+   <toctitle>Oh ! dans ces jours lointains où l'on n'ose descendre</toctitle>
+   <indextitle>Oh ! dans ces jours lointains où l'on n'ose descendre</indextitle>
+   <firstline>Oh ! dans ces jours lointains où l'on n'ose descendre</firstline>
    <quality>korrektur1</quality>
 </head>
 <body>
 <poetry>
-Oh! dans ces jours lointains où l'on n'ose descendre,
+Oh ! dans ces jours lointains où l'on n'ose descendre,
 Quand trois mille ans auront passé sur notre cendre
 A nous qui maintenant vivons, pensons, allons,
 Quand nos fosses auront fait place à des sillons,
 Si, vers le soir, un homme assis sur la colline
 S'oublie à contempler cette Seine orpheline,
-O Dieu! de quel aspect triste et silencieux
-Les lieux où fut Paris étonneront ses yeux!
+O Dieu ! de quel aspect triste et silencieux
+Les lieux où fut Paris étonneront ses yeux !
 Si c'est l'heure où déjà des vapeurs sont tombées
 Sur le couchant rougi de l'or des scarabées,
 Si la touffe de l'arbre est noire sur le ciel,
@@ -1213,71 +1213,71 @@ La plaine immense et brune apparaître à ses pieds,
 S'élargir lentement dans le vague nocturne,
 Et comme une eau qui s'enfle et monte aux dors de l'urne,
 Absorbant par degrés forêt, coteau, gazon,
-Quand la nuit sera noire, emplir tout l'horizon!
-Oh! dans cette heure sombre où l'on croit voir les choses
+Quand la nuit sera noire, emplir tout l'horizon !
+Oh ! dans cette heure sombre où l'on croit voir les choses
 Fuir, sous une autre forme étrangement éclose,
 Quelle extase de voir dormir, quant rien ne luit,
-Ces champs dont chaque pierre a contenu du bruit!
-Comme il tendra l'oreille aux rumeurs indécises!
+Ces champs dont chaque pierre a contenu du bruit !
+Comme il tendra l'oreille aux rumeurs indécises !
 Comme il ira rêvant des figures assises
 Dans le buisson penché, dans l'arbre aux bord des eaux,
-Dans le vieux pan de mur que lèchent les roseaux!
-Qu'il cherchera de vie en ce tombeau suprême!
+Dans le vieux pan de mur que lèchent les roseaux !
+Qu'il cherchera de vie en ce tombeau suprême !
 Et comme il se fera, s'éblouissant lui-même,
 A travers la nuit trouble et les rameaux touffus,
-Des visions de chars et de passants confus!
+Des visions de chars et de passants confus !
 - Mais non, tout sera mort. Plus rien dans cette plaine
-Qu'un peuple évanoui dont elle est encor pleine;
-Que l'oeil éteint de l'homme et l'oeil vivant de dieu;
+Qu'un peuple évanoui dont elle est encor pleine ;
+Que l'oeil éteint de l'homme et l'oeil vivant de dieu ;
 Un arc, une colonne, et, là-bas, au milieu
 De ce fleuve argenté dont on entend l'écume,
-Une église échouée à demi dans la brume!
+Une église échouée à demi dans la brume !
 
-O spectacle! - ainsi meurt ce que les peuples fonts!
-Qu'un tel passé pour l'âme est un gouffre profond!
-Pour ce passant pieux quel poids de notre histoire!
+O spectacle ! - ainsi meurt ce que les peuples fonts !
+Qu'un tel passé pour l'âme est un gouffre profond !
+Pour ce passant pieux quel poids de notre histoire !
 Surtout si tout à coup réveillant sa mémoire,
 L'année a ce soir-là ramené dans son cours
 Une des grandes nuits, veilles de nos grands jours,
 Où l'empereur, rêvant un lendemain de gloire,
-Dormait en attendant l'aube d'une victoire!
+Dormait en attendant l'aube d'une victoire !
 
 Lorsqu'enfin, fatigué de songes, vers minuit,
 Las d'écouter au seuil de ce monde détruit,
 Après s'être accoudé longtemps, oubliant,
 Au bord de ce néant immense où rien ne pleure,
-Il aura lentement regagné son chemin;
+Il aura lentement regagné son chemin ;
 Quant ce grand désert, pur de tout pas humain,
 Rien ne troublera plus cette pudeur que Rome
-Ou Paris ruiné doit avoir devant l'homme;
+Ou Paris ruiné doit avoir devant l'homme ;
 Lorsque la solitude, enfin libre et sans bruit,
 Pourra continuer ce qu'elle fait la nuit,
 Si quelque être animé veille encor dans la plaine
 Peut-être verra-t-il, comme sous une haleine
 Soudain un pâle éclair de ta tête jaillir,
-Et la colonne au loin répondre et tressaillir!
+Et la colonne au loin répondre et tressaillir !
 Et ses soldats de cuivre et tes soldats de pierre
-Ouvrir subitement leur pesante paupière!
-Et tous s'entre-heurter, réveil miraculeux!
+Ouvrir subitement leur pesante paupière !
+Et tous s'entre-heurter, réveil miraculeux !
 Tels que d'anciens guerriers d'un âge fabuleux
 Qu'un noir magicien, loin des temps où nous sommes,
-Jadis aurait fait marbre et qu'il referait homme!
+Jadis aurait fait marbre et qu'il referait homme !
 Alors l'aigle d'airain à ton faîte endormi,
 Superbe, et tout à coup se dressant à demi,
 Sur ces héros baignés du feu de ses prunelles
-Secouera largement ses ailes éternelles!
-D'où viendra ce réveil? d'où viendront ces clartés?
+Secouera largement ses ailes éternelles !
+D'où viendra ce réveil ? d'où viendront ces clartés ?
 Et ce vent qui, soufflant sur ces guerriers sculptés,
 Les fera remuer sur ta face hautaine
-Comme tremble un feuillage autour du tronc de chêne?
-Qu'importe? Dieu le sait. Le mystère est dans tout.
-L'un à l'autre à voix basse ils se diront: Debout!
+Comme tremble un feuillage autour du tronc de chêne ?
+Qu'importe ? Dieu le sait. Le mystère est dans tout.
+L'un à l'autre à voix basse ils se diront : Debout !
 Ceux de quatre-vingt-seize et de mil huit cent onze,
 Ceux que conduit au ciel la spirale de bronze,
 Ceux que scelle à la terre un socle de granit,
 Tous, poussant au combat le cheval qui hennit,
 Le drapeau qui se gonfle et le canon qui roule,
-A l'immense mêlée ils se rueront en foule!
+A l'immense mêlée ils se rueront en foule !
 Alors on entendra sur ton mur les clairons,
 Les bombes, les tambours, le choc des escadrons,
 Les cris, et le bruit sourd des plaines ébranlées,
@@ -1287,32 +1287,32 @@ Cent batailles rugir avec des voix d'airain.
 Tout à coup, écrasant l'ennemi qui s'effare,
 La victoire aux cent voix sonnera sa fanfare.
 De la colonne à toi les cris se répondront.
-Et puis tout se taira sur votre double front;
+Et puis tout se taira sur votre double front ;
 Une rumeur de fête emplira la vallée,
 Et Notre-Dame au loin, aux ténèbres mêlée,
 Illuminant sa croix ainsi qu'un labarum,
-Vous chantera dans l'ombre un vague Te Deum!
+Vous chantera dans l'ombre un vague Te Deum !
 
-Monument! voilà donc la rêverie immense
-Qu'à ton ombre déjà le poète commence!
-Piédestal qu'eût aimé Bélénus ou Mithra!
-Arche aujourd'hui guerrière, un jour religieuse!
-Rêve en pierre ébauché! porte prodigieuse
-D'un palais de géants qu'on se figurera!
+Monument ! voilà donc la rêverie immense
+Qu'à ton ombre déjà le poète commence !
+Piédestal qu'eût aimé Bélénus ou Mithra !
+Arche aujourd'hui guerrière, un jour religieuse !
+Rêve en pierre ébauché ! porte prodigieuse
+D'un palais de géants qu'on se figurera !
 
 Quand d'un lierre poudreux je couvre tes sculptures,
 Lorsque je vois, au fond des époques futures,
 La liste des héros sur ton mur constellé
 Reluire et rayonner, malgré les destinées,
 A travers les rameaux des profondes années,
-1 Comme à travers un bois brille un ciel étoilé;
+1 Comme à travers un bois brille un ciel étoilé ;
 
 Quand ma pensée ainsi, vieillissant ton attique,
 Te fait de l'avenir un passé magnifique,
 Alors sous ta grandeur je me courbe effrayé,
 J'admire, et, fils pieux, passant que l'art anime,
 Je ne regrette rien devant ton mur sublime
-Que Phidias absent et mon père oublié!
+Que Phidias absent et mon père oublié !
 
 2 février 1837
 </poetry>
@@ -1329,22 +1329,22 @@ Que Phidias absent et mon père oublié!
 
 <text id="hugo1999070322">
 <head>
-   <title>Quand l'été vient, le pauvre adore!</title>
-   <toctitle>Quand l'été vient, le pauvre adore!</toctitle>
-   <indextitle>Quand l'été vient, le pauvre adore!</indextitle>
-   <firstline>Quand l'été vient, le pauvre adore!</firstline>
+   <title>Quand l'été vient, le pauvre adore !</title>
+   <toctitle>Quand l'été vient, le pauvre adore !</toctitle>
+   <indextitle>Quand l'été vient, le pauvre adore !</indextitle>
+   <firstline>Quand l'été vient, le pauvre adore !</firstline>
    <quality>korrektur1</quality>
 </head>
 <body>
 <poetry>
-Quand l'été vient, le pauvre adore!
+Quand l'été vient, le pauvre adore !
 L'été, c'est la saison de feu,
-C'est l'air tiède et la fraîche aurore;
+C'est l'air tiède et la fraîche aurore ;
 L'été, c'est le regard de Dieu.
 
 L'été, la nuit bleue et profonde
-S'accouple au jour limpide et claire;
-Le soir est d'or, la plaine est blonde;
+S'accouple au jour limpide et claire ;
+Le soir est d'or, la plaine est blonde ;
 On entend des chansons dans l'air.
 
 L'été, la nature éveillée
@@ -1352,20 +1352,20 @@ Partout se répand en tous sens,
 Sur l'arbre en épaisse feuillée,
 Sur l'homme en bienfaits caressants.
 
-Tout ombrage alors semble dire:
-Voyageur, viens te reposer!
+Tout ombrage alors semble dire :
+Voyageur, viens te reposer !
 Elle met dans l'aube un sourire,
 Elle met dans l'onde un baiser.
 
 Elle cache et recouvre d'ombre,
 Loin du monde sourd et moqueur,
 Une lyre dans le bois sombre,
-Une oreille dans notre coeur!
+Une oreille dans notre coeur !
 
 Elle donne vie et pensée
 Aux pauvres de l'hiver sauvés,
 Du soleil à pleine croisée,
-Et le ciel pur qui dit: Vivez!
+Et le ciel pur qui dit : Vivez !
 
 Sur les chaumières dédaignées
 Par les maîtres et les valets,
@@ -1380,7 +1380,7 @@ De se salir à des haillons.
 Sur un toit où l'herbe frissonne
 Le jasmin veut bien se poser.
 Le lys ne méprise personne,
-Lui qui pourrait tout mépriser!
+Lui qui pourrait tout mépriser !
 
 Alors la masure où la mousse
 Sur l'humble chaume a débordé
@@ -1395,22 +1395,22 @@ Entre les poutres du plafond.
 Alors l'âme du pauvre est pleine.
 Humble, il bénit ce Dieu lointain
 Dont il sent la céleste haleine
-Dans tous les souffles du matin!
+Dans tous les souffles du matin !
 
 L'air le réchauffe et le pénètre.
 Il fête le printemps vainqueur.
 Un oiseau chante à sa fenêtre,
-La gaîté chante dans son coeur!
+La gaîté chante dans son coeur !
 
 Alors, si l'orphelin s'éveille,
 Sans toit, sans mère et priant Dieu,
-Une voix lui dit à l'oreille:
-"Eh bien! viens sous mon dôme bleu!
+Une voix lui dit à l'oreille :
+"Eh bien ! viens sous mon dôme bleu !
 
 Le Louvre est égal aux chaumières
 Sous ma coupole de saphirs.
 Viens sous mon ciel plein de lumières,
-Viens sous mon ciel plein de zéphirs!
+Viens sous mon ciel plein de zéphirs !
 
 J'ai connu ton père et ta mère
 Dans leurs bons et leurs mauvais jours.
@@ -1419,50 +1419,50 @@ Mais moi je fut douce toujours.
 
 C'est moi qui sur leur sépulture
 Ai mis l'herbe qui la défend.
-Viens, je suis la grande nature!
+Viens, je suis la grande nature !
 Je suis l'aïeule, et toi l'enfant.
 
 Viens, j'ai des fruits d'or, j'ai des roses,
 J'en remplirai tes petits bras,
 Je te dirai de douces choses,
-Et peut-être tu souriras!
+Et peut-être tu souriras !
 
 Car je voudrais te voir sourire,
-Pauvre enfant si triste et si beau!
+Pauvre enfant si triste et si beau !
 Et puis tout bas j'irais le dire
-A ta mère dans son tombeau!"
+A ta mère dans son tombeau !"
 
 Et l'enfant à cette voix tendre,
 De la vie oubliant le poids,
 Rêve et se hâte de descendre
 Le long des coteaux dans les bois.
 
-Là du plaisir tout a la forme;
-L'arbre a des fruits, l'herbe a des fleurs;
+Là du plaisir tout a la forme ;
+L'arbre a des fruits, l'herbe a des fleurs ;
 Il entend dans le chêne énorme
 Rire les oiseaux querelleurs.
 
-Dans l'onde, il mire son visage;
-Tout lui parle; adieu son ennui!
+Dans l'onde, il mire son visage ;
+Tout lui parle ; adieu son ennui !
 Le buisson l'arrête au passage,
 Et le caillou joue avec lui.
 
 Le soir, point d'hôtesse cruelle
 Qui l'accueille d'un front hagard.
 Il trouve l'étoile si belle
-Qu'il s'endort à son doux regard!
+Qu'il s'endort à son doux regard !
 
-- Oh! qu'en dormant rien ne t'oppresse!
-Dieu sera là pour ton réveil!-
+- Oh ! qu'en dormant rien ne t'oppresse !
+Dieu sera là pour ton réveil !-
 La lune vient qui le caresse
 Plus doucement que le soleil.
 
 Car elle a de plus molles trêves
 Pour nos travaux et nos douleurs.
 Elle fait éclore nos rêves,
-Lui ne fait naître que les fleurs!
+Lui ne fait naître que les fleurs !
 
-Oh! quand la fauvette dérobe
+Oh ! quand la fauvette dérobe
 Son nid sous les rameaux penchants,
 Lorsqu'au soleil séchant sa robe
 Mai tout mouillé rit dans les champs
@@ -1470,42 +1470,42 @@ Mai tout mouillé rit dans les champs
 J'ai souvent pensé dans mes veilles
 Que la nature au front sacré
 Dédiait tout bas ses merveilles
-A ceux qui l'hiver ont pleuré!
+A ceux qui l'hiver ont pleuré !
 
 Pour tous et pour le méchant même
 Elle est bonne, Dieu le permet,
 Dieu le veut, mais surtout elle aime
-Le pauvre que Jésus aimait!
+Le pauvre que Jésus aimait !
 
 Toujours sereine et pacifique,
 Elle offre à l'auguste indigent
 Des dons de reine magnifique,
-Des soins d'esclave intelligent!
+Des soins d'esclave intelligent !
 
-A-t-il faim? au fruit de la branche
-Elle dit: - Tombe, ô fruit vermeil!
-A-t-il soif? - Que l'onde s'épanche!
-A-t-il froid? - Lève-toi, soleil!
+A-t-il faim ? au fruit de la branche
+Elle dit : - Tombe, ô fruit vermeil !
+A-t-il soif ? - Que l'onde s'épanche !
+A-t-il froid ? - Lève-toi, soleil !
 </poetry>
 </body>
 </text>
 
 <text id="hugo1999070323">
 <head>
-   <title>Mais hélas! juillet fait sa gerbe</title>
-   <toctitle>Mais hélas! juillet fait sa gerbe</toctitle>
-   <indextitle>Mais hélas! juillet fait sa gerbe</indextitle>
-   <firstline>Mais hélas! juillet fait sa gerbe</firstline>
+   <title>Mais hélas ! juillet fait sa gerbe</title>
+   <toctitle>Mais hélas ! juillet fait sa gerbe</toctitle>
+   <indextitle>Mais hélas ! juillet fait sa gerbe</indextitle>
+   <firstline>Mais hélas ! juillet fait sa gerbe</firstline>
    <quality>korrektur1</quality>
 </head>
 <body>
 <poetry>
-Mais hélas! juillet fait sa gerbe;
+Mais hélas ! juillet fait sa gerbe ;
 L'été, lentement effacé,
 Tombe feuille à feuille dans l'herbe
 Et jour à jour dans le passé.
 
-Puis octobre perd sa dorure;
+Puis octobre perd sa dorure ;
 Et les bois dans les lointains bleus
 Couvrent de leur rousse fourrure
 L'épaule des coteaux frileux.
@@ -1513,42 +1513,42 @@ L'épaule des coteaux frileux.
 L'hiver des nuages sans nombre
 Sort, et chasse l'été du ciel,
 Pareil au temps, ce faucheur sombre
-Qui suit le semeur éternel!
+Qui suit le semeur éternel !
 
 Le pauvre alors s'effraie te prie.
-L'hiver, hélas! c'est Dieu qui dort;
+L'hiver, hélas ! c'est Dieu qui dort ;
 C'est la faim livide et maigrie
-Qui tremble auprès du foyer mort!
+Qui tremble auprès du foyer mort !
 
 Il croit voir une main de marbre
 Qui, mutilant le jour obscur,
 Retire tous les fruits de l'arbre
 Et tout les rayons d'azur.
 
-Il pleure, la nature est morte!
-O rude hiver! ô dure loi!
+Il pleure, la nature est morte !
+O rude hiver ! ô dure loi !
 Soudain un ange ouvre sa porte
-Et dit en souriant: C'est moi!
+Et dit en souriant : C'est moi !
 
 Cet ange qui donne et tremble,
 C'est l'aumône aux yeux de douceur,
 Au front crédule, et qui ressemble
-A la foi dont elle est la soeur!
+A la foi dont elle est la soeur !
 
 Je suis la Charité, l'amie
 Qui se réveille avant le jour,
 Quand la nature est rendormie,
-Et que dieu m'a dit: A ton tour!
+Et que dieu m'a dit : A ton tour !
 
 "Je viens visiter ta chaumière
-Veuve de l'été si charmant!
+Veuve de l'été si charmant !
 Je suis fille de la prière.
 J'ai des mains qu'on ouvre aisément.
 
 "J'accours, car la saison est dure,
 j'accours, car l'indigent a froid"
 J'accours, car la tiède verdure
-Ne fait plus d'ombre sur le toit!
+Ne fait plus d'ombre sur le toit !
 
 "je prie, et jamais je n'ordonne.
 Chère à tout homme quel qu'il soit,
@@ -1558,7 +1558,7 @@ Et je l'apporte à qui reçoit."
 O figure auguste et modeste,
 Où le Seigneur mêla pour nous
 Ce que l'ange a de plus céleste,
-Ce que la femme a de plus doux!
+Ce que la femme a de plus doux !
 
 Au lit du vieillard solitaire
 Elle penche un front gracieux,
@@ -1568,32 +1568,32 @@ Et rien n'est plus grand sous les cieux,
 Lorsque, réchauffant leurs poitrines
 Entre ses genoux triomphants,
 Elle tient dans ses mains divines
-Les pieds nus des petits enfants!
+Les pieds nus des petits enfants !
 
 Elle va dans chaque masure,
 Laissant au pauvre réjoui
 Le vin, le pain frais, l'huile pure,
-Et le courage épanoui!
+Et le courage épanoui !
 
-Et le feu! le beau feu folâtre,
+Et le feu ! le beau feu folâtre,
 A la pourpre ardente pareil,
 Qui fait qu'amené devant l'âtre
-L'aveugle croit rire au soleil!
+L'aveugle croit rire au soleil !
 
 Puis elle cherche au coin des bornes,
 Transis par la froide vapeur,
 Ces enfants qu'on voit nus et mornes
 Et se mourant avec stupeur.
 
-Oh! voilà surtout ceux qu'elle aime!
-Faibles fronts dans l'ombre engloutis!
+Oh ! voilà surtout ceux qu'elle aime !
+Faibles fronts dans l'ombre engloutis !
 Parés d'un triple diadème,
-Innocents, pauvres et petits!
+Innocents, pauvres et petits !
 
-Ils sont meilleurs que nous ne sommes!
+Ils sont meilleurs que nous ne sommes !
 Elle leur donne en même temps,
 Avec le pain qu'il faut aux hommes,
-Le baiser qu'il faut aux enfants!
+Le baiser qu'il faut aux enfants !
 
 Tandis que leur faim secourue
 Mange ce pain de pleurs noyé,
@@ -1603,19 +1603,19 @@ Son bras de passants coudoyé.
 Et si, le front dans la lumière,
 Un riche passe en ce moment,
 Par le bord de sa robe altière
-Elle le tire doucement!
+Elle le tire doucement !
 
 Puis pour eux elle prie encore
 La grande foule au coeur étroit,
 La foule qui, dès qu'on l'implore,
-S'en va comme l'eau qui décroît!
+S'en va comme l'eau qui décroît !
 
-"- Oh! malheureux celui qui chante
+"- Oh ! malheureux celui qui chante
 Un chant joyeux, peut-être impur,
 Pendant que la bise méchante
-Mord un pauvre enfant sous son mur!
+Mord un pauvre enfant sous son mur !
 
-Oh! la chose triste et fatale,
+Oh ! la chose triste et fatale,
 Lorsque chez le riche hautain
 Un grand feu tremble dans la salle,
 Reflété par un grand festin,
@@ -1623,94 +1623,94 @@ Reflété par un grand festin,
 De voir, quand l'orgie enrouée
 Dans la pourpre s'égaie et rit,
 A peine une toile trouée
-Sur les membres de Jésus-Christ!
+Sur les membres de Jésus-Christ !
 
-Oh! donnez-moi pour que je donne!
+Oh ! donnez-moi pour que je donne !
 J'ai des oiseaux nus dans mon nid.
-Donnez, méchants, Dieu vous pardonne!
-Donnez, ô bons, Dieu vous bénit!
+Donnez, méchants, Dieu vous pardonne !
+Donnez, ô bons, Dieu vous bénit !
 
-Heureux ceux que mon zèle enflamme!
+Heureux ceux que mon zèle enflamme !
 Qui donne au pauvres prête à Dieu.
-Le bien qu'on fait parfume l'âme;
-On s'en souvient toujours un peu!
+Le bien qu'on fait parfume l'âme ;
+On s'en souvient toujours un peu !
 
 Le soir, au seuil de sa demeure,
 Heureux celui qui sait encor
 Ramasser un enfant qui pleure,
-Comme un avare un sequin d'or!
+Comme un avare un sequin d'or !
 
 Le vrai trésor rempli de charmes,
 C'est un groupe pour vous priant
 D'enfants qu'on a trouvés en larmes
-Et qu'on a laissés souriant!
+Et qu'on a laissés souriant !
 
 Les biens que je donne à qui m'aime,
 Jamais Dieu ne les retira.
 L'or que sur le pauvre je sème
-Pour le riche au ciel germera!"
+Pour le riche au ciel germera !"
 </poetry>
 </body>
 </text>
 
 <text id="hugo1999070324">
 <head>
-   <title>Oh! que l'été brille ou s'éteigne</title>
-   <toctitle>Oh! que l'été brille ou s'éteigne</toctitle>
-   <indextitle>Oh! que l'été brille ou s'éteigne</indextitle>
-   <firstline>Oh! que l'été brille ou s'éteigne</firstline>
+   <title>Oh ! que l'été brille ou s'éteigne</title>
+   <toctitle>Oh ! que l'été brille ou s'éteigne</toctitle>
+   <indextitle>Oh ! que l'été brille ou s'éteigne</indextitle>
+   <firstline>Oh ! que l'été brille ou s'éteigne</firstline>
    <quality>korrektur1</quality>
 </head>
 <body>
 <poetry>
-Oh! que l'été brille ou s'éteigne,
-Pauvres, ne désespérez pas!
+Oh ! que l'été brille ou s'éteigne,
+Pauvres, ne désespérez pas !
 Le Dieu qui souffrit et qui règne
-A mis ses pieds où sont vos pas!
+A mis ses pieds où sont vos pas !
 
-Pour vous couvrir il se dépouille;
+Pour vous couvrir il se dépouille ;
 Bon même pour l'homme fatal
 Qui, comme l'airain dans la rouille,
-Va s'endurcissant dans le mal!
+Va s'endurcissant dans le mal !
 Tendre, même durant l'absinthe,
 Pour l'impie au regard obscur
 Qui l'insulte sans plus de crainte
-Qu'un passant qui raie un vieux mur!
+Qu'un passant qui raie un vieux mur !
 
 Ils ont beau traîner sur les claies
-Ce Dieu mort dans leur abandon;
+Ce Dieu mort dans leur abandon ;
 Ils ne font couler de ses plaies
 Qu'un intarissable pardon.
 
 Il n'est pas l'aigle altier qui vole,
-Ni le grand lion ravisseur;
+Ni le grand lion ravisseur ;
 Il compose son auréole
-D'une lumineuse douceur!
+D'une lumineuse douceur !
 
 Quand sur nous une chaîne tombe,
 Il la brise anneau par anneau.
 Pour l'esprit il se fait colombe,
-Pour le coeur il se fait agneau!
+Pour le coeur il se fait agneau !
 
 Vous pour qui la vie est mauvaise,
-Espérez! il veille sur vous!
+Espérez ! il veille sur vous !
 Il sait bien ce que cela pèse,
-Lui qui tomba sur ses genoux!
+Lui qui tomba sur ses genoux !
 
-Il est le Dieu de l'évangile;
+Il est le Dieu de l'évangile ;
 Il tient votre coeur dans sa main,
 Et c'est une chose fragile
-Qu'il ne veut pas briser, enfin!
+Qu'il ne veut pas briser, enfin !
 
 Lorsqu'il est temps que l'été meure
 Sous l'hiver sombre et solennel,
 Même à travers le ciel qui pleure
-On voit son sourire éternel!
+On voit son sourire éternel !
 
 Car sur les familles souffrantes,
 L'hiver, l'été, la nuit, le jour,
 Avec des urnes différentes
-Dieu verse à grands flots son amour!
+Dieu verse à grands flots son amour !
 
 Et dans ses bontés éternelles
 Il penche sur l'humanité
@@ -1724,90 +1724,90 @@ La nature et la charité.
 
 <text id="hugo1999070325">
 <head>
-   <title>Oh! vivons! disent-ils dans leur enivrement</title>
-   <toctitle>Oh! vivons! disent-ils dans leur enivrement</toctitle>
-   <indextitle>Oh! vivons! disent-ils dans leur enivrement</indextitle>
-   <firstline>Oh! vivons! disent-ils dans leur enivrement</firstline>
+   <title>Oh ! vivons ! disent-ils dans leur enivrement</title>
+   <toctitle>Oh ! vivons ! disent-ils dans leur enivrement</toctitle>
+   <indextitle>Oh ! vivons ! disent-ils dans leur enivrement</indextitle>
+   <firstline>Oh ! vivons ! disent-ils dans leur enivrement</firstline>
    <quality>korrektur1</quality>
 </head>
 <body>
 <poetry>
-Oh! vivons! disent-ils dans leur enivrement.
+Oh ! vivons ! disent-ils dans leur enivrement.
 Voyez la longue table et le festin charmant
-Qui rayonne dans nos demeures!
+Qui rayonne dans nos demeures !
 Nous semons tous nos biens n'importe en quels sillons.
 Riches, nous dépensons, nous perdons, nous pillons
-Nos onces d'or; jeunes, nos heures
+Nos onces d'or ; jeunes, nos heures
 
-Jette ta vielle Bible, ô jeune homme pieux!
-Quitte église et collège, et viens chez nous! - Joyeux,
+Jette ta vielle Bible, ô jeune homme pieux !
+Quitte église et collège, et viens chez nous ! - Joyeux,
 Entourés de cent domestiques,
 Buvant, chantant, riant, nous n'insultons pas Dieu,
 Et nous lui permettons de montrer son ciel bleu
-Par le cintre de nos portiques!
+Par le cintre de nos portiques !
 
-De quoi te servira ton labeur ennuyeux?
+De quoi te servira ton labeur ennuyeux ?
 Sais-tu ce que diront les belles aux doux yeux
-Dont le sourire vaut un trône?
-- O jeune homme inutile! - Et puis elles riront.
-- Oh! que de peine il prend pour donner à son front
-La couleur de son livre jaune!
+Dont le sourire vaut un trône ?
+- O jeune homme inutile ! - Et puis elles riront.
+- Oh ! que de peine il prend pour donner à son front
+La couleur de son livre jaune !
 
 Nous, éblouis de feux, de concerts, de seins nus,
-Nous vivons! - Nous avons des bonheurs inconnus
+Nous vivons ! - Nous avons des bonheurs inconnus
 A la foule avare et grossière,
 Quand dans l'orchestre, où rien ne grandit qu'en tremblant,
 La fanfare, tantôt montant, tantôt croulant,
-S'enfle en onde ou vole en poussière!
+S'enfle en onde ou vole en poussière !
 
 L'homme à tout ce qu'il fait dans tous les temps mêla
 La musique et les chants. - Amis c'est pour cela
 Que la Guerre qui nous enivre,
 Noble déesse à qui tout enfants nous songions,
 Fait chanter en avant des sombres légions
-Les clairons aux bouches de cuivre!
+Les clairons aux bouches de cuivre !
 
-O rois, pour vous la guerre et pour nous le plaisir!
+O rois, pour vous la guerre et pour nous le plaisir !
 Vous vivez par l'orgueil et nous par le désir.
 Nous avons tous notre part d'âmes.
 Nous avons, les uns craints et les autres aimés,
 Vous les empires, nous les boudoirs parfumés,
 Vous les homme, et nous les femmes.
 
-Prêtres, mages, docteurs, savants, nous font pitié!
+Prêtres, mages, docteurs, savants, nous font pitié !
 Pauvres songeurs qui vont expliquant à moitié
 L'ombre dont l'Eternel se voile,
 Tantôt lisant un livre et hués des valets,
 Tantôt assis la nuit sur le toit des palais,
-Epelant d'étoile en étoile!
+Epelant d'étoile en étoile !
 
-Fous qui cherchent un centre au globe obscur du ciel!
-Nous, rions! - Il n'est rien ici-bas de réel
+Fous qui cherchent un centre au globe obscur du ciel !
+Nous, rions ! - Il n'est rien ici-bas de réel
 Que ce que tient la main e l'homme.
 Donnons leur saint bonheur pour les plaisirs maudits,
 Pour une Eve au front pur leur vague paradis,
-Et leur sphère pour une pomme!
+Et leur sphère pour une pomme !
 
-Qu'est-ce que la science à côté de l'amour?
+Qu'est-ce que la science à côté de l'amour ?
 L'hiver donne la neige et le soleil le jour.
-Aimons! chantons! trêve aux paroles!
+Aimons ! chantons ! trêve aux paroles !
 Préférons, puisque enfin, nos coeurs flambent encor,
 Aux discours larmoyants le choc des coupes d'or,
-Aux vieux sages les belles folles!
+Aux vieux sages les belles folles !
 
-Nature, nous buvons aux flots que tu répands!
+Nature, nous buvons aux flots que tu répands !
 Toujours nous nos hâtons de jouir aux dépens
 Du penseur prudent qui diffère.
 Nous ne songeons, prenant les biens sans les choisir,
 Qu'à dissoudre ici-bas toute chose en plaisir.
-Quant à Dieu, nous le laissons faire!"
+Quant à Dieu, nous le laissons faire !"
 
 Le sage cependant, qui songe à leur destin,
 Ramasse tristement les miettes du festin,
-Tandis que l'un l'autre ils s'enchantent;
+Tandis que l'un l'autre ils s'enchantent ;
 Puis il donne ce pain aux pauvres oubliés,
-Aux mendiants rêveurs, en leur disant: - Priez,
-Priez pour ces hommes qui chantent!
+Aux mendiants rêveurs, en leur disant : - Priez,
+Priez pour ces hommes qui chantent !
 
  4 mars 1837
 </poetry>
@@ -1819,12 +1819,12 @@ Priez pour ces hommes qui chantent!
    <title>A Virgile</title>
    <toctitle>A Virgile</toctitle>
    <indextitle>A Virgile</indextitle>
-   <firstline>O Virgile! ô poète! ô mon maître divin!</firstline>
+   <firstline>O Virgile ! ô poète ! ô mon maître divin !</firstline>
    <quality>korrektur1</quality>
 </head>
 <body>
 <poetry>
-O Virgile! ô poète! ô mon maître divin!
+O Virgile ! ô poète ! ô mon maître divin !
 Viens, quittons cette ville au cri sinistre et vain,
 Qui, géante, et jamais ne fermant la paupière,
 Presse un flot écumant entre ses flancs de pierre,
@@ -1838,23 +1838,23 @@ Tomber de feuille en feuille un vers mystérieux,
 Pour toi dont la pensée emplit ma rêverie,
 J'ai trouvé dans une ombre où rit l'herbe fleurie,
 Entre Buc et Meudon, dans un profond oubli,
-- Et quand je dis Meudon, suppose Tivoli! -
+- Et quand je dis Meudon, suppose Tivoli ! -
 J'ai trouvé, mon poète, une chaste vallée
 A des coteaux charmants nonchalamment mêlée,
 Retraite favorable à des amants cachés,
 Faite de flots dormants et de rameaux penchés,
 Où midi baigne en vain de ses rayons sans nombre
-La grotte et la forêt, frais asiles de l'ombre!
+La grotte et la forêt, frais asiles de l'ombre !
 
 Pour toi je l'ai cherchée, un matin, fier, joyeux,
-Avec l'amour au coeur et l'aube dans les yeux;
+Avec l'amour au coeur et l'aube dans les yeux ;
 Pour toi je l'ai cherchée, accompagné de celle
 Qui sait tous les secrets que mon âme recèle,
 Et qui, seule avec moi sous les bois chevelus,
 Serait ma Lycoris si j'étais ton Gallus.
 
 Car elle a dans le coeur cette fleur large et pure,
-L'amour mystérieux de l'antique nature!
+L'amour mystérieux de l'antique nature !
 Elle aime comme nous, maître, ces douces voix,
 Ce bruit de nids joyeux qui sort des sombres bois,
 Et, le soir, tout au fond de la vallée étroite,
@@ -1864,9 +1864,9 @@ Les marais irrités des pas du voyageur,
 Et l'humble chaume, et l'antre obstrué d'herbe verte,
 Et qui semble une bouche avec terreur ouverte,
 Les eaux, les prés, les monts, les refuges charmants,
-Et les grands horizons pleins de rayonnements!
+Et les grands horizons pleins de rayonnements !
 
-Maître! puisque voici la saison des pervenches,
+Maître ! puisque voici la saison des pervenches,
 Si tu veux, chaque nuit, en écartant les branches,
 Sans éveiller d'échos à nos pas hasardeux,
 Nous irons tous les trois, c'est-à-dire tous deux,
@@ -1888,15 +1888,15 @@ Les satyres dansants qu'imite Alphésibée.
 
 <text id="hugo1999070327">
 <head>
-   <title>Venez que je vous parle, ô jeune enchanteresse!</title>
-   <toctitle>Venez que je vous parle, ô jeune enchanteresse!</toctitle>
-   <indextitle>Venez que je vous parle, ô jeune enchanteresse!</indextitle>
-   <firstline>Venez que je vous parle, ô jeune enchanteresse!</firstline>
+   <title>Venez que je vous parle, ô jeune enchanteresse !</title>
+   <toctitle>Venez que je vous parle, ô jeune enchanteresse !</toctitle>
+   <indextitle>Venez que je vous parle, ô jeune enchanteresse !</indextitle>
+   <firstline>Venez que je vous parle, ô jeune enchanteresse !</firstline>
    <quality>korrektur1</quality>
 </head>
 <body>
 <poetry>
-Venez que je vous parle, ô jeune enchanteresse!
+Venez que je vous parle, ô jeune enchanteresse !
 Dante vous eût faite ange et Virgile déesse.
 Vous avez le front haut, le pied vif et charmant,
 Une bouche qu'entrouvre un bel air d'enjouement,
@@ -1910,12 +1910,12 @@ Et, dans un vase grec sculptant votre figure,
 Il vous ferait sortir d'un beau calice d'or,
 D'un lys qui devient femme en restant lys encor,
 Ou d'un de ces lotus qui lui doivent la vie,
-Etranges fleurs de l'art que la nature envie!
+Etranges fleurs de l'art que la nature envie !
 
 Venez que je vous parle, ô belle aux yeux divins,
 Pour la première fois quand près de vous je vins,
 Ce fut un jour doré. Ce souvenir, madame,
-A-t-il comme en mon coeur son rayon dans votre âme?
+A-t-il comme en mon coeur son rayon dans votre âme ?
 Vous souriez. Mettez votre main dans ma main,
 Venez. Le printemps rit, l'ombre est sur le chemin,
 L'air est tiède, et là-bas, dans les forêts prochaines,
@@ -1938,47 +1938,47 @@ La mousse épaisse et verte abonde au pied des chênes.
 <poetry>
 Poète, ta fenêtre était ouverte au vent,
 Quand celle à qui tout bas ton coeur parle souvent
-Sur ton fauteuil posait sa tête:
--"Oh! disait-elle, ami, ne vous y fiez pas!
+Sur ton fauteuil posait sa tête :
+-"Oh ! disait-elle, ami, ne vous y fiez pas !
 Parce que maintenant, attachée à vos pas,
-Ma vie à votre ombre s'arrête;
+Ma vie à votre ombre s'arrête ;
 
-Parce que mon regard est fixé sur vos yeux;
+Parce que mon regard est fixé sur vos yeux ;
 Parce que je n'ai plus de sourire joyeux
-Que pour votre grave sourire;
+Que pour votre grave sourire ;
 Parce que, de l'amour me faisant un linceul,
 Je vous offre mon coeur comme un livre où vous seul
-Avez encor le droit d'écrire;
+Avez encor le droit d'écrire ;
 
 Il n'est pas dit qu'enfin je n'aurai pas un jour
 La curiosité de troubler votre amour
 Et d'alarmer votre oeil sévère,
 Et l'inquiet caprice et le désir moqueur
 De renverser soudain la paix de votre coeur
-Comme un enfant renverse un verre!
+Comme un enfant renverse un verre !
 
 Hommes, vous voulez tous qu'une femme ait longtemps
 Des fiertés, des hauteurs, puis vous êtes contents,
 Dans votre orgueil que rien ne brise,
 Quand, aux feux de l'amour qui rayonne sur nous,
 Pareille à ces fruits verts que le soleil fait doux,
-La hautaine devient soumise!
+La hautaine devient soumise !
 
-Aimez-moi d'être ainsi! - Ces hommes, ô mon roi,
+Aimez-moi d'être ainsi ! - Ces hommes, ô mon roi,
 Que vous voyez passer si froids autour de moi,
 Empressés près des autres femmes,
-Je n'y veux pas songer, car le repos vous plaît;
+Je n'y veux pas songer, car le repos vous plaît ;
 Mais mon oeil endormi ferait, s'il le voulait,
-De tous ces fronts jaillir des flammes!"
+De tous ces fronts jaillir des flammes !"
 
 Elle parlait, charmante et fière et tendre encor,
 Laissant sur le dossier de velours à clous d'or
-Déborder sa manche traînante;
+Déborder sa manche traînante ;
 Et toi tu croyais voir à ce beau front si doux
 Sourire ton vieux livre ouvert sur tes genoux,
-Ton Iliade rayonnante!
+Ton Iliade rayonnante !
 
-Beau livre que souvent vous lisez tous les deux!
+Beau livre que souvent vous lisez tous les deux !
 Elle aime comme toi ces combats hasardeux
 Où la guerre agite ses ailes.
 Femme, elle ne hait pas, en t'y voyant rêver,
@@ -1987,10 +1987,10 @@ Les plus vieux devant les plus belles.
 
 Elle vient là, du haut de ses jeunes amours,
 Regarder quelquefois dans le flot des vieux jours
-Quelle ombre y fait cette chimère;
+Quelle ombre y fait cette chimère ;
 Car, ainsi que d'un mont tombe de vivent eaux,
 Le passé murmurant sort et coule à ruisseaux
-De ton flanc, ô géant Homère!
+De ton flanc, ô géant Homère !
 
 26 février 1837
 </poetry>
@@ -2009,10 +2009,10 @@ De ton flanc, ô géant Homère!
 <poetry>
 Dans les vieilles forêts où la sève à grands flots
 Court du fût noir de l'aulne au tronc blanc des bouleaux,
-Bien des fois, n'est ce pas? à travers la clairière,
+Bien des fois, n'est ce pas ? à travers la clairière,
 Pâle, effaré, n'osant regarder en arrière,
 Tu t'es hâté, tremblant et d'un pas convulsif,
-O mon maître Albert Dure, ô vieux peintre pensif!
+O mon maître Albert Dure, ô vieux peintre pensif !
 
 On devine, devant tes tableaux qu'on vénère,
 que dans les noirs taillis ton oeil visionnaire
@@ -2027,16 +2027,16 @@ Là se penchent rêveurs les vieux pins, les grands ormes
 Dont les rameaux tordus font cent coudes difformes,
 Et dans ce groupe sombre agité par le vent
 Rien n'est tout à fait mort ni tout à fait vivant.
-Le cresson boit; l'eau court; les frênes sur les pentes,
+Le cresson boit ; l'eau court ; les frênes sur les pentes,
 Sous la broussaille horrible et les ronces grimpantes,
-Contractent lentement leurs pieds noueux et noirs;
-Les fleurs au cou de cygne ont les lacs pour miroirs:
+Contractent lentement leurs pieds noueux et noirs ;
+Les fleurs au cou de cygne ont les lacs pour miroirs :
 Et, sur vous qui passez et l'avez réveillée,
 Mainte chimère étrange à la gorge écaillée,
 D'un arbre entre ses doigts serrant les larges noeuds,
 Du fond d'un antre obscur fixe un oeil lumineux.
-O végétation! esprit! matière! force!
-Couverte de peau rude ou de vivante écorce!
+O végétation ! esprit ! matière ! force !
+Couverte de peau rude ou de vivante écorce !
 
 Aux bois, ainsi que toi, je n'ai jamais erré,
 Maître, sans qu'en mon coeur l'horreur ait pénétré,
@@ -2067,61 +2067,61 @@ Les chênes monstrueux qui remplissent les bois.
 Puisqu'ici-bas toute âme
 Donne à quelqu'un
 Sa musique, sa flamme,
-Ou son parfum;
+Ou son parfum ;
 
 Puisqu'ici toute chose
 Donne toujours
 Son épine ou sa rose
-A ses amours;
+A ses amours ;
 
 Puisqu'avril donne aux chênes
-Un bruit charmant;
+Un bruit charmant ;
 Que la nuit donne aux peines
-L'oubli dormant;
+L'oubli dormant ;
 
 Puisque l'air à la branche
-Donne l'oiseau;
+Donne l'oiseau ;
 Que l'aube à la pervenche
-Donne un peu d'eau;
+Donne un peu d'eau ;
 
 Puisque, lorsqu'elle arrive
 S'y reposer,
 L'onde amère à la rive
-Donne un baiser;
+Donne un baiser ;
 
 Je te donne à cette heure,
 Penché sur toi,
 La chose la meilleure
-Que j'ai en moi!
+Que j'ai en moi !
 
 Reçois donc ma pensée,
 Triste d'ailleurs,
 Qui, comme une rosée,
-T'arrive en pleurs!
+T'arrive en pleurs !
 Reçois mes voeux sans nombre,
-O mes amours!
+O mes amours !
 Reçois la flamme ou l'ombre
-De tout mes jours!
+De tout mes jours !
 
 Mes transports pleins d'ivresses,
 Pur de soupçons,
 Et toutes les caresses
-De mes chansons!
+De mes chansons !
 
 Mon esprit qui sans voile
 Vogue au hasard,
 Et qui n'a pour étoile
-Que ton regard!
+Que ton regard !
 
 Ma muse, que les heures
 Bercent rêvant,
 Qui, pleurant quand tu pleures,
-Pleure souvent!
+Pleure souvent !
 
 Reçois, mon bien céleste,
 O ma beauté,
 Mon coeur, dont rien ne reste,
-L'amour ôté!
+L'amour ôté !
 
  19 mai 1837
 (Retour à la table des matières)
@@ -2132,19 +2132,19 @@ L'amour ôté!
 <text id="hugo1999070331">
 <head>
    <title>A Ol</title>
-   <firstline>O poète! je vais dans ton âme blessée</firstline>
+   <firstline>O poète ! je vais dans ton âme blessée</firstline>
    <quality>korrektur1</quality>
 </head>
 <body>
 <poetry>
-O poète! je vais dans ton âme blessée
+O poète ! je vais dans ton âme blessée
 Remuer jusqu'au fond ta profonde pensée.
 
 Tu ne l'avais pas vue encore, ce fut un soir,
 A l'heure ou dans le ciel les astres se font voir,
 Qu'elle apparut soudain à tes yeux, fraîche et belle,
 Dans un lieu radieux qui rayonnait moins qu'elle.
-Ses cheveux pétillaient de mille diamants;
+Ses cheveux pétillaient de mille diamants ;
 Un orchestre tremblait à tous ses mouvements
 Tandis qu'elle enivrait la foule haletante,
 Blanche avec des yeux noirs, jeune, grande, éclatante.
@@ -2161,7 +2161,7 @@ Ses yeux ou l'on voyait luire son coeur brûlant.
 Elle allait et passait comme un oiseau de flamme,
 Mettant sans le savoir le feu dans plus d'une âme,
 Et dans les yeux fixés sur tous ses pas charmants
-Jetant de toute part des éblouissements!
+Jetant de toute part des éblouissements !
 
 Toi, tu la contemplais n'osant approcher d'elle,
 Car le baril de poudre a peur de l'étincelle.
@@ -2185,14 +2185,14 @@ Jeune homme, ce méchant fait une lâche guerre.
 Ton indignation ne l'épouvante guère.
 Crois-moi donc, laisse en paix, jeune homme au noble
 Ce Zoïle à l'oeil faux, ce malheureux moqueur. Coeur,
-Ton mépris? mais c'est l'air qui respire. Ta haine?
-La haine est son odeur, sa sueur, son haleine:
+Ton mépris ? mais c'est l'air qui respire. Ta haine ?
+La haine est son odeur, sa sueur, son haleine :
 Il sait qu'il peut souiller sans peur les noms fameux,
 Et que pour qu'on le touche il est trop venimeux.
-Il ne craint rien; pareil au champignon difforme
+Il ne craint rien ; pareil au champignon difforme
 Poussé dans une nuit au pied d'un chêne énorme,
 Qui laisse les chevreaux autour de lui paissant
-Essayer leur dent folle à l'arbuste innocent;
+Essayer leur dent folle à l'arbuste innocent ;
 Sachant qu'il porte en lui des vengeances trop sûres,
 Tout gonflé de poison il attend les morsures.
 
@@ -2212,7 +2212,7 @@ Tout gonflé de poison il attend les morsures.
 <body>
 <poetry>
 Louis, voici le temps de respirer les roses,
-Et d'ouvrir bruyamment les vitres longtemps closes;
+Et d'ouvrir bruyamment les vitres longtemps closes ;
 Le temps d'admirer en rêvant
 Tout ce que la nature a de beautés divines
 Qui flottent sur les monts, les bois et les ravines,
@@ -2220,28 +2220,28 @@ Avec l'onde, l'ombre et le vent.
 
 Louis voici le temps de reposer son âme
 Dans ce calme sourire empreint de vague flamme
-Qui rayonne au front du ciel pur;
+Qui rayonne au front du ciel pur ;
 De dilater son coeur ainsi qu'une eau qui fume,
 Et d'en faire envoler la nuée et la brume
-A travers le limpide azur!
+A travers le limpide azur !
 
-O Dieu! que les amants sous les vertes feuillées
-S'en aillent, par l'hiver pauvres ailes mouillées!
-Qu'ils errent joyeux et vainqueurs!
+O Dieu ! que les amants sous les vertes feuillées
+S'en aillent, par l'hiver pauvres ailes mouillées !
+Qu'ils errent joyeux et vainqueurs !
 Que le rossignol chante, oiseau dont la voix tendre
 Contient de l'harmonie assez pour en répandre
-Sur tout l'amour qui sort des coeurs!
+Sur tout l'amour qui sort des coeurs !
 
 Que, blé qui monte, enfant qui joue, eau qui murmure,
 Fleur rose où le semeur rêve une pêche mûre,
-Que tout semble rire ou prier!
+Que tout semble rire ou prier !
 Que le chevreau gourmand, furtif et plein de grâces,
 De quelques arbre incliné mordant les feuilles basses,
-Fasse accourir le chevrier!
+Fasse accourir le chevrier !
 
-Qu'on songe aux deuils passés en se disant: qu'était-ce?
-Que rien sous le soleil ne garde de tristesse!
-Qu'un nid chante sur les vieux troncs!
+Qu'on songe aux deuils passés en se disant : qu'était-ce ?
+Que rien sous le soleil ne garde de tristesse !
+Qu'un nid chante sur les vieux troncs !
 Nous, tandis que de joie au loin tout vibre et tremble,
 Allons dans la forêt, et là, marchant ensemble,
 Si vous voulez, nous songerons,
@@ -2291,18 +2291,18 @@ Sous leurs mains par moments faisant frémir à peine
 Son beau flanc plus ombré qu'un flanc de léopard,
 Distraite, regardait vaguement quelque part.
 
-Ainsi, Nature! abri de toute créature!
-O mère universelle! indulgente Nature!
+Ainsi, Nature ! abri de toute créature !
+O mère universelle ! indulgente Nature !
 Ainsi, tous à la fois, mystiques et charnels,
 Cherchant l'ombre et le lait sous tes flancs éternels,
 Nous sommes là, savants, poètes, pêle-mêle,
-Pendus de toutes parts à ta forte mamelle!
+Pendus de toutes parts à ta forte mamelle !
 Et tandis qu'affamés, avec des cris vainqueurs,
 A tes sources sans fin désaltérant nos coeurs,
 Pour en faire plus tard notre sang et notre âme,
 Nous aspirons à flots ta lumière et ta flamme,
 Les feuillages, le sommets, les prés verts, le ciel bleu,
-Toi, sans te déranger, tu rêves à ton Dieu!
+Toi, sans te déranger, tu rêves à ton Dieu !
 
 (Retour à la table des matières)
 </poetry>
@@ -2331,25 +2331,25 @@ Où dans un coin, de lierre à demi revêtue,
 Sur un piédestal gris, l'hiver, morne statue,
 Se chauffe avec un feu de marbre sous sa main.
 
-O deuil! Le grand bassin, lac solitaire.
+O deuil ! Le grand bassin, lac solitaire.
 Un Neptune verdâtre y moisissait dans l'eau.
 Les roseaux cachaient l'onde et l'eau rongeait la terre.
 Et les arbres mêlaient leur vieux branchage austère,
 D'où tombaient autrefois des rimes pour Boileau.
 
 On voyait par moments errer dans la futaie
-De beaux cerfs qui semblaient regretter les chasseur;
+De beaux cerfs qui semblaient regretter les chasseur ;
 Et, pauvres marbres blancs qu'un vieux tronc d'arbre étaie
-Seules, sous la charmille, hélas! changé en haie,
-Soupirer Gabrielle et Vénus, ces deux soeurs!
+Seules, sous la charmille, hélas ! changé en haie,
+Soupirer Gabrielle et Vénus, ces deux soeurs !
 
 Les manteaux relevés par la longue rapière,
-Hélas! ne passaient plus dans ce jardin sans voix;
+Hélas ! ne passaient plus dans ce jardin sans voix ;
 Les tritons avaient l'air de fermer la paupière.
 Et, dans l'ombre, entr'ouvrant ses mâchoires de pierre,
 Un vieux antre ennuyé bâillait au fond du bois.
 
-Et je vous dis alors:- Ce château dans son ombre
+Et je vous dis alors :- Ce château dans son ombre
 A contenu l'amour, frais comme en votre coeur,
 Et la gloire, et le rire, et les fêtes sans nombre,
 Et toute cette joie aujourd'hui le rend sombre,
@@ -2365,25 +2365,25 @@ Alors comme aujourd'hui, pour Candale ou Caussade,
 La nuée au ciel bleu mêlait son blond duvet,
 Un doux rayon dorait le toit grave et maussade,
 Les vitres flamboyaient sur toute la façade,
-Le soleil souriait, la nature rêvait!
+Le soleil souriait, la nature rêvait !
 
 Alors comme aujourd'hui, deux coeurs unis, deux âmes,
-Erraient sous ce feuillage où tant d'amour a lui;
+Erraient sous ce feuillage où tant d'amour a lui ;
 Il nommait sa duchesse un ange entre les femmes,
 Et l'oeil plein de rayons et l'oeil rempli de flammes
-S'éblouissaient l'un l'autre, alors comme aujourd'hui!
+S'éblouissaient l'un l'autre, alors comme aujourd'hui !
 
 Au loin dans le bois vague on entendait des rires.
 C'étaient d'autres amants, dans leur bonheur plongés.
 Par moments un silence arrêtait leurs délires.
-Tendre il lui demandait: D'où vient que tu soupires?
-Douce, elle répondait: D'où vient que vous songez?
+Tendre il lui demandait : D'où vient que tu soupires ?
+Douce, elle répondait : D'où vient que vous songez ?
 
 Tous deux, l'ange et le roi, les mains entrelacées,
 Ils marchaient, fiers, joyeux, foulant le vert gazon,
 Ils mêlaient leurs regards, leur souffle, leurs pensées..-
-O temps évanouis! ô splendeurs éclipsées!
-O soleils descendus derrière l'horizon!
+O temps évanouis ! ô splendeurs éclipsées !
+O soleils descendus derrière l'horizon !
 
 1 er avril 1835
 </poetry>
@@ -2404,37 +2404,37 @@ Près du pêcheur qui ruisselle,
 Quand tous deux, au jour baissant,
 Nous errons dans la nacelle,
 Laissant chanter l'homme frêle
-Et gémir le flot puissant;
+Et gémir le flot puissant ;
 
 Sous l'abri que font les voiles
 Lorsque nous nous asseyons,
 Dans cette ombre où tu te voiles
 Quand ton regard aux étoiles
-Semble cueillir des rayons;
+Semble cueillir des rayons ;
 
 Quand tous deux nous croyons lire
 Ce que la nature écrit,
 Réponds, ô toi que j'admire,
-D'où vient que mon coeur soupire?
-D'où vient que ton front sourit?
+D'où vient que mon coeur soupire ?
+D'où vient que ton front sourit ?
 
 Dis, d'où vient qu'à chaque lame
 Comme une coupe de fiel,
-La pensée emplit mon âme?
+La pensée emplit mon âme ?
 C'est que moi je vois la rame
-Tandis que tu vois le ciel!
+Tandis que tu vois le ciel !
 
 C'est que je vois les flots sombres,
-Toi, les astres enchantés!
+Toi, les astres enchantés !
 C'est que, perdu dans leurs nombres,
-Hélas! je compte les ombres
-Quand tu comptes les clartés!
+Hélas ! je compte les ombres
+Quand tu comptes les clartés !
 
 Chacun, c'est la loi suprême,
-Rame, hélas! jusqu'à la fin.
-Pas d'homme, ô fatal problème!
+Rame, hélas ! jusqu'à la fin.
+Pas d'homme, ô fatal problème !
 Qui ne laboure ou ne sème
-Sur quelque chose de vain!
+Sur quelque chose de vain !
 
 L'homme est sur un flot qui gronde.
 L'ouragan tord son manteau.
@@ -2446,85 +2446,85 @@ Sa voile que le vent troue
 Se déchire à tout moment,
 De sa route l'eau se joue,
 Les obstacles sur sa proue
-Ecument incessamment!
+Ecument incessamment !
 
-Hélas! hélas! tout travaille
-Sous tes yeux, ô Jéhova!
+Hélas ! hélas ! tout travaille
+Sous tes yeux, ô Jéhova !
 De quelque côté qu'on aille,
 Partout un flot qui tressaille,
-Partout un homme qui va!
+Partout un homme qui va !
 
-Où vas-tu? - Vers la nuit noire.
-Où vas-tu? - Vers le grand jour.
-Toi!- Je cherche s'il faut croire.
-Et toi?- Je vais à la gloire.
-Et toi?- Je vais à l'amour.
+Où vas-tu ? - Vers la nuit noire.
+Où vas-tu ? - Vers le grand jour.
+Toi !- Je cherche s'il faut croire.
+Et toi ?- Je vais à la gloire.
+Et toi ?- Je vais à l'amour.
 
-Vous allez tous à la tombe!
-Vous allez à l'inconnu!
+Vous allez tous à la tombe !
+Vous allez à l'inconnu !
 Aigle, vautour, ou colombe,
 Vous allez où tout retombe
-Et d'où rien n'est revenu!
+Et d'où rien n'est revenu !
 
 Vous allez où vont encore
-Ceux qui font le plus de bruit!
-Où va la fleur qu'avril dore!
-Vous allez où va l'aurore!
-Vous allez où va la nuit!
+Ceux qui font le plus de bruit !
+Où va la fleur qu'avril dore !
+Vous allez où va l'aurore !
+Vous allez où va la nuit !
 
-A quoi bon toutes ces peines?
-Pourquoi tant de soins jaloux?
+A quoi bon toutes ces peines ?
+Pourquoi tant de soins jaloux ?
 Buvez l'onde des fontaines,
 Secouez le gland des chênes,
-Aimez, et rendormez- vous!
+Aimez, et rendormez- vous !
 
 Lorsque ainsi que des abeilles
-On a travaillé toujours;
-Qu'on a rêvé des merveilles;
+On a travaillé toujours ;
+Qu'on a rêvé des merveilles ;
 Lorsqu'on a sur bien des veilles
-Amoncelé bien des jours;
+Amoncelé bien des jours ;
 
 Sur votre plus belle rose,
 Sur votre lys le plus beau,
-Savez-vous ce qui se pose?
+Savez-vous ce qui se pose ?
 C'est l'oubli pour toute chose,
-Pour tout homme le tombeau!
+Pour tout homme le tombeau !
 
 Car le Seigneur nous retire
 Les fruits à peine cueillis.
-Il dit: Echoue! au navire.
-Il dit à la flamme: Expire!
-Il dit à la fleur: Pâlis!
+Il dit : Echoue ! au navire.
+Il dit à la flamme : Expire !
+Il dit à la fleur : Pâlis !
 
-Il dit au guerrier qui fonde:
+Il dit au guerrier qui fonde :
 - Je garde le dernier mot.
-Monte, monte, ô roi du monde!
+Monte, monte, ô roi du monde !
 La chute la plus profonde
 Pend au sommet le plus haut. -
 
-Il a dit à la mortelle:
-- Vite! éblouis ton amant.
+Il a dit à la mortelle :
+- Vite ! éblouis ton amant.
 Avant de mourir sois belle.
 Sois un instant étincelle,
-Puis cendre éternellement! -
+Puis cendre éternellement ! -
 
 Cet ordre auquel tu t'opposes
 T'enveloppe et l'engloutit.
 Mortel, plains-toi, si tu l'oses,
 Au Dieu qui fit ces deux choses,
-Le ciel grand, l'homme petit!
+Le ciel grand, l'homme petit !
 
 Chacun, qu'il doute ou qu'il nie,
-Lutte en frayant son chemin;
+Lutte en frayant son chemin ;
 Et l'éternelle harmonie
 Pèse comme une ironie
-Sur tout ce tumulte humain!
+Sur tout ce tumulte humain !
 
 Tous ces faux biens qu'on envie
 Passent comme un soir de mai.
-Vers l'ombre, hélas! tout dévie.
+Vers l'ombre, hélas ! tout dévie.
 Que reste-t-il de la vie,
-Excepté d'avoir aimé!
+Excepté d'avoir aimé !
 
 Ainsi je courbe ma tête
 Quand tu redresses ton front.
@@ -2533,22 +2533,22 @@ J'écoute, sombre poète,
 Ce que les flots me diront.
 
 Ainsi, pour qu'on me réponde,
-J'interroge avec effroi;
+J'interroge avec effroi ;
 Et dans ce gouffre où je sonde
 La fange se mêle à l'onde...
-Oh! ne fais pas comme moi!
+Oh ! ne fais pas comme moi !
 
 Que sur la vague troublée
-J'abaisse un sourcil hagard;
+J'abaisse un sourcil hagard ;
 Mais toi, belle âme voilée,
 Vers l'espérance étoilée
-Lève un tranquille regard!
+Lève un tranquille regard !
 
 Tu fais bien. Vois les cieux luire.
 Vois les astres s'y mirer.
 Un instinct là-haut t'attire.
-Tu regardes Dieu sourire;
-Moi, je vois l'homme pleurer!
+Tu regardes Dieu sourire ;
+Moi, je vois l'homme pleurer !
 
 9 novembre 1836. Minuit et demi
 </poetry>
@@ -2572,7 +2572,7 @@ Il chantait presque à l'heure où jésus vagissait.
 C'est qu'à son issu même il est une des âmes
 Que l'orient lointain teignait de vagues flammes.
 C'est qu'il est un des coeur que, déjà sous les cieux,
-Dorait le jour naissant du Christ Mystérieux!
+Dorait le jour naissant du Christ Mystérieux !
 
 Dieu voulait qu'avant tout, rayon du fils de l'homme,
 L'aube de Bethléem blanchit le front de Rome.
@@ -2587,18 +2587,18 @@ Nuit du 21 au 22 mars 1837
    <title>A un riche</title>
    <toctitle>A un riche</toctitle>
    <indextitle>A un riche</indextitle>
-   <firstline>Jeune homme! je te plains; et cependant j'admire</firstline>
+   <firstline>Jeune homme ! je te plains ; et cependant j'admire</firstline>
    <quality>korrektur1</quality>
 </head>
 <body>
 <poetry>
-Jeune homme! je te plains; et cependant j'admire
+Jeune homme ! je te plains ; et cependant j'admire
 Ton grand parc enchanté qui semble nous sourire,
 Qui fait, vu de ton seuil, le tour de l'horizon,
 Grave ou joyeux suivant le jour et la saison,
 Coupé d'herbe et d'eau vive, et remplissant huit lieues
 De ses vagues massifs et de ses ombres bleues.
-J'admire ton domaine, et pourtant je te plains!
+J'admire ton domaine, et pourtant je te plains !
 Car dans ces bois touffus de tant de grandeur pleins,
 Où le printemps épanche un faste sans mesure,
 Quelle plus misérable et plus pauvre masure
@@ -2607,9 +2607,9 @@ Riche et sans volupté, jeune et sans passion,
 Dont le coeur délabré, dans ses recoins livides,
 N'a plus qu'un triste amas d'anciennes coupes vides,
 Vases brisés qui n'ont rien gardé que l'ennui,
-Et d'où l'amour, la joie et la candeur ont fui!
+Et d'où l'amour, la joie et la candeur ont fui !
 
-Oui, tu me fais pitié, toi qui crois faire envie!
+Oui, tu me fais pitié, toi qui crois faire envie !
 Ce splendide séjour sur ton coeur, sur ta vie,
 Jette une ombre ironique, et rit en écrasant
 Ton front terne et chétif d'un cadre éblouissant.
@@ -2619,13 +2619,13 @@ D'ombre et de fleurs, où l'arbre arrondi comme un dôme,
 L'étang, lame d'argent que le couchant fait d'or,
 L'allée entrant au bois comme un noir corridor,
 Et là, sur la forêt, ce mont qu'une tour garde,
-Font un groupe si beau pour l'âme qui regarde!
+Font un groupe si beau pour l'âme qui regarde !
 Lieu sacré pour qui sait dans l'immense univers,
 Dans les prés, dans les eaux et dans les vallons verts,
 Retrouver les profils de la face éternelle
-Dont le visage humain n'est qu'une ombre charnelle!
+Dont le visage humain n'est qu'une ombre charnelle !
 
-Que fais-tu donc ici? Jamais on ne te voit,
+Que fais-tu donc ici ? Jamais on ne te voit,
 Quand le matin blanchit l'angle ardoisé du toit,
 sortir, songer, cueillir la fleur, coupe irisée
 Que la plante à l'oiseau tend pleine de rosée,
@@ -2635,7 +2635,7 @@ Quand le bruit du vent coupe en strophes incertaines
 Cette longue chanson qui coule des fontaines.
 
 Jamais tu n'as suivi de sommets en sommets
-La ligne des coteaux qui fait rêve; jamais
+La ligne des coteaux qui fait rêve ; jamais
 Tu n'as joui de voir, sur l'eau qui reflète,
 Quelque saule noueux tordu comme un athlète.
 Jamais, sévère esprit au mystère attaché,
@@ -2652,7 +2652,7 @@ Grave, et comme ayant peur de réveiller quelqu'un,
 Errer dans les forêts ténébreuses et douces
 Où le silence dort sur le velours des mousses.
 
-Que te fais tout cela? Les nuages des cieux,
+Que te fais tout cela ? Les nuages des cieux,
 La verdure et l'azur sont l'ennui de tes yeux.
 Tu n'est pas de ces fous qui vont, et qui s'en vantent,
 Tendant partout l'oreille aux voix qui partout chantent,
@@ -2662,16 +2662,16 @@ Quelque noir champignon, monstre étrange de l'herbe.
 Toi, comme un sac d'argent, tu vois passer la gerbe.
 Ta futaie, en avril, sous ses bras plus nombreux
 A l'air de réclamer bien des pas amoureux,
-Bien des coeurs soupirants, bien des têtes pensives;
+Bien des coeurs soupirants, bien des têtes pensives ;
 
 Toi qui jouis aussi sous ses branches massives,
 Tu songes, calculant le taillis qui s'accroît,
 Que Paris, ce vieillard qui, l'hiver, a si froid,
 Attend, sous ses vieux quais percés de rampes neuves,
-Ces longs serpents de bois qui descendent les fleuves!
+Ces longs serpents de bois qui descendent les fleuves !
 Ton regard voit, tandis que ton oeil flotte au loin,
-Les blés d'or en farine et la prairie en foin;
-Pour toi le laboureur est un rustre qu'on paie;
+Les blés d'or en farine et la prairie en foin ;
+Pour toi le laboureur est un rustre qu'on paie ;
 Pour toi toute fumée ondulant, noire ou gaie,
 Sur le clair paysage, est un foyer impur
 Où l'on cuit quelque viande à l'angle d'un vieux mur.
@@ -2682,16 +2682,16 @@ Pique tes boeufs géants qui par le chemin creux
 Se hâtent pêle-mêle et s'en vont à la crèche,
 Toi, devant ce tableau tu rêves à la brèche
 Qu'il faudra réparer, en vendant tes silos,
-Dans ta rente qui tremble aux pas de don Carlos!
+Dans ta rente qui tremble aux pas de don Carlos !
 
 Au crépuscule, après un long jour monotone,
 Tu t'enferme chez toi. Les tièdes nuits d'automne
 Versent leur chaste haleine aux coteaux veloutés.
-Tu n'en sais rien. D'ailleurs, qu'importe! A tes côtés,
+Tu n'en sais rien. D'ailleurs, qu'importe ! A tes côtés,
 Belles, leur bruns cheveux appliqués sur les tempes,
 Fronts roses empourprés par le reflet des lampes,
 Des femmes aux yeux purs sont assises, formant
-Un cercle frais qui borde et cause doucement;
+Un cercle frais qui borde et cause doucement ;
 Toutes, dans leurs discours où rien n'ose apparaître,
 Cachant leurs voeux, leur âmes et leur coeur que peut-être
 Embaume un vague amour, fleur qu'on ne cueille pas,
@@ -2701,21 +2701,21 @@ Tomber ton froid sourire, où, sous quatre bougies,
 D'autres hommes et toi, dans un coin attablés
 Autour d'un tapis vert, bruyants, vous querellez
 Les caprices du whist, du brelan ou de l'hombre.
-La fenêtre est pourtant pleine de lune et d'ombre!
+La fenêtre est pourtant pleine de lune et d'ombre !
 
-O risible insensé! vraiment, je te le dis,
+O risible insensé ! vraiment, je te le dis,
 Cette terre, ces prés, ces vallons arrondis,
 Nids de feuilles et d'herbe où jasent les villages,
 Ces blés où les moineaux ont leurs joyeux pillages,
 Ces champs qui, l'hiver même, ont d'austères appas,
-Ne t'appartiennent point: tu ne les comprends pas.
+Ne t'appartiennent point : tu ne les comprends pas.
 
 Vois-tu, tous les passants, les enfants, les poètes,
 Sur qui ton bois répand ses ombres inquiètes,
 Le pauvre jeune peintre épris de ciel et d'air,
 L'amant plein d'un seul nom, le sage au coeur amer,
 Qui viennent rafraîchir dans cette solitude,
-Hélas! l'un son amour et l'autre son étude,
+Hélas ! l'un son amour et l'autre son étude,
 Tous ceux qui, savourant la beauté de ce lieu,
 Aiment, en quittant l'homme, à s'approcher de Dieu,
 Et qui, laissant ici le bruit vague et morose
@@ -2727,7 +2727,7 @@ Te fait rire emporté par ton landau superbe,
 Sont dans ce parc touffu, que tu crois sous ta loi,
 Plus riches, plus chez eux, plus les maîtres que toi,
 Quoique de leur forêt que ta main grille et mure
-Tu puisses couper l'ombre et vendre le murmure!
+Tu puisses couper l'ombre et vendre le murmure !
 
 Pour eux rien n'est stérile en ces asiles frais.
 Pour qui les sait cueillir tout a des dons secrets.
@@ -2738,57 +2738,57 @@ Tout objet dont le bois se compose répond
 A quelque objet pareil dans la forêt de l'âme.
 Un feu de pâtre éteint parle à l'amour en flamme.
 Tout donne des conseils au penseur, jeune ou vieux.
-On se pique aux chardons ainsi qu'aux envieux;
-La feuille invite à croître; et l'onde, en coulant vite,
+On se pique aux chardons ainsi qu'aux envieux ;
+La feuille invite à croître ; et l'onde, en coulant vite,
 Avertit qu'on se hâte et que l'heure nous quitte.
 Pour eux rien n'est muet, rien n'est froid, rien n'est mort.
-Un peu de plume en sang leur éveille un remord;
-Les sources sont des pleurs; la fleur qui boit aux fleuves,
-Leur dit: Souvenez-vous, ô pauvres âmes veuves!
+Un peu de plume en sang leur éveille un remord ;
+Les sources sont des pleurs ; la fleur qui boit aux fleuves,
+Leur dit : Souvenez-vous, ô pauvres âmes veuves !
 
-Pour eux l'antre profond cache un songe étoilé;
+Pour eux l'antre profond cache un songe étoilé ;
 Et la nuit, sous l'azur d'un beau ciel constellé,
 L'arbre sur ses rameaux, comme à travers ses branches,
 Leur montre l'astre d'or et les colombes blanches,
 Choses douces aux coeurs par le malheur ployés,
-Car l'oiseau dit: Aimez! et l'étoile: Croyez!
+Car l'oiseau dit : Aimez ! et l'étoile : Croyez !
 
 Voilà ce que chez toi verse aux âmes souffrantes
-La chaste obscurité des branches murmurantes!
-Mais toi, qu'en fais tu? dis. - Tous les ans, en flots d'or,
+La chaste obscurité des branches murmurantes !
+Mais toi, qu'en fais tu ? dis. - Tous les ans, en flots d'or,
 Ce murmure, cette ombre, ineffable trésor,
 Ces bruits de vent qui joue et d'arbre qui tressaille,
-Vont s'enfouir au fond de ton coffre qui bâille;
+Vont s'enfouir au fond de ton coffre qui bâille ;
 Et tu changes ces bois où l'amour s'enivra,
-Toute cette nature, en loge à l'opéra!
+Toute cette nature, en loge à l'opéra !
 
-Encor si la musique arrivait à ton âme!
+Encor si la musique arrivait à ton âme !
 Mais entre l'art et toi l'or met son mur infâme.
 L'esprit qui comprend l'art comprend le reste aussi.
-Tu vas donc dormir là! sans te douter qu'ainsi
+Tu vas donc dormir là ! sans te douter qu'ainsi
 Que tous ces verts trésors que dévore ta bourse,
 Gluck est une forêt et Mozart une source.
 
-Tu dors; et quand parfois la mode, en souriant,
-Te dit: Admire, riche! alors, joyeux, criant,
+Tu dors ; et quand parfois la mode, en souriant,
+Te dit : Admire, riche ! alors, joyeux, criant,
 Tu surgis, demandant comment l'auteur se nomme,
-Pourvu que toutefois la muse soit un homme!
+Pourvu que toutefois la muse soit un homme !
 Car tu te roidiras dans ton étrange orgueil
 Si l'on t'apporte, un soir, quelque musique en deuil,
 Urne que la pensée a chauffée à sa flamme,
 Beau vase où s'est versé tout le coeur d'une femme.
 
-O seigneur malvenu de ce superbe lieu!
-Caillou vil incrusté dans ces rubis en feu!
-Maître pour qui ces champs sont pleins de sourdes haines!
-Gui parasite enflé de la sève des chênes!
-Pauvre riche! - Vis donc, puisque cela pour toi
+O seigneur malvenu de ce superbe lieu !
+Caillou vil incrusté dans ces rubis en feu !
+Maître pour qui ces champs sont pleins de sourdes haines !
+Gui parasite enflé de la sève des chênes !
+Pauvre riche ! - Vis donc, puisque cela pour toi
 C'est vivre. Vis sans coeur, sans pensée et sans foi.
 Vis pour l'or, chose vile, et l'orgueil, chose vaine.
 Végète, toi qui n'as que du sang dans la veine,
 
 Toi qui ne sens pas Dieu frémir dans le roseau,
-Regarder dans l'aurore et chanter dans l'oiseau!
+Regarder dans l'aurore et chanter dans l'oiseau !
 
 Car, - et bien que tu sois celui qui rit aux belles
 Et, le soir, se récrie aux romances nouvelles, -
@@ -2797,7 +2797,7 @@ Près des lacs, près des fleurs, sous les larges rameaux,
 Dans tes propres jardins, tu vas aussi stupide,
 Aussi peu clairvoyant dans ton instinct cupide,
 Aussi sourd à la vie à l'harmonie, aux voix,
-Qu'un loup sauvage errant au milieu des grands bois!
+Qu'un loup sauvage errant au milieu des grands bois !
 
  22 mai 1837
 </poetry>
@@ -2806,17 +2806,17 @@ Qu'un loup sauvage errant au milieu des grands bois!
 
 <text id="hugo1999070339">
 <head>
-   <title>Regardez: les enfants se sont assis en rond</title>
-   <toctitle>Regardez: les enfants se sont assis en rond</toctitle>
-   <indextitle>Regardez: les enfants se sont assis en rond</indextitle>
-   <firstline>Regardez: les enfants se sont assis en rond</firstline>
+   <title>Regardez : les enfants se sont assis en rond</title>
+   <toctitle>Regardez : les enfants se sont assis en rond</toctitle>
+   <indextitle>Regardez : les enfants se sont assis en rond</indextitle>
+   <firstline>Regardez : les enfants se sont assis en rond</firstline>
    <quality>korrektur1</quality>
 </head>
 <body>
 <poetry>
-Regardez: les enfants se sont assis en rond.
+Regardez : les enfants se sont assis en rond.
 Leur mère est à coté, leur mère au jeune front
-Qu'on prend pour une soeur aînée;
+Qu'on prend pour une soeur aînée ;
 Inquiète, au milieu de leurs jeux ingénus,
 De sentir s'agiter leurs chiffres inconnus
 Dans l'urne de la destinée.
@@ -2826,20 +2826,20 @@ Et son coeur est si pur et si pareil aux leurs.
 Et sa lumière est si choisie,
 Qu'en passant à travers les rayons de ses jours,
 La vie aux mille soins, laborieux et lourds,
-Se transfigure en poésie!
+Se transfigure en poésie !
 
 Toujours elle les suit, veillant et regardant,
 Soit que janvier rassemble au coin de l'âtre ardent
-Leur joie aux plaisirs occupée;
+Leur joie aux plaisirs occupée ;
 Soit qu'un doux vent de mai, qui ride le ruisseau,
 Remue au-dessus d'eux les feuilles, vert monceau
 D'où tombe une ombre découpée.
 Parfois, lorsque, passant près d'eux, un indigent
 Contemple avec envie un beau hochet d'argent
 Que sa faim dévorante admire,
-La mère est là; pour faire, au nom du Dieu vivant,
+La mère est là ; pour faire, au nom du Dieu vivant,
 Du hochet une aumône, un ange de l'enfant,
-Il ne lui faut qu'un doux sourire!
+Il ne lui faut qu'un doux sourire !
 
 Et moi qui, mère, enfants, les vois tous sous mes yeux,
 Tandis qu'auprès de moi les petits sont joyeux
@@ -2869,14 +2869,14 @@ Que toute fleur qui s'ouvre y semble un encensoir,
 Où, marquant tous ses pas de l'aube jusqu'au soir,
 L'heure met tour à tour dans les vases de marbre
 Les rayons du soleil et les ombres de l'arbre,
-Anges, vous le savez, oh! comme avec amour,
+Anges, vous le savez, oh ! comme avec amour,
 Rêveur, je regardais dans la clarté du jour
 Jouer l'oiseau qui vole et la branche qui plie,
 Et de quels doux pensers mon âme était remplie,
 Tandis que l'humble enfant dont je baise le front,
 Avec son pas joyeux pressant mon pas moins prompt,
 Marchait en m'entraînant vers la grotte où le lierre
-Met une barbe verte au vieux fleuve de pierre!
+Met une barbe verte au vieux fleuve de pierre !
 
 20 février 1837
 </poetry>
@@ -2888,19 +2888,19 @@ Met une barbe verte au vieux fleuve de pierre!
    <title>A des oiseaux envolés</title>
    <toctitle>A des oiseaux envolés</toctitle>
    <indextitle>A des oiseaux envolés</indextitle>
-   <firstline>Enfants! - Oh! revenez! tout à l'heure, imprudent</firstline>
+   <firstline>Enfants ! - Oh ! revenez ! tout à l'heure, imprudent</firstline>
    <quality>korrektur1</quality>
 </head>
 <body>
 <poetry>
-Enfants! - Oh! revenez! tout à l'heure, imprudent,
+Enfants ! - Oh ! revenez ! tout à l'heure, imprudent,
 je vous ai de ma chambre exilés en grondant,
 Rauque et tout hérissé de paroles morose.
-Et qu'aviez-vous donc fait, bandits aux lèvres roses?
-Quel crime? Quel exploit? Quel forfait insensé?
-Quel vase du japon en mille éclats brisé?
-Quel vieux portrait crevé? Quel beau missel gothique
-Enrichi par vos mains d'un dessin fantastique?
+Et qu'aviez-vous donc fait, bandits aux lèvres roses ?
+Quel crime ? Quel exploit ? Quel forfait insensé ?
+Quel vase du japon en mille éclats brisé ?
+Quel vieux portrait crevé ? Quel beau missel gothique
+Enrichi par vos mains d'un dessin fantastique ?
 Non, rien de tout cela. Vous aviez seulement,
 Ce matin, restés seuls dans ma chambre un moment,
 Pris, parmi ces papiers que mon esprit colore,
@@ -2913,27 +2913,27 @@ Des lumières courir dans les maisons le soir.
 
 Voilà tout. Vous jouiez et vous croyiez bien faire.
 
-Belle perte, en effet! beau sujet de colère!
+Belle perte, en effet ! beau sujet de colère !
 Une strophe, mal née au doux bruit de vos jeux,
-Qui remuait les mots d'un vol trop orageux!
+Qui remuait les mots d'un vol trop orageux !
 Une ode qui chargeait d'une rime gonflée
-Sa stance paresseuse en marchant essoufflée!
+Sa stance paresseuse en marchant essoufflée !
 De lourds alexandrins l'un sur l'autre enjambant
-Comme des écoliers qui sortent de leur banc!
-Un autre eût dit: - Merci! Vous ôtez une proie
+Comme des écoliers qui sortent de leur banc !
+Un autre eût dit : - Merci ! Vous ôtez une proie
 Au feuilleton méchant qui bondissait de joie
 Et d'avance poussait des rires infernaux
 Dans l'antre qu'il se creuse au bas des grands journaux
-Moi, je vous ai grondés. Tort grave et ridicule!
+Moi, je vous ai grondés. Tort grave et ridicule !
 Nains charmants que n'eût pas voulu fâcher Hercule,
 Moi, je vous ai fait peur. J'ai, rêveur triste et dur,
 Reculé brusquement ma chaise jusqu'au mur,
 Et, vous jetant ces noms dont l'envieux vous nomme,
-J'ai dit: - Allez-vous-en! laissez-moi seul! - Pauvre homme!
-Seul! le beau résultat! le beau triomphe! seul!
+J'ai dit : - Allez-vous-en ! laissez-moi seul ! - Pauvre homme !
+Seul ! le beau résultat ! le beau triomphe ! seul !
 Comme on oublie un mort roulé dans son linceul,
 Vous m'avez laissé là, l'oeil fixé sur ma porte,
-Hautain, grave et puni. - Mais vous, que vous importe!
+Hautain, grave et puni. - Mais vous, que vous importe !
 Vous avez retrouvé dehors la liberté,
 Le grand air, le beau parc, le gazon souhaité,
 L'eau courante où l'on jette une herbe à l'aventure,
@@ -2941,7 +2941,7 @@ Le ciel bleu, le printemps, la sereine nature,
 Ce livre des oiseaux et des bohémiens,
 Ce poème de Dieu qui vaut mieux que les miens,
 Où l'enfant peut cueillir la fleur, strophe vivante,
-Sans qu'une grosse voix tout à coup l'épouvante!
+Sans qu'une grosse voix tout à coup l'épouvante !
 Moi, je suis resté seul, toute joie ayant fui,
 Seul avec ce pédant qu'on appelle l'ennui.
 Car, depuis le matin assis dans l'antichambre,
@@ -2949,10 +2949,10 @@ Ce docteur, né dans Londre, un dimanche, en décembre,
 Qui ne vous aime pas, ô mes pauvres petits,
 Attendait pour entrer que vous fussiez sortis.
 Dans l'angle où vous jouiez il est là qui soupire,
-Et je le vois bâiller, moi qui vous voyais rire!
+Et je le vois bâiller, moi qui vous voyais rire !
 
-Que faire? lire un livre? oh non! - Dicter des vers?
-A quoi bon? - Emaux bleus ou blancs, céladons verts,
+Que faire ? lire un livre ? oh non ! - Dicter des vers ?
+A quoi bon ? - Emaux bleus ou blancs, céladons verts,
 Sphère qui fait tourner tout le ciel sur son axe,
 Les beaux insectes peints sur mes tasses de Saxe,
 Tout m'ennuie, et je pense à vous. En vérité,
@@ -2964,9 +2964,9 @@ L'éclat de rire franc, sincère, épanoui,
 Qui met subitement des perles sur les lèvres,
 Les beaux grands yeux naïfs admirant mon vieux Sèvres,
 La curiosité qui cherche à tour savoir,
-Et les coudes qu'on pousse en disant: Viens donc voir!
+Et les coudes qu'on pousse en disant : Viens donc voir !
 
-Oh! certes, les esprits, les sylphes et les fées
+Oh ! certes, les esprits, les sylphes et les fées
 Que le vent dans ma chambre apporte par bouffées,
 Les gnomes accroupis là-haut, près du plafond,
 Dans les angles obscurs que mes vieux livres font,
@@ -2979,10 +2979,10 @@ Ces hexamètres nus, boiteux, difformes, gauches,
 Les traîner au grand jour, pauvres hiboux fâchés,
 Et puis, battant des mains, autour du feu penchés,
 De tout ces corps hideux soudain tirant une âme,
-Avec ces vers si laids faire une belle flamme!
+Avec ces vers si laids faire une belle flamme !
 
 Espiègles radieux que j'ai fait envoler,
-Oh! revenez ici chanter, danser, parler,
+Oh ! revenez ici chanter, danser, parler,
 Tantôt, groupe folâtre, ouvrir un gros volume,
 Tantôt courir, pousser mon bras qui tient ma plume,
 Et faire dans le vers que je viens retoucher
@@ -2992,25 +2992,25 @@ Mon âme se réchauffe à vos douces haleines.
 Revenez près de moi, souriant de plaisir,
 Bruire et gazouiller, et sans peur obscurcir
 Le vieux livre où je lis de vos ombres penchées,
-Folles têtes d'enfants! gaîtés effarouchées!
+Folles têtes d'enfants ! gaîtés effarouchées !
 
 J'en conviens, j'avais tort, et vous aviez raison.
-Mais qui n'a quelquefois grondé hors de saison?
+Mais qui n'a quelquefois grondé hors de saison ?
 Il faut être indulgent. Nous avons nos misères.
 Les petits pour les grands ont tort d'être sévères.
-Enfants! chaque matin, votre âme avec amour
+Enfants ! chaque matin, votre âme avec amour
 S'ouvre à la joie ainsi que la fenêtre au jour.
 Beau miracle, vraiment, que l'enfant, gai sans cesse,
-Ayant tout le bonheur, ait toute la sagesse!
+Ayant tout le bonheur, ait toute la sagesse !
 Le destin vous caresse en vos commencements.
 Vous n'avez qu'à jouer et vous êtes charmants.
 Mais nous, nous qui pensons, nous qui vivons, nous somme
-Hargneux, tristes, mauvais, ô mes chers petits hommes!
+Hargneux, tristes, mauvais, ô mes chers petits hommes !
 
 On a ses jours d'humeur, de déraison, d'ennui.
 Il pleuvait ce matin. Il fait froid aujourd'hui.
 Un nuage mal fait dans le ciel tout à l'heure
-A passé. Que nous veut cette cloche qui pleure?
+A passé. Que nous veut cette cloche qui pleure ?
 Puis on a dans le coeur quelque remords. Voilà
 Ce qui nous rend méchants. Vous saurez tout cela,
 Quand l'âge à votre tour ternira vos visages,
@@ -3024,35 +3024,35 @@ Mes laques et mes grès, qu'une vitre défend,
 Tous ces hochets de l'homme enviés par l'enfant,
 Mes gros chinois ventrus faits comme des concombres,
 Mon vieux tableau trouvé sous d'antiques décombres,
-Je vous livrerai tout, vous toucherez à tout!
+Je vous livrerai tout, vous toucherez à tout !
 Vous pourrez sur ma table être assis ou debout,
 Et chanter, et traîner, sans que je me récrie,
 Mon grand fauteuil de chêne et de tapisserie,
 Et sur mon banc sculpté jeter tous à la fois
-Vos jouets anguleux qui déchirent le bois!
+Vos jouets anguleux qui déchirent le bois !
 Je vous laisserai même, et gaîment, et sans crainte,
-O prodige! en vos mains tenir ma bible peinte,
+O prodige ! en vos mains tenir ma bible peinte,
 Que vous n'avez touchée encor qu'avec terreur,
-Où l'on voit Dieu le père en habit d'empereur!
+Où l'on voit Dieu le père en habit d'empereur !
 
 Et puis, brûlez les vers dont ma table est semée,
-Si vous tenez à voir ce qu'ils font de fumée!
-Brûlez ou déchirez! - Je serais moins clément
+Si vous tenez à voir ce qu'ils font de fumée !
+Brûlez ou déchirez ! - Je serais moins clément
 Si c'était chez Méry, le poète charmant,
 Que Marseille la grecque, heureuse et noble ville,
 Blonde fille d'Homère, a fait fils de Virgile.
-Je vous dirais: - "Enfants, ne touchez que des yeux
+Je vous dirais : - "Enfants, ne touchez que des yeux
 A ces vers qui demain s'envoleront aux cieux.
 Ces papiers, c'est le nid, retraite caressée,
 Où du poète ailé rampe encor la pensée.
-Oh! n'en approchez pas! car les vers nouveau-nés,
+Oh ! n'en approchez pas ! car les vers nouveau-nés,
 Au manuscrit natal encore emprisonnés,
 Souffrent entre vos mains innocemment cruelles.
-Vous leur blessez le pied, vous leur froissez les ailes;
+Vous leur blessez le pied, vous leur froissez les ailes ;
 Et, sans vous en douter, vous leur faites ces maux
 Que les petits enfants font aux petits oiseaux." -
 
-Mais qu'importe les miens! - Toute ma poésie,
+Mais qu'importe les miens ! - Toute ma poésie,
 C'est vous, et mon esprit suit votre fantaisie.
 Vous êtes les reflets et les rayonnements
 Dont j'éclaire mon vers si sombre par moments.
@@ -3061,15 +3061,15 @@ Enfants, vous dont la joie est faite d'ignorance,
 Vous n'avez pas souffert et vous ne savez pas,
 Quand la pensée en nous a marché pas à pas,
 Sur le poète morne et fatigué d'écrire
-Quelle douce chaleur répand votre sourire!
+Quelle douce chaleur répand votre sourire !
 Combien il a besoin, quand sa tête se rompt,
-De la sérénité qui luit sur votre front;
+De la sérénité qui luit sur votre front ;
 Et quel enchantement l'enivre et le fascine,
 Quand le charmant hasard de quelque cour voisine,
 Où vous vous ébattez sous un arbre penchant,
-Mêle vos joyeux cris à son douloureux chant!
+Mêle vos joyeux cris à son douloureux chant !
 
-Revenez donc, hélas! revenez dans mon ombre,
+Revenez donc, hélas ! revenez dans mon ombre,
 Si vous ne voulez pas que je sois triste et sombre,
 Pareil, dans l'abandon où vous m'avez laissé,
 Au pêcheur d'Etretat, d'un long hiver lassé,
@@ -3083,28 +3083,28 @@ De voir à sa fenêtre un ciel rayé de pluie.
 
 <text id="hugo1999070342">
 <head>
-   <title>A quoi je songe? - Hélas! loin du toit où vous êtes</title>
-   <toctitle>A quoi je songe? - Hélas! loin du toit où vous êtes</toctitle>
-   <indextitle>A quoi je songe? - Hélas! loin du toit où vous êtes</indextitle>
-   <firstline>A quoi je songe? - Hélas! loin du toit où vous êtes</firstline>
+   <title>A quoi je songe ? - Hélas ! loin du toit où vous êtes</title>
+   <toctitle>A quoi je songe ? - Hélas ! loin du toit où vous êtes</toctitle>
+   <indextitle>A quoi je songe ? - Hélas ! loin du toit où vous êtes</indextitle>
+   <firstline>A quoi je songe ? - Hélas ! loin du toit où vous êtes</firstline>
    <quality>korrektur1</quality>
 </head>
 <body>
 <poetry>
-A quoi je songe? - Hélas! loin du toit où vous êtes,
-Enfants, je songe à vous! à vous, mes jeunes têtes,
+A quoi je songe ? - Hélas ! loin du toit où vous êtes,
+Enfants, je songe à vous ! à vous, mes jeunes têtes,
 Espoir de mon été déjà penchant et mûr,
 Rameaux dont, tous les ans, l'ombre croît sur mon mur,
 Douces âmes à peine au jour épanouies,
-Des rayons de votre aube encor tout éblouies!
+Des rayons de votre aube encor tout éblouies !
 Je songe aux deux petits qui pleurent en riant,
 Et qui font gazouiller sur le seuil verdoyant,
 Comme deux jeunes fleures qui se heurtent entre elles,
-Leurs jeux charmants mêlés de charmantes querelles!
+Leurs jeux charmants mêlés de charmantes querelles !
 Et puis, père inquiet, je rêve aux deux aînés
 Qui s'avancent déjà de plus de flot baignés,
 Laissant pencher parfois leur tête encor naïve,
-L'un déjà curieux, l'autre déjà pensive!
+L'un déjà curieux, l'autre déjà pensive !
 
 Seul et triste au milieu des chants des matelots,
 Le soir, sous la falaise, à cette heure où les flots,
@@ -3112,10 +3112,10 @@ S'ouvrant et se fermant comme autant de narines,
 Mêlent au vent des cieux mille haleines marines,
 Où l'on entend dans l'air d'ineffables échos
 Qui viennent de la terre ou qui viennent des eaux,
-Ainsi je songe! - à vous, enfants, maisons, famille,
+Ainsi je songe ! - à vous, enfants, maisons, famille,
 A la table qui rit, au foyer qui pétille,
 A tous les soins pieux que répandent sur vous
-Votre mère si tendre et votre aïeul si doux!
+Votre mère si tendre et votre aïeul si doux !
 Et tandis qu'à mes pieds s'étend, couvert de voiles,
 Le limpide océan, ce miroir des étoiles,
 Tandis que les nochers laissent errer leurs yeux
@@ -3123,7 +3123,7 @@ De l'infini des mers à l'infini des cieux,
 Moi, rêvant à vous seuls, je contemple et je sonde
 L'amour que j'ai pour vous dans mon âme profonde,
 Amour doux et puissant qui toujours m'est resté.
-Et cette grande mer est petite à côté!
+Et cette grande mer est petite à côté !
 
 15 juillet 1837. - Fécamp. - Ecrit au bord de la mer.
 </poetry>
@@ -3135,12 +3135,12 @@ Et cette grande mer est petite à côté!
    <title>Une nuit qu'on entendait la mer sans la voir</title>
    <toctitle>Une nuit qu'on entendait la mer sans la voir</toctitle>
    <indextitle>Une nuit qu'on entendait la mer sans la voir</indextitle>
-   <firstline>Quels sont ces bruits sourds?</firstline>
+   <firstline>Quels sont ces bruits sourds ?</firstline>
    <quality>korrektur1</quality>
 </head>
 <body>
 <poetry>
-Quels sont ces bruits sourds?
+Quels sont ces bruits sourds ?
 Ecoutez vers l'onde
 Cette voix profonde
 Qui pleure toujours
@@ -3150,31 +3150,31 @@ Parfois l'interrompe... -
 Le vent de la mer
 Souffle dans sa trompe.
 
-Comme il pleut ce soir!
-N'est-ce pas, mon hôte?
+Comme il pleut ce soir !
+N'est-ce pas, mon hôte ?
 Là-bas, à la côte,
 Le ciel est bien noir,
-La mer est bien haute!
-On dirait l'hiver;
+La mer est bien haute !
+On dirait l'hiver ;
 Parfois on s'y trompe... -
 Le vent de la mer
 Souffle dans sa trompe.
 
-Oh! marins perdus!
+Oh ! marins perdus !
 Au loin, dans cette ombre
 Sur la nef qui sombre,
 Que de bras tendus
-Vers la terre sombre!
+Vers la terre sombre !
 Pas d'ancre de fer
 Que le flot ne rompe. -
 Le vent de la mer
 Souffle dans sa trompe.
 
-Nochers imprudents!
+Nochers imprudents !
 Le vent dans la voile
 Déchire la toile
-Comme avec les dents!
-Là-haut pas d'étoile!
+Comme avec les dents !
+Là-haut pas d'étoile !
 L'un lutte avec l'air,
 L'autre est à la pompe. -
 Le vent de la mer
@@ -3186,7 +3186,7 @@ Quand le flot s'élève,
 Chandelier que Dieu
 Pose sur la grève,
 Phare au rouge éclair
-Que la brume estompe!
+Que la brume estompe !
 Le vent de la mer
 Souffle dans sa trompe
 
@@ -3213,17 +3213,17 @@ Voit l'océan vers lui monter du fond de l'ombre,
 Il regarde déjà la vie immense et sombre.
 Il rêve de le voir s'avancer pas à pas.
 O mère au coeur divin, ne vous effrayez pas,
-Vous en qui, - tant votre âme est un charmant mélange! -
+Vous en qui, - tant votre âme est un charmant mélange ! -
 L'ange voit un enfant et l'enfant voit un ange.
 
 Allons, mère, sans trouble et d'un air triomphant
 Baisez-moi le grand front de ce petit enfant.
 Ce n'est pas un savant, ce n'est pas un prodige,
-C'est un songeur; tant mieux. Soyez fière, vous dis-je!
+C'est un songeur ; tant mieux. Soyez fière, vous dis-je !
 La méditation du génie est la soeur,
 Mère, et l'enfant songeur fait un homme penseur,
 Et la pensée est tout, et la pensée ardente
-Donne à Milton le ciel, donne l'enfer à Dante!
+Donne à Milton le ciel, donne l'enfer à Dante !
 Un jour il sera grand. L'avenir glorieux
 Attend, n'en doutez pas, l'enfant mystérieux
 Qui veut savoir comment chaque chose se nomme,
@@ -3231,21 +3231,21 @@ Et questionne tout, un mur autant qu'un homme.
 Qui sait si, ramassant à terre sans effort
 Le ciseau colossal de Michel-Ange mort,
 Il ne doit pas, livrant au granit des batailles,
-Faire au marbre étonné de superbes entailles?
+Faire au marbre étonné de superbes entailles ?
 Ou, comme Bonaparte ou bien François premier,
-Prendre, joueur d'échecs, l'Europe pour damier?
+Prendre, joueur d'échecs, l'Europe pour damier ?
 Qui sait s'il n'ira point, voguant à toute voile,
 Ajoutant à son oeil, que l'ombre humaine voile,
 L'oeil du long télescope au regard effrayant,
 Ou l'oeil de la pensée encor plus clairvoyant,
 Saisir, dans l'azur vaste ou dans la mer profonde,
-Un astre comme Herschell, comme Colomb un monde?
+Un astre comme Herschell, comme Colomb un monde ?
 
-Qui sait? Laissez grandir ce petit sérieux.
+Qui sait ? Laissez grandir ce petit sérieux.
 Il ne voit même pas nos regards curieux.
 Peut-être que déjà ce pauvre enfant fragile
 Rêve, comme rêvait l'enfant qui fut Virgile,
-Au combat que poursuit le poète éclatant;
+Au combat que poursuit le poète éclatant ;
 Et qu'il veut, aussi lui, tenter, vaincre, et sortant
 Par un chemin nouveau de la sphère où nous sommes,
 Voltiger, nom ailé, sur les bouches des hommes.
@@ -3267,15 +3267,15 @@ Voltiger, nom ailé, sur les bouches des hommes.
 <poetry>
 Jeune fille, l'amour, c'est d'abord un miroir
 Où la femme coquette et belle aime à se voir,
-Et, gaie ou rêveuse, se penche;
+Et, gaie ou rêveuse, se penche ;
 Puis, comme la vertu, quand il a votre coeur,
 Il en chasse le mal et le vice moqueur,
-Et vous fait l'âme pure et blanche;
+Et vous fait l'âme pure et blanche ;
 
 Puis on descend un peu, le pied vous glisse... - Alors
-C'est un abîme! en vain la main s'attache aux bords,
-On s'en va dans l'eau qui tournoie! -
-L'amour est charmant, pur, et mortel. N'y crois pas!
+C'est un abîme ! en vain la main s'attache aux bords,
+On s'en va dans l'eau qui tournoie ! -
+L'amour est charmant, pur, et mortel. N'y crois pas !
 Tel l'enfant, par un fleuve attiré pas à pas,
 S'y mire, s'y lave et s'y noie.
 
@@ -3294,40 +3294,40 @@ S'y mire, s'y lave et s'y noie.
 </head>
 <body>
 <poetry>
-Quand le poète peint l'enfer, il peint sa vie:
-Sa vie, ombre qui fuit de spectres poursuivie;
+Quand le poète peint l'enfer, il peint sa vie :
+Sa vie, ombre qui fuit de spectres poursuivie ;
 Forêt mystérieuse où ses pas effrayés
-S'égarent à tâtons hors des chemins frayés;
-Noir voyage obstrué de rencontres difformes;
+S'égarent à tâtons hors des chemins frayés ;
+Noir voyage obstrué de rencontres difformes ;
 Spirale aux bords douteux, aux profondeurs énormes,
 Dont les cercles hideux vont toujours plus avant
-Dans une ombre où se meut l'enfer vague et vivant!
-Cette rampe se perd dans la bruime indécise;
+Dans une ombre où se meut l'enfer vague et vivant !
+Cette rampe se perd dans la bruime indécise ;
 
 Au bas de chaque marche une plainte est assise,
 Et l'on y voit passer avec un faible bruit
 Des grincements de dents blancs dans la sombre nuit.
-Là sont les visions, les rêves, les chimères;
+Là sont les visions, les rêves, les chimères ;
 Les yeux que la douleur change en sources amères,
 L'amour, couple enlacé, triste, et toujours brûlant,
-Qui dans un tourbillon passe une plaie au flanc;
+Qui dans un tourbillon passe une plaie au flanc ;
 Dans un coin la vengeance et la faim, soeurs impies,
-Sur un crâne rongé côte à côte accroupies;
-Puis la pâle misère au sourire appauvri;
+Sur un crâne rongé côte à côte accroupies ;
+Puis la pâle misère au sourire appauvri ;
 L'ambition, l'orgueil, de soi-même nourri,
 Et la luxure immonde, et l'avarice infâme,
-Tous les manteaux de plomb dont peut se charger l'âme!
+Tous les manteaux de plomb dont peut se charger l'âme !
 Plus loin, la lâcheté, la peur, la trahison
-Offrant des clefs à vendre et goûtant du poison;
+Offrant des clefs à vendre et goûtant du poison ;
 Et puis, plus bas encore, et tout au fond du gouffre,
-Le masque grimaçant de la Haine qui souffre!
+Le masque grimaçant de la Haine qui souffre !
 
 Oui, c'est bien là la vie, ô poète inspiré,
 Et son chemin brumeux d'obstacles encombré.
 Mais, pour que rien n'y manque, en cette route étroite
 Vous nous montrez toujours debout à votre droite
 Le génie au front calme, aux yeux pleins de rayons,
-Le Virgile serein qui dit: Continuons!
+Le Virgile serein qui dit : Continuons !
 
  6 août 1836
 </poetry>
@@ -3356,32 +3356,32 @@ Qui fait que notre coeur en abîmes se fond,
 Quand un matin le sort, qui nous a dans sa serre,
 Nous mettant face à face avec notre misère,
 Nous jette brusquement, lui notre maître à tous,
-Cette question sombre:- Ame, que croyez-vous?
+Cette question sombre :- Ame, que croyez-vous ?
 C'est l'hésitation redoutable et profonde
 Qui prend, devant ce sphinx qu'on appelle le monde,
 Notre esprit effrayé plus encor qu'ébloui,
-Qui n'ose dire non et ne peut dire oui!
+Qui n'ose dire non et ne peut dire oui !
 
 C'est là l'infirmité de toute notre race.
-De quoi l'homme est-il sûr? qui demeure? qui passe?
-Quel est le chimérique et quel est le réel?
-Quand l'explication viendra-t-elle du ciel?
+De quoi l'homme est-il sûr ? qui demeure ? qui passe ?
+Quel est le chimérique et quel est le réel ?
+Quand l'explication viendra-t-elle du ciel ?
 D'où vient qu'en nos sentiers que le sophisme encombre
-Nous trébuchons toujours? d'où vient qu'esprits faits d'ombre,
+Nous trébuchons toujours ? d'où vient qu'esprits faits d'ombre,
 
 Nous tremblons tous, la nuit, à l'heure où lentement
-La brume monte au coeur ainsi qu'au firmament?
-Que l'aube même est sombre et cache un grand problème?
-Et que plus d'un penseur, ô misère suprême!
+La brume monte au coeur ainsi qu'au firmament ?
+Que l'aube même est sombre et cache un grand problème ?
+Et que plus d'un penseur, ô misère suprême !
 Jusque dans les enfants trouvant de noirs écueils,
-Doute auprès des berceaux comme auprès des cercueils?
+Doute auprès des berceaux comme auprès des cercueils ?
 
-Voyez: cet homme est juste, il est bon; c'est un sage.
-Nul fiel intérieur ne verdit son visage;
+Voyez : cet homme est juste, il est bon ; c'est un sage.
+Nul fiel intérieur ne verdit son visage ;
 Si par quelques endroits son coeur est déjà mort,
-Parmi tous ses regrets il n'a pas un remord;
+Parmi tous ses regrets il n'a pas un remord ;
 Les ennemis qu'il a, s'il faut qu'il s'en souvienne,
-Lui viennent de leur haine et non pas de la sienne;
+Lui viennent de leur haine et non pas de la sienne ;
 C'est un sage - du temps d'Aurèle ou d'Adrien.
 Il est pauvre, et s'y plaît. Il ne tombe plus rien
 De sa tête vieillie aux rumeurs apaisées,
@@ -3396,24 +3396,24 @@ Les vieux héros d'Athène et de Lacédémone,
 Les enfants rencontrés à qui l'on fait l'aumône,
 Le chien à qui l'on parle et dont l'oeil vous comprend,
 L'étude d'un insecte en des mousses errant,
-Le soir, quelque humble vieille au logis ramenée:
+Le soir, quelque humble vieille au logis ramenée :
 Voilà de quels rayons est faite sa journée.
 Chaque jour, car pour lui chaque jour passe ainsi,
-Quand le soleil descend, il redescend aussi;
+Quand le soleil descend, il redescend aussi ;
 Il regagne, abordé des passants qui l'accueillent,
 Son toit sur qui, l'hiver, de grands chênes s'effeuillent.
 Si sa table, où jamais rien ne peut abonder,
 N'a qu'un maigre repas, il sourit, sans gronder
 La servante au front gris, qui sous les ans chancelle,
-A qui manque aujourd'hui la force et non le zèle;
+A qui manque aujourd'hui la force et non le zèle ;
 Puis il rentre à sa chambre où le sommeil l'attend.
-Et là, seul, que fait-il? lui, ce juste content?
-Lui, ce coeur sans désirs, sans fautes et sans peines?
-Il pense, il rêve, il doute... - O ténèbres humaines!
+Et là, seul, que fait-il ? lui, ce juste content ?
+Lui, ce coeur sans désirs, sans fautes et sans peines ?
+Il pense, il rêve, il doute... - O ténèbres humaines !
 
-Sombre loi! tout est donc brumeux et vacillant!
+Sombre loi ! tout est donc brumeux et vacillant !
 
-Oh! surtout dans ces jours où tout s'en va croulant,
+Oh ! surtout dans ces jours où tout s'en va croulant,
 Où le malheur saisit notre âme qui dévie,
 Et souffle affreusement sur notre folle vie,
 Où le sort envieux nous tient, où l'on a plus
@@ -3423,18 +3423,18 @@ Qu'une pensée en proie au gouffre qui se creuse,
 Qu'un coeur désemparé de ses illusions,
 Frêle esquif démâté, sur qui les passions,
 Matelots furieux, qu'en vain l'esprit écoute,
-Trépignent, se battant pour le choix de la route;
+Trépignent, se battant pour le choix de la route ;
 Quand on ne songe plus, triste et mourant effort,
 Qu'à chercher un salut, une boussole, un port,
 Une ancre où l'on s'attache, un phare où l'on s'adresse,
-Oh! comme avec terreur, pilotes en détresse,
+Oh ! comme avec terreur, pilotes en détresse,
 Nous nous apercevons qu'il nous manque la foi,
 La foi, ce pur flambeau qui rassure l'effroi,
 Ce mot d'espoir écrit sur la dernière page,
-Cette chaloupe où peut se sauver l'équipage!
+Cette chaloupe où peut se sauver l'équipage !
 
 Comment donc se fait-il, ô pauvres insensés,
-Que nous soyons si fiers? - Dites, vous qui pensez,
+Que nous soyons si fiers ? - Dites, vous qui pensez,
 Vous que le sort expose, âme toujours sereine,
 Si modeste à la gloire et si douce à la haine,
 Vous dont l'esprit, toujours égal et toujours pur,
@@ -3444,30 +3444,30 @@ Comme une étoile fixe au fond du ciel splendide,
 Soleil que n'atteint pas, tant il est abrité,
 Ce roulis de l'abîme et de l'immensité,
 Où flottent, dispersés par les vents qui s'épanchent,
-Tant d'astres fatigués et de mondes qui penchent!
-Hélas! que vous devez méditer à côté
-De l'arrogance unie à notre cécité!
-Que vous devez sourire en voyant notre gloire!
+Tant d'astres fatigués et de mondes qui penchent !
+Hélas ! que vous devez méditer à côté
+De l'arrogance unie à notre cécité !
+Que vous devez sourire en voyant notre gloire !
 Et, comme un feu brillant jette une vapeur noire,
 Que notre fol orgueil au néant appuyé
-Vous doit jeter dans l'âme une étrange pitié!
+Vous doit jeter dans l'âme une étrange pitié !
 
-Hélas! ayez pitié, mais une pitié tendre;
-Car nous écoutons tout sans pouvoir rien entendre!
+Hélas ! ayez pitié, mais une pitié tendre ;
+Car nous écoutons tout sans pouvoir rien entendre !
 
 Cette absence de foi, cette incrédulité,
 Ignorance ou savoir, sagesse ou vanité,
 Est-ce, de quelque nom que notre orgueil la nomme,
-Le vice de ce siècle ou le malheur de l'homme?
-Est-ce un mal passager? est-ce un mal éternel?
+Le vice de ce siècle ou le malheur de l'homme ?
+Est-ce un mal passager ? est-ce un mal éternel ?
 Dieu peut-être a fait l'homme ainsi pour que le ciel,
-Plein d'ombres pour nos yeux, soit toujours notre étude?
+Plein d'ombres pour nos yeux, soit toujours notre étude ?
 Dieu n'a scellé dans l'homme aucune certitude.
 Penser, ce n'est pas croire. A peine par moment
-Entend-on une voix dire confusément:
--"Ne vous y fiez pas, votre oeuvre est périssable!
-Tout ce que bâtit l'homme est bâti sur le sable;
-Ce qu'il fait tôt ou tard par l'herbe est recouvert;
+Entend-on une voix dire confusément :
+-"Ne vous y fiez pas, votre oeuvre est périssable !
+Tout ce que bâtit l'homme est bâti sur le sable ;
+Ce qu'il fait tôt ou tard par l'herbe est recouvert ;
 Ce qu'il dresse est dressé pour le vent du désert.
 Tous ces asiles vains où vous mettez votre âme,
 Gloire qui n'est que pourpre, amour qui n'est que flamme,
@@ -3476,91 +3476,91 @@ Qui livre à tous les vents ses pavillons gonflés,
 La richesse toujours assise sur sa gerbe,
 La science de loin si haute et si superbe,
 Le pouvoir sous le dais, le plaisir sous les fleurs,
-Tentes que tout cela! l'édifice est ailleurs.
-Passez outre! cherchez plus loin les biens sans nombre.
+Tentes que tout cela ! l'édifice est ailleurs.
+Passez outre ! cherchez plus loin les biens sans nombre.
 Une tente, ô mortels, ne contient que de l'ombre."
 
 On entend cette voix et l'on rêve longtemps.
 Et l'on croit voir le ciel, moins obscur par instants,
 Comme à travers la brume on distingue des rives,
-Presque entr'ouvert, s'emplir de vagues perspectives!
+Presque entr'ouvert, s'emplir de vagues perspectives !
 
-Que croire? Oh! j'ai souvent, d'un oeil peut-être expert,
-Fouillé ce noir problème où la sonde se perd!
+Que croire ? Oh ! j'ai souvent, d'un oeil peut-être expert,
+Fouillé ce noir problème où la sonde se perd !
 Ces vastes questions dont l'aspect toujours change,
 Comme la mer tantôt cristal et tantôt fange,
-J'en ai tout remué! la surface et le fond!
-J'ai plongé dans ce gouffre et l'ai trouvé profond!
+J'en ai tout remué ! la surface et le fond !
+J'ai plongé dans ce gouffre et l'ai trouvé profond !
 
 Je vous atteste, ô vents du soir et de l'aurore,
 Etoiles de la nuit, je vous atteste encore,
 Par l'austère pensée à toute heure asservi,
 Que de fois j'ai tenté, que de fois j'ai gravi,
 Seul, cherchant dans l'espace un point qui me réponde,
-Ces hauts lieux d'où l'on voit la figure du monde!
-Le glacier sur l'abîme ou le cap sur les mers!
+Ces hauts lieux d'où l'on voit la figure du monde !
+Le glacier sur l'abîme ou le cap sur les mers !
 Que de fois j'ai songé sur les sommets déserts,
 Tandis que fleuves, champs, forêts, cité, ruines
 Que tous les monts fumaient comme des encensoirs,
 Et qu'au loin l'océan, répandant ses flots noirs,
 Sculptant des fiers écueils la haute architecture,
-Mêlait son bruit sauvage à l'immense nature!
+Mêlait son bruit sauvage à l'immense nature !
 
-Et je disais aux flots: Flots qui grondez toujours!
-Je disais aux donjons, croulant avec leurs tours:
-Tours où vit le passé! donjons que les années
-Mordent incessamment de leurs dents acharnées!
-Je disais à la nuit: Nuit pleine de soleils!
+Et je disais aux flots : Flots qui grondez toujours !
+Je disais aux donjons, croulant avec leurs tours :
+Tours où vit le passé ! donjons que les années
+Mordent incessamment de leurs dents acharnées !
+Je disais à la nuit : Nuit pleine de soleils !
 Je disais aux torrents, aux fleurs, aux fruits vermeils,
 A ces formes sans nom que la mort décompose,
-Aux monts, aux champs, aux bois: Savez-vous quelque chose?
+Aux monts, aux champs, aux bois : Savez-vous quelque chose ?
 
 Bien des fois, à cette heure où le soir et le vent
 Font que le voyageur s'achemine en rêvant,
-Je me suis dit en moi:- cette grande nature,
+Je me suis dit en moi :- cette grande nature,
 Cette création qui sert la créature,
-Sait tout! Tout serait clair pour qui la comprendrait!-
+Sait tout ! Tout serait clair pour qui la comprendrait !-
 Comme un muet qui sait le mot d'un grand secret
 Et dont la lèvre écume à ce mot qu'il déchire,
 Il semble par moment qu'elle voudrait tout dire.
-Mais Dieu le lui défend! En vain vous écoutez.
-Aucun verbe en ces bruits l'un par l'autre heurtés!
+Mais Dieu le lui défend ! En vain vous écoutez.
+Aucun verbe en ces bruits l'un par l'autre heurtés !
 Cette chanson qui sort des campagnes fertiles,
 Mêlée à la rumeur qui déborde des villes,
 Les tonnerres grondants, les vents plaintifs et sourds,
 La vague de la mer, gueule ouverte toujours,
 Qui vient, hurle, et s'en va, puis sans fin recommence,
-Toutes ces voix ne sont qu'un bégaiement immense!
+Toutes ces voix ne sont qu'un bégaiement immense !
 
-L'homme seul peut parler et l'homme ignore, hélas!
-Inexplicable arrêt! quoi qu'il rêve ici-bas,
+L'homme seul peut parler et l'homme ignore, hélas !
+Inexplicable arrêt ! quoi qu'il rêve ici-bas,
 Tout se voile à ses yeux sous un nuage austère.
-Et l'âme du mourant s'en va dans le mystère!
+Et l'âme du mourant s'en va dans le mystère !
 Aussi repousser Rome et rejeter Sion,
 Rire, et conclure tout par la négation,
 Comme c'est plus aisé, c'est ce que font les hommes.
 Le peu que nous croyons tient au peu que nous sommes.
 
-Puisque Dieu l'a voulu, c'est qu'ainsi tout est mieux!
+Puisque Dieu l'a voulu, c'est qu'ainsi tout est mieux !
 Plus de clarté peut-être aveuglerait nos yeux.
 Souvent la branche casse où trop de fruit abonde.
 Que deviendrons-nous si, sans mesurer l'onde,
 Le Dieu vivant, du haut de son éternité,
-Sur l'humaine raison versait la vérité?
+Sur l'humaine raison versait la vérité ?
 Le vase est trop petit pour la contenir toute.
 
 Il suffit que chaque âme en recueille une goutte,
-Même à l'erreur mêlée! Hélas! tout homme en soi
+Même à l'erreur mêlée ! Hélas ! tout homme en soi
 Porte un obscur repli qui refuse la foi.
-Dieu! la mort! mots sans fond qui cachent un abîme!
+Dieu ! la mort ! mots sans fond qui cachent un abîme !
 L'épouvante saisit le coeur le plus sublime
 Dès qu'il s'est hasardé sur de si grandes eaux.
 On ne les franchit pas tout d'un vol. Peu d'oiseaux
 Traversent l'océan sans reposer leur aile.
 Il n'est pas de croyant si pur et si fidèle
 Qui ne tremble et n'hésite à de certains moments.
-Quelle âme est sans faiblesse et sans accablements?
-Enfants! résignons-nous et suivons notre route.
+Quelle âme est sans faiblesse et sans accablements ?
+Enfants ! résignons-nous et suivons notre route.
 Tout corps traîne son ombre, et tout esprit son doute.
 
 8 septembre 1837
@@ -3578,236 +3578,236 @@ Tout corps traîne son ombre, et tout esprit son doute.
 </head>
 <body>
 <poetry>
-Puisqu'il plut au Seigneur de te briser, poète;
+Puisqu'il plut au Seigneur de te briser, poète ;
 Puisqu'il plut au Seigneur de comprimer ta tête
 De son doigt souverain,
 D'en faire une urne sainte à contenir l'extase,
 D'y mettre le génie, et de sceller ce vase
-Avec un sceau d'airain;
+Avec un sceau d'airain ;
 
-Puisque le Seigneur Dieu t'accorda, noir mystère!
+Puisque le Seigneur Dieu t'accorda, noir mystère !
 Un puits pour ne point boire, une voix pour te taire,
 Et souffla sur ton front,
 Et, comme une nacelle errante et d'eau remplie,
 Fit rouler ton esprit à travers la folie,
-Cet océan sans fond;
+Cet océan sans fond ;
 
 Puisqu'il voulut ta chute, et que la mort glacée,
 Seule, te fît revivre en rouvrant ta pensée
-Pour un autre horizon;
+Pour un autre horizon ;
 Puisque Dieu, t'enfermant dans la cage charnelle,
 Pauvre aigle, te donna l'aile et non la prunelle,
-L'âme et non la raison;
+L'âme et non la raison ;
 
-Tu pars du moins, mon frère, avec ta robe blanche!
+Tu pars du moins, mon frère, avec ta robe blanche !
 Tu retournes à Dieu comme l'eau qui s'épanche
-Par son poids naturel!
+Par son poids naturel !
 Tu retournes à Dieu, tête de candeur pleine,
 Comme y va la lumière, et comme y va l'haleine
-Qui des fleurs monte au ciel!
+Qui des fleurs monte au ciel !
 
 Tu n'as rien dit de mal, tu n'as rien fait d'étrange.
 Comme une vierge meurt, comme s'envole un ange,
-Jeune homme, tu t'en vas!
-Rien n'a souillé ta main ni ton coeur; dans ce monde
+Jeune homme, tu t'en vas !
+Rien n'a souillé ta main ni ton coeur ; dans ce monde
 Où chacun court, se hâte, se forge, et crie, et gronde,
-A peine tu rêvas!
+A peine tu rêvas !
 
 Comme le diamant, quant le feu le vient prendre,
 Disparaît tout entier, et sans laisser de cendre,
 Au regard ébloui,
 Comme un rayon s'enfuit sans rien jeter de sombre,
 Sur la terre après toi tu n'as pas laissé d'ombre,
-Esprit évanoui!
+Esprit évanoui !
 
 Doux et blond compagnon de toute mon enfance,
-Oh! dis-moi, maintenant, frère marqué d'avance
+Oh ! dis-moi, maintenant, frère marqué d'avance
 Pour un morne avenir,
 Maintenant que la mort a rallumé ta flamme,
 Maintenant que la mort a réveillé ton âme,
-Tu dois te souvenir!
+Tu dois te souvenir !
 
-Tu dois te souvenir de nos jeunes années!
+Tu dois te souvenir de nos jeunes années !
 Quand les flots transparents de nos deux destinées
 Se côtoyaient encor,
 Lorsque Napoléon flamboyait comme un phare,
 Et qu'enfants nous prêtions l'oreille à sa fanfare
-Comme un meute au cor!
+Comme un meute au cor !
 
 Tu dois te souvenir des vertes Feuillantines,
 Et de la grande allée où nos voix enfantines,
 Nos purs gazouillements,
 Ont laissé dans les coins des murs, dans les fontaines,
 Dans le nid des oiseaux et dans le creux des chênes,
-Tant d'échos si charmants!
+Tant d'échos si charmants !
 
-O temps! jours radieux! aube trop tôt ravie!
+O temps ! jours radieux ! aube trop tôt ravie !
 Pourquoi Dieu met-il donc le meilleur de la vie
-Tout au commencement?
-Nous naissions! on eût dit que le vieux monastère
+Tout au commencement ?
+Nous naissions ! on eût dit que le vieux monastère
 Pour nous voir rayonner ouvrait avec mystère
 Son doux regard dormant.
 
-T'en souviens-tu, mon frère? après l'heure d'étude,
-Oh! comme nous courions dans cette solitude!
+T'en souviens-tu, mon frère ? après l'heure d'étude,
+Oh ! comme nous courions dans cette solitude !
 Sous les arbres blottis,
 Nous avions, en chassant quelque insecte qui saute,
 L'herbe jusqu'aux genoux, car l'herbe était bien haute,
 Nos genoux bien petits.
 
 Vives têtes d'enfants par la course effarées,
-Nous poursuivons dans l'air cent ailes bigarrées;
+Nous poursuivons dans l'air cent ailes bigarrées ;
 Le soir nous étions las,
 Nous revenions, jouant avec tout ce qui joue,
 Frais, joyeux, et tous deux baisés à pleine joue
-Par notre mère, hélas!
+Par notre mère, hélas !
 
-Elle grondait: - Voyez! comme ils sont faits! ces hommes!
-Les monstres! ils auront cueilli toutes nos pommes!
+Elle grondait : - Voyez ! comme ils sont faits ! ces hommes !
+Les monstres ! ils auront cueilli toutes nos pommes !
 Pourtant nous les aimons.
 Madame, les garçons sont les soucis des mères,
 Car ils ont la fureur de courir dans les pierres
-Comme font les démons! -
+Comme font les démons ! -
 
 Puis un même sommeil, nous berçant comme un hôte,
-Tous deux au même lit nous couchait côte à côte;
+Tous deux au même lit nous couchait côte à côte ;
 Puis un même réveil.
 Puis, trempé dans un lait sorti chaud de l'étable,
 Le même pain faisait rire à la même table
-Notre appétit vermeil!
+Notre appétit vermeil !
 
 Et nous recommencions nos jeux, cueillant par gerbe
 Les fleurs, tous les bouquets qui réjouissent l'herbe,
 Le lys à Dieu pareil,
 Surtout ces fleurs de flamme et d'or qu'on voit, si belles,
 Luire à terre en avril comme des étincelles
-Qui tombent du soleil!
+Qui tombent du soleil !
 
 On nous voyait tous deux, gaîté de la famille,
 Le front épanoui, courir sous la charmille,
 L'oeil de joie enflammé... -
-Hélas! hélas! quel deuil pour ma tête orpheline!
+Hélas ! hélas ! quel deuil pour ma tête orpheline !
 Tu vas donc désormais dormir sur la colline,
-Mon pauvre bien-aimé!
+Mon pauvre bien-aimé !
 
 Tu vas dormir là-haut sur la colline verte,
 Qui, livrée à l'hiver, à tous les vents ouverte,
-A le ciel pour plafond;
-Tu vas dormir, poussière, au fond d'un lit d'argile;
+A le ciel pour plafond ;
+Tu vas dormir, poussière, au fond d'un lit d'argile ;
 Et moi je resterai parmi ceux de la ville
-Qui parlent et qui vont!
+Qui parlent et qui vont !
 
-Et moi je vais rester, souffrir, agir et vivre;
+Et moi je vais rester, souffrir, agir et vivre ;
 Voir mon nom se grossir dans les bouches de cuivre
-De la célébrité;
+De la célébrité ;
 Et cacher, comme à Sparte, en riant quand on entre,
 Le renard envieux qui me ronge le ventre,
-Sous ma robe abrité!
+Sous ma robe abrité !
 
-Je vais reprendre, hélas! mon oeuvre commencée,
+Je vais reprendre, hélas ! mon oeuvre commencée,
 Rendre ma barque frêle à l'onde courroucée,
-Lutter contre le sort;
+Lutter contre le sort ;
 Enviant souvent ceux qui dorment sans murmure,
 Comme un doux nid couvé pour la saison future,
-Sous l'aile de la mort!
+Sous l'aile de la mort !
 
 J'ai d'austères plaisirs. Comme un prêtre à l'église,
 Je rêve à l'art qui charme, à l'art qui civilise,
 Qui change l'homme un peu,
 Et qui, comme un semeur qui jette au loin sa graine,
 En semant la nature à travers l'âme humaine,
-Y fera germer Dieu!
+Y fera germer Dieu !
 
 Quand le peuple au théâtre écoute ma pensée,
 J'y cours, et là, courbé vers la foule pressée,
 L'étudiant de près,
 Sur mon drame touffu dont le branchage plie,
 J'entends tomber ses pleurs comme la large pluie
-Aux feuilles des forêts!
+Aux feuilles des forêts !
 
-Mais quel labeur aussi! que de flots! quelle écume!
+Mais quel labeur aussi ! que de flots ! quelle écume !
 Surtout lorsque l'envie, au coeur plein d'amertume,
 Au regard vide et mort,
 Fait, pour les vils besoins de ses luttes vulgaires,
 D'une bouche d'ami qui souriait naguères
-Une bouche qui mord!
+Une bouche qui mord !
 
-Quel vie! et quel siècle alentour! - Vertu, gloire,
+Quel vie ! et quel siècle alentour ! - Vertu, gloire,
 Pouvoir, génie et foi, tout ce qu'il faudrait croire,
 Tout ce que nous valons,
 Le peu qui nous restait de nos splendeurs décrues,
 Est traîné sur la claie et suivi dans les rues
-Par le rire en haillons!
+Par le rire en haillons !
 
-Combien de calomnie et combien de bassesse!
+Combien de calomnie et combien de bassesse !
 Combien de pamphlets vils qui flagellent sans cesse
 Quiconque vient du ciel,
 Et qui font, la blessant de leur lance payée,
 Boire à la vérité, pâle et crucifiée,
-Leur éponge de fiel!
+Leur éponge de fiel !
 
-Combien d'acharnements sur toutes les victimes!
+Combien d'acharnements sur toutes les victimes !
 Que de rhéteurs, penchés sur le bord des abîmes,
-Riant, ô cruauté!
+Riant, ô cruauté !
 De voir l'affreux poison qui de leurs doigts découle,
 Goutte à goutte, ou par flots, quand leurs mains sur la foule
-Tordent l'impiété!
+Tordent l'impiété !
 
 L'homme, vers le plaisir se ruant par cent voies,
-Ne songent qu'à bien vivre et qu'à chercher des proies;
-L'argent est adoré;
-Hélas! nos passions ont des serres infâmes
+Ne songent qu'à bien vivre et qu'à chercher des proies ;
+L'argent est adoré ;
+Hélas ! nos passions ont des serres infâmes
 Où pend, triste lambeau, tout ce qu'avaient nos âmes
-De chaste et de sacré!
+De chaste et de sacré !
 
-A quoi bon, cependant? à quoi bon tant de haine,
+A quoi bon, cependant ? à quoi bon tant de haine,
 Et faire tant de mal, et prendre tant de peine,
-Puisque la mort viendra!
-Pour aller avec tous où tous doivent descendre!
+Puisque la mort viendra !
+Pour aller avec tous où tous doivent descendre !
 Et pour n'être après tout qu'une ombre, un peu de cendre
-Sur qui l'herbe croîtra!
+Sur qui l'herbe croîtra !
 
-A quoi bon s'épuiser en voluptés diverses?
+A quoi bon s'épuiser en voluptés diverses ?
 A quoi bon se bâtir des fortunes perverses
-Avec les maux d'autrui?
-Tout s'écroule; et, fruit vert qui pend à la ramée,
+Avec les maux d'autrui ?
+Tout s'écroule ; et, fruit vert qui pend à la ramée,
 Demain ne mûrit pas pour la bouche affamée
-Qui dévore aujourd'hui!
+Qui dévore aujourd'hui !
 
 Ce que nous croyons être avec ce que nous sommes,
 Beauté, richesse, honneurs, ce que rêvent les hommes,
-Hélas! et ce qu'ils font,
+Hélas ! et ce qu'ils font,
 Pêle-mêle, à travers les champs ou les huées,
 Comme s'est emporté par rapides nuées
-Dans un oubli profond!
+Dans un oubli profond !
 
 Et puis quelle éternelle et lugubre fatigue
 De voir le peuple enflé monter jusqu'à sa digue,
-Dans ces terribles jeux!
+Dans ces terribles jeux !
 Sombre océan d'esprits dont l'eau n'est pas sondée,
 Et qui vient faire autour de toute grande idée
-Un murmure orageux!
+Un murmure orageux !
 
 Quel choc d'ambitions luttant le long des routes,
-Toutes contre chacune et chacune avec toutes!
-Quel tumulte ennemi!
-Comme on raille d'un bas tout astre qui décline!... -
-Oh! ne regrette rien sur la haute colline
-Où tu t'es endormi!
+Toutes contre chacune et chacune avec toutes !
+Quel tumulte ennemi !
+Comme on raille d'un bas tout astre qui décline !... -
+Oh ! ne regrette rien sur la haute colline
+Où tu t'es endormi !
 
-Là, tu reposes, toi! Là, meurt toute voix fausse.
+Là, tu reposes, toi ! Là, meurt toute voix fausse.
 Chaque jour, du Levant au Couchant, sur ta fosse
 Promenant son flambeau,
 L'impartial soleil, pareil à l'espérance,
 Dore des deux côtés sans choix ni préférence
-La croix de ton tombeau!
+La croix de ton tombeau !
 
 Là, tu n'entends plus rien que l'herbe et la broussaille,
 Le pas du fossoyeur dont la terre tressaille
 La chute du fruit mûr
 Et, par moments, le chant, dispersé dans l'espace,
 Du bouvier qui descend dans la plaine et qui passe
-Derrière le vieux mur!
+Derrière le vieux mur !
 
  6 mars 1837
 </poetry>
@@ -3827,34 +3827,34 @@ Derrière le vieux mur!
 Un jour l'ami qui reste à ton coeur qu'on déchire
 Contemplait tes malheurs,
 Et, tandis qu'il parlait, ton sublime sourire
-Se mêlait à ses pleurs:
+Se mêlait à ses pleurs :
 
       I
 
 "Te voilà donc, ô toi dont la foule rampante
 Admirait la vertu,
 Déraciné, flétri, tombé sur une pente
-Comme un cèdre abattu!
+Comme un cèdre abattu !
 
 Te voilà sous les pieds des envieux sans nombre
 Et des passants rieurs
 Toi dont le front superbe accoutumait à l'ombre
-Les fronts inférieurs!
+Les fronts inférieurs !
 
 Ta feuille est dans la poudre, et ta racine austère
 Est découverte aux yeux.
-Hélas! tu n'as plus rien d'abrité dans la terre
-Ni d'éclos dans les cieux!
+Hélas ! tu n'as plus rien d'abrité dans la terre
+Ni d'éclos dans les cieux !
 
 Jeune homme, on vénérait jadis ton oeil sévère,
-Ton front calme et tonnant;
+Ton front calme et tonnant ;
 Ton nom était de ceux qu'on craint et qu'on révère,
-Hélas! et maintenant
+Hélas ! et maintenant
 
 Les méchants, accourus pour déchirer ta vie,
 L'ont prise entre leurs dents,
 Et les hommes alors se sont avec envie
-Penchés pour voir dedans!
+Penchés pour voir dedans !
 
 Avec des cris de joie ils ont compté tes plaies
 Et compté tes douleurs,
@@ -3874,12 +3874,12 @@ Offerte à tout venant
 Où cent flèches, toujours sifflant dans la nuit noire,
 S'enfoncent tour à tour,
 Chacun cherchant ton coeur, l'un visant à ta gloire
-Et l'autre à ton amour!
+Et l'autre à ton amour !
 
 Ta réputation, dont souvent nous nous sommes
 Ecriés en rêvant,
 Se disperse et s'en va dans les discours des hommes,
-Comme un feuillage au vent!
+Comme un feuillage au vent !
 
 Ton âme, qu'autrefois on prenait pour arbitre
 Du droit et du devoir,
@@ -3889,24 +3889,24 @@ Vient regarder le soir,
 Afin d'y voir à table une orgie aux chants grêles,
 Au propos triste et vain,
 Qui renverse à grand bruit les coeurs pleins de querelles
-Et les brocs pleins de vin!
+Et les brocs pleins de vin !
 
 Tes ennemis ont pris ta belle destinée
 Et l'ont brisée en fleur.
 Ils ont fait de ta gloire aux carrefours traînée
-Ta plus grande douleur!
+Ta plus grande douleur !
 
 Leurs mains ont retourné ta robe, dont le lustre
-Irritait leur fureur;
+Irritait leur fureur ;
 Avec la même pourpre ils t'ont fait vil d'illustre,
-Et forçat d'empereur!
+Et forçat d'empereur !
 
 Nul ne te défend plus. On se fait une fête
 De tes maux aggravés.
 On ne parle de toi qu'en secouant la tête,
-Et l'on dit: Vous savez!
+Et l'on dit : Vous savez !
 
-Hélas! pour te haïr tous les coeurs se rencontrent.
+Hélas ! pour te haïr tous les coeurs se rencontrent.
 Tous t'ont abandonné.
 Et tes amis pensifs sont comme ceux qui montrent
 Un palais ruiné.
@@ -3921,40 +3921,40 @@ La rumeur du torrent.
 Tous ceux qui de tes jours orageux et sublimes
 S'approchent sans effroi
 Reviennent en disant qu'ils ont vu des abîmes
-En se penchant sur toi!
+En se penchant sur toi !
 
 Mais peut-être, à travers l'eau de ce gouffre immense
 Et de ce coeur profond,
 On verrait cette perle appelée innocence,
-En regardant au fond!
+En regardant au fond !
 
 On s'arrête aux brouillards dont ton âme est voilée,
 Mais moi, juge et témoin,
 Je sais qu'on trouverait une voûte étoilée
-Si l'on allait plus loin!
+Si l'on allait plus loin !
 
 Et qu'importe, après tout, que le monde t'assiège
 De ses discours mouvants,
 Et que ton nom se mêle à ces flocons de neige
-Poussés à tous les vents!
+Poussés à tous les vents !
 
-D'ailleurs que savent-ils? Nous devrions nous taire.
-De quel droit jugeons-nous?
+D'ailleurs que savent-ils ? Nous devrions nous taire.
+De quel droit jugeons-nous ?
 Nous qui ne voyons rien au ciel ou sur la terre
-Sans nous mettre à genoux!
+Sans nous mettre à genoux !
 
-La certitude - hélas! insensés que nous sommes
-De croire à l'oeil humain! -
+La certitude - hélas ! insensés que nous sommes
+De croire à l'oeil humain ! -
 Ne séjourne pas plus dans la raison des hommes
 Que l'onde dans leur main.
 
 Elle mouille un moment, puis s'écoule infidèle,
-Sans que l'homme, ô douleur!
+Sans que l'homme, ô douleur !
 Puisse désaltérer à ce qui reste d'elle
-Ses lèvres ou son coeur!
+Ses lèvres ou son coeur !
 
 L'apparence de tout nous trompe et nous fascine.
-Est-il jour? Est-il nuit?
+Est-il jour ? Est-il nuit ?
 Rien d'absolu. Tout fruit contient une racine,
 Toute racine un fruit.
 
@@ -3966,49 +3966,49 @@ Et par l'autre clarté.
 Le lourd nuage, effroi des matelots livides
 Sur le pont accroupis,
 Pour le brun laboureur dont les champs sont arides
-Est un sac plein d'épis!
+Est un sac plein d'épis !
 
 Pour juger un destin il en faudrait connaître
-Le fond mystérieux;
+Le fond mystérieux ;
 Ce qui gît dans la frange aura bientôt peut-être
-Des ailes dans les cieux!
+Des ailes dans les cieux !
 
 Cette âme se transforme, elle est tout près d'éclore,
 Elle rampe, elle attend,
 Aujourd'hui larve informe, et demain dès l'aurore
-Papillon éclatant!
+Papillon éclatant !
 
      III
 
-Tu souffres cependant! toi sur qui l'ironie
+Tu souffres cependant ! toi sur qui l'ironie
 Epuise tous ses traits,
 Et qui te sens poursuivre, et par la calomnie
-Mordre aux endroits secrets!
+Mordre aux endroits secrets !
 
 Tu fuis, pâle et saignant, et, pénétrant dans l'ombre
 Par ton flanc déchiré,
 La tristesse en ton âme ainsi qu'en un puits sombre
-Goutte à goutte a filtré!
+Goutte à goutte a filtré !
 
 Tu fuis, lion blessé, dans une solitude,
 Rêvant sur ton destin,
 Et le soir te retrouve en la même attitude
-Où t'a vu le matin!
+Où t'a vu le matin !
 
 Là, pensif, cherchant l'ombre où ton âme repose,
-L'ombre que nous aimons;
+L'ombre que nous aimons ;
 Ne songeant quelquefois, de l'aube à la nuit close,
-Qu'à la forme des monts;
+Qu'à la forme des monts ;
 
 Attentif aux ruisseaux, aux mousses étoilées,
 Aux champs silencieux,
 A la virginité des herbes non foulées,
-A la beauté des cieux;
+A la beauté des cieux ;
 
 Ou parfois contemplant, de quelque grève austère,
 L'esquif en proie aux flots
 Qui fuit, rompant les fils qui liaient à la terre
-Les coeurs des matelots;
+Les coeurs des matelots ;
 
 Contemplant le front vert et la noire narine
 De l'autre ténébreux
@@ -4018,7 +4018,7 @@ Tord ses bras douloureux,
 Et l'immense océan où la voile s'incline,
 Où le soleil descend,
 L'océan qui respire ainsi qu'une poitrine,
-S'enflant et s'abaissant;
+S'enflant et s'abaissant ;
 
 Du haut de la falaise aux rumeurs infinies,
 Du fond des bois touffus,
@@ -4028,11 +4028,11 @@ Plaines de sens confus,
 Qui, tenant ici-bas toute chose embrassée,
 Vont de l'aigle au serpent,
 Que toute voix grossit, et que sur la pensée
-La nature répand!
+La nature répand !
 
      IV
 
-Console-toi, poète! - Un jour, bientôt peut-être,
+Console-toi, poète ! - Un jour, bientôt peut-être,
 Les coeurs te reviendront,
 Et pour tous les regards on verra reparaître
 Les flammes de ton front.
@@ -4058,14 +4058,14 @@ Ils passeront ainsi que ces lueurs qui courent
 A travers les roseaux.
 
 Ils auront bien toujours pour toi toute la haine
-Des démons pour le Dieu;
+Des démons pour le Dieu ;
 Mais un souffle éteindra leur bouche impure pleine
 De parole de feu.
 
 Ils s'évanouiront, et la foule et ravie
 Verra, d'un oeil pieux,
 Sortir de ce tas d'ombre amassé par l'envie
-Ton front majestueux!
+Ton front majestueux !
 
 En attendant, regarde en pitié cette foule
 Qui méconnaît tes chants,
@@ -4073,44 +4073,44 @@ Et qui de toutes parts se répand et s'écoule
 Dans les mauvais penchant.
 
 Laisse en ce noir chaos qu'aucun rayon n'éclaire
-Ramper les ignorants;
+Ramper les ignorants ;
 L'orgueilleux dont la voix grossit dans la colère
-Comme l'eau des torrents;
+Comme l'eau des torrents ;
 
 La beauté sans amour dont les pats nous entraîne,
 Femme aux yeux exercés
 Dont la robe flottante est un piège ou se prennent
-Les pieds insensés;
+Les pieds insensés ;
 
 Les rhéteurs qui de bruit emplissent leur parole
-Quand nous les écoutons;
+Quand nous les écoutons ;
 Et ces hommes sans foi, sans culte, sans boussole,
-Qui vivent à tâtons;
+Qui vivent à tâtons ;
 
 Et les flatteurs courbés, aux douceurs familières,
-Aux fronts bas et rampants;
+Aux fronts bas et rampants ;
 Et les ambitieux qui sont comme des lierres
-L'un sur l'autre grimpants!
+L'un sur l'autre grimpants !
 
 Non, tu ne portes pas, ami, la même chaîne
 Que ces hommes d'un jour.
 Ils sont vils, et toi grand. Leur joug est fait de haine,
-Le tien est fait d'amour!
+Le tien est fait d'amour !
 
 Tu n'as rien de commun avec le monde infime
-Au souffle empoisonneur;
+Au souffle empoisonneur ;
 Car c'est pour tous les yeux un spectacle sublime
 Quand la main du Seigneur
 
 Loin du sentier banal où la foule se rue
 Sur quelque illusion,
 Laboure le génie avec cette charrue
-Qu'on nomme passion!"
+Qu'on nomme passion !"
 
 Et quand il eut fini, toi que la haine abreuve,
 Tu lui dis d'une voix attendrie un instant,
 Voix pareille à la sienne et plus haute pourtant,
-Comme la grande mer qui parlerait au fleuve;
+Comme la grande mer qui parlerait au fleuve ;
 
 "Ne me console point et ne t'afflige pas.
 Je suis calme et paisible.
@@ -4122,7 +4122,7 @@ Mais le sort est sévère.
 C'est lui qui teint de vin ou de lie à son choix
 Le pur cristal du verre.
 
-Moi, je rêve! écoutant le cyprès soupirer
+Moi, je rêve ! écoutant le cyprès soupirer
 Autour des croix d'ébène,
 Et murmurer le fleuve et la cloche pleurer
 Dans un coin de la plaine,
@@ -4135,24 +4135,24 @@ Que fait la touffe d'herbe,
 Prêtant l'oreille aux flots qui ne peuvent dormir,
 A l'air dans la nuée,
 J'erre sur les hauts lieux d'ou l'on entend gémir
-Toute chose crée!
+Toute chose crée !
 
 Là, je vois, comme un vase allumé sur l'autel,
-Le toit lointain qui fume;
+Le toit lointain qui fume ;
 Et le soir je compare aux purs flambeaux du ciel
 Tout flambeau qui s'allume.
 
 Là j'abandonne aux vents mon esprit sérieux,
-Comme l'oiseau sa plume;
+Comme l'oiseau sa plume ;
 Là, je songe au malheur de l'homme, et j'entends mieux
 Le bruit de cette enclume,
 
 Là, je contemple, ému, tout ce qui s'offre aux yeux,
-Onde, terre, verdure;
+Onde, terre, verdure ;
 Et je vois l'homme au loin, mage mystérieux,
-Traverser la nature!
+Traverser la nature !
 
-Pourquoi me plaindre, ami? Tout homme à tout
+Pourquoi me plaindre, ami ? Tout homme à tout
 Souffre des maux sans nombre. [moment
 Moi, sur qui vient la nuit, j'ai gardé seulement
 Dans mon horizon sombre,
@@ -4160,25 +4160,25 @@ Dans mon horizon sombre,
 Comme un rayon du soir au front d'un mont obscur,
 L'amour, divine flamme,
 L'amour, qui dore encor ce que j'ai de plus pur
-Et de plus haut dans l'âme!
+Et de plus haut dans l'âme !
 
 Sans doute en mon avril, ne sachant rien à fond,
 Jeune, crédule, austère,
 J'ai fait des songes d'or comme tous ceux qui font
-Des songes sur la terre!
+Des songes sur la terre !
 
 J'ai vu la vie en fleur sur mon front s'élever
 Pleine de douces choses.
-Mais quoi! me crois-tu assez fou pour rêver
-L'éternité des roses?
+Mais quoi ! me crois-tu assez fou pour rêver
+L'éternité des roses ?
 
 Les chimères, qu'enfant mes mains croyaient toucher,
-Maintenant sont absentes;
+Maintenant sont absentes ;
 Et je dis au bonheur ce que dit le nocher
 Aux rives décroissantes.
 
-Qu'importe! je m'abrite en un calme profond,
-Plaignant surtout les femmes;
+Qu'importe ! je m'abrite en un calme profond,
+Plaignant surtout les femmes ;
 Et je vis l'oeil fixé sur le ciel où s'en vont
 Les ailes et les âmes.
 
@@ -4193,7 +4193,7 @@ Se croiser sur nos pieds la foudre et le soleil,
 Ces deux clartés célestes.
 
 Laissons gronder en bas cet orage irrité
-Qui toujours nous assiège;
+Qui toujours nous assiège ;
 Et gardons au-dessus notre tranquillité,
 Comme le mont sa neige.
 
@@ -4202,10 +4202,10 @@ Vainement obstinée,
 Cette âpre loi que l'un nomme Expiation
 Et l'autre Destinée.
 
-Hélas! de quelque nom que, broyé sous l'essieu,
+Hélas ! de quelque nom que, broyé sous l'essieu,
 L'orgueil humain la nomme,
 Roue immense et fatale, elle tourne sur Dieu,
-Elle roule sur l'homme!"
+Elle roule sur l'homme !"
 
 15 octobre 1837
 </poetry>
@@ -4222,19 +4222,19 @@ Elle roule sur l'homme!"
 </head>
 <body>
 <poetry>
-La tombe dit à la rose:
+La tombe dit à la rose :
 - Des pleurs dont l'aube t'arrose
-Que fais-tu, fleur des amours?
-La rose dit à la tombe:
+Que fais-tu, fleur des amours ?
+La rose dit à la tombe :
 - Que fais-tu de ce qui tombe
-Dans ton gouffre ouvert toujours?
+Dans ton gouffre ouvert toujours ?
 
-La rose dit: - Tombeau sombre,
+La rose dit : - Tombeau sombre,
 De ces pleurs je fais dans l'ombre
 Un parfum d'ambre et de miel.
-La tombe dit: - Fleur plaintive,
+La tombe dit : - Fleur plaintive,
 De chaque âme qui m'arrive
-Je fais un ange du ciel!
+Je fais un ange du ciel !
 
  3 juin 1837
 </poetry>
@@ -4243,20 +4243,20 @@ Je fais un ange du ciel!
 
 <text id="hugo1999070351">
 <head>
-   <title>O Muse, contiens-toi! muse aux hymnes d'airain!</title>
-   <toctitle>O Muse, contiens-toi! muse aux hymnes d'airain!</toctitle>
-   <indextitle>O Muse, contiens-toi! muse aux hymnes d'airain!</indextitle>
-   <firstline>O Muse, contiens-toi! muse aux hymnes d'airain!</firstline>
+   <title>O Muse, contiens-toi ! muse aux hymnes d'airain !</title>
+   <toctitle>O Muse, contiens-toi ! muse aux hymnes d'airain !</toctitle>
+   <indextitle>O Muse, contiens-toi ! muse aux hymnes d'airain !</indextitle>
+   <firstline>O Muse, contiens-toi ! muse aux hymnes d'airain !</firstline>
    <quality>korrektur1</quality>
 </head>
 <body>
 <poetry>
-O Muse, contiens-toi! muse aux hymnes d'airain!
-Muse de loi juste et du droit souverain!
+O Muse, contiens-toi ! muse aux hymnes d'airain !
+Muse de loi juste et du droit souverain !
 Toi dont la bouche abonde en mots trempés de flamme,
 Etincelles de feu qui sortent de ton âme,
 
-Oh! ne dis rien encore et laisse-les aller!
+Oh ! ne dis rien encore et laisse-les aller !
 Attends que l'heure vienne où tu puisses parler.
 Endure le spectacle en vierge résignée.
 Qu'à peine un mouvement de ta lèvre indignée.
@@ -4274,9 +4274,9 @@ Ne te dépense pas. Qui se contient s'accroît.
 Aie au milieu de tous l'attitude élevée
 D'une lente déesse à punir réservée,
 Qui, recueillant sa force ainsi qu'un saint trésor,
-Pourrait depuis longtemps et ne veut pas encor!
+Pourrait depuis longtemps et ne veut pas encor !
 
-Va cependant! - contemple et le ciel et le monde.
+Va cependant ! - contemple et le ciel et le monde.
 Et que tous ceux qui font quelque travail immonde,
 Que ces trafiquants vils épris d'un sac d'argent,
 Que ces menteurs publics, au langage changeant,
@@ -4293,20 +4293,20 @@ Et ceux qui nuit et jour occupent leur démence
 D'une orgie effrontée au tumulte hideux,
 Te regardent passer tranquille au milieu d'eux,
 Saluant gravement les fronts que tu révères,
-Muette, et l'oeil pourtant plein de choses sévères!
+Muette, et l'oeil pourtant plein de choses sévères !
 Fouille ces coeurs profonds de ton regard ardent.
-Et que, lorsque le peuple ira se demandant:
+Et que, lorsque le peuple ira se demandant :
 - Sur qui donc va tomber, dans la foule éperdue,
-Cette foudre en éclairs dans ses yeux suspendue? -
+Cette foudre en éclairs dans ses yeux suspendue ? -
 Chacun d'eux, contemplant son oeuvre avec effroi,
-Se dise en frissonnant: C'est peut-être sur moi!
+Se dise en frissonnant : C'est peut-être sur moi !
 
 En attendant, demeure impassible et sereine.
-Qu'aucun pan de ta robe en leur fange ne traîne;
+Qu'aucun pan de ta robe en leur fange ne traîne ;
 Et que tous ces pervers tremblent dès à présent
 De voir auprès de toi, formidable, et posant
 Son ongle de lion sur ta lyre étoilée,
-Ta colère superbe à tes pieds muselée!
+Ta colère superbe à tes pieds muselée !
 
 6 septembre 1836.
 </poetry>

--- a/fdirs/hugo/andre.xml
+++ b/fdirs/hugo/andre.xml
@@ -23,14 +23,14 @@ Il lui sembla dans l’ombre entendre un faible bruit.
 C’était un Espagnol de l’armée en déroute 
 Qui se traînait sanglant sur le bord de la route, 
 Râlant, brisé, livide, et mort plus qu’à moitié. 
-Et qui disait :  » A boire! à boire par pitié! » 
+Et qui disait :  » A boire ! à boire par pitié ! » 
 Mon père, ému, tendit à son housard fidèle 
 Une gourde de rhum qui pendait à sa selle, 
 Et dit : « Tiens, donne à boire à ce pauvre blessé. » 
 Tout à coup, au moment où le housard baissé 
 Se penchait vers lui, l’homme, une espèce de maure, 
 Saisit un pistolet qu’il étreignait encore, 
-Et vise au front mon père en criant: « Caramba! » 
+Et vise au front mon père en criant : « Caramba ! » 
 Le coup passa si près que le chapeau tomba 
 Et que le cheval fit un écart en arrière. 
 » Donne-lui tout de même à boire «, dit mon père.
@@ -61,16 +61,16 @@ Il est parti pour l’Aquitaine
 Comme timbalier, et pourtant
 On le prend pour un capitaine, 
 Rien qu’à voir sa mine hautaine, 
-Et son pourpoint, d’or éclatant!
+Et son pourpoint, d’or éclatant !
 
 Depuis ce jour, l’effroi m’agite. 
 J’ai dit, joignant son sort au mien :
 – Ma patronne, sainte Brigitte, 
 Pour que jamais il ne le quitte, 
-Surveillez son ange gardien! –
+Surveillez son ange gardien ! –
 
 J’ai dit à notre abbé : – Messire, 
-Priez bien pour tous nos soldats! –
+Priez bien pour tous nos soldats ! –
 Et, comme on sait qu’il le désire, 
 J’ai brûlé trois cierges de cire 
 Sur la châsse de saint Gildas.
@@ -91,45 +91,45 @@ Il doit aujourd’hui de la guerre
 Revenir avec monseigneur ; 
 Ce n’est plus un amant vulgaire ;
 Je lève un front baissé naguère, 
-Et mon orgueil est du bonheur!
+Et mon orgueil est du bonheur !
 
 Le duc triomphant nous rapporte
 Son drapeau dans les camps froissé ; 
 Venez tous sous la vieille porte 
 Voir passer la brillante escorte, 
-Et le prince, et mon fiancé!
+Et le prince, et mon fiancé !
 
 Venez voir pour ce jour de fête 
 Son cheval caparaçonné, 
 Qui sous son poids hennit, s’arrête, 
 Et marche en secouant la tête, 
-De plumes rouges couronné!
+De plumes rouges couronné !
  
 Mes soeurs, à vous parer si lentes, 
 Venez voir près de mon vainqueur 
 Ces timbales étincelantes 
 Qui sous sa main toujours tremblantes, 
-Sonnent, et font bondir le coeur!
+Sonnent, et font bondir le coeur !
 
 Venez surtout le voir lui-même
 Sous le manteau que j’ai brodé. 
-Qu’il sera beau! c’est lui que j’aime! 
+Qu’il sera beau ! c’est lui que j’aime ! 
 Il porte comme un diadème 
-Son casque, de crins inondé!
+Son casque, de crins inondé !
 
 L’Égyptienne sacrilège,
 M’attirant derrière un pilier, 
-M’a dit hier (Dieu nous protège!) 
+M’a dit hier (Dieu nous protège !) 
 Qu’à la fanfare du cortège 
 Il manquerait un timbalier.
 
-Mais j’ai tant prié, que j’espère! 
+Mais j’ai tant prié, que j’espère ! 
 Quoique, me montrant de la main 
 Un sépulcre, son noir repaire, 
 La vieille aux regards de vipère 
-M’ait dit : – Je t’attends là demain!
+M’ait dit : – Je t’attends là demain !
 
-Volons! plus de noires pensées! 
+Volons ! plus de noires pensées ! 
 Ce sont les tambours que j’entends. 
 Voici les dames entassées, 
 Les tentes de pourpre dressées, 
@@ -157,10 +157,10 @@ Le duc n’est pas loin : ses bannières
 Flottent parmi les chevaliers ;
 Quelques enseignes prisonnières,
 Honteuses, passent les dernières…
-Mes soeurs! voici les timbaliers!… «
+Mes soeurs ! voici les timbaliers !… «
 
 Elle dit, et sa vue errante 
-Plonge, hélas! dans les rangs pressés ; 
+Plonge, hélas ! dans les rangs pressés ; 
 Puis, dans la foule indifférente,
 Elle tomba, froide et mourante…
 Les timbaliers étaient passés.    
@@ -188,8 +188,8 @@ Il en est qui, bannis des célestes phalanges,
 Ont de si douces voix qu'on les prend pour des anges. 
 Craignez-les : pour mille ans exclus du paradis, 
 Ils vous entraîneraient, enfants, au purgatoire ! -
-Ne me demandez pas d'où me vient cette histoire; 
-Nos pères l'ont contée; et moi, je la redis.
+Ne me demandez pas d'où me vient cette histoire ; 
+Nos pères l'ont contée ; et moi, je la redis.
 
 ---
 
@@ -197,32 +197,32 @@ Nos pères l'ont contée; et moi, je la redis.
 
 <nonum><center>La Péri</center></nonum>
 
-Où vas-tu donc, jeune âme?... Écoute ! 
+Où vas-tu donc, jeune âme ?... Écoute ! 
 Mon palais pour toi veut s'ouvrir. 
-Suis-moi, des cieux quitte la route; 
+Suis-moi, des cieux quitte la route ; 
 Hélas ! tu t'y perdrais sans doute, 
 Nouveau-né, qui viens de mourir !
 
 Tu pourras jouer à toute heure 
-Dans mes beaux jardins aux fruits d'or; 
+Dans mes beaux jardins aux fruits d'or ; 
 Et de ma riante demeure 
 Tu verras ta mère qui pleure 
 Près de ton berceau, tiède encor.
 
-Des Péris je suis la plus belle;
-Mes sueurs règnent où naît le jour; 
+Des Péris je suis la plus belle ;
+Mes sueurs règnent où naît le jour ; 
 Je brille en leur troupe immortelle, 
 Comme entre les fleurs brille celle 
 Que l'on cueille en rêvant d'amour.
 
-Mon front porte un turban de soie;
-Mes bras de rubis sont couverts; 
+Mon front porte un turban de soie ;
+Mes bras de rubis sont couverts ; 
 Quand mon vol ardent se déploie, 
 L'aile de pourpre qui tournoie 
 Roule trois yeux de flamme ouverts.
 
 Plus blanc qu'une lointaine voile, 
-Mon corps n'en a point la pâleur; 
+Mon corps n'en a point la pâleur ; 
 En quelque lieu qu'il se dévoile, 
 Il l'éclaire comme une étoile, 
 Il l'embaume comme une fleur.
@@ -236,29 +236,29 @@ Au sein de l'onde réchauffée
 Se plonge, éclatant et vermeil. 
 Les peuples d'Occident m'adorent 
 Les vapeurs de leur ciel se dorent, 
-Lorsque je passe en les touchant; 
+Lorsque je passe en les touchant ; 
 Reine des ombres léthargiques, 
 Je bâtis mes palais magiques 
 Dans les nuages du couchant.
 
-Mon aile bleue est diaphane; 
+Mon aile bleue est diaphane ; 
 L'essaim des Sylphes enchantés 
 Croit voir sur mon dos, quand je plane, 
 Frémir deux rayons argentés. 
-Ma main luit, rose et transparente; 
+Ma main luit, rose et transparente ; 
 Mon souffle est la brise odorante 
-Qui, le soir, erre dans les champs; 
+Qui, le soir, erre dans les champs ; 
 Ma chevelure est radieuse, 
 Et ma bouche mélodieuse 
 Mêle un sourire à tous ses chants.
 
-J'ai des grottes de coquillages; 
-J'ai des tentes de rameaux verts; 
+J'ai des grottes de coquillages ; 
+J'ai des tentes de rameaux verts ; 
 C'est moi que bercent les feuillages, 
 Moi que berce le flot des mers. 
 Si tu me suis, ombre ingénue, 
 Je puis t'apprendre où va la nue, 
-Te montrer d'où viennent les eaux; 
+Te montrer d'où viennent les eaux ; 
 Viens, sois ma compagne nouvelle, 
 Si tu veux que je te révèle 
 Ce que dit la voix des oiseaux.
@@ -278,7 +278,7 @@ Vogue un navire d'or sur une ruer d'azur.
 
 Tous les dons ont comblé la zone orientale. 
 Dans tout autre climat, par une loi fatale, 
-Près des fruits savoureux croissent les fruits amers; 
+Près des fruits savoureux croissent les fruits amers ; 
 Mais Dieu, qui pour l'Asie a des yeux moins austères, 
 Y donne plus de fleurs aux terres, 
 Plus d'étoiles aux cieux, plus de perles aux mers.
@@ -291,13 +291,13 @@ Environnant tout un empire,
 Garde dans l'univers comme un monde étranger.
 
 J'ai de vastes cités qu'en tous lieus on admire 
-Lahore aux champs fleuris; Golconde; Cachemire; 
-La guerrière Damas; la royale Ispahan; 
-Bagdad, que ses remparts couvrent comme une armure; 
+Lahore aux champs fleuris ; Golconde ; Cachemire ; 
+La guerrière Damas ; la royale Ispahan ; 
+Bagdad, que ses remparts couvrent comme une armure ; 
 Alep, dont l'immense murmure 
 Semble au pâtre lointain le bruit d'un océan.
 
-Mysore est sur son trône une reine placée; 
+Mysore est sur son trône une reine placée ; 
 Médine aux mille tours, d'aiguilles hérissée, 
 Avec ses flèches d'or, ses kiosques brillants, 
 Est comme un bataillon, arrêté dans les plaines, 
@@ -314,19 +314,19 @@ Douze éléphants de front passent avec leurs tours.
 Bel enfant ! viens errer, parmi tant de merveilles, 
 Sur ces toits pleins de fleurs ainsi que des corbeilles, 
 Dans le camp vagabond des arabes ligués. 
-Viens; nous verrons danser les jeunes bayadères, 
+Viens ; nous verrons danser les jeunes bayadères, 
 Le soir, lorsque les dromadaires 
 Près du puits du désert s'arrêtent fatigués.
 
 Là, sous de verts figuiers, sous d'épais sycomores, 
-Luit le dôme d'étain du minaret des maures; 
-La pagode de nacre au toit rose et changeant; 
-La tour de porcelaine aux clochettes dorées; 
+Luit le dôme d'étain du minaret des maures ; 
+La pagode de nacre au toit rose et changeant ; 
+La tour de porcelaine aux clochettes dorées ; 
 Et, dans les jonques azurées, 
 Le palanquin de pourpre aux longs rideaux d'argent.
 
 J'écarterai pour toi les rameaux du platane 
-Qui voile dans son bain la rêveuse sultane; 
+Qui voile dans son bain la rêveuse sultane ; 
 Viens, nous rassurerons contre un ingrat oubli 
 La vierge qui, timide, ouvrant la nuit sa porte, 
 Écoute si le vent lui porte 
@@ -335,9 +335,9 @@ La voix qu'elle préfère au chant du bengali.
 L'Orient fut jadis le paradis du monde. 
 Un printemps éternel de ses roses l'inonde, 
 Et ce vaste hémisphère est un riant jardin. 
-Toujours autour de nous sourit la douce joie; 
+Toujours autour de nous sourit la douce joie ; 
 Toi qui gémis, suis notre voie, 
-Que t'importe le ciel, quand je t'ouvre l'éden?
+Que t'importe le ciel, quand je t'ouvre l'éden ?
 
 
 <nonum><center>La Fée</center></nonum>
@@ -365,57 +365,57 @@ Qui t'endormait dans ton berceau.
 
 Crains des bleus horizons le cercle monotone. 
 Les brouillards, les vapeurs, le nuage qui tonne, 
-Tempèrent le soleil dans nos cieux parvenu; 
+Tempèrent le soleil dans nos cieux parvenu ; 
 Et l'œil voit au loin fuir leurs lignes nébuleuses, 
 Comme des flottes merveilleuses 
 Qui viennent d'un monde inconnu.
 
 C'est pour moi que les vents font, sur nos mers bruyantes, 
-Tournoyer l'air et l'onde en trombes foudroyantes; 
-La tempête à mes chants suspend son vol fatal; 
+Tournoyer l'air et l'onde en trombes foudroyantes ; 
+La tempête à mes chants suspend son vol fatal ; 
 L'arc-en-ciel pour mes pieds, qu'un or fluide arrose, 
 Comme un pont de nacre, se pose 
 Sur les cascades de cristal.
 
-Du moresque Alhambra j'ai les frêles portiques; 
+Du moresque Alhambra j'ai les frêles portiques ; 
 J'ai la grotte enchantée aux piliers basaltiques, 
-Où la mer de Staffa brise un flot inégal; 
+Où la mer de Staffa brise un flot inégal ; 
 Et j'aide le pécheur, roi des vagues brumeuses, 
 A bâtir ses huttes fumeuses 
 Sur les vieux palais de Fingal.
 
 Épouvantant les nuits d'une trompeuse aurore, 
 Là, souvent à ma voix un rouge météore 
-Croise en voûte de feu ses gerbes dans les airs; 
+Croise en voûte de feu ses gerbes dans les airs ; 
 Et le chasseur, debout sur la roche pendante, 
 Croit voir une comète ardente 
 Baignant ses flammes dans les mers.
 
 Viens, jeune âme, avec moi, de mes sueurs obéie, 
-Peupler de gais follets la morose abbaye; 
-Mes nains et mes géants te suivront à ma voix; 
+Peupler de gais follets la morose abbaye ; 
+Mes nains et mes géants te suivront à ma voix ; 
 Viens, troublant de ton cor les monts inaccessibles, 
 Guider ces meutes invisibles 
 Qui, la nuit, chassent dans nos bois.
 
 Tu verras les barons, sous leurs tours féodales, 
-De l'humble pèlerin détachant les sandales; 
-Et les sombres créneaux d'écussons décorés; 
+De l'humble pèlerin détachant les sandales ; 
+Et les sombres créneaux d'écussons décorés ; 
 Et la dame tout bas priant, pour un beau page, 
 Quelque mystérieuse image 
 Peinte sur des vitraux dorés.
 
 C'est nous qui, visitant les gothiques églises, 
-Ouvrons leur nef sonore au murmure des brises; 
+Ouvrons leur nef sonore au murmure des brises ; 
 Quand la lune du tremble argente les rameaux, 
 Le pâtre voit dans l'air, avec des chants mystiques, 
 Folâtrer nos chœurs fantastiques 
 Autour du clocher des hameaux.
 
-De quels enchantements l'Occident se décore! -
+De quels enchantements l'Occident se décore ! -
 Viens, le ciel est bien loin, ton aile est faible encore ! 
 Oublie en notre empire un voyage fatal. 
-Un charme s'y révèle aux lieux les plus sauvages; 
+Un charme s'y révèle aux lieux les plus sauvages ; 
 Et l'étranger dit nos rivages 
 Plus doux que le pays natal !
 
@@ -424,7 +424,7 @@ Plus doux que le pays natal !
 <nonum><center>IV</center></nonum>
 
 Et l'enfant hésitait, et déjà moins rebelle 
-Écoutait des esprits l'appel fallacieux; 
+Écoutait des esprits l'appel fallacieux ; 
 La terre qu'il fuyait semblait pourtant si belle ! 
 Soudain il disparut à leur vue infidèle... 
 Il avait entrevu les cieux !

--- a/fdirs/lisle/andre.xml
+++ b/fdirs/lisle/andre.xml
@@ -21,71 +21,71 @@
 <poetry>
 1.
 Allons enfants de la Patrie,
-Le jour de gloire est arrivé!
+Le jour de gloire est arrivé !
 Contre nous de la tyrannie,
 L'étendard sanglant est levé, (bis)
 Entendez-vous dans les campagnes
 Mugir ces féroces soldats ?
 Ils viennent jusque dans vos bras
-Égorger vos fils et vos compagnes!
+Égorger vos fils et vos compagnes !
 
     <nonum><i>Refrain</i></nonum>
 
     Aux armes, citoyens,
     Formez vos bataillons,
-    Marchons, marchons!
+    Marchons, marchons !
     Qu'un sang impur
-    Abreuve nos sillons!
+    Abreuve nos sillons !
 
 2.
 Que veut cette horde d'esclaves,
 De traîtres, de rois conjurés ?
 Pour qui ces ignobles entraves,
 Ces fers dès longtemps préparés ? (bis)
-Français, pour nous, ah! quel outrage
-Quels transports il doit exciter!
+Français, pour nous, ah ! quel outrage
+Quels transports il doit exciter !
 C'est nous qu'on ose méditer
-De rendre à l'antique esclavage!
+De rendre à l'antique esclavage !
 
 3.
-Quoi! des cohortes étrangères
-Feraient la loi dans nos foyers!
-Quoi! ces phalanges mercenaires
-Terrasseraient nos fiers guerriers! (bis)
-Grand Dieu! par des mains enchaînées
+Quoi ! des cohortes étrangères
+Feraient la loi dans nos foyers !
+Quoi ! ces phalanges mercenaires
+Terrasseraient nos fiers guerriers ! (bis)
+Grand Dieu ! par des mains enchaînées
 Nos fronts sous le joug se ploieraient
 De vils despotes deviendraient
-Les maîtres de nos destinées!
+Les maîtres de nos destinées !
 
 4.
 Tremblez, tyrans et vous perfides
 L'opprobre de tous les partis,
-Tremblez! vos projets parricides
-Vont enfin recevoir leurs prix! (bis)
+Tremblez ! vos projets parricides
+Vont enfin recevoir leurs prix ! (bis)
 Tout est soldat pour vous combattre,
 S'ils tombent, nos jeunes héros,
 La terre en produit de nouveaux,
-Contre vous tout prêts à se battre!
+Contre vous tout prêts à se battre !
 
 5.
 Français, en guerriers magnanimes,
-Portez ou retenez vos coups!
+Portez ou retenez vos coups !
 Epargnez ces tristes victimes,
 A regret s'armant contre nous. (bis)
 Mais ces despotes sanguinaires,
 Mais ces complices de Bouillé,
 Tous ces tigres qui, sans pitié,
-Déchirent le sein de leur mère!
+Déchirent le sein de leur mère !
 
 6.
 Amour sacré de la Patrie,
 Conduis, soutiens nos bras vengeurs
 Liberté, Liberté chérie,
-Combats avec tes défenseurs! (bis)
+Combats avec tes défenseurs ! (bis)
 Sous nos drapeaux que la victoire
 Accoure à tes mâles accents,
 Que tes ennemis expirants
-Voient ton triomphe et notre gloire!
+Voient ton triomphe et notre gloire !
 
 7.
 Nous entrerons dans la carrière

--- a/fdirs/mallarme/poesies.xml
+++ b/fdirs/mallarme/poesies.xml
@@ -23,14 +23,14 @@
 <body>
 <poetry>
 Rien, cette écume, vierge vers
-À ne désigner que la coupe;
+À ne désigner que la coupe ;
 Telle loin se noie une troupe
 De sirènes mainte à l'envers.
 
 Nous naviguons, ô mes divers
 Amis, moi déjà sur la poupe
 Vous l'avant fastueux qui coupe
-Le flot de foudres et d'hivers;
+Le flot de foudres et d'hivers ;
 
 Une ivresse belle m'engage
 Sans craindre même son tangage
@@ -67,17 +67,17 @@ Mordant au citron d'or de l'idéal amer.
 
 La plupart râla dans les défilés nocturnes,
 S'enivrant du bonheur de voir couler son sang,
-O Mort le seul baiser aux bouches taciturnes!
+O Mort le seul baiser aux bouches taciturnes !
 
 Leur défaite, c'est par un ange très puissant
-Debout à l'horizon dans le nu de son glaive:
+Debout à l'horizon dans le nu de son glaive :
 Une pourpre se caille au sein reconnaissant.
 
 Ils tettent la douleur comme ils tétaient le rêve
 Et quand ils vont rythmant de pleurs voluptueux
 Le peuple s'agenouille et leur mère se lève.
 
-Ceux-là sont consolés, sûrs et majestueux;
+Ceux-là sont consolés, sûrs et majestueux ;
 Mais traînent à leurs pas cent frères qu'on bafoue,
 Dérisoires martyrs de hasards tortueux.
 
@@ -87,13 +87,13 @@ Mais vulgaire ou bouffon le destin qui les roue.
 
 Ils pouvaient exciter aussi comme un tambour
 La servile pitié des races à voix terne,
-Égaux de Prométhée à qui manque un vautour!
+Égaux de Prométhée à qui manque un vautour !
 
 Non, vils et fréquentant les déserts sans citerne,
 Ils courent sous le fouet d'un monarque rageur,
 Le Guignon, dont le rire inouï les prosterne.
 
-Amants, il saute en croupe à trois, le partageur!
+Amants, il saute en croupe à trois, le partageur !
 Puis le torrent franchi, vous plonge en une mare
 Et laisse un bloc boueux du blanc couple nageur.
 
@@ -129,9 +129,9 @@ Les disent ennuyeux et sans intelligence.
 « Comme un vierge cheval écume de tempête
 « Plutôt que de partir en galops cuirassés.
 
-« Nous soûlerons d'encens le vainqueur de la fête:
+« Nous soûlerons d'encens le vainqueur de la fête :
 « Mais eux, pourquoi n'endosser pas, ces baladins,
-« D'écarlate haillon hurlant que l'on s'arrête! »
+« D'écarlate haillon hurlant que l'on s'arrête ! »
 
 Quand en face tous leur ont craché les dédains,
 Nuls et la barbe à mots bas priant le tonnerre,
@@ -177,13 +177,13 @@ Neiger de blancs bouquets d'étoiles parfumées.
    <title>Placet futile</title>
    <toctitle>Placet futile</toctitle>
    <indextitle>Placet futile</indextitle>
-   <firstline>Princesse! à jalouser le destin d'une Hébé</firstline>
+   <firstline>Princesse ! à jalouser le destin d'une Hébé</firstline>
    <quality>korrektur1</quality>
    <keywords>sonnet</keywords>
 </head>
 <body>
 <poetry>
-Princesse! à jalouser le destin d'une Hébé
+Princesse ! à jalouser le destin d'une Hébé
 Qui poind sur cette tasse au baiser de vos lèvres,
 J'use mes feux mais n'ai rang discret que d'abbé
 Et ne figurerai même nu sur le Sèvres.
@@ -191,7 +191,7 @@ Et ne figurerai même nu sur le Sèvres.
 Comme je ne suis pas ton bichon embarbé,
 Ni la pastille ni du rouge, ni jeux mièvres
 Et que sur moi je sais ton regard clos tombé,
-Blonde dont les coiffeurs divins sont des orfèvres!
+Blonde dont les coiffeurs divins sont des orfèvres !
 
 Nommez-nous... toi de qui tant de ris framboisés
 Se joignent en troupeau d'agneaux apprivoisés
@@ -222,7 +222,7 @@ J'ai troué dans le mur de toile une fenêtre.
 
 De ma jambe et des bras limpide nageur traître,
 À bonds multipliés, reniant le mauvais
-Hamlet! c'est comme si dans l'onde j'innovais
+Hamlet ! c'est comme si dans l'onde j'innovais
 Mille sépulcres pour y vierge disparaître.
 
 Hilare or de cymbale à des poings irrité,
@@ -230,7 +230,7 @@ Tout à coup le soleil frappe la nudité
 Qui pure s'exhala dans ma fraîcheur de nacre,
 
 Rance nuit de la peau quand sur moi vous passiez,
-Ne sachant pas, ingrat! que c'était tout mon sacre,
+Ne sachant pas, ingrat ! que c'était tout mon sacre,
 Ce fard noyé dans l'eau perfide des glaciers.
 </poetry>
 </body>
@@ -250,7 +250,7 @@ Ce fard noyé dans l'eau perfide des glaciers.
 Une négresse par le démon secouée
 Veut goûter une enfant triste de fruits nouveaux
 Et criminels aussi sous leur robe trouée
-Cette goinfre s'apprête à de rusés travaux:
+Cette goinfre s'apprête à de rusés travaux :
 
 À son ventre compare heureuse deux tétines
 Et, si haut que la main ne le saura saisir,
@@ -260,7 +260,7 @@ Ainsi que quelque langue inhabile au plaisir
 Contre la nudité peureuse de gazelle
 Qui tremble, sur le dos tel un fol éléphant
 Renversée elle attend et s'admire avec zèle,
-En riant de ses dents naïves à l'enfant;
+En riant de ses dents naïves à l'enfant ;
 
 Et, dans ses jambes où la victime se couche,
 Levant une peau noire ouverte sous le crin,
@@ -284,7 +284,7 @@ Mon âme vers ton front où rêve, ô calme soeur,
 Un automne jonché de taches de rousseur,
 Et vers le ciel errant de ton oeil angélique
 Monte, comme dans un jardin mélancolique,
-Fidèle, un blanc jet d'eau soupire vers l'Azur!
+Fidèle, un blanc jet d'eau soupire vers l'Azur !
 - Vers l'Azur attendri d'Octobre pâle et pur
 Qui mire aux grands bassins sa langeur infinie
 Et laisse, sur l'eau morte où la fauve agonie
@@ -316,18 +316,18 @@ Aux fenêtres qu'un beau rayon clair veut hâler.
 
 Et la bouche, fiévreuse et d'azur bleu vorace,
 Telle, jeune, elle alla respirer son trésor,
-Une peau virginale et de jadis! encrasse
+Une peau virginale et de jadis ! encrasse
 D'un long baiser amer les tièdes carreaux d'or.
 
 Ivre, il vit, oubliant l'horreur des saintes huiles,
 Les tisanes, l'horloge et le lit infligé,
-La toux; et quand le soir saigne parmi les tuiles,
+La toux ; et quand le soir saigne parmi les tuiles,
 Son oeil, à l'horizon de lumière gorgé,
 
 Voit des galères d'or, belles comme des cygnes,
 Sur un fleuve de pourpre et de parfums dormir
 En berçant l'éclair fauve et riche de leurs lignes
-Dans un grand nonchaloir chargé de souvenirs!
+Dans un grand nonchaloir chargé de souvenirs !
 
 Ainsi, pris du dégoût de l'homme à l'âme dure
 Vautré dans le bonheur, où ses seuls appétits
@@ -339,12 +339,12 @@ D'ou l'on tourne l'épaule à la vie et, béni,
 Dans leur verre, lavé d'éternelles rosées,
 Que dore le matin chaste de l'Infini
 
-Je me mire et me vois ange! et je meurs, et j'aime
+Je me mire et me vois ange ! et je meurs, et j'aime
 - Que la vitre soit l'art, soit la mysticité -
 À renaître, portant mon rêve en diadème,
-Au ciel antérieur où fleurit la Beauté!
+Au ciel antérieur où fleurit la Beauté !
 
-Mais hélas! Ici-bas est maître: sa hantise
+Mais hélas ! Ici-bas est maître : sa hantise
 Vient m'écoeurer parfois jusqu'en cet abri sûr,
 Et le vomissement impur de la Bêtise
 Me force à me boucher le nez devant l'azur.
@@ -352,7 +352,7 @@ Me force à me boucher le nez devant l'azur.
 Est-il moyen, ô Moi qui connais l'amertume,
 D'enfoncer le cristal par le monstre insulté
 Et de m'enfuir, avec mes deux ailes sans plume
-- Au risque de tomber pendant l'éternité?
+- Au risque de tomber pendant l'éternité ?
 </poetry>
 </body>
 </text>
@@ -380,17 +380,17 @@ Que rougit la pudeur des aurores foulées,
 L'hyacinthe, le myrte à l'adorable éclair
 Et, pareille à la chair de la femme, la rose
 Cruelle, Hérodiade en fleur du jardin clair,
-Celle qu'un sang farouche et radieux arrose!
+Celle qu'un sang farouche et radieux arrose !
 
 Et tu fis la blancheur sanglotante des lys
 Qui roulant sur des mers de soupirs qu'elle effleure
 À travers l'encens bleu des horizons pâlis
-Monte rêveusement vers la lune qui pleure!
+Monte rêveusement vers la lune qui pleure !
 
 Hosannah sur le cistre et dans les encensoirs,
-Notre Dame, hosannah du jardin de nos limbes!
+Notre Dame, hosannah du jardin de nos limbes !
 Et finisse l'écho par les célestes soirs,
-Extase des regards, scintillements des nimbes!
+Extase des regards, scintillements des nimbes !
 
 O Mère qui créas en ton sein juste et fort,
 Calice balançant la future fiole,
@@ -446,12 +446,12 @@ De tant d'oiseaux en fleur gazouillant au soleil.
 Je ne viens pas ce soir vaincre ton corps, ô bête
 En qui vont les péchés d'un peuple, ni creuser
 Dans tes cheveux impurs une triste tempête
-Sous l'incurable ennui que verse mon baiser:
+Sous l'incurable ennui que verse mon baiser :
 
 Je demande à ton lit le lourd sommeil sans songes
 Planant sous les rideaux inconnus du remords,
 Et que tu peux goûter après tes noirs mensonges,
-Toi qui sur le néant en sais plus que les morts:
+Toi qui sur le néant en sais plus que les morts :
 
 Car le Vice, rongeant ma native noblesse,
 M'a comme toi marqué de sa stérilité,
@@ -483,7 +483,7 @@ Dans le terrain avare et froid de ma cervelle,
 Fossoyeur sans pitié pour la stérilité,
 - Que dire à cette Aurore, ô Rêves, visité
 Par les roses, quand, peur de ses roses livides,
-Le vaste cimetière unira les trous vides? -
+Le vaste cimetière unira les trous vides ? -
 Je veux délaisser l'Art vorace d'un pays
 Cruel, et, souriant aux reproches vieillis
 Que me font mes amis, le passé, le génie,
@@ -527,11 +527,11 @@ Chevauchant tristement en geignant du latin
 Sur la pierre qui tend la corde séculaire,
 N'entend descendre à lui qu'un tintement lointain.
 
-Je suis cet homme. Hélas! de la nuit désireuse,
+Je suis cet homme. Hélas ! de la nuit désireuse,
 J'ai beau tirer le câble à sonner l'Idéal,
 De froids péchés s'ébat un plumage féal,
 
-Et la voix ne me vient que par bribes et creuse!
+Et la voix ne me vient que par bribes et creuse !
 Mais, un jour, fatigué d'avoir en vain tiré,
 O Satan, j'ôterai la pierre et me pendrai.
 </poetry>
@@ -557,7 +557,7 @@ Il mêle avec les pleurs un breuvage amoureux.
 De ce blanc Flamboiement l'immuable accalmie
 T'a fait dire, attristée, ô mes baisers peureux,
 « Nous ne serons jamais une seule momie
-Sous l'antique désert et les palmiers heureux! »
+Sous l'antique désert et les palmiers heureux ! »
 
 Mais ta chevelure est une rivière tiède,
 Où noyer sans frissons l'âme qui nous obsède
@@ -587,25 +587,25 @@ Le poëte impuissant qui maudit son génie
 
 Fuyant, les yeux fermés, je le sens qui regarde
 Avec l'intensité d'un remords atterrant,
-Mon âme vide. Où fuir? Et quelle nuit hagarde
-Jeter, lambeaux, jeter sur ce mépris navrant?
+Mon âme vide. Où fuir ? Et quelle nuit hagarde
+Jeter, lambeaux, jeter sur ce mépris navrant ?
 
-Brouillards, montez! Versez vos cendres monotones
+Brouillards, montez ! Versez vos cendres monotones
 Avec de longs haillons de brume dans les cieux
 Qui noiera le marais livide des automnes
-Et bâtissez un grand plafond silencieux!
+Et bâtissez un grand plafond silencieux !
 
 Et toi, sors des étangs léthéens et ramasse
 En t'en venant la vase et les pâles roseaux,
 Cher Ennui, pour boucher d'une main jamais lasse
 Les grands trous bleus que font méchamment les oiseaux.
 
-Encor! que sans répit les tristes cheminées
+Encor ! que sans répit les tristes cheminées
 Fument, et que de suie une errante prison
 Éteigne dans l'horreur de ses noires traînées
-Le soleil se mourant jaunâtre à l'horizon!
+Le soleil se mourant jaunâtre à l'horizon !
 
-- Le Ciel est mort. - Vers toi, j'accours! donne, ô matière,
+- Le Ciel est mort. - Vers toi, j'accours ! donne, ô matière,
 L'oubli de l'Idéal cruel et du Péché
 À ce martyr qui vient partager la litière
 Où le bétail heureux des hommes est couché,
@@ -615,15 +615,15 @@ Comme le pot de fard gisant au pied d'un mur,
 N'a plus l'art d'attifer la sanglotante idée,
 Lugubrement bâiller vers un trépas obscur...
 
-En vain! l'Azur triomphe, et je l'entends qui chante
+En vain ! l'Azur triomphe, et je l'entends qui chante
 Dans les cloches. Mon âme, il se fait voix pour plus
 Nous faire peur avec sa victoire méchante,
-Et du métal vivant sort en bleus angelus!
+Et du métal vivant sort en bleus angelus !
 
 Il roule par la brume, ancien et traverse
-Ta native agonie ainsi qu'un glaive sûr;
-Où fuir dans la révolte inutile et perverse?
-Je suis hanté. L'Azur! l'Azur! l'Azur! l'Azur!
+Ta native agonie ainsi qu'un glaive sûr ;
+Où fuir dans la révolte inutile et perverse ?
+Je suis hanté. L'Azur ! l'Azur ! l'Azur ! l'Azur !
 </poetry>
 </body>
 </text>
@@ -633,27 +633,27 @@ Je suis hanté. L'Azur! l'Azur! l'Azur! l'Azur!
    <title>Brise marine</title>
    <toctitle>Brise marine</toctitle>
    <indextitle>Brise marine</indextitle>
-   <firstline>La chair est triste, hélas! et j'ai lu tous les livres</firstline>
+   <firstline>La chair est triste, hélas ! et j'ai lu tous les livres</firstline>
    <quality>korrektur1</quality>
 </head>
 <body>
 <poetry>
-La chair est triste, hélas! et j'ai lu tous les livres.
-Fuir! là-bas fuir! Je sens que des oiseaux sont ivres
-D'être parmi l'écume inconnue et les cieux!
+La chair est triste, hélas ! et j'ai lu tous les livres.
+Fuir ! là-bas fuir ! Je sens que des oiseaux sont ivres
+D'être parmi l'écume inconnue et les cieux !
 Rien, ni les vieux jardins reflétés par les yeux
 Ne retiendra ce coeur qui dans la mer se trempe
-O nuits! ni la clarté déserte de ma lampe
+O nuits ! ni la clarté déserte de ma lampe
 Sur le vide papier que la blancheur défend
 Et ni la jeune femme allaitant son enfant.
-Je partirai! Steamer balançant ta mâture,
-Lève l'ancre pour une exotique nature!
+Je partirai ! Steamer balançant ta mâture,
+Lève l'ancre pour une exotique nature !
 Un Ennui, désolé par les cruels espoirs,
-Croit encore à l'adieu suprême des mouchoirs!
+Croit encore à l'adieu suprême des mouchoirs !
 Et, peut-être, les mâts, invitant les orages
 Sont-ils de ceux qu'un vent penche sur les naufrages
 Perdus, sans mâts, sans mâts, ni fertiles îlots...
-Mais, ô mon coeur, entends le chant des matelots!
+Mais, ô mon coeur, entends le chant des matelots !
 </poetry>
 </body>
 </text>
@@ -663,34 +663,34 @@ Mais, ô mon coeur, entends le chant des matelots!
    <title>Aumone</title>
    <toctitle>Aumone</toctitle>
    <indextitle>Aumone</indextitle>
-   <firstline>Prends ce sac, Mendiant! tu ne le cajolas</firstline>
+   <firstline>Prends ce sac, Mendiant ! tu ne le cajolas</firstline>
    <quality>korrektur1</quality>
 </head>
 <body>
 <poetry>
-Prends ce sac, Mendiant! tu ne le cajolas
+Prends ce sac, Mendiant ! tu ne le cajolas
 Sénile nourrisson d'une tétine avare
 Afin de pièce à pièce en égoutter ton glas.
 
 Tire du métal cher quelque péché bizarre
 Et vaste comme nous, les poings pleins, le baisons
-Souffles-y qu'il se torde! une ardente fanfare.
+Souffles-y qu'il se torde ! une ardente fanfare.
 
 Église avec l'encens que toutes ces maisons
 Sur les murs quand berceur d'une bleue éclaircie
 Le tabac sans parler roule les oraisons,
 
-Et l'opium puissant brise la pharmacie!
+Et l'opium puissant brise la pharmacie !
 Robes et peaux, veux-tu lacérer le satin
 Et boire en la salive l'heureuse inertie,
 
-Par les cafés princiers attendre le matin?
+Par les cafés princiers attendre le matin ?
 Les plafonds enrichis de nymphes et de voiles,
 On jette, au mendiant de la vitre, un festin.
 
 Et quand tu sors, vieux dieu, grelottant sous tes toiles
 D'emballage, l'aurore est un lac de vin d'or
-Et tu jures avoir au gosier les étoiles!
+Et tu jures avoir au gosier les étoiles !
 
 Faute de supputer l'éclat de ton trésor,
 Tu peux du moins t'orner d'une plume, à complies
@@ -720,7 +720,7 @@ Et surtout ne va pas, frère, acheter du pain.
 Sur les bois oubliés quand passe l'hiver sombre
 Tu te plains, ô captif solitaire du seuil,
 Que ce sépulcre à deux qui fera notre orgueil
-Hélas! du manque seul des lourds bouquet s'encombre.
+Hélas ! du manque seul des lourds bouquet s'encombre.
 
 Sans écouter Minuit qui jeta son vain nombre,
 Une veille t'exalte à ne pas fermer l'oeil
@@ -743,7 +743,7 @@ Le souffle de mon nom murmuré tout un soir.
    <title>Don du poème</title>
    <toctitle>Don du poème</toctitle>
    <indextitle>Don du poème</indextitle>
-   <firstline>Je t'apporte l'enfant d'une nuit d'Idumée!</firstline>
+   <firstline>Je t'apporte l'enfant d'une nuit d'Idumée !</firstline>
    <quality>korrektur1</quality>
    <keywords>sonnet</keywords>
 </head>
@@ -752,9 +752,9 @@ Le souffle de mon nom murmuré tout un soir.
 Je t'apporte l'enfant d'une nuit d'Idumée !
 Noire, à l'aile saignante et pâle, déplumée,
 Par le verre brûlé d'aromates et d'or,
-Par les carreaux glacés, hélas! mornes encor,
+Par les carreaux glacés, hélas ! mornes encor,
 L'aurore se jeta sur la lampe angélique.
-Palmes! et quand elle a montré cette relique
+Palmes ! et quand elle a montré cette relique
 A ce père essayant un sourire ennemi,
 La solitude bleue et stérile a frémi.
 Ô la berceuse, avec ta fille et l'innocence
@@ -773,17 +773,17 @@ Pour des lèvres que l'air du vierge azur affame ?
    <subtitle>La Nourrice - Hérodiade</subtitle>
    <toctitle>Scene</toctitle>
    <indextitle>Scene</indextitle>
-   <firstline>Tu vis! ou vois-je ici l'ombre d'une princesse?</firstline>
+   <firstline>Tu vis ! ou vois-je ici l'ombre d'une princesse ?</firstline>
    <quality>korrektur1</quality>
 </head>
 <body>
 <poetry>
-  N.:
-Tu vis! ou vois-je ici l'ombre d'une princesse?
+  N. :
+Tu vis ! ou vois-je ici l'ombre d'une princesse ?
 À mes lèvres tes doigts et leurs bagues et cesse
 De marcher dans un âge ignoré...
 
-  H.:
+  H. :
 Reculez.
 Le blond torrent de mes cheveux immaculés
 Quand il baigne mon corps solitaire le glace
@@ -794,12 +794,12 @@ Si la beauté n'était la mort...
 Par quel attrait
 Menée et quel matin oublié des prophètes
 Verse, sur les lointains mourants, ses tristes fêtes,
-Le sais-je? tu m'as vue, ô nourrice d'hiver,
+Le sais-je ? tu m'as vue, ô nourrice d'hiver,
 Sous la lourde prison de pierres et de fer
 Où de mes vieux lions traînent les siècles fauves
 Entrer, et je marchais, fatale, les mains sauves,
-dans le parfum désert de ses anciens rois:
-Mais encore as-tu-vu quels furent mes effrois?
+dans le parfum désert de ses anciens rois :
+Mais encore as-tu-vu quels furent mes effrois ?
 Je m'arrête rêvant aux exils, et j'effeuille,
 Comme près d'un bassin dont le jet d'eau m'accueille
 Les pâles lys qui sont en moi, tandis qu'épris
@@ -813,16 +813,16 @@ Trop farouches qui font votre peur des crinières,
 Aide-moi, puisqu'ainsi tu n'oses plus me voir,
 A me peigner nonchalamment dans un miroir.
 
-  N.:
+  N. :
 Sinon la myrrhe gaie en ses bouteilles closes,
 De l'essence ravie aux vieillesses de roses,
 Voulez-vous, mon enfant, essayer la vertu
-Funèbre?
+Funèbre ?
 
-  H.:
-Laisse-là ces parfums! ne sais-tu
+  H. :
+Laisse-là ces parfums ! ne sais-tu
 Que je les hais, nourrice, et veux-tu que je sente
-Leur ivresse noyer ma tête languissante?
+Leur ivresse noyer ma tête languissante ?
 Je veux que mes cheveux qui ne sont pas des fleurs
 À répandre l'oubli des humaines douleurs
 Mais de l'or, à jamais vierge des aromates,
@@ -831,97 +831,97 @@ Observent la froideur stérile du métal,
 Vous ayant reflétés, joyaux du mur natal,
 Armes, vases depuis ma solitaire enfance.
 
-  N.:
-Pardon! l'âge effaçait, reine, votre défense
+  N. :
+Pardon ! l'âge effaçait, reine, votre défense
 De mon esprit pâli comme un vieux livre ou noir...
 
-  H.:
-Assez! Tiens devant moi ce miroir.
+  H. :
+Assez ! Tiens devant moi ce miroir.
 
-O miroir!
+O miroir !
 Eau froide par l'ennui dans ton cadre gelée
 Que de fois et pendant les heures, désolée
 Des songes et cherchant mes souvenirs qui sont
 Comme des feuilles sous ta glace au trou profond,
 Je m'apparus en toi comme une ombre lointaine
-Mais, horreur! des soirs, dans ta sévère fontaine,
-J'ai de mon rêve épars connu la nudité!
+Mais, horreur ! des soirs, dans ta sévère fontaine,
+J'ai de mon rêve épars connu la nudité !
 
-Nourrice, suis-je belle?
+Nourrice, suis-je belle ?
 
-  N.:
+  N. :
 Un astre, en vérité
 Mais cette tresse tombe...
 
-  H.:
+  H. :
 Arrête dans ton crime
 Qui refroidit mon sang vers sa source, et réprime
-Ce geste, impiété fameuse: ah! conte-moi
+Ce geste, impiété fameuse : ah ! conte-moi
 Quel sûr démon te jette en le sinistre émoi,
-Ce baiser, ces parfums offerts et, le dirai-je?
+Ce baiser, ces parfums offerts et, le dirai-je ?
 O mon coeur, cette main encore sacrilège,
 Car tu voulais, je crois, me toucher, sont un jour
 Qui ne finira pas sans malheur sur la tour...
-O jour qu'Hérodiade avec effroi regarde!
+O jour qu'Hérodiade avec effroi regarde !
 
-  N.:
-Temps bizarre, en effet, de quoi le ciel vous garde!
+  N. :
+Temps bizarre, en effet, de quoi le ciel vous garde !
 Vous errez, ombre seule et nouvelle fureur,
-Et regardant en vous précoce avec terreur;
+Et regardant en vous précoce avec terreur ;
 Mais toujours adorable autant qu'une immortelle,
 O mon enfant, et belle affreusement, et telle
 Que...
 
-  H.:
-Mais n'allais-tu pas me toucher?
+  H. :
+Mais n'allais-tu pas me toucher ?
 
-  N.:
+  N. :
 ... J'aimerais
 Etre à qui le Destin réserve vos secrets.
 
-  H.:
-Oh! tais-toi!
+  H. :
+Oh ! tais-toi !
 
-  N.:
-Viendra-t-il parfois?
+  N. :
+Viendra-t-il parfois ?
 
-  H.:
+  H. :
 Étoiles pures,
-N'entendez pas!
+N'entendez pas !
 
-  N.:
+  N. :
 Comment, sinon parmi d'obscures
 Épouvantes, songer plus implacable encor
 Et comme suppliant le dieu que le trésor
-De votre grâce attend! et pour qui, dévorée
+De votre grâce attend ! et pour qui, dévorée
 D'angoisse, gardez-vous la splendeur ignorée
-Et le mystère vain de votre être?
+Et le mystère vain de votre être ?
 
-  H.:
+  H. :
 Pour moi.
 
-  N.:
+  N. :
 Triste fleur qui croît seule et n'a pas d'autre émoi
 Que son ombre dans l'eau vue avec atonie.
 
-  H.:
+  H. :
 Va, garde to pitié comme ton ironie.
 
-  N.:
-Toutefois expliquez: oh! non, naïve enfant,
+  N. :
+Toutefois expliquez : oh ! non, naïve enfant,
 Décroîtra, quelque jour, ce dédain triomphant...
 
-  H.:
-Mais qui me toucherait, des lions respectée?
+  H. :
+Mais qui me toucherait, des lions respectée ?
 Du reste, je ne veux rien d'humain et, sculptée,
 Si tu me vois les yeux perdus au paradis,
 C'est quand je me souviens de ton lait bu jadis.
 
-  N.:
-Victime lamentable à son destin offerte!
+  N. :
+Victime lamentable à son destin offerte !
 
-  H.:
-Oui, c'est pour moi, pour moi, que je fleuris, déserte!
+  H. :
+Oui, c'est pour moi, pour moi, que je fleuris, déserte !
 Vous le savez, jardins d'améthyste, enfouis
 Sans fin dans vos savants abîmes éblouis,
 Ors ignorés, gardant votre antique lumière
@@ -929,16 +929,16 @@ Sous le sombre sommeil d'une terre première,
 Vous, pierres où mes yeux comme de purs bijoux
 Empruntent leur clarté mélodieuse, et vous
 Métaux qui donnez à ma jeune chevelure
-Une splendeur fatale et sa massive allure!
+Une splendeur fatale et sa massive allure !
 Quant à toi, femme née en des siècles malins
 Pour la méchanceté des antres sibyllins,
-Qui parles d'un mortel! selon qui, des calices
+Qui parles d'un mortel ! selon qui, des calices
 De mes robes, arôme aux farouches délices,
 Sortirait le frisson blanc de ma nudité,
 Prophétise que si le tiède azur d'été,
 Vers lui nativement la femme se dévoile,
 Me voit dans ma pudeur grelottante d'étoile,
-Je meurs!
+Je meurs !
 
 J'aime l'horreur d'être vierge et je veux
 Vivre parmi l'effroi que me font mes cheveux
@@ -946,31 +946,31 @@ Pour, le soir, retirée en ma couche, reptile
 Inviolé sentir en la chair inutile
 Le froid scintillement de ta pâle clarté
 Toi qui te meurs, toi qui brûles de chasteté
-Nuit blanches de glaçons et de neige cruelle!
+Nuit blanches de glaçons et de neige cruelle !
 
 Et ta soeur solitaire, ô ma soeur éternelle
-Mon rêve montera vers toi: telle déjà,
+Mon rêve montera vers toi : telle déjà,
 Rare limpidité d'un coeur qui le songea,
 Je me crois seule en ma monotone patrie
 Et tout, autour de moi, vit dans l'idolâtrie
 D'un miroir qui reflète en son calme dormant
 Hérodiade au clair regard de diamant...
-O charme dernier, oui! je le sens, je suis seule.
+O charme dernier, oui ! je le sens, je suis seule.
 
-  N.:
-Madame, allez-vous donc mourir?
+  N. :
+Madame, allez-vous donc mourir ?
 
-  H.:
+  H. :
 Non, pauvre aïeule,
 Sois calme et, t'éloignant, pardonne à ce coeur dur,
 Mais avant, si tu veux, clos les volets, l'azur
 Séraphique sourit dans les vitres profondes,
-Et je déteste, moi, le bel azur!
+Et je déteste, moi, le bel azur !
 
 Des ondes
 Se bercent et, là-bas, sais-tu pas un pays
 Où le sinistre ciel ait les regards haïs
-De Vénus qui, le soir, brûle dans le feuillage:
+De Vénus qui, le soir, brûle dans le feuillage :
 J'y partirais.
 
 Allume encore, enfantillage
@@ -978,10 +978,10 @@ Dis-tu, ces flambeaux où la cire au feu léger
 Pleure parmi l'or vain quelque pleur étranger
 Et...
 
-  N.:
-Maintenant?
+  N. :
+Maintenant ?
 
-  H.:
+  H. :
 Adieu.
 Vous mentez, ô fleur nue
 De mes lèvres.
@@ -1053,31 +1053,31 @@ Principe qui m'élut
 </head>
 <body>
 <poetry>
-Le Faune:
+Le Faune :
 Ces nymphes, je les veux perpétuer.
 
 Si clair,
 Leur incarnat léger, qu'il voltige dans l'air
 Assoupi de sommeils touffus.
 
-Aimai-je un rêve?
+Aimai-je un rêve ?
 Mon doute, amas de nuit ancienne, s'achève
 En maint rameau subtil, qui, demeuré les vrais
-Bois même, prouve, hélas! que bien seul je m'offrais
+Bois même, prouve, hélas ! que bien seul je m'offrais
 Pour triomphe la faute idéale de roses.
 
 Réfléchissons...
 
 ou si les femmes dont tu gloses
-Figurent un souhait de tes sens fabuleux!
+Figurent un souhait de tes sens fabuleux !
 Faune, l'illusion s'échappe des yeux bleus
-Et froids, comme une source en pleurs, de la plus chaste:
+Et froids, comme une source en pleurs, de la plus chaste :
 Mais, l'autre tout soupirs, dis-tu qu'elle contraste
-Comme brise du jour chaude dans ta toison?
-Que non! par l'immobile et lasse pâmoison
+Comme brise du jour chaude dans ta toison ?
+Que non ! par l'immobile et lasse pâmoison
 Suffoquant de chaleurs le matin frais s'il lutte,
 Ne murmure point d'eau que ne verse ma flûte
-Au bosquet arrosé d'accords; et le seul vent
+Au bosquet arrosé d'accords ; et le seul vent
 Hors des deux tuyaux prompt à s'exhaler avant
 Qu'il disperse le son dans une pluie aride,
 C'est, à l'horizon pas remué d'une ride
@@ -1088,40 +1088,40 @@ O bords siciliens d'un calme marécage
 Qu'à l'envi de soleils ma vanité saccage
 Tacite sous les fleurs d'étincelles, CONTEZ
 « Que je coupais ici les creux roseaux domptés
-» Par le talent; quand, sur l'or glauque de lointaines
+» Par le talent ; quand, sur l'or glauque de lointaines
 » Verdures dédiant leur vigne à des fontaines,
-» Ondoie une blancheur animale au repos:
+» Ondoie une blancheur animale au repos :
 » Et qu'au prélude lent où naissent les pipeaux
-» Ce vol de cygnes, non! de naïades se sauve
+» Ce vol de cygnes, non ! de naïades se sauve
 » Ou plonge...
 
 Inerte, tout brûle dans l'heure fauve
 Sans marquer par quel art ensemble détala
-Trop d'hymen souhaité de qui cherche le la:
+Trop d'hymen souhaité de qui cherche le la :
 Alors m'éveillerai-je à la ferveur première,
 Droit et seul, sous un flot antique de lumière,
-Lys! et l'un de vous tous pour l'ingénuité.
+Lys ! et l'un de vous tous pour l'ingénuité.
 
 Autre que ce doux rien par leur lèvre ébruité,
 Le baiser, qui tout bas des perfides assure,
 Mon sein, vierge de preuve, atteste une morsure
-Mystérieuse, due à quelque auguste dent;
-Mais, bast! arcane tel élut pour confident
-Le jonc vaste et jumeau dont sous l'azur on joue:
+Mystérieuse, due à quelque auguste dent ;
+Mais, bast ! arcane tel élut pour confident
+Le jonc vaste et jumeau dont sous l'azur on joue :
 Qui, détournant à soi le trouble de la joue,
 Rêve, dans un solo long, que nous amusions
 La beauté d'alentour par des confusions
-Fausses entre elle-même et notre chant crédule;
+Fausses entre elle-même et notre chant crédule ;
 Et de faire aussi haut que l'amour se module
 Évanouir du songe ordinaire de dos
 Ou de flanc pur suivis avec mes regards clos,
 Une sonore, vaine et monotone ligne.
 
 Tâche donc, instrument des fuites, ô maligne
-Syrinx, de refleurir aux lacs où tu m'attends!
+Syrinx, de refleurir aux lacs où tu m'attends !
 Moi, de ma rumeur fier, je vais parler longtemps
-Des déesses; et par d'idolâtres peintures
-À leur ombre enlever encore des ceintures:
+Des déesses ; et par d'idolâtres peintures
+À leur ombre enlever encore des ceintures :
 Ainsi, quand des raisins j'ai sucé la clarté,
 Pour bannir un regret par ma feinte écarté,
 Rieur, j'élève au ciel d'été la grappe vide
@@ -1131,12 +1131,12 @@ D'ivresse, jusqu'au soir je regarde au travers.
 O nymphes, regonflons des SOUVENIRS divers.
 « Mon oeil, trouant le joncs, dardait chaque encolure
 » Immortelle, qui noie en l'onde sa brûlure
-» Avec un cri de rage au ciel de la forêt;
+» Avec un cri de rage au ciel de la forêt ;
 » Et le splendide bain de cheveux disparaît
-» Dans les clartés et les frissons, ô pierreries!
-» J'accours; quand, à mes pieds, s'entrejoignent (meurtries
+» Dans les clartés et les frissons, ô pierreries !
+» J'accours ; quand, à mes pieds, s'entrejoignent (meurtries
 » De la langueur goûtée à ce mal d'être deux)
-» Des dormeuses parmi leurs seuls bras hasardeux;
+» Des dormeuses parmi leurs seuls bras hasardeux ;
 » Je les ravis, sans les désenlacer, et vole
 » À ce massif, haï par l'ombrage frivole,
 » De roses tarissant tout parfum au soleil,
@@ -1144,45 +1144,45 @@ O nymphes, regonflons des SOUVENIRS divers.
 Je t'adore, courroux des vierges, ô délice
 Farouche du sacré fardeau nu qui se glisse
 Pour fuir ma lèvre en feu buvant, comme un éclair
-Tressaille! la frayeur secrète de la chair:
+Tressaille ! la frayeur secrète de la chair :
 Des pieds de l'inhumaine au coeur de la timide
 Qui délaisse à la fois une innocence, humide
 De larmes folles ou de moins tristes vapeurs.
 « Mon crime, c'est d'avoir, gai de vaincre ces peurs
 » Traîtresses, divisé la touffe échevelée
-» De baisers que les dieux gardaient si bien mêlée:
+» De baisers que les dieux gardaient si bien mêlée :
 » Car, à peine j'allais cacher un rire ardent
 » Sous les replis heureux d'une seule (gardant
 » Par un doigt simple, afin que sa candeur de plume
 » Se teignît à l'émoi de sa soeur qui s'allume,
-» La petite, naïve et ne rougissant pas: )
+» La petite, naïve et ne rougissant pas : )
 » Que de mes bras, défaits par de vagues trépas,
 » Cette proie, à jamais ingrate se délivre
 » Sans pitié du sanglot dont j'étais encore ivre.
 
-Tant pis! vers le bonheur d'autres m'entraîneront
-Par leur tresse nouée aux cornes de mon front:
+Tant pis ! vers le bonheur d'autres m'entraîneront
+Par leur tresse nouée aux cornes de mon front :
 Tu sais, ma passion, que, pourpre et déjà mûre,
-Chaque grenade éclate et d'abeilles murmure;
+Chaque grenade éclate et d'abeilles murmure ;
 Et notre sang, épris de qui le va saisir,
 Coule pour tout l'essaim éternel du désir.
 À l'heure où ce bois d'or et de cendres se teinte
-Une fête s'exalte en la feuillée éteinte:
-Etna! c'est parmi toi visité de Vénus
+Une fête s'exalte en la feuillée éteinte :
+Etna ! c'est parmi toi visité de Vénus
 Sur ta lave posant tes talons ingénus,
 Quand tonne une somme triste ou s'épuise la flamme.
-Je tiens la reine!
+Je tiens la reine !
 
 O sûr châtiment...
 
 Non, mais l'âme
 De paroles vacante et ce corps alourdi
-Tard succombent au fier silence de midi:
+Tard succombent au fier silence de midi :
 Sans plus il faut dormir en l'oubli du blasphème,
 Sur le sable altéré gisant et comme j'aime
-Ouvrir ma bouche à l'astre efficace des vins!
+Ouvrir ma bouche à l'astre efficace des vins !
 
-Couple, adieu; je vais voir l'ombre que tu devins.
+Couple, adieu ; je vais voir l'ombre que tu devins.
 </poetry>
 </body>
 </text>
@@ -1205,7 +1205,7 @@ Jadis avec flûte ou mandore,
 Est la Sainte pâle, étalant
 Le livre vieux qui se déplie
 Du Magnificat ruisselant
-Jadis selon vêpre et complie:
+Jadis selon vêpre et complie :
 
 À ce vitrage d'ostensoir
 Que frôle une harpe par l'Ange
@@ -1225,31 +1225,31 @@ Musicienne du silence.
    <title>Toast Funebre</title>
    <toctitle>Toast Funebre</toctitle>
    <indextitle>Toast Funebre</indextitle>
-   <firstline>O de notre bonheur, toi, le fatal emblème!</firstline>
+   <firstline>O de notre bonheur, toi, le fatal emblème !</firstline>
    <quality>korrektur1</quality>
 </head>
 <body>
 <poetry>
-O de notre bonheur, toi, le fatal emblème!
+O de notre bonheur, toi, le fatal emblème !
 
 Salut de la démence et libation blême,
 Ne crois pas qu'au magique espoir du corridor
-J'offre ma coupe vide où souffre un monstre d'or!
-Ton apparition ne va pas me suffire:
+J'offre ma coupe vide où souffre un monstre d'or !
+Ton apparition ne va pas me suffire :
 Car je t'ai mis, moi-même, en un lieu de porphyre.
 Le rite est pour les mains d'éteindre le flambeau
-Contre le fer épais des portes du tombeau:
+Contre le fer épais des portes du tombeau :
 Et l'on ignore mal, élu pour notre fête
 Très-simple de chanter l'absence du poëte,
-Que ce beau monument l'enferme tout entier:
+Que ce beau monument l'enferme tout entier :
 Si ce n'est que la gloire ardente du métier,
 Jusqu'à l'heure commune et vile de la cendre,
 Par le carreau qu'allume un soir fier d'y descendre,
-Retourne vers les feux du pur soleil mortel!
+Retourne vers les feux du pur soleil mortel !
 
 Magnifique, total et solitaire, tel
 Tremble de s'exhaler le faux orgueil des hommes.
-Cette foule hagarde! Elle annonce: Nous sommes
+Cette foule hagarde ! Elle annonce : Nous sommes
 La triste opacité de nos spectres futurs.
 Mais le blason des deuils épars sur de vains murs
 J'ai méprisé l'horreur lucide d'une larme,
@@ -1259,16 +1259,16 @@ Hôte de son linceul vague, se transmuait
 En le vierge héros de l'attente posthume.
 Vaste gouffre apporté dans l'amas de la brume
 Par l'irascible vent des mots qu'il n'a pas dits,
-Le Néant à cet Homme aboli de jadis:
-« Souvenirs d'horizons, qu'est-ce, ô toi, que la Terre? »
-Hurle ce songe; et, voix dont la clarté s'altère,
-L'espace a pour jouet le cri: « Je ne sais pas! »
+Le Néant à cet Homme aboli de jadis :
+« Souvenirs d'horizons, qu'est-ce, ô toi, que la Terre ? »
+Hurle ce songe ; et, voix dont la clarté s'altère,
+L'espace a pour jouet le cri : « Je ne sais pas ! »
 
 Le Maître, par un oeil profond, a, sur ses pas,
 Apaisé de l'éden l'inquiète merveille
 Dont le frisson final, dans sa voix seule, éveille
 Pour la Rose et le Lys le mystère d'un nom.
-Est-il de ce destin rien qui demeure, non?
+Est-il de ce destin rien qui demeure, non ?
 O vous tous, oubliez une croyance sombre.
 Le splendide génie éternel n'a pas d'ombre.
 Moi, de votre désir soucieux, je veux voir,
@@ -1279,10 +1279,10 @@ Une agitation solennelle par l'air
 De paroles, pourpre ivre et grand calice clair,
 Que, pluie et diamant, le regard diaphane
 Reste là sur ces fleurs dont nulle ne se fane
-Isole parmi l'heure et le rayon du jour!
+Isole parmi l'heure et le rayon du jour !
 C'est de nos vrais bosquets déjà tout le séjour,
 Où le poëte pur a pour geste humble et large
-De l'interdire au rêve, ennemi de sa charge:
+De l'interdire au rêve, ennemi de sa charge :
 Afin que le matin de son repos altier,
 Quand la mort ancienne et comme pour Gautier
 De n'ouvrir pas les yeux sacrés et de se taire,
@@ -1298,15 +1298,15 @@ Et l'avare silence et la massive nuit.
    <title>Prose pour des Esseintes</title>
    <toctitle>Prose pour des Esseintes</toctitle>
    <indextitle>Prose pour des Esseintes</indextitle>
-   <firstline>Hyperbole! de ma mémoire</firstline>
+   <firstline>Hyperbole ! de ma mémoire</firstline>
    <quality>korrektur1</quality>
 </head>
 <body>
 <poetry>
-Hyperbole! de ma mémoire
+Hyperbole ! de ma mémoire
 Triomphalement ne sais-tu
 Te lever, aujourd'hui grimoire
-Dans un livre de fer vêtu:
+Dans un livre de fer vêtu :
 
 Car j'installe, par la science,
 L'hymne des coeurs spirituels
@@ -1348,7 +1348,7 @@ Ne porta son regard plus loin
 Que sourire, et comme à l'entendre
 J'occupe mon antique soin.
 
-Oh! sache l'Esprit de litige,
+Oh ! sache l'Esprit de litige,
 À cette heure où nous nous taisons,
 Que de lis multiples la tige
 Grandissait trop pour nos raisons
@@ -1365,12 +1365,12 @@ Que ce pays n'exista pas.
 
 L'enfant abdique son extase
 Et docte déjà par chemins
-Elle dit le mot: Anastase!
+Elle dit le mot : Anastase !
 Né pour d'éternels parchemins,
 
 Avant qu'un sépulcre ne rie
 Sous aucun climat, son aïeul,
-De porter ce nom: Pulchérie!
+De porter ce nom : Pulchérie !
 Caché par le trop grand glaïeul.
 </poetry>
 </body>
@@ -1427,7 +1427,7 @@ Te vient à chaque battement
 Dont le coup prisonnier recule
 L'horizon délicatement.
 
-Vertige! voici que frissonne
+Vertige ! voici que frissonne
 L'espace comme un grand baiser
 Qui, fou de naître pour personne,
 Ne peut jaillir ni s'apaiser.
@@ -1435,7 +1435,7 @@ Ne peut jaillir ni s'apaiser.
 Sens-tu le paradis farouche
 Ainsi qu'un rire enseveli
 Se couler du coin de ta bouche
-Au fond de l'unanime pli!
+Au fond de l'unanime pli !
 
 Le sceptre des rivages roses
 Stagnants sur les soirs d'or, ce l'est,
@@ -1525,7 +1525,7 @@ Délicieusement toi, Mary, que je songe
 À quelque baume rare émané par mensonge
 Sur aucun bouquetier de cristal obscurci
 
-Le sais-tu, oui! pour moi voici des ans, voici
+Le sais-tu, oui ! pour moi voici des ans, voici
 Toujours que ton sourire éblouissant prolonge
 La même rose avec son bel été qui plonge
 Dans autrefois et puis dans le futur aussi.
@@ -1598,7 +1598,7 @@ Sur la semelle l'envie
 Toujours conduisant ailleurs.
 
 Il recréerait des souliers,
-O pieds! si vous le vouliez!
+O pieds ! si vous le vouliez !
 </poetry>
 </body>
 </text>
@@ -1754,7 +1754,7 @@ Et comme un dieu je vais nu.
 <poetry>
 Pas les rafales à propos
 De rien comme occuper la rue
-Sujette au noir vol de chapeaux;
+Sujette au noir vol de chapeaux ;
 Mais une danseuse apparue
 
 Tourbillon de mousseline ou
@@ -1888,7 +1888,7 @@ Si de mon sein pas du sien
 A jailli le sanglot pire
 
 Déchiré va-t-il entier
-Rester sur quelque sentier!
+Rester sur quelque sentier !
 </poetry>
 </body>
 </text>
@@ -1970,7 +1970,7 @@ Que c'est d'un astre en fête allumé le génie.
 Le vierge, le vivace et le bel aujourd'hui
 Va-t-il nous déchirer avec un coup d'aile ivre
 Ce lac dur oublié que hante sous le givre
-Le transparent glacier des vols qui n'ont pas fui!
+Le transparent glacier des vols qui n'ont pas fui !
 
 Un cygne d'autrefois se souvient que c'est lui
 Magnifique mais qui sans espoir se délivre
@@ -2000,16 +2000,16 @@ Que vêt parmi l'exil inutile le Cygne.
 <body>
 <poetry>
 Victorieusement fui le suicide beau
-Tison de gloire, sang par écume, or, tempête!
+Tison de gloire, sang par écume, or, tempête !
 O rire si là-bas une pourpre s'apprête
 À ne tendre royal que mon absent tombeau.
 
-Quoi! de tout cet éclat pas même le lambeau
+Quoi ! de tout cet éclat pas même le lambeau
 S'attarde, il est minuit, à l'ombre qui nous fête
 Excepté qu'un trésor présomptueux de tête
 Verse son caressé nonchaloir sans flambeau,
 
-La tienne si toujours le délice! la tienne
+La tienne si toujours le délice ! la tienne
 Oui seule qui du ciel évanoui retienne
 Un peu de puéril triomphe en t'en coiffant
 
@@ -2036,7 +2036,7 @@ L'Angoisse, ce minuit, soutient, lampadophore,
 Main rêve vespéral brûlé par le Phénix
 Que ne recueille pas de cinéraire amphore
 
-Sur les crédences, au salon vide: nul ptyx,
+Sur les crédences, au salon vide : nul ptyx,
 Aboli bibelot d'inanité sonore,
 (Car le Maître est aller puiser des pleurs au Styx
 Avec ce seul objet dont le Néant s'honore).
@@ -2099,14 +2099,14 @@ Ainsi qu'une joyeuse et tutélaire torche.
 Tel qu'en Lui-même enfin l'éternité le change,
 Le Poëte suscite avec un glaive nu
 Son siècle épouvanté de n'avoir pas connu
-Que la mort triomphait dans cette voix étrange!
+Que la mort triomphait dans cette voix étrange !
 
 Eux, comme un vil sursaut d'hydre oyant jadis l'Ange
 Donner un sens plus pur aux mots de la tribu
 Proclamèrent très haut le sortilège bu
 Dans le flot sans honneur de quelque noir mélange.
 
-Du sol et de la nue hostiles, ô grief!
+Du sol et de la nue hostiles, ô grief !
 Si notre idée avec ne sculpte un bas-relief
 Dont la tombe de Poe éblouissante s'orne
 
@@ -2173,7 +2173,7 @@ Dont un scintillement argentera la foule.
 
 Qui cherche, parcourant le solitaire bond
 Tantôt extérieur de notre vagabond -
-Verlaine? Il est caché parmi l'herbe, Verlaine
+Verlaine ? Il est caché parmi l'herbe, Verlaine
 
 À ne surprendre que naïvement d'accord
 La lèvre sans y boire ou tarir son haleine
@@ -2200,7 +2200,7 @@ Précipiter avec le manque de mémoire.
 
 Notre si vieil ébat triomphal du grimoire,
 Hiéroglyphes dont s'exalte le millier
-À propager de l'aile un frisson familier!
+À propager de l'aile un frisson familier !
 Enfouissez-le-moi plutôt dans une armoire.
 
 Du souriant fracas originel haï
@@ -2323,7 +2323,7 @@ Sourire du pâle Vasco.
 Tout Orgueil fume-t-il du soir,
 Torche dans un branle étouffée
 Sans que l'immortelle bouffée
-Ne puisse à l'abandon surseoir!
+Ne puisse à l'abandon surseoir !
 
 La chambre ancienne de l'hoir
 De maint riche mais chu trophée
@@ -2360,13 +2360,13 @@ Le col ignoré s'interrompt.
 Je crois bien que deux bouches n'ont
 Bu, ni son amant ni ma mère,
 Jamais à la même Chimère,
-Moi, sylphe de ce froid plafond!
+Moi, sylphe de ce froid plafond !
 
 Le pur vase d'aucun breuvage
 Que l'inexhaustible veuvage
 Agonise mais ne consent,
 
-Naïf baiser des plus funèbres!
+Naïf baiser des plus funèbres !
 À rien expirer annonçant
 Une rose dans les ténèbres.
 </poetry>
@@ -2419,14 +2419,14 @@ Filial on aurait pu naître.
 Quelle soie aux baumes de temps
 Où la Chimère s'exténue
 Vaut la torse et native nue
-Que, hors de ton miroir, tu tends!
+Que, hors de ton miroir, tu tends !
 
 Les trous de drapeaux méditants
-S'exaltent dans notre avenue:
+S'exaltent dans notre avenue :
 Moi, j'ai la chevelure nue
 Pour enfouir mes yeux contents.
 
-Non! La bouche ne sera sûre
+Non ! La bouche ne sera sûre
 De rien goûter à sa morsure
 S'il ne fait, ton princier amant,
 
@@ -2523,8 +2523,8 @@ Si ce très blanc ébat au ras du sol dénie
 À tout site l'honneur du paysage faux.
 
 Ma faim qui d'aucuns fruits ici ne se régale
-Trouve dans leur docte manque une saveur égale:
-Qu'un éclate de chair humain et parfumant!
+Trouve dans leur docte manque une saveur égale :
+Qu'un éclate de chair humain et parfumant !
 
 Le pied sur quelque guivre où notre amour tisonne,
 Je pense plus longtemps peut-être éperdument

--- a/fdirs/musset/1850.xml
+++ b/fdirs/musset/1850.xml
@@ -1914,12 +1914,12 @@ D'expirer comme toi pour un amour divin !
 <body>
 <poetry>
 J'ai perdu ma force et ma vie,
-Et mes amis et ma gaîté;
+Et mes amis et ma gaîté ;
 J'ai perdu jusqu'à la fierté
 Qui faisait croire à mon génie.
 
 Quand j'ai connu la Vérité,
-J'ai cru que c'était une amie;
+J'ai cru que c'était une amie ;
 Quand je l'ai comprise et sentie,
 J'en étais déjà dégoûté.
 
@@ -1945,10 +1945,10 @@ Est d'avoir quelquefois pleuré.
 <body>
 <poetry>
 Avez-vous vu, dans Barcelone,
-Une Andalouse au sein bruni?
-Pâle comme un beau soir d'automne!
-C'est ma maîtresse, ma lionne!
-La Marquesa d'Amaëgui!
+Une Andalouse au sein bruni ?
+Pâle comme un beau soir d'automne !
+C'est ma maîtresse, ma lionne !
+La Marquesa d'Amaëgui !
 
 J'ai bien fait des chansons pour elle,
 Je me suis battu bien souvent,
@@ -1960,15 +1960,15 @@ Elle est à moi, moi seul au monde.
 Ses grands sourcils noirs sont à moi,
 Son corps souple et sa jambe ronde,
 Sa chevelure qui l'inonde,
-Plus longue qu'un manteau de roi!
+Plus longue qu'un manteau de roi !
 
 C'est à moi son beau col qui penche
 Quand elle dort dans son boudoir,
 Et sa basquina sur sa hanche,
 Son bras dans sa mitaine blanche,
-Son pieds dans son brodequin noir!
+Son pieds dans son brodequin noir !
 
-Vrai Dieu! Lorsque son oeil pétille
+Vrai Dieu ! Lorsque son oeil pétille
 Sous la frange de ses réseaux,
 Rien que pour toucher sa mantille,
 De par tous les saints de Castille,
@@ -1978,16 +1978,16 @@ Qu'elle est superbe en son désordre,
 Quand elle tombe, les seins nus,
 Qu'on la voit, béante, se tordre
 Dans un baiser de rage, et mordre
-En criant des mots inconnus!
+En criant des mots inconnus !
 
 Et qu'elle est folle dans sa joie,
 Lorsqu'elle chante le matin,
 Lorsqu'en tirant son bas de soie,
 Elle fait, sur son flanc qui ploie,
-Craquer son corset de satin!
+Craquer son corset de satin !
 
-Allons, mon page, en embuscades!
-Allons! la belle nuit d'été!
+Allons, mon page, en embuscades !
+Allons ! la belle nuit d'été !
 Je veux ce soir des sérénades
 A faire damner les alcades
 De Tolose au Guadalété.

--- a/fdirs/musset/andre.xml
+++ b/fdirs/musset/andre.xml
@@ -23,15 +23,15 @@
 </head>
 <body>
 <poetry>
-Ce livre est toute ma jeunesse;
+Ce livre est toute ma jeunesse ;
 Je l'ai fait sans presque y songer.
 Il y paraît, je le confesse,
 Et j'aurais pu le corriger.
 
 Mais quand l'homme change sans cesse,
-Au passé pourquoi rien changer?
-Va-t'en, pauvre oiseau passager;
-Que Dieu te mène à ton adresse!
+Au passé pourquoi rien changer ?
+Va-t'en, pauvre oiseau passager ;
+Que Dieu te mène à ton adresse !
 
 Qui que tu sois qui me liras
 Lis-en le plus que tu pourras,
@@ -91,15 +91,15 @@ Révérend, répondit
 Mardoche, je m'ennuie,
 Shakspeare dans
 Hamlet, dit qu'on tient à la vie
-Parce qu'on ne sait pas ce qu'on doit voir après;
+Parce qu'on ne sait pas ce qu'on doit voir après ;
 Ses vers me semblent beaux, mais ils seraient plus vrais,
 S'ils disaient qu'on y tient parce qu'une cervelle
 A peur d'un pistolet qui s'applique sur elle,
 Pour la faire craquer et sauter d'un seul bond,
 Comme un bouchon de vin de
 Champagne, au plafond.
-Je ne suis pas douillet! —
-Un suicide! on se damne,
+Je ne suis pas douillet ! —
+Un suicide ! on se damne,
 Mon fils ! —
 Nous n'avons pas, dit
 Mardoche, le crâne

--- a/fdirs/nerval/1854.xml
+++ b/fdirs/nerval/1854.xml
@@ -21,7 +21,7 @@
 <body>
 <poetry>
 Je suis le ténébreux, - le veuf, - l'inconsolé,
-Le prince d'Aquitaine à la tour abolie:
+Le prince d'Aquitaine à la tour abolie :
 Ma seule étoile est morte, - et mon luth constellé
 Porte le soleil noir de la Mélancolie.
 
@@ -30,11 +30,11 @@ Rends-moi le Pausilippe et la mer d'Italie,
 La fleur qui plaisait tant à mon coeur désolé
 Et la treille où le pampre à la rose s'allie.
 
-Suis-je Amour ou Phébus?... Lusignan ou Biron?
-Mon front est rouge encor du baiser de la reine;
+Suis-je Amour ou Phébus ?... Lusignan ou Biron ?
+Mon front est rouge encor du baiser de la reine ;
 J'ai rêvé dans la grotte où nage la sirène...
 
-Et j'ai deux fois vainqueur traversé l'Achéron:
+Et j'ai deux fois vainqueur traversé l'Achéron :
 Modulant tour à tour sur la lyre d'Orphée
 Les soupirs de la sainte et les cris de la fée.
 </poetry>
@@ -68,7 +68,7 @@ Et de cendres soudain l'horizon s'est couvert.
 
 Depuis qu'un duc normand brisa tes dieux d'argile,
 Toujours, sous les rameaux du laurier de Virgile,
-Le pâle Hortensia s'unit au Myrte vert!
+Le pâle Hortensia s'unit au Myrte vert !
 </poetry>
 </body>
 </text>
@@ -84,7 +84,7 @@ Le pâle Hortensia s'unit au Myrte vert!
 </head>
 <body>
 <poetry>
-Le dieu Kneph en tremblant ébranlait l'univers:
+Le dieu Kneph en tremblant ébranlait l'univers :
 Isis, la mère, alors se leva sur sa couche,
 Fit un geste de haine à son époux farouche
 Et l'ardeur d'autrefois brilla dans ses yeux verts.
@@ -92,11 +92,11 @@ Et l'ardeur d'autrefois brilla dans ses yeux verts.
 "Le voyez-vous, dit-elle, il meurt, ce vieux pervers,
 Tous les frimas du monde ont passé par sa bouche,
 Attachez son pied tors, éteignez son oeil louche,
-C'est le dieu des volcans et le roi des hivers!
+C'est le dieu des volcans et le roi des hivers !
 
 L'aigle a déjà passé, l'esprit nouveau m'appelle,
 J'ai revêtu pour lui la robe de Cybèle...
-C'est l'enfant bien-aimé d'Hermès et d'Osiris!"
+C'est l'enfant bien-aimé d'Hermès et d'Osiris !"
 
 La déesse avait fui sur sa conque dorée,
 La mer nous renvoyait son image adorée,
@@ -117,17 +117,17 @@ Et les cieux rayonnaient sous l'écharpe d'Iris.
 <body>
 <poetry>
 Tu demandes pourquoi j'ai tant de rage au coeur
-Et sur un col flexible une tête indomptée;
+Et sur un col flexible une tête indomptée ;
 C'est que je suis issu de la race d'Antée,
 Je retourne les dards contre le dieu vainqueur.
 
 Oui, je suis de ceux-là qu'inspire le Vengeur,
-Il m'a marqué le front de sa lèvre irritée;
-Sous la pâleur d'Abel, hélas! ensanglantée,
-J'ai parfois de Caïn l'implacable rougeur!
+Il m'a marqué le front de sa lèvre irritée ;
+Sous la pâleur d'Abel, hélas ! ensanglantée,
+J'ai parfois de Caïn l'implacable rougeur !
 
-Jéhovah! le dernier, vaincu par ton génie,
-Qui, du fond des enfers, criait: "O tyrannie!"
+Jéhovah ! le dernier, vaincu par ton génie,
+Qui, du fond des enfers, criait : "O tyrannie !"
 C'est mon aïeul Bélus ou mon père Dagon...
 
 Ils m'ont plongé trois fois dans les eaux du Cocyte,
@@ -151,15 +151,15 @@ Je ressème à ses pieds les dents du vieux dragon.
 La connais-tu, Dafné, cette ancienne romance,
 Au pied du sycomore, ou sous les lauriers blancs,
 Sous l'olivier, le myrte, ou les saules tremblants,
-Cette chanson d'amour qui toujours recommence?...
+Cette chanson d'amour qui toujours recommence ?...
 
 Reconnais-tu le Temple au péristyle immense,
 Et les citrons amers où s'imprimaient tes dents,
 Et la grotte, fatale aux hôtes imprudents,
-Où du dragon vaincu dort l'antique semence?...
+Où du dragon vaincu dort l'antique semence ?...
 
-Ils reviendront, ces dieux que tu pleures toujours!
-Le temps va ramener l'ordre des anciens jours;
+Ils reviendront, ces dieux que tu pleures toujours !
+Le temps va ramener l'ordre des anciens jours ;
 La terre a tressailli d'un souffle prophétique...
 
 Cependant la sibylle au visage latin
@@ -180,23 +180,23 @@ Est endormie encor sous l'arc de Constantin
 </head>
 <body>
 <poetry>
-La Treizième revient... C'est encor la première;
-Et c'est toujours la seule, - ou c'est le seul moment;
-Car es-tu reine, ô toi! la première ou dernière?
-Es-tu roi, toi le seul ou le dernier amant?...
+La Treizième revient... C'est encor la première ;
+Et c'est toujours la seule, - ou c'est le seul moment ;
+Car es-tu reine, ô toi ! la première ou dernière ?
+Es-tu roi, toi le seul ou le dernier amant ?...
 
-Aimez qui vous aima du berceau dans la bière;
-Celle que j'aimai seul m'aime encor tendrement:
-C'est la mort - ou la morte... O délice! ô tourment!
+Aimez qui vous aima du berceau dans la bière ;
+Celle que j'aimai seul m'aime encor tendrement :
+C'est la mort - ou la morte... O délice ! ô tourment !
 La rose qu'elle tient, c'est la Rose trémière.
 
 Sainte napolitaine aux mains pleines de feux,
-Rose au coeur violet, fleur de sainte Gudule:
-As-tu trouvé ta croix dans le désert des cieux?
+Rose au coeur violet, fleur de sainte Gudule :
+As-tu trouvé ta croix dans le désert des cieux ?
 
-Roses blanches, tombez! vous insultez nos dieux,
-Tombez, fantômes blancs, de votre ciel qui brûle:
-- La sainte de l'abîme est plus sainte à mes yeux!
+Roses blanches, tombez ! vous insultez nos dieux,
+Tombez, fantômes blancs, de votre ciel qui brûle :
+- La sainte de l'abîme est plus sainte à mes yeux !
 </poetry>
 </body>
 </text>
@@ -205,8 +205,8 @@ Tombez, fantômes blancs, de votre ciel qui brûle:
 <head>
    <title>Le Christ aux Oliviers</title>
    <subtitle>
-      <line><i>Dieu est mort! le ciel est vide...</i></line>
-      <line><i>Pleurez! enfants, vous n'avez plus de père!</i></line>
+      <line><i>Dieu est mort ! le ciel est vide...</i></line>
+      <line><i>Pleurez ! enfants, vous n'avez plus de père !</i></line>
       <line>Jean Paul</line>
    </subtitle>
    <toctitle>Le Christ aux Oliviers</toctitle>
@@ -227,22 +227,22 @@ Et se jugea trahi par des amis ingrats,
 Il se tourna vers ceux qui l'attendaient en bas
 Rêvant d'être des rois, des sages, des prophètes...
 Mais engourdis, perdus dans le sommeil des bêtes,
-Et se prit à crier: "Non, Dieu n'existe pas!"
+Et se prit à crier : "Non, Dieu n'existe pas !"
 
-Ils dormaient. "Mes amis, savez-vous la nouvelle?
-J'ai touché de mon front à la voûte éternelle;
-Je suis sanglant, brisé, souffrant pour bien des jours!
+Ils dormaient. "Mes amis, savez-vous la nouvelle ?
+J'ai touché de mon front à la voûte éternelle ;
+Je suis sanglant, brisé, souffrant pour bien des jours !
 
-Frères, je vous trompais: Abîme! abîme! abîme!
+Frères, je vous trompais : Abîme ! abîme ! abîme !
 Le dieu manque à l'autel où je suis la victime...
-Dieu n'est pas! Dieu n'est plus!" Mais ils dormaient toujours!...
+Dieu n'est pas ! Dieu n'est plus !" Mais ils dormaient toujours !...
 
 		 II
 
-Il reprit: "Tout est mort! J'ai parcouru les mondes;
+Il reprit : "Tout est mort ! J'ai parcouru les mondes ;
 Et j'ai perdu mon vol dans leurs chemins lactés,
 Aussi loin que la vie, en ses veines fécondes,
-Répand des sables d'or et des flots argentés:
+Répand des sables d'or et des flots argentés :
 
 Partout le sol désert côtoyé par des ondes,
 Des tourbillons confus d'océans agités...
@@ -251,70 +251,70 @@ Mais nul esprit n'existe en ces immensités.
 
 En cherchant l'oeil de Dieu, je n'ai vu qu'une orbite
 Vaste, noir. et sans fond, d'où la nuit qui l'habite
-Rayonne sur le monde et s'épaissit toujours;
+Rayonne sur le monde et s'épaissit toujours ;
 
 Un arc-en-ciel étrange entoure ce puits sombre,
 Seuil de l'ancien chaos dont le néant est l'ombre,
-Spirale engloutissant les Mondes et les Jours!
+Spirale engloutissant les Mondes et les Jours !
 
 		III
 
 Immobile Destin, muette sentinelle,
-Froide Nécessité!... Hasard qui, t'avançant
+Froide Nécessité !... Hasard qui, t'avançant
 Parmi les mondes morts sous la neige éternelle,
 Refroidis, par degrés, l'univers pâlissant,
 
 Sais-tu ce que tu fais, puissance originelle,
 De tes soleils éteints, l'un l'autre se froissant...
 Es-tu sûr de transmettre une haleine immortelle,
-Entre un monde qui meurt et l'autre renaissant?...
+Entre un monde qui meurt et l'autre renaissant ?...
 
-O mon père! est-ce toi que je sens en moi-même?
-As-tu pouvoir de vivre et de vaincre la mort?
+O mon père ! est-ce toi que je sens en moi-même ?
+As-tu pouvoir de vivre et de vaincre la mort ?
 Aurais-tu succombé sous un dernier effort
 
-De cet ange des nuits que frappa l'anathème?...
-Car je me sens tout seul à pleurer et souffrir;
-Hélas! et, si je meurs, c'est que tout va mourir!"
+De cet ange des nuits que frappa l'anathème ?...
+Car je me sens tout seul à pleurer et souffrir ;
+Hélas ! et, si je meurs, c'est que tout va mourir !"
 
 		 IV
 
 Nul n'entendait gémir l'éternelle victime,
-Livrant au monde en vain tout son coeur épanché;
+Livrant au monde en vain tout son coeur épanché ;
 Mais prêt à défaillir et sans force penché,
-Il appela le seul - éveillé dans Solyme:
+Il appela le seul - éveillé dans Solyme :
 
-"Judas! lui cria-t-il, tu sais ce qu'on m'estime,
-Hâte-toi de me vendre, et finis ce marché:
-Je suis souffrant, ami! sur la terre couché...
-Viens! ô toi qui, du moins, as la force du crime!"
+"Judas ! lui cria-t-il, tu sais ce qu'on m'estime,
+Hâte-toi de me vendre, et finis ce marché :
+Je suis souffrant, ami ! sur la terre couché...
+Viens ! ô toi qui, du moins, as la force du crime !"
 
 Mais Judas s'en allait, mécontent et pensif,
 Se trouvant mal payé, plein d'un remords si vif
 Qu'il lisait ses noirceurs sur tous les murs écrites...
 
 Enfin Pilate seul, qui veillait pour César,
-Sentant quelque pitié, se tourna par hasard:
-"Allez chercher ce fou!" dit-il aux satellites.
+Sentant quelque pitié, se tourna par hasard :
+"Allez chercher ce fou !" dit-il aux satellites.
 
 		 V
 
 C'était bien lui, ce fou, cet insensé sublime...
 Cet Icare oublié qui remontait les cieux,
 Ce Phaéton perdu sous la foudre des dieux,
-Ce bel Atys meurtri que Cybèle ranime!
+Ce bel Atys meurtri que Cybèle ranime !
 
 L'augure interrogeait le flanc de la victime,
 La terre s'enivrait de ce sang précieux...
 L'univers étourdi penchait sur ses essieux,
 Et l'Olympe un instant chancela vers l'abîme.
 
-"Réponds! criait César à Jupiter Ammon,
-Quel est ce nouveau dieu qu'on impose à la terre?
+"Réponds ! criait César à Jupiter Ammon,
+Quel est ce nouveau dieu qu'on impose à la terre ?
 Et si ce n'est un dieu, c'est au moins un démon..."
 
-Mais l'oracle invoqué pour jamais dut se taire;
-Un seul pouvait au monde expliquer ce mystère:
+Mais l'oracle invoqué pour jamais dut se taire ;
+Un seul pouvait au monde expliquer ce mystère :
 - Celui qui donna l'âme aux enfants du limon.
 </poetry>
 </body>
@@ -324,34 +324,34 @@ Un seul pouvait au monde expliquer ce mystère:
 <head>
    <title>Vers Dores</title>
    <subtitle>
-      <line><i>Eh quoi! tout est sensible.</i></line>
+      <line><i>Eh quoi ! tout est sensible.</i></line>
       <line>Pythagore</line>
    </subtitle>
    <toctitle>Vers Dores</toctitle>
    <indextitle>Vers Dores</indextitle>
-   <firstline>Homme! libre penseur! te crois-tu seul pensant</firstline>
+   <firstline>Homme ! libre penseur ! te crois-tu seul pensant</firstline>
    <quality>korrektur1</quality>
    <keywords>sonnet</keywords>
 </head>
 <body>
 <poetry>
-Homme! libre penseur! te crois-tu seul pensant
-Dans ce monde où la vie éclate en toute chose?
+Homme ! libre penseur ! te crois-tu seul pensant
+Dans ce monde où la vie éclate en toute chose ?
 Des forces que tu tiens ta liberté dispose,
 Mais de tous tes conseils l'univers est absent.
 
-Respecte dans la bête un esprit agissant:
-Chaque fleur est une âme à la Nature éclose;
-Un mystère d'amour dans le métal repose;
-"Tout est sensible!" Et tout sur ton être est puissant.
+Respecte dans la bête un esprit agissant :
+Chaque fleur est une âme à la Nature éclose ;
+Un mystère d'amour dans le métal repose ;
+"Tout est sensible !" Et tout sur ton être est puissant.
 
-Crains, dans le mur aveugle, un regard qui t'épie:
+Crains, dans le mur aveugle, un regard qui t'épie :
 A la matière même un verbe est attaché...
-Ne la fais pas servir à quelque usage impie!
+Ne la fais pas servir à quelque usage impie !
 
-Souvent dans l'être obscur habite un Dieu caché;
+Souvent dans l'être obscur habite un Dieu caché ;
 Et, comme un oeil naissant couvert par ses paupières,
-Un pur esprit s'accroît sous l'écorce des pierres!
+Un pur esprit s'accroît sous l'écorce des pierres !
 </poetry>
 </body>
 </text>

--- a/fdirs/soulary/1876-83.xml
+++ b/fdirs/soulary/1876-83.xml
@@ -12,14 +12,14 @@
     <title>Les deux cortèges</title>
     <firstline>Deux cortèges se sont rencontrés à l'église</firstline>
     <notes>
-        <note>Teksten følger Joséphin Soulary: <i>Oeuvres poétiques</i>, (1876-84), bd. 1, p. 177.</note>
+        <note>Teksten følger Joséphin Soulary : <i>Oeuvres poétiques</i>, (1876-84), bd. 1, p. 177.</note>
         <!-- https://gallica.bnf.fr/ark:/12148/bpt6k207013s/f181.image -->
     </notes>
 </head>
 <body>
 <poetry>
 Deux cortèges se sont rencontrés à l'église.
-L'un est morne: - il conduit le cercueil d'un enfant ;
+L'un est morne : - il conduit le cercueil d'un enfant ;
 Une femme le suit, presque folle, étouffant
 Dans sa poitrine en feu le sanglot qui la brise.
 

--- a/fdirs/verlaine/1874.xml
+++ b/fdirs/verlaine/1874.xml
@@ -35,7 +35,7 @@ Parmi l'étreinte des brises,
 C'est, vers les ramures grises,
 Le choeur des petites voix.
 
-O le frêle et frais murmure!
+O le frêle et frais murmure !
 Cela gazouille et susurre,
 Cela ressemble au cri doux
 Que l'herbe agitée expire...
@@ -44,10 +44,10 @@ Le roulis sourd des cailloux.
 
 Cette âme qui se lamente
 En cette plainte dormante
-C'est la nôtre, n'est-ce pas?
+C'est la nôtre, n'est-ce pas ?
 La mienne, dis, et la tienne,
 Dont s'exhale l'humble antienne
-Par ce tiède soir, tout bas?
+Par ce tiède soir, tout bas ?
 </poetry>
 </body>
 </text>
@@ -63,17 +63,17 @@ Par ce tiède soir, tout bas?
 Je devine, à travers un murmure,
 Le contour subtil des voix anciennes
 Et dans les lueurs musiciennes,
-Amour pâle, une aurore future!
+Amour pâle, une aurore future !
 
 Et mon âme et mon coeur en délires
 Ne sont plus qu'une espèce d'oeil double
 Où tremblote à travers un jour trouble
-L'ariette, hélas! de toutes lyres!
+L'ariette, hélas ! de toutes lyres !
 
 O mourir de cette mort seulette
 Que s'en vont, - cher amour qui t'épeures,
-Balançant jeunes et vieilles heures!
-O mourir de cette escarpolette!
+Balançant jeunes et vieilles heures !
+O mourir de cette escarpolette !
 </poetry>
 </body>
 </text>
@@ -92,24 +92,24 @@ O mourir de cette escarpolette!
 <body>
 <poetry>
 Il pleure dans mon coeur
-Comme il pleut sur la ville;
+Comme il pleut sur la ville ;
 Quelle est cette langueur
-Qui pénètre mon coeur?
+Qui pénètre mon coeur ?
 
 Ô bruit doux de la pluie
-Par terre et sur les toits!
+Par terre et sur les toits !
 Pour un coeur qui s'ennuie
-Ô le chant de la pluie!
+Ô le chant de la pluie !
 
 Il pleure sans raison
 Dans ce coeur qui s'écoeure
-Quoi! nulle trahison?...
+Quoi ! nulle trahison ?...
 Ce deuil est sans raison.
 
 C'est bien la pire peine
 De ne savoir pourquoi
 Sans amour et sans haine
-Mon coeur a tant de peine!
+Mon coeur a tant de peine !
 </poetry>
 </body>
 </text>
@@ -126,15 +126,15 @@ Mon coeur a tant de peine!
 </head>
 <body>
 <poetry>
-Il faut, voyez-vous, nous pardonner les choses:
+Il faut, voyez-vous, nous pardonner les choses :
 De cette façon nous serons bien heureuses
 Et si notre vie a des instants moroses
-Du moins nous serons, n'est-ce pas? deux pleureuses.
+Du moins nous serons, n'est-ce pas ? deux pleureuses.
 
 O que nous mêlions, âmes soeurs que nous sommes,
 A nos voeux confus la douceur puérile
 De cheminer loin des femmes et des hommes,
-Dans le frais oubli de ce qui nous exile!
+Dans le frais oubli de ce qui nous exile !
 
 Soyons deux enfants, soyons deux jeunes filles
 Eprises de rien et de tout étonnées
@@ -164,11 +164,11 @@ Rôde discret, épeuré quasiment,
 Par le boudoir longtemps parfumé d'Elle.
 
 Qu'est-ce que c'est que ce berceau soudain
-Qui lentement dorlote mon pauvre être?
-Que voudrais-tu de moi, doux Chant badin?
+Qui lentement dorlote mon pauvre être ?
+Que voudrais-tu de moi, doux Chant badin ?
 Qu'as-tu voulu, fin refrain incertain
 Qui vas tantôt mourir vers la fenêtre
-Ouverte un peu sur le petit jardin?
+Ouverte un peu sur le petit jardin ?
 </poetry>
 </body>
 </text>
@@ -194,27 +194,27 @@ Verdissent sur le pauvre mur.
 Et voici venir La Ramée
 Sacrant, en bon soldat du Roy
 Sous son habit blanc mal famé
-Son coeur ne se tient pas de joie:
+Son coeur ne se tient pas de joie :
 
-Car la Boulangère... - Elle? - Oui dam!
+Car la Boulangère... - Elle ? - Oui dam !
 Bernant Lustucru son vieil homme
 A tantôt couronné sa flamme...
-Enfants, Dominus vobiscum!
+Enfants, Dominus vobiscum !
 
-Place! En sa longue robe bleue
+Place ! En sa longue robe bleue
 Toute en satin qui fait frou-frou,
-C'est une impure palsambleu!
+C'est une impure palsambleu !
 Dans sa chaise qu'il faut qu'on loue,
 
 Fût-on philosophe ou grigou,
 Car tant d'or s'y relève en bosse
 Que ce luxe insolent bafoue
-Tout le papier de Monsieur Los!
+Tout le papier de Monsieur Los !
 
-Arrière robin crotté! place,
+Arrière robin crotté ! place,
 Petit courtaud, petit abbé,
 Petit poète jamais las
-De la rime non attrapée!...
+De la rime non attrapée !...
 
 Voici que la nuit vraie arrive...
 Cependant jamais fatigué
@@ -245,16 +245,16 @@ Je ne me suis pas consolé,
 Bien que mon coeur s'en soit allé.
 
 Et mon coeur, mon coeur trop sensible
-Dit à mon âme: Est-il possible,
+Dit à mon âme : Est-il possible,
 
 Est-il possible, - le fût-il -
-Ce fier exil, ce triste exil?
+Ce fier exil, ce triste exil ?
 
-Mon âme dit à mon coeur: Sais-je
+Mon âme dit à mon coeur : Sais-je
 Moi-même que nous veut ce piège
 
 D'être présents bien qu'exilés,
-Encore que loin en allés?
+Encore que loin en allés ?
 </poetry>
 </body>
 </text>
@@ -290,7 +290,7 @@ Et mourir la lune.
 Corneille poussive
 Et vous, les loups maigres,
 Par ces bises aigres
-Quoi donc vous arrive?
+Quoi donc vous arrive ?
 
 Dans l'interminable
 Ennui de la plaine
@@ -321,7 +321,7 @@ Se plaignent les tourterelles.
 Combien, ô voyageur, ce paysage blême
 Te mira blême toi-même,
 Et que tristes pleuraient dans les hautes feuillées
-Tes espérances noyées!
+Tes espérances noyées !
 
 Mai, juin 72.
 </poetry>
@@ -349,22 +349,22 @@ Mai, juin 72.
 Briques et tuiles
 O les charmants
 Petits asiles
-Pour les amants!
+Pour les amants !
 
 Houblons et vignes,
 Feuilles et fleurs,
 Tentes insignes
-Des francs buveurs!
+Des francs buveurs !
 
 Guinguettes claires,
 Bières, clameurs,
 Servantes chères
-A tous fumeurs!
+A tous fumeurs !
 
 Gares prochaines,
 Gais chemins grands...
 Quelles aubaines,
-Bons juifs-errants!
+Bons juifs-errants !
 
 Juillet 72.
 </poetry>
@@ -386,7 +386,7 @@ Les Kobolds vont.
 Le vent profond
 Pleure, on veut croire.
 
-Quoi donc se sent?
+Quoi donc se sent ?
 L'avoine siffle.
 Un buisson gifle
 L'oeil au passant.
@@ -394,22 +394,22 @@ L'oeil au passant.
 Plutôt des bouges
 Que des maisons.
 Quels horizons
-De forges rouges!
+De forges rouges !
 
-On sent donc quoi?
+On sent donc quoi ?
 Des gares tonnent,
 Les yeux s'étonnent,
-Où Charleroi?
+Où Charleroi ?
 
-Parfums sinistres!
-Qu'est-ce que c'est?
+Parfums sinistres !
+Qu'est-ce que c'est ?
 Quoi bruissait
-Comme des sistres?
+Comme des sistres ?
 
-Sites brutaux!
-Oh! votre haleine,
+Sites brutaux !
+Oh ! votre haleine,
 Sueur humaine
-Cris des métaux!
+Cris des métaux !
 
 Dans l'herbe noire
 Les Kobolds vont.
@@ -449,24 +449,24 @@ II
 
 L'allée est sans fin
 Sous le ciel, divin
-D'être pâle ainsi:
+D'être pâle ainsi :
 Sais-tu qu'on serait
 Bien sous le secret
-De ces arbres-ci?
+De ces arbres-ci ?
 
 Des messieurs bien mis,
 Sans nul doute amis
 Des Royers-Collards,
-Vont vers le château:
+Vont vers le château :
 J'estimerais beau
 D'être ces vieillards.
 
 Le château, tout blanc
 Avec, à son flanc,
 Le soleil couché,
-Les champs à l'entour:
-Oh! que notre amour
-N'est-il là niché!
+Les champs à l'entour :
+Oh ! que notre amour
+N'est-il là niché !
 
 Estaminet du Jeune Renard, août 72.
 </poetry>
@@ -480,7 +480,7 @@ Estaminet du Jeune Renard, août 72.
         <line>Par saint Gille,</line>
         <line>Viens-nous-en,</line>
         <line>Mon agile</line>
-        <line>Alezan!</line>
+        <line>Alezan !</line>
         <line>(V. Hugo)</line>
     </subtitle>
     <toctitle>Bruxelles - Chevaux de bois</toctitle>
@@ -506,7 +506,7 @@ Clignote l'oeil du filou sournois
 Tournez au son du piston vainqueur.
 
 C'est ravissant comme ça vous soûle
-D'aller ainsi dans ce cirque bête:
+D'aller ainsi dans ce cirque bête :
 Bien dans le ventre et mal dans la tête,
 Du mal en masse et du bien en foule.
 
@@ -515,15 +515,15 @@ D'user jamais de nuls éperons
 Pour commander à vos galops ronds,
 Tournez, tournez, sans espoir de foin
 
-Et dépêchez, chevaux de leur âme:
+Et dépêchez, chevaux de leur âme :
 Déjà voici que la nuit qui tombe
 Va réunir pigeon et colombe
 Loin de la foire et loin de madame.
 
-Tournez, tournez! le ciel en velours
+Tournez, tournez ! le ciel en velours
 D'astres en or se vêt lentement.
 Voici partir l'amante et l'amant.
-Tournez au son joyeux des tambours!
+Tournez au son joyeux des tambours !
 
 Champ de foire de Saint-Gilles, août 72.
 </poetry>
@@ -554,9 +554,9 @@ Trèfle, luzerne et blancs gazons.
 
 Les wagons filent en silence
 Parmi ces sites apaisés.
-Dormez, les vaches! Reposez,
+Dormez, les vaches ! Reposez,
 Doux taureaux de la plaine immense,
-Sous vos cieux à peine irisés!
+Sous vos cieux à peine irisés !
 
 Le train glisse sans un murmure,
 Chaque wagon est un salon
@@ -579,18 +579,18 @@ Août 72
 </head>
 <body>
 <poetry>
-Vous n'avez pas eu toute patience:
+Vous n'avez pas eu toute patience :
 Cela se comprend par malheur, de reste
-Vous êtes si jeune! Et l'insouciance,
-C'est le lot amer de l'âge céleste!
+Vous êtes si jeune ! Et l'insouciance,
+C'est le lot amer de l'âge céleste !
 
 Vous n'avez pas eu toute la douceur.
-Cela par malheur d'ailleurs se comprend;
+Cela par malheur d'ailleurs se comprend ;
 Vous êtes si jeune, ô ma froide soeur,
-Que votre coeur doit être indifférent!
+Que votre coeur doit être indifférent !
 
 Aussi, me voici plein de pardons chastes,
-Non, certes! joyeux, mais très calme en somme
+Non, certes ! joyeux, mais très calme en somme
 Bien que je déplore en ces mois néfastes
 D'être, grâce à vous, le moins heureux homme.
 
@@ -602,19 +602,19 @@ Ne couvaient plus rien que la trahison.
 Vous juriez alors que c'était mensonge
 Et votre regard qui mentait lui-même
 Flambait comme un feu mourant qu'on prolonge,
-Et de votre voix vous disiez: "Je t'aime!"
+Et de votre voix vous disiez : "Je t'aime !"
 
-Hélas! on se prend toujours au désir
+Hélas ! on se prend toujours au désir
 Qu'on a d'être heureux malgré la saison...
 Mais ce fut un jour plein d'amer plaisir
-Quand je m'aperçus que j'avais raison!
+Quand je m'aperçus que j'avais raison !
 
-Aussi bien pourquoi me mettrais-je à geindre?
+Aussi bien pourquoi me mettrais-je à geindre ?
 Vous ne m'aimiez pas, l'affaire est conclue,
 Et, ne voulant pas qu'on ose me plaindre,
 Je souffrirai d'une âme résolue.
 
-Oui! je souffrirai, car je vous aimais!
+Oui ! je souffrirai, car je vous aimais !
 Mais je souffrirai comme un bon soldat
 Blessé qui s'en va dormir à jamais
 Plein d'amour pour quelque pays ingrat.
@@ -622,9 +622,9 @@ Plein d'amour pour quelque pays ingrat.
 Vous qui fûtes ma Belle, ma Chérie,
 Encor que de vous vienne ma souffrance,
 N'êtes-vous donc pas toujours ma Patrie,
-Aussi jeune, aussi folle que la France?
+Aussi jeune, aussi folle que la France ?
 
-Or, je ne veux pas - le puis-je d'abord? -
+Or, je ne veux pas - le puis-je d'abord ? -
 Plonger dans ceci mes regards mouillés.
 Pourtant mon amour que vous croyez mort
 A peut-être enfin les yeux dessillés.
@@ -637,14 +637,14 @@ Souffrir longtemps jusqu'à ce qu'il en meure,
 Peut-être a raison de croire entrevoir
 En vous un remords (qui n'est pas banal)
 Et d'entendre dire, en son désespoir,
-A votre mémoire. "Ah! fi! que c'est mal!"
+A votre mémoire. "Ah ! fi ! que c'est mal !"
 
 Je vous vois encor. J'entr'ouvris la porte.
 Vous étiez au lit comme fatiguée.
 Mais, ô corps léger que l'amour emporte,
 Vous bondîtes nue, éplorée et gaie.
 
-O quels baisers, quels enlacements fous!
+O quels baisers, quels enlacements fous !
 J'en riais moi-même à travers mes pleurs.
 Certes, ces instants seront, entre tous
 Mes plus tristes, mais aussi mes meilleurs.
@@ -654,7 +654,7 @@ Et de vos bons yeux en cette occurrence
 Et de vous enfin, qu'il faudrait maudire,
 Et du piège exquis, rien que l'apparence.
 
-Je vous vois encore! En robe d'été
+Je vous vois encore ! En robe d'été
 Blanche et jaune avec des fleurs de rideaux.
 Mais vous n'aviez plus l'humide gaîté
 Du plus délirant de tous nos tantôts.
@@ -664,8 +664,8 @@ Etait reparue avec la toilette
 Et c'était déjà notre destinée
 Qui me regardait sous votre voilette.
 
-Soyez pardonnée! Et c'est pour cela
-Que je garde, hélas! avec quelque orgueil,
+Soyez pardonnée ! Et c'est pour cela
+Que je garde, hélas ! avec quelque orgueil,
 En mon souvenir, qui vous cajola,
 L'éclair de côté que coulait votre oeil.
 
@@ -679,10 +679,10 @@ Qui se sait damné s'il n'est confessé
 Et, perdant l'espoir de nul confesseur,
 Se tord dans l'Enfer, qu'il a devancé.
 
-O mais! par instants, j'ai l'extase rouge
+O mais ! par instants, j'ai l'extase rouge
 Du premier chrétien sous la dent rapace,
 Qui rit à Jésus témoin, sans que bouge
-Un poil de sa chair, un nerf de sa face!
+Un poil de sa chair, un nerf de sa face !
 
 Bruxelles. Londres, septembre - octobre 72
 </poetry>
@@ -744,14 +744,14 @@ Renaissent tous mes désespoirs.
 Le ciel était trop bleu, trop tendre,
 La mer trop verte et l'air trop doux.
 
-Je crains toujours, - ce qu'est d'attendre! -
+Je crains toujours, - ce qu'est d'attendre ! -
 Quelque fuite atroce de vous.
 
 Du houx à la feuille vernie
 Et du luisant buis je suis las,
 
 Et de la campagne infinie
-Et de tout, fors de vous, hélas!
+Et de tout, fors de vous, hélas !
 </poetry>
 </body>
 </text>
@@ -761,44 +761,44 @@ Et de tout, fors de vous, hélas!
     <title>Streets</title>
     <toctitle>Streets</toctitle>
     <indextitle>Streets</indextitle>
-    <firstline>Dansons la gigue!</firstline>
+    <firstline>Dansons la gigue !</firstline>
     <quality>korrektur1</quality>
 </head>
 <body>
 <poetry>
 I
 
-Dansons la gigue!
+Dansons la gigue !
 
 J'aimais surtout ses jolis yeux
 Plus clairs que l'étoile des cieux,
 J'aimais ses yeux malicieux.
 
-Dansons la gigue!
+Dansons la gigue !
 
 Elle avait des façons vraiment
 De désoler un pauvre amant,
-Que c'en était vraiment charmant!
+Que c'en était vraiment charmant !
 
-Dansons la gigue!
+Dansons la gigue !
 
 Mais je trouve encore meilleur
 Le baiser de sa bouche en fleur
 Depuis qu'elle est morte à mon coeur.
 
-Dansons la gigue!
+Dansons la gigue !
 
 Je me souviens, je me souviens
 Des heures et des entretiens,
 Et c'est le meilleur de mes biens.
 
-Dansons la gigue!
+Dansons la gigue !
 
 Soho
 
 II
 
-O la rivière dans la rue!
+O la rivière dans la rue !
 Fantastiquement apparue
 Derrière un mur haut de cinq pieds,
 Elle roule sans un murmure
@@ -828,7 +828,7 @@ Paddington.
 <body>
 <poetry>
 Vous n'avez rien compris à ma simplicité,
-Rien, ô ma pauvre enfant!
+Rien, ô ma pauvre enfant !
 Et c'est avec un front éventé, dépité,
 Que vous fuyez devant.
 
@@ -839,18 +839,18 @@ Qui nous fait mal à voir.
 
 Et vous gesticulez avec vos petits bras
 Comme un héros méchant,
-En poussant d'aigres cris poitrinaires, hélas!
-Vous qui n'étiez que chant!
+En poussant d'aigres cris poitrinaires, hélas !
+Vous qui n'étiez que chant !
 
 Car vous avez eu peur de l'orage et du coeur
 Qui grondait et sifflait,
-Et vous bêlâtes vers votre mère - ô douleur! -
+Et vous bêlâtes vers votre mère - ô douleur ! -
 Comme un triste agnelet.
 
 Et vous n'aurez pas su la lumière et l'honneur
 D'un amour brave et fort,
 Joyeux dans le malheur, grave dans le bonheur,
-Jeune jusqu'à la mort!
+Jeune jusqu'à la mort !
 
 Londres, 2 avril 1873
 </poetry>
@@ -870,31 +870,31 @@ Londres, 2 avril 1873
 J'ai peur d'un baiser
 Comme d'une abeille.
 Je souffre et je veille
-Sans me reposer:
-J'ai peur d'un baiser!
+Sans me reposer :
+J'ai peur d'un baiser !
 
 Pourtant j'aime Kate
 Et ses yeux jolis.
 Elle est délicate,
 Aux longs traits pâlis.
-Oh! que j'aime Kate!
+Oh ! que j'aime Kate !
 
-C'est Saint-Valentin!
+C'est Saint-Valentin !
 Je dois et je n'ose
 Lui dire au matin...
 La terrible chose
-Que Saint-Valentin!
+Que Saint-Valentin !
 
 Elle m'est promise,
-Fort heureusement!
+Fort heureusement !
 Mais quelle entreprise
 Que d'être un amant
-Près d'une promise!
+Près d'une promise !
 
 J'ai peur d'un baiser
 Comme d'une abeille.
 Je souffre et je veille
-Sans me reposer:
+Sans me reposer :
 J'ai peur d'un baiser
 </poetry>
 </body>
@@ -918,7 +918,7 @@ Et nous voilà marchant par le chemin amer.
 Le soleil luisait haut dans le ciel calme et lisse,
 Et dans ses cheveux blonds c'étaient des rayons d'or,
 Si bien que nous suivions son pas plus calme encor
-Que le déroulement des vagues, ô délice!
+Que le déroulement des vagues, ô délice !
 
 Des oiseaux blancs volaient alentour mollement
 Et des voiles au loin s'inclinaient toutes blanches.


### PR DESCRIPTION
Denne PR genskaber fransk tegnsætningsmellemrum før `?`, `!`, `;` og `:` i nyere franske værk-filer.

Ældre franske tekster er bevidst rullet tilbage og ikke rettet i denne omgang.

Der er også tilføjet en test i `poem-lines`, som kontrollerer moderne fransk tegnsætningsmellemrum for franske digte, hvor digteren er født i eller efter 1800, eller hvor værkets filnavn angiver udgivelsesår i eller efter 1800. Testen læser metadata som tekst og undgår at XML-parse alle værker.

Testet med:

```sh
npm test -- --runTestsByPath __tests__/poem-lines.js
```