### PR TITLE
Fjern overflødige keyword-referencer

### DIFF
--- a/fdirs/ahlmann/1913.xml
+++ b/fdirs/ahlmann/1913.xml
@@ -458,7 +458,7 @@ Du talte saa dybt til mit Hjerte:
         <note>Se Stuckenbergs <xref poem="stuckenberg20000924177C"/>.</note>
     </notes>
     <source pages="23-24"/>
-    <keywords>verlaine,stuckenberg</keywords>
+    <keywords>verlaine</keywords>
     <quality>korrektur1,kilde,side</quality>
 </head>
 <body>

--- a/fdirs/andersen/1832.xml
+++ b/fdirs/andersen/1832.xml
@@ -845,7 +845,6 @@ Men ægte Guldet er i den.
    <indextitle>P. M. Møller</indextitle>
    <firstline>Digtertræet staaer i Danas Have</firstline>
    <source pages="25"/>
-   <keywords>moellerpm</keywords>
    <quality>korrektur1,kilde,side</quality>
 </head>
 <body>
@@ -1345,7 +1344,6 @@ Og lærte: der er ogsaa Fryd i Taarer
       <note>Alluderer til Wessels <xref poem="wessel2002092216"/>.</note>
    </notes>
    <source pages="37"/>
-   <keywords>wessel</keywords>
    <quality>korrektur1,kilde,side</quality>
 </head>
 <body>

--- a/fdirs/andersen/andre.xml
+++ b/fdirs/andersen/andre.xml
@@ -1639,7 +1639,7 @@ Den veed, man kan æde den ud af sit Huus!
       <note>Om Rosenvænget og udsigten derfra over Øresund, se også Ibsens <xref poem="ibsen2002010601"/> fra 1871. Ejendommen ,,Rolighed'' tilhørte familien Melchior som tog sig meget af HCA i disse år, og dér døde han den 4. august 1875.</note>
       <note type="credits">Bidrag fra Sven Sørensen.</note>
    </notes>
-   <keywords>oersted,wilster,heibergjohanne,bergsoe,ewald</keywords>
+   <keywords>oersted,wilster,heibergjohanne,bergsoe</keywords>
    <quality>korrektur1,kilde</quality>
 </head>
 <body>

--- a/fdirs/arentzen/1862.xml
+++ b/fdirs/arentzen/1862.xml
@@ -4077,7 +4077,7 @@ for Fremtids Storme betrygget!
     <title>Ambrosius Stub</title>
     <firstline>Han var kun en stakkels fattig Student</firstline>
     <source pages="165-166"/>
-    <keywords>stub,holberg</keywords>
+    <keywords>holberg</keywords>
     <quality>korrektur1,kilde,side</quality>
 </head>
 <body>

--- a/fdirs/arentzen/1888.xml
+++ b/fdirs/arentzen/1888.xml
@@ -7452,7 +7452,7 @@ hvor Amor svinger sin Bue.
     <title>Ambrosius Stub</title>
     <firstline>Han var kun en stakkels fattig Student</firstline>
     <source pages="267-268"/>
-    <keywords>stub,holberg</keywords>
+    <keywords>holberg</keywords>
     <quality>korrektur1,kilde,side</quality>
 </head>
 <body>

--- a/fdirs/baggesen/1816d.xml
+++ b/fdirs/baggesen/1816d.xml
@@ -25,7 +25,6 @@
       <note>Teksten følger <i>Danfana</i> 1816, bind I, side 9-11.</note>
       <note>Første strofe alluderer til Oehlenschlägers <xref poem="oehlenschlaegers-valravnen,81-101"/>.</note>
    </notes>
-   <keywords>oehlenschlaeger</keywords>
    <quality>korrektur1,kilde,side</quality>
 </head>
 <body>
@@ -231,7 +230,7 @@ Og fandt en venlig Andagts-Gnist herneden,
    <notes>
       <note>Teksten følger <i>Danfana</i> 1816, bind I, side 60-66.</note>
    </notes>
-   <keywords>oehlenschlaeger,thiele</keywords>
+   <keywords>thiele</keywords>
    <quality>korrektur1,kilde,side</quality>
 </head>
 <body>

--- a/fdirs/baggesen/1819.xml
+++ b/fdirs/baggesen/1819.xml
@@ -1943,7 +1943,6 @@ At den eeneste Trøst endnu maa qvæge mit Hierte!
    </notes>
    <source pages="81-83"/>
    <quality>korrektur1,kilde,side</quality>
-   <keywords>oehlenschlaeger</keywords>
 </head>
 <body>
 <poetry>

--- a/fdirs/bergenhammer/andre.xml
+++ b/fdirs/bergenhammer/andre.xml
@@ -146,7 +146,7 @@ saa mange glade Qvad.
       <note>Indtastet fra <i>Digter-Krands - En Samling af udkaarede ældre og nyere Selskabssange</i>, Odense, 1826. Trykker og udgiver er S. Hempel "Eier af Fyens Adressekontoir".</note>
    </notes>
    <quality>korrektur1,kilde</quality>
-   <keywords>drikkevise,zetlitz</keywords>
+   <keywords>drikkevise</keywords>
 </head>
 <body>
 <poetry>

--- a/fdirs/bering/andre.xml
+++ b/fdirs/bering/andre.xml
@@ -86,7 +86,6 @@ Beklæde mange Aar sit Kongelige Sæde /
       <note>Der hersker imidlertid tvivl om digtet vitterligt er fra Berings egen hånd, da ,,Alconius Patismus'' ikke er et kendt pseudonym for Bering. En anden kilde angiver en ,,Nic: Stampe'' som forfatter.</note>
       <note>Indtastet efter Viggo J. von Holstein Rathlou: <i>Dansk Renaissance Digtning</i>, Kbh., 1914, pp. 26-27.</note>
    </notes>
-   <keywords>bording</keywords>
    <quality>korrektur1,kilde,side</quality>
 </head>
 <body>

--- a/fdirs/berntsen/1910.xml
+++ b/fdirs/berntsen/1910.xml
@@ -540,7 +540,6 @@ er som en Klang af fjærne, gyldne Klokker.
         <note>Se <xref poem="oehlen2002101107"/>.</note>
     </notes>
     <source pages="30-31"/>
-    <keywords>oehlenschlaeger</keywords>
     <quality>korrektur1,kilde,side</quality>
 </head>
 <body>

--- a/fdirs/blicher/1847.xml
+++ b/fdirs/blicher/1847.xml
@@ -6734,7 +6734,6 @@ Griffenfelder ingen mere.
     <notes>
        <note>Cf. Johannes Ewalds <xref poem="ewlad1999022205"/>.</note>
     </notes>
-    <keywords>ewald</keywords>
     <firstline>Niels Juel gav Agt paa Stormens Brag</firstline>
     <source in="bd1" pages="197-199"/>
 </head>

--- a/fdirs/bording/andre.xml
+++ b/fdirs/bording/andre.xml
@@ -432,7 +432,6 @@ Jo glattere Hud, jo stoltere Møe.
       <note>Bering svarer tilbage med digtet <xref poem="bering2002111601"/>.</note>
       <note>Indtastet efter Viggo J. von Holstein Rathlou: <i>Dansk Renaissance Digtning</i>, Kbh., 1914, pp. 23-25.</note>
    </notes>
-   <keywords>bering</keywords>
    <quality>korrektur1,kilde,side</quality>
 </head>
 <body>

--- a/fdirs/bruunmc/1796.xml
+++ b/fdirs/bruunmc/1796.xml
@@ -344,7 +344,6 @@ Udvalgte Hær! Med Trin, som Langulaffers,
       <note>Teksten følger Malthe Conrad Bruun: <i>Akristokraternes Catechismus</i>, K.F. Plesner (red.), Fagskolen for Boghaandværk, Kbh., 1945, pp. 34-37.</note>
       <note>Melodien er fra Jens Zetlitz' <xref poem="zetlitz2017101301"/>.</note>
    </notes>
-   <keywords>zetlitz</keywords>
    <quality>korrektur1,kilde,side</quality>
 </head>
 <body>
@@ -445,7 +444,6 @@ Til Kamp! Til Kamp imod Kjætterskokken!
       <note>Melodien er fra Jens Zetlitz' vise <xref poem="zetlitz2001070701"/>.</note>
       <note type="credits">Bidrag fra Sven Sørensen.</note>
    </notes>
-   <keywords>zetlitz</keywords>
    <quality>korrektur1,kilde,side</quality>
 </head>
 <body>

--- a/fdirs/dolleris/1894.xml
+++ b/fdirs/dolleris/1894.xml
@@ -126,7 +126,7 @@ og vies til din Tjener,
     <dates>
         <event>1893-04-22</event>
     </dates>
-    <keywords>boedtcher,winther</keywords>
+    <keywords>winther</keywords>
     <source pages="11-14"/>
     <quality>korrektur1,korrektur2,side,side</quality>
 </head>
@@ -1217,7 +1217,6 @@ for al Skabningens Sol i Fortærelsens Brand!
     <firstline>Der findes en gammel Vise</firstline>
     <!-- TODO: Find folkevisen »Det haver saa nyligen regnet«. -->
     <source pages="58-60"/>
-    <keywords>reckee</keywords>
     <quality>korrektur1,korrektur2,side,side</quality>
 </head>
 <body>

--- a/fdirs/drachmann/1875.xml
+++ b/fdirs/drachmann/1875.xml
@@ -2619,7 +2619,6 @@ En Haabende blandt Haabets sidste Rester.
         <note>Citatet stammer fra Goethes digt <xref poem="goethe2018012902,9-12"/>.</note>
     </notes>
     <source pages="106-120"/>
-    <keywords>goethe</keywords>
     <quality>korrektur1,korrektur2,kilde,side</quality>
 </head>
 <body>
@@ -3068,7 +3067,6 @@ Og Svaret det samme: Stene!
         <note>Citatet stammer fra Goethes digt <xref poem="goethe2018012901,198-201"/>.</note>
     </notes>
     <source pages="124-138"/>
-    <keywords>goethe</keywords>
     <quality>korrektur1,korrektur2,kilde,side</quality>
 </head>
 <body>

--- a/fdirs/fonss/1898.xml
+++ b/fdirs/fonss/1898.xml
@@ -320,7 +320,6 @@ vi høre tvende Verdner til.
     <firstline>Hvor Valmuer ved Gærdet gror</firstline>
     <source pages="14-16"/>
     <!-- TODO: Hvilket digt af Aarestrup -->
-    <keywords>aarestrup</keywords>
     <quality>korrektur1,kilde,side</quality>
 </head>
 <body>

--- a/fdirs/hauch/1854.xml
+++ b/fdirs/hauch/1854.xml
@@ -3373,7 +3373,6 @@ Til vi Din Lige skue skal igjen;
     </subtitle>
     <firstline>Saa est Du da nu skriinlagt Hakon Jarl</firstline>
     <source pages="118-122"/>
-    <keywords>oehlenschlaeger</keywords>
     <quality>korrektur1,korrektur2,kilde,side</quality>
 </head>
 <body>

--- a/fdirs/heibergjl/1842.xml
+++ b/fdirs/heibergjl/1842.xml
@@ -1510,7 +1510,7 @@ Som drömmer i Menneskets Bryst.
     <toctitle><num>7.</num>Roeskilde-Domkirke</toctitle>
     <firstline>Du, Danmarks ældste Kirke</firstline>
     <source in="1842a" pages="57-59" facsimile-pages="99-101"/>
-    <keywords>homer,weyze,oehlenschlaeger</keywords>
+    <keywords>homer,weyze</keywords>
     <pictures>
         <picture src="heibergjl2018092309-p1.jpg">C.F. Christensen: <i>Roskilde Domkirke</i>.</picture>.
     </pictures>

--- a/fdirs/heibergjl/andre.xml
+++ b/fdirs/heibergjl/andre.xml
@@ -24,7 +24,7 @@
       <picture src="heibergjl2001042803-p1.jpg">Faksimile af <i>Adresseavisen</i> hvori Heiberg indrykkede mindedigtet over Ida Brun.</picture>
    </pictures>
    <quality>korrektur1</quality>
-   <keywords>ottavarima,baggesen,oehlenschlaeger,goethe</keywords>
+   <keywords>ottavarima</keywords>
 </head>
 <body>
 <poetry>

--- a/fdirs/hertzh/1851a.xml
+++ b/fdirs/hertzh/1851a.xml
@@ -2780,7 +2780,7 @@ Ak nei! af Kunst det er kun en - <w>Skygge</w>.
     <subtitle>(Skrevet som Prolog til Lystspillet ,,Amors Geniestreger''.)</subtitle>
     <firstline>Imens den iisgraa Trækfugl, Frosten, bygger</firstline>
     <source pages="117-122"/>
-    <keywords>baggesen,oehlenschlaeger</keywords>
+    <keywords>oehlenschlaeger</keywords>
     <quality>korrektur1,kilde,side</quality>
 </head>
 <body>
@@ -4294,7 +4294,6 @@ Saa staaer man fast, naar der fægtes.
         <note type="credits">Bidrag fra bla. Sven Sørensen og Bo Nissen.</note>
     </notes>
     <source pages="181-186"/>
-    <keywords>bellman</keywords>
     <quality>korrektur1,kilde,side</quality>
 </head>
 <body>
@@ -4455,7 +4454,6 @@ Sover nok du for os begge.
         <note>Cf. Bellmans <xref poem="bellman2001061369"/>.</note>
     </notes>
     <source pages="187-195"/>
-    <keywords>bellman</keywords>
     <quality>korrektur1,kilde,side</quality>
 </head>
 <body>

--- a/fdirs/ingemann/1812.xml
+++ b/fdirs/ingemann/1812.xml
@@ -907,7 +907,6 @@ For eet Øjeblik at elskes saa.
    </notes>
    <quality>korrektur1,korrektur2,kilde,side</quality>
    <source pages="40-45"/>
-   <keywords>oehlenschlaeger</keywords>
 </head>
 <body>
 <poetry>

--- a/fdirs/matthison/1915.xml
+++ b/fdirs/matthison/1915.xml
@@ -1269,7 +1269,6 @@ Verden har glemt dig!
         <note>Se Helge Rodes <xref poem="rodeh2018091534"/>.</note>
     </notes>
     <source pages="41"/>
-    <keywords>rodeh</keywords>
     <quality>korrektur1,kilde,side</quality>
 </head>
 <body>

--- a/fdirs/meier/1905.xml
+++ b/fdirs/meier/1905.xml
@@ -1037,7 +1037,6 @@ Tænk paa mig, hver Gang du har en Dimmelim.
 <head>
     <title>A Kerteminde, 16/6 1901</title>
     <source pages="49-51"/>
-    <keywords>larsent</keywords>
     <quality>korrektur1,kilde,side</quality>
 </head>
 <body>

--- a/fdirs/moellern/1888.xml
+++ b/fdirs/moellern/1888.xml
@@ -193,7 +193,6 @@ drag did, min sang, den stakkel at husvale.
     <note>Mottoet stammer fra Algernon C. Swinburne: <xref poem="swinburne2017100701"/>.</note>
   </notes>
   <source pages="8-12"/>
-  <keywords>swinburne</keywords>
   <quality>korrektur1,kilde,side</quality>
 </head>
 <body>

--- a/fdirs/moellerpl/1840.xml
+++ b/fdirs/moellerpl/1840.xml
@@ -3778,7 +3778,6 @@ Og han slumred ind. —
         <note>En variant med sidste strofe udeladt tryktes senere i <a work="moellerpl/1847"><i>Billeder og Sange</i> (1847)</a> med titlen »Ved Poul Møllers Død«.</note>
     </notes>
     <source pages="123-127"/>
-    <keywords>moellerpm</keywords>
     <quality>korrektur1,korrektur2,kilde,side</quality>
 </head>
 <body>

--- a/fdirs/moellerpl/1847.xml
+++ b/fdirs/moellerpl/1847.xml
@@ -1461,7 +1461,7 @@ Thi han paa Verden <w>retter!</w>
     <title>Digterundervisning</title>
     <firstline>I sit Pallads i Sevilla</firstline>
     <source pages="172"/>
-    <keywords>oehlenschlaeger,heine,winther,byron</keywords>
+    <keywords>byron</keywords>
     <quality>korrektur1,korrektur2,kilde,side</quality>
 </head>
 <body>

--- a/fdirs/oehlenschlaeger/1860-21.xml
+++ b/fdirs/oehlenschlaeger/1860-21.xml
@@ -9298,7 +9298,6 @@ Og ønske med min Reise mig til Lykke.
     <firstline>Du vil, jeg skal beskrive dig Klippen, Himlens Brud</firstline>
     <source pages="244-250"/>
     <quality>korrektur1,korrektur2,kilde,side</quality>
-    <keywords>welhaven</keywords>
 </head>
 <body>
 <poetry>
@@ -10660,7 +10659,6 @@ Med den lune Kappe paa.
     <title>Kongsberg</title>
     <firstline>Nu mere mørkt sig Fieldet sammendrager</firstline>
     <source pages="281-286"/>
-    <keywords>novalis</keywords>
     <quality>korrektur1,korrektur2,kilde,side</quality>
 </head>
 <body>

--- a/fdirs/oehlenschlaeger/1861-23.xml
+++ b/fdirs/oehlenschlaeger/1861-23.xml
@@ -8368,7 +8368,7 @@ Elegisk from at siunge som en Christen.
     <title>Lyriske Digtere</title>
     <firstline>Hvo kunde vel hver yndig Urt dig nævne?</firstline>
     <source pages="218-219"/>
-    <keywords>petrarca,goethe,schiller,ewald,baggesen,thaarup,wessel</keywords>
+    <keywords>petrarca,goethe,schiller,baggesen,thaarup,wessel</keywords>
     <quality>korrektur1,korrektur2,kilde,side</quality>
 </head>
 <body>

--- a/fdirs/rahbek/1802.xml
+++ b/fdirs/rahbek/1802.xml
@@ -3840,7 +3840,7 @@ O! maae de tækkes Nordens Huldgudinde!
         <note>C.A. Lund ønskede ikke at udgive sine digte, men lod <a person="rahbekk">Kamma Rahbek</a> afskrive dem.</note>
     </notes>
     <source pages="181-182"/>
-    <keywords>lundca,thomson,leonora</keywords>
+    <keywords>thomson,leonora</keywords>
     <quality>korrektur1,korrektur2,kilde,side</quality>
 </head>
 <body>

--- a/fdirs/rodeh/1922.xml
+++ b/fdirs/rodeh/1922.xml
@@ -1816,7 +1816,6 @@ Danmark, paa dit Alter!
         <note>Teksten følger <i>Den stille Have</i> (1922), s. 107-108.</note>
         <note>Vedr. tilegnelsen, se Poul Martin Møllers <xref poem="moellerpm2001052550"/>.</note>
     </notes>
-    <keywords>moellerpm</keywords>
 </head>
 <body>
 <poetry>

--- a/fdirs/rodeh/1928.xml
+++ b/fdirs/rodeh/1928.xml
@@ -232,7 +232,7 @@ Naar vi ved Efteraar tænker tilbage paa den svundne Sommer, staar den for os so
    <pictures>
        <picture src="rodeh201709107-p1.jpg">J.F. Willumsen: <i>Sophus Claussen læser sit digt <a poem="claussen2002090101">,,Imperia''</a> for Helge Rode og J. F. Willumsen</i>, 1915, olie på lærred, 147 × 187 cm, ARoS, Aarhus.</picture>
    </pictures>
-   <keywords>claussen,jensenjv,moellerpm,ewald,heine,byron</keywords>
+   <keywords>jensenjv,moellerpm,ewald,heine,byron</keywords>
 </head>
 <body>
 <prose>

--- a/fdirs/schandorph/1886.xml
+++ b/fdirs/schandorph/1886.xml
@@ -2792,7 +2792,7 @@ som har fulgt ham paa hver hans Vej.
     <dates>
         <event>1886-06-06</event>
     </dates>
-    <keywords>oehlenschlaeger,winther,heibergjl,hauch,hertzh,andersen</keywords>
+    <keywords>oehlenschlaeger,winther,heibergjl,hauch,andersen</keywords>
     <quality>korrektur1,kilde,side</quality>
 </head>
 <body>

--- a/fdirs/welhaven/andre.xml
+++ b/fdirs/welhaven/andre.xml
@@ -164,7 +164,6 @@ Taushed, Stumhed er det Bedste.
       <note>Heiberg og Welhaven var beslægtede, cf. <xref poem="heibergjl2002010601"/>.</note>
       <note type="credits">Bidrag fra Sven Sørensen.</note>
    </notes>
-   <keywords>heibergjl</keywords>
    <quality>korrektur1</quality>
 </head>
 <body>

--- a/fdirs/winther/1860-2.xml
+++ b/fdirs/winther/1860-2.xml
@@ -5998,7 +5998,6 @@ Enhver sin egen gyldne Tid.
         <note>Gendigtning af Rückerts <xref type="translation" poem="rueckert2018101001"/>.</note>
     </notes>
     <source pages="212-213"/>
-    <keywords>rueckert</keywords>
     <quality>korrektur1,korrektur2,kilde,side</quality>
 </head>
 <body>
@@ -6467,7 +6466,6 @@ Har Nattevagt!
     </notes>
     <source pages="230-236"/>
     <quality>korrektur1,korrektur2,kilde,side</quality>
-    <keywords>heine</keywords>
 </head>
 <body>
 <poetry>

--- a/fdirs/winther/1865.xml
+++ b/fdirs/winther/1865.xml
@@ -1372,7 +1372,6 @@ Mens dine Genier end vaage.
       <note type="credits">Bidrag fra Margit Ammentorp.<!-- Oprindeligt fra Chr. Winther: <i>Samlede Digtninger</i>, Chr. Winther og F. L. Liebenberg (red.), bd. 1-11, 1860-72. --></note>
    </notes>
    <source pages="57-58"/>
-   <keywords>boedtcher</keywords>
    <quality>korrektur1,korrektur2,kilde,side</quality>
 </head>
 <body>

--- a/tools/build-static/mentions.js
+++ b/tools/build-static/mentions.js
@@ -83,7 +83,9 @@ const build_person_or_keyword_refs = (collected) => {
         });
       }
     } else {
-      throw new Error(`${filename} has xref with unknown type ${type}`);
+      throw new Error(
+        `${filename} ${fromPoemId}: has xref with unknown type ${type}`
+      );
     }
     person_or_keyword_refs.set(toKey, collection);
     person_mentions_dirty.add(toKey);
@@ -106,6 +108,7 @@ const build_person_or_keyword_refs = (collected) => {
           const fromId = safeGetAttr(text, 'id');
           const head = getChildByTagName(text, 'head');
           const body = getChildByTagName(text, 'body');
+          const linkedPoetIds = new Set();
           const notes = [
             ...getElementsByTagNames(head, ['note', 'picture']),
             ...getElementsByTagNames(body, ['note', 'footnote']),
@@ -123,11 +126,12 @@ const build_person_or_keyword_refs = (collected) => {
                     const toPoetId = toText.poetId;
                     if (toPoetId !== poetId) {
                       // Skip self-refs
+                      linkedPoetIds.add(toPoetId);
                       register(filename, toPoetId, fromId, refType, toPoemId);
                     }
                   } else {
                     throw new Error(
-                      `${filename} points to unknown text ${toPoemId}`
+                      `${filename} ${fromId}: points to unknown text ${toPoemId}`
                     );
                   }
                 } else if (rule.type === 'person') {
@@ -140,14 +144,14 @@ const build_person_or_keyword_refs = (collected) => {
                   const pictureRef = match[2];
                   if (!pictureRef.match('/')) {
                     throw new Error(
-                      `${filename} points has illegal picture ref ${pictureRef}. 
+                      `${filename} ${fromId}: points has illegal picture ref ${pictureRef}. 
                       It should be on the form "{artist-id}/{picture-id}" or "kunst/{picture-id}"`
                     );
                   }
                   const picture = collected.artwork.get(pictureRef);
                   if (picture == null) {
                     throw new Error(
-                      `${filename} points to unknown picture ${pictureRef}`
+                      `${filename} ${fromId}: points to unknown picture ${pictureRef}`
                     );
                   }
                   register(filename, picture.artistId, fromId, 'mention');
@@ -158,7 +162,16 @@ const build_person_or_keyword_refs = (collected) => {
           const keywords = safeGetText(head, 'keywords') || '';
           if (keywords.trim().length > 0) {
             keywords.split(',').forEach((keyword) => {
-              register(filename, keyword, fromId, 'mention');
+              const keywordId = keyword.trim();
+              if (keywordId.length === 0) {
+                return;
+              }
+              if (linkedPoetIds.has(keywordId)) {
+                throw new Error(
+                  `${filename} ${fromId}: Overflødig keyword-reference ${keywordId}`
+                );
+              }
+              register(filename, keywordId, fromId, 'mention');
             });
           }
         });


### PR DESCRIPTION
## Resumé
- fjerner overflødige digter-keywords, når teksten allerede linker til et digt af samme digter
- tilføjer build-static-validering med fejlen "Overflødig keyword-reference"
- lader relevante build-fejl i mentions-opsamlingen inkludere tekst-id

## Test
- npm run build-static-force-reload

Bemærk: Buildet slutter som sædvanligt med "Elasticsearch server not found on localhost:9200."