### PR TITLE
Tilføj lastmod-datoer til sitemaps

### DIFF
--- a/tools/build-static/git.js
+++ b/tools/build-static/git.js
@@ -1,0 +1,41 @@
+const { execFileSync } = require('child_process');
+
+const collect_git_modified_dates = () => {
+  const log = execFileSync(
+    'git',
+    [
+      '--no-pager',
+      'log',
+      '--pretty=format:%ct',
+      '--name-only',
+      '--',
+      ':(glob)fdirs/**/*.xml',
+    ],
+    { encoding: 'utf8' }
+  );
+  const modifiedDates = new Map();
+  let timestamp = null;
+
+  log.split('\n').forEach((line) => {
+    const trimmed = line.trim();
+    if (trimmed.length === 0) {
+      return;
+    }
+    if (/^\d+$/.test(trimmed)) {
+      timestamp = parseInt(trimmed, 10);
+      return;
+    }
+    if (timestamp != null && !modifiedDates.has(trimmed)) {
+      modifiedDates.set(
+        trimmed,
+        new Date(timestamp * 1000).toISOString().slice(0, 10)
+      );
+    }
+  });
+
+  return modifiedDates;
+};
+
+module.exports = {
+  collect_git_modified_dates,
+};

--- a/tools/build-static/sitemap.js
+++ b/tools/build-static/sitemap.js
@@ -1,26 +1,57 @@
-const { safeMkdir, writeText, fileExists } = require('../libs/helpers.js');
+const {
+  safeMkdir,
+  writeText,
+  fileExists,
+  fileModifiedTime,
+} = require('../libs/helpers.js');
 const { isFileModified } = require('../libs/caching.js');
 const {
   loadXMLDoc,
-  safeGetInnerXML,
-  safeGetText,
   safeGetAttr,
   getElementsByTagNames,
-  getChildByTagName,
 } = require('./xml.js');
+const { collect_git_modified_dates } = require('./git.js');
+
+const sitemapLastmod = (filename) => {
+  const modifiedTime = fileModifiedTime(filename);
+  return modifiedTime == null
+    ? null
+    : new Date(modifiedTime).toISOString().slice(0, 10);
+};
+
+const latestDate = (dates) => {
+  return dates.filter((date) => date != null).sort().pop() || null;
+};
 
 const build_sitemap_xml = (collected) => {
   safeMkdir(`public/sitemaps`);
+  const modifiedDates = collect_git_modified_dates();
 
   const write_sitemap = (filename, urls) => {
     let xmlUrls = urls.map((url) => {
-      return `  <url><loc>${url}</loc></url>`;
+      const loc = typeof url === 'string' ? url : url.loc;
+      const lastmod = typeof url === 'string' ? null : url.lastmod;
+      return (
+        `  <url><loc>${loc}</loc>` +
+        (lastmod == null ? '' : `<lastmod>${lastmod}</lastmod>`) +
+        '</url>'
+      );
     });
     let xml = '<?xml version="1.0" encoding="UTF-8"?>\n';
     xml += '<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">\n';
     xml += xmlUrls.join('\n');
     xml += '\n</urlset>\n';
     writeText(filename, xml);
+  };
+
+  const sitemap_index_entry = (filename) => {
+    const loc = `https://kalliope.org/sitemaps/${filename}`;
+    const lastmod = sitemapLastmod(`public/sitemaps/${filename}`);
+    return (
+      `  <sitemap><loc>${loc}</loc>` +
+      (lastmod == null ? '' : `<lastmod>${lastmod}</lastmod>`) +
+      '</sitemap>'
+    );
   };
 
   let urls = [];
@@ -43,29 +74,39 @@ const build_sitemap_xml = (collected) => {
     const filenames = collected.workids
       .get(poetId)
       .map((workId) => `fdirs/${poetId}/${workId}.xml`);
+    const poetLastmod = latestDate(
+      filenames.map((filename) => modifiedDates.get(filename))
+    );
     if (!isFileModified(...filenames)) {
       return;
     }
     const poet_text_urls = [];
     ['da', 'en'].forEach((lang) => {
       if (poet.has_works || poet.has_artwork) {
-        poet_text_urls.push(`https://kalliope.org/${lang}/works/${poetId}`);
+        poet_text_urls.push({
+          loc: `https://kalliope.org/${lang}/works/${poetId}`,
+          lastmod: poetLastmod,
+        });
       }
       if (poet.has_poems) {
-        poet_text_urls.push(
-          `https://kalliope.org/${lang}/texts/${poetId}/titles`
-        );
-        poet_text_urls.push(
-          `https://kalliope.org/${lang}/texts/${poetId}/first`
-        );
+        poet_text_urls.push({
+          loc: `https://kalliope.org/${lang}/texts/${poetId}/titles`,
+          lastmod: poetLastmod,
+        });
+        poet_text_urls.push({
+          loc: `https://kalliope.org/${lang}/texts/${poetId}/first`,
+          lastmod: poetLastmod,
+        });
       }
       collected.workids.get(poetId).forEach((workId) => {
         const work = collected.works.get(`${poetId}/${workId}`);
         if (work.has_content) {
-          poet_text_urls.push(
-            `https://kalliope.org/${lang}/work/${poetId}/${workId}`
-          );
           const filename = `fdirs/${poetId}/${workId}.xml`;
+          const lastmod = modifiedDates.get(filename);
+          poet_text_urls.push({
+            loc: `https://kalliope.org/${lang}/work/${poetId}/${workId}`,
+            lastmod,
+          });
           if (!fileExists(filename)) {
             return;
           }
@@ -77,9 +118,10 @@ const build_sitemap_xml = (collected) => {
           getElementsByTagNames(doc, ['text', 'section']).forEach((part) => {
             const textId = safeGetAttr(part, 'id');
             if (textId != null) {
-              poet_text_urls.push(
-                `https://kalliope.org/${lang}/text/${textId}`
-              );
+              poet_text_urls.push({
+                loc: `https://kalliope.org/${lang}/text/${textId}`,
+                lastmod,
+              });
             }
           });
         }
@@ -91,17 +133,12 @@ const build_sitemap_xml = (collected) => {
   const sitemaps_urls_xml = Array.from(collected.poets.values())
     .filter((poet) => poet.has_works || poet.has_artwork)
     .map((poet) => {
-      return `https://kalliope.org/sitemaps/${poet.id}.xml`;
-    })
-    .map((url) => {
-      return `  <sitemap><loc>${url}</loc></sitemap>`;
+      return sitemap_index_entry(`${poet.id}.xml`);
     });
-  sitemaps_urls_xml.push(
-    `  <sitemap><loc>https://kalliope.org/sitemaps/global.xml</loc></sitemap>`
-  );
+  sitemaps_urls_xml.push(sitemap_index_entry('global.xml'));
   let xml = '<?xml version="1.0" encoding="UTF-8"?>\n';
   xml +=
-    '<sitemapindex xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">>\n';
+    '<sitemapindex xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">\n';
   xml += sitemaps_urls_xml.join('\n');
   xml += '\n</sitemapindex>\n';
   writeText('public/sitemap.xml', xml);

--- a/tools/build-static/toc.js
+++ b/tools/build-static/toc.js
@@ -1,5 +1,4 @@
 const { isFileModified } = require('../libs/caching.js');
-const { execFileSync } = require('child_process');
 const {
   safeMkdir,
   writeJSON,
@@ -7,6 +6,7 @@ const {
   replaceDashes,
   fileExists,
 } = require('../libs/helpers.js');
+const { collect_git_modified_dates } = require('./git.js');
 const { extractTitle, get_notes, get_pictures } = require('./parsing.js');
 const { sortWorks } = require('../../common/worksort.js');
 const {
@@ -69,42 +69,6 @@ const extract_subworks = (poetId, workbody, collected) => {
     }
     return subwork;
   });
-};
-
-const collect_git_modified_dates = () => {
-  const log = execFileSync(
-    'git',
-    [
-      '--no-pager',
-      'log',
-      '--pretty=format:%ct',
-      '--name-only',
-      '--',
-      ':(glob)fdirs/**/*.xml',
-    ],
-    { encoding: 'utf8' }
-  );
-  const modifiedDates = new Map();
-  let timestamp = null;
-
-  log.split('\n').forEach((line) => {
-    const trimmed = line.trim();
-    if (trimmed.length === 0) {
-      return;
-    }
-    if (/^\d+$/.test(trimmed)) {
-      timestamp = parseInt(trimmed, 10);
-      return;
-    }
-    if (timestamp != null && !modifiedDates.has(trimmed)) {
-      modifiedDates.set(
-        trimmed,
-        new Date(timestamp * 1000).toISOString().slice(0, 10)
-      );
-    }
-  });
-
-  return modifiedDates;
 };
 
 const build_works_toc = async (collected) => {


### PR DESCRIPTION
## Ændringer
- tilføjer <lastmod> på værk- og tekst-URLer i sitemap ud fra git-datoer på værkfiler
- tilføjer <lastmod> i sitemap-indexet ud fra de genererede sitemap-filers mtime
- deler git-datoopsamlingen mellem TOC og sitemap

Fixes #408

## Test
- node -c tools/build-static/sitemap.js
- node -c tools/build-static/toc.js
- node -c tools/build-static/git.js
- npm run build-static-force-reload