### PR TITLE
Valider picture-attributter

### DIFF
--- a/docs/xml-portraits-format.md
+++ b/docs/xml-portraits-format.md
@@ -188,8 +188,8 @@ så XML kan skrive:
 - Lokale `src`-billeder skal ligge i `public/images/<id>/`.
 - `square-src` skal også ligge i `public/images/<id>/`.
 - `museum` skal være et kendt museums-id for at give meningsfuldt link.
-- Der findes gamle stavefejl i data, fx `musem`, `invbr` og `yaer`; de bør rettes til
-  `museum`, `invnr` og `year` når de opdages.
+- Ukendte attributter på `<picture>` er build-fejl. Brug fx `museum`, `invnr` og
+  `year`; gamle stavefejl som `musem`, `invbr` og `yaer` må ikke genindføres.
 
 ## Nyttige eksempler
 
@@ -198,4 +198,3 @@ så XML kan skrive:
 - `fdirs/steffens/portraits.xml`: portræt udelukkende via artwork.
 - `fdirs/hugo/portraits.xml`: lokalt portræt, som også genbruges fra keyword-data.
 - `fdirs/luther/portraits.xml`: Cranach-billede via `kunst/cranach-luther`.
-

--- a/fdirs/frederik4/portraits.xml
+++ b/fdirs/frederik4/portraits.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <pictures>
-  <picture src="p1.jpg" primary="true" square-src="p1-square.jpg" year="1709" museum="fnm" invbr="A 4085">
+  <picture src="p1.jpg" primary="true" square-src="p1-square.jpg" year="1709" museum="fnm" invnr="A 4085">
       Rosalba Carriera: <i>Frederik 4.</i>, 1709, pastel.
   </picture>
 </pictures>

--- a/fdirs/herder/portraits.xml
+++ b/fdirs/herder/portraits.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <pictures>
-  <picture src="p2.jpg" primary="true" square-src="p2-square.jpg" yaer="1785" museum="gleimhaus" objid="917">
+  <picture src="p2.jpg" primary="true" square-src="p2-square.jpg" year="1785" museum="gleimhaus" objid="917">
     Anton Graff (1736-1813): <i>Johann Gottfried Herder</i>, 1785, olie på lærred, 52,2×42,5 cm.
   </picture>
 </pictures>

--- a/fdirs/kingo/portraits.xml
+++ b/fdirs/kingo/portraits.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <pictures>
     <picture src="p1.jpg"/>
-    <picture src="p4.jpg" primary="true" square-src="p4-square.jpg" museum="fnm" invbr="A 62">
+    <picture src="p4.jpg" primary="true" square-src="p4-square.jpg" museum="fnm" invnr="A 62">
         Ukendt maler: <i>Thomas Kingo</i>, ca. 1670.
     </picture>
 </pictures>

--- a/fdirs/tode/portraits.xml
+++ b/fdirs/tode/portraits.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <pictures>
-  <picture src="p1.jpg" primary="true" square-src="p1-square.jpg" musem="fnm" invnr="a-6176">
+  <picture src="p1.jpg" primary="true" square-src="p1-square.jpg" museum="fnm" invnr="a-6176">
     Jens Juels værksted: <i>Johan Clemens Tode</i>, omkr. 1700. Frederiksborg.
   </picture>
   <picture src="p2.jpg">

--- a/tools/build-static/artwork.js
+++ b/tools/build-static/artwork.js
@@ -15,13 +15,18 @@ const {
   getChildByTagName,
   safeTrim,
 } = require('./xml.js');
-const { get_picture } = require('./parsing.js');
+const { get_picture, validate_picture_attrs } = require('./parsing.js');
 const { build_museum_url } = require('./museums.js');
 
 const readArtworkFile = async (personId, artworkFilename, collected) => {
   const artworksDoc = loadXMLDoc(artworkFilename);
+  const onError = (message) => {
+    throw `${artworkFilename}: ${message}`;
+  };
   return await Promise.all(
     getElementsByTagName(artworksDoc, 'picture').map(async (picture) => {
+      validate_picture_attrs(picture, onError);
+
       const pictureId = safeGetAttr(picture, 'id');
       const subjectAttr = safeGetAttr(picture, 'subject');
       let subjects = subjectAttr != null ? subjectAttr.split(',') : [];

--- a/tools/build-static/parsing.js
+++ b/tools/build-static/parsing.js
@@ -16,6 +16,50 @@ const { imageSizeSync } = require('./image.js');
 
 const publicPathFromSrc = src => `public${src}`;
 
+const knownPictureAttrs = new Set([
+  // Reference to a shared artwork entry, e.g. "cranach/luther".
+  'artwork',
+  // Optional CSS clip-path used to crop the displayed image.
+  'clip-path',
+  // Local image id, primarily in artwork and portrait registries.
+  'id',
+  // Museum inventory number.
+  'invnr',
+  // Language for image text or description content.
+  'lang',
+  // Museum id used for remote collection links.
+  'museum',
+  // Museum object id used for remote collection links.
+  'objid',
+  // Reference to a shared portrait entry, e.g. "hugo/p1".
+  'portrait',
+  // Marks the preferred image when several pictures are available.
+  'primary',
+  // Legacy generic picture reference.
+  'ref',
+  // Alternative source used when a square crop is needed.
+  'square-src',
+  // Direct image source path.
+  'src',
+  // Artwork subject id, primarily in artwork registries.
+  'subject',
+  // Local picture type/classification.
+  'type',
+  // Wikidata entity id for external lookup.
+  'wikidata',
+  // Artwork or portrait year.
+  'year',
+]);
+
+const validate_picture_attrs = (pictureNode, onError) => {
+  for (let i = 0; i < pictureNode.attributes.length; i++) {
+    const attrName = pictureNode.attributes.item(i).name;
+    if (!knownPictureAttrs.has(attrName)) {
+      onError(`fandt ukendt picture-attribut "${attrName}"`);
+    }
+  }
+};
+
 const get_local_picture_content = (pictureNode) => {
   if (getChildByTagName(pictureNode, 'description') != null) {
     return {
@@ -128,6 +172,8 @@ const extractSubtitles = (head, tag = 'subtitle', collected) => {
 };
 
 const get_picture = async (pictureNode, srcPrefix, collected, onError) => {
+  validate_picture_attrs(pictureNode, onError);
+
   const primary = safeGetAttr(pictureNode, 'primary') == 'true';
   let src = safeGetAttr(pictureNode, 'src');
   const artworkRef =
@@ -234,4 +280,5 @@ module.exports = {
   get_notes,
   get_pictures,
   get_picture,
+  validate_picture_attrs,
 };


### PR DESCRIPTION
## Resumé
- retter gamle stavefejl i picture-attributter (`invbr`, `musem`, `yaer`)
- tilføjer build-validering af ukendte attributter på `<picture>`
- genbruger valideringen for både portrætter/tekstbilleder og artwork-registre

## Test
- `npm run build-static-force-reload`