### PR TITLE
Ret xmldom-regressions

### DIFF
--- a/components/textcontent.js
+++ b/components/textcontent.js
@@ -340,7 +340,8 @@ const renderXmlString = (inputString) => {
   };
 
   const frag = new DOMParser().parseFromString(
-    '<content>' + inputString + '</content>'
+    '<content>' + inputString + '</content>',
+    'text/xml'
   );
   return handle_nodes(frag.childNodes);
 };

--- a/tools/build-static/dict.js
+++ b/tools/build-static/dict.js
@@ -47,7 +47,8 @@ const build_dict_second_pass = collected => {
   let items = new Array();
 
   const createItem = (id, title, phrase, variants, body, collected) => {
-    const content_html = htmlToXml(safeGetInnerXML(body), collected);
+    const bodyXml = typeof body === 'string' ? body : safeGetInnerXML(body);
+    const content_html = htmlToXml(bodyXml, collected);
     const has_footnotes =
       content_html.indexOf('<footnote') !== -1 ||
       content_html.indexOf('<note') !== -1;


### PR DESCRIPTION
## Resumé
- angiver eksplicit text/xml når frontend parser XML-fragmenter med @xmldom/xmldom
- undgår at serialisere dictionary-variantens string-indhold som DOM-node

Refs #1155

## Test
- npm run build-static
- curl -sS -o /tmp/fontaine.html -w "%{http_code}\n" http://localhost:3000/da/bio/fontaine