### PR TITLE
Nedbring memory-forbrug i build-static

### DIFF
--- a/tools/build-static.js
+++ b/tools/build-static.js
@@ -88,6 +88,7 @@ const {
   b,
   print_benchmarking_results,
 } = require('./build-static/benchmarking.js');
+const { mapLimit } = require('./build-static/concurrency.js');
 const { build_works_toc, build_section_toc } = require('./build-static/toc.js');
 const { update_elasticsearch } = require('./build-static/elastic.js');
 const {
@@ -151,8 +152,9 @@ const buildTextAliasRedirects = (redirects, texts) => {
 };
 
 const build_bio_json = async (collected) => {
-  return Promise.all(
-    Array.from(collected.poets.entries()).map(async (entry) => {
+  return mapLimit(
+    Array.from(collected.poets.entries()),
+    async (entry) => {
       const [poetId, poet] = entry;
       // Skip if all of the participating xml files aren't modified
       if (
@@ -190,7 +192,7 @@ const build_bio_json = async (collected) => {
       const destFilename = `public/api/${poet.id}/bio.json`;
       console.log(destFilename);
       writeJSON(destFilename, data);
-    })
+    }
   );
 };
 
@@ -459,9 +461,8 @@ const handle_work = async (work) => {
     let proses = [];
     let toc = [];
 
-    await Promise.all(
-      getChildren(section).map(async (part) => {
-        const partName = tagName(part);
+    for (const part of getChildren(section)) {
+      const partName = tagName(part);
         if (partName === 'text') {
           const textId = safeGetAttr(part, 'id');
           const head = getChildByTagName(part, 'head');
@@ -566,8 +567,7 @@ const handle_work = async (work) => {
             section_titles
           );
         }
-      })
-    );
+    }
     return toc;
   };
 
@@ -873,82 +873,76 @@ const works_first_pass = (collected) => {
 };
 
 const works_second_pass = async (collected) => {
-  return Promise.all(
-    Array.from(collected.poets.entries()).map(async (entry) => {
-      const [poetId, poet] = entry;
-      safeMkdir(`public/api/${poetId}`);
+  const jobs = [];
+  collected.poets.forEach((poet, poetId) => {
+    safeMkdir(`public/api/${poetId}`);
+    collected.workids.get(poetId).forEach((workId) => {
+      jobs.push({ poetId, workId });
+    });
+  });
 
-      return Promise.all(
-        collected.workids.get(poetId).map(async (workId) => {
-          const filename = `fdirs/${poetId}/${workId}.xml`;
-          if (!fileExists(filename)) {
-            return;
-          }
-          if (!isFileModified(filename)) {
-            return;
-          }
-          let doc = loadXMLDoc(filename);
-          const work = getChildByTagName(doc, 'kalliopework');
-          const status = safeGetAttr(work, 'status');
-          const type = safeGetAttr(work, 'type');
-          const head = getChildByTagName(work, 'workhead');
-          const title = safeGetText(head, 'title');
-          const year = safeGetText(head, 'year');
-          //const data = { id: workId, title, year, status, type };
-          const data = collected.works.get(`${poetId}/${workId}`);
-          let sources = {};
-          getChildrenByTagName(head, 'source').forEach((sourceNode) => {
-            let source = null;
-            const sourceInner = safeGetInnerXML(sourceNode);
-            if (sourceInner != null && sourceInner.length > 0) {
-              source = { source: sourceInner };
-            }
-            if (source == null || source.source == null) {
-              throw new Error(
-                `fdirs/${poetId}/${workId}.xml has source with no title.`
-              );
-            }
-            const sourceId = safeGetAttr(sourceNode, 'id') || 'default';
-            let facsimile = safeGetAttr(sourceNode, 'facsimile');
-            if (facsimile != null) {
-              facsimile = facsimile.replace(/.pdf$/, '');
-              let facsimilePagesOffset = safeGetAttr(
-                sourceNode,
-                'facsimile-pages-offset'
-              );
-              if (facsimilePagesOffset != null) {
-                facsimilePagesOffset = parseInt(facsimilePagesOffset, 10);
-              }
+  return mapLimit(jobs, async ({ poetId, workId }) => {
+    const filename = `fdirs/${poetId}/${workId}.xml`;
+    if (!fileExists(filename)) {
+      return;
+    }
+    if (!isFileModified(filename)) {
+      return;
+    }
+    let doc = loadXMLDoc(filename);
+    const work = getChildByTagName(doc, 'kalliopework');
+    const head = getChildByTagName(work, 'workhead');
+    const data = collected.works.get(`${poetId}/${workId}`);
+    let sources = {};
+    getChildrenByTagName(head, 'source').forEach((sourceNode) => {
+      let source = null;
+      const sourceInner = safeGetInnerXML(sourceNode);
+      if (sourceInner != null && sourceInner.length > 0) {
+        source = { source: sourceInner };
+      }
+      if (source == null || source.source == null) {
+        throw new Error(
+          `fdirs/${poetId}/${workId}.xml has source with no title.`
+        );
+      }
+      const sourceId = safeGetAttr(sourceNode, 'id') || 'default';
+      let facsimile = safeGetAttr(sourceNode, 'facsimile');
+      if (facsimile != null) {
+        facsimile = facsimile.replace(/.pdf$/, '');
+        let facsimilePagesOffset = safeGetAttr(
+          sourceNode,
+          'facsimile-pages-offset'
+        );
+        if (facsimilePagesOffset != null) {
+          facsimilePagesOffset = parseInt(facsimilePagesOffset, 10);
+        }
 
-              const facsimilePageCount = safeGetAttr(
-                sourceNode,
-                'facsimile-pages-num'
-              );
-              if (facsimilePageCount == null) {
-                throw new Error(
-                  `fdirs/${poetId}/${workId}.xml is missing facsimile-pages-num in source.`
-                );
-              }
-              source = {
-                ...source,
-                facsimile,
-                facsimilePageCount: parseInt(facsimilePageCount, 10),
-                facsimilePagesOffset,
-              };
-            }
-            sources[sourceId] = source;
-          });
-          data.sources = sources;
-          collected_works.set(poetId + '-' + workId, data);
+        const facsimilePageCount = safeGetAttr(
+          sourceNode,
+          'facsimile-pages-num'
+        );
+        if (facsimilePageCount == null) {
+          throw new Error(
+            `fdirs/${poetId}/${workId}.xml is missing facsimile-pages-num in source.`
+          );
+        }
+        source = {
+          ...source,
+          facsimile,
+          facsimilePageCount: parseInt(facsimilePageCount, 10),
+          facsimilePagesOffset,
+        };
+      }
+      sources[sourceId] = source;
+    });
+    data.sources = sources;
+    collected_works.set(poetId + '-' + workId, data);
 
-          // TODO: Make handle_work non-recursive by using a simple XPath
-          // to select all the poems and prose texts.
-          await handle_work(work); // Creates texts
-          doc = null;
-        })
-      );
-    })
-  );
+    // TODO: Make handle_work non-recursive by using a simple XPath
+    // to select all the poems and prose texts.
+    await handle_work(work); // Creates texts
+    doc = null;
+  });
 };
 
 const build_poet_works_json = (collected) => {

--- a/tools/build-static/about.js
+++ b/tools/build-static/about.js
@@ -13,6 +13,7 @@ const {
   safeGetAttr,
   getChildByTagName,
 } = require('./xml.js');
+const { mapLimit } = require('./concurrency.js');
 
 const build_about_pages = async (collected) => {
   safeMkdir(`public/api/about`);
@@ -23,62 +24,60 @@ const build_about_pages = async (collected) => {
     })
     .reduce((result, b) => b || result, false);
   const folder = 'data/about';
-  return Promise.all(
-    fs
-      .readdirSync(folder)
-      .filter((x) => x.endsWith('.xml'))
-      .map((x) => {
-        return {
-          xml: `${folder}/${x}`,
-          json: `public/api/about/${x.replace(/.xml$/, '.json')}`,
-        };
-      })
-      .filter((paths) => isFileModified(paths.xml) || areAnyWorkModified)
-      .map(async (paths) => {
-        let lang = 'da';
-        const m = paths.xml.match(/_(..)\.xml$/);
-        if (m) {
-          lang = m[1];
-        }
-        const doc = loadXMLDoc(paths.xml);
-        const about = getChildByTagName(doc, 'about');
-        const head = getChildByTagName(about, 'head');
-        const body = getChildByTagName(about, 'body');
-        const title = safeGetText(head, 'title');
-        const pictures = await get_pictures(
-          head,
-          '/images/about',
-          paths.xml,
-          collected
-        );
-        const author = safeGetText(head, 'author');
-        const poemsNum = Array.from(collected.texts.values())
-          .map((t) => (t.type === 'text' ? 1 : 0))
-          .reduce((sum, v) => sum + v, 0);
-        const poetsNum = Array.from(collected.poets.values())
-          .map((t) => (t.type === 'poet' ? 1 : 0))
-          .reduce((sum, v) => sum + v, 0);
-        const notes = get_notes(head, collected, {
-          poemsNum: poemsNum.toLocaleString(lang),
-          poetsNum: poetsNum.toLocaleString(lang),
-          worksNum: collected.works.size.toLocaleString(lang),
-          langsNum: 8 - 1, // gb og us er begge engelsk.
-        });
-        // Data er samme format som keywords
-        const data = {
-          id: paths.xml,
-          title,
-          author,
-          has_footnotes: false,
-          pictures,
-          notes,
-          content_lang: 'da',
-          content_html: htmlToXml(safeGetInnerXML(body), collected),
-        };
-        console.log(paths.json);
-        writeJSON(paths.json, data);
-      })
-  );
+  const pages = fs
+    .readdirSync(folder)
+    .filter((x) => x.endsWith('.xml'))
+    .map((x) => {
+      return {
+        xml: `${folder}/${x}`,
+        json: `public/api/about/${x.replace(/.xml$/, '.json')}`,
+      };
+    })
+    .filter((paths) => isFileModified(paths.xml) || areAnyWorkModified);
+  return mapLimit(pages, async (paths) => {
+    let lang = 'da';
+    const m = paths.xml.match(/_(..)\.xml$/);
+    if (m) {
+      lang = m[1];
+    }
+    const doc = loadXMLDoc(paths.xml);
+    const about = getChildByTagName(doc, 'about');
+    const head = getChildByTagName(about, 'head');
+    const body = getChildByTagName(about, 'body');
+    const title = safeGetText(head, 'title');
+    const pictures = await get_pictures(
+      head,
+      '/images/about',
+      paths.xml,
+      collected
+    );
+    const author = safeGetText(head, 'author');
+    const poemsNum = Array.from(collected.texts.values())
+      .map((t) => (t.type === 'text' ? 1 : 0))
+      .reduce((sum, v) => sum + v, 0);
+    const poetsNum = Array.from(collected.poets.values())
+      .map((t) => (t.type === 'poet' ? 1 : 0))
+      .reduce((sum, v) => sum + v, 0);
+    const notes = get_notes(head, collected, {
+      poemsNum: poemsNum.toLocaleString(lang),
+      poetsNum: poetsNum.toLocaleString(lang),
+      worksNum: collected.works.size.toLocaleString(lang),
+      langsNum: 8 - 1, // gb og us er begge engelsk.
+    });
+    // Data er samme format som keywords
+    const data = {
+      id: paths.xml,
+      title,
+      author,
+      has_footnotes: false,
+      pictures,
+      notes,
+      content_lang: 'da',
+      content_html: htmlToXml(safeGetInnerXML(body), collected),
+    };
+    console.log(paths.json);
+    writeJSON(paths.json, data);
+  });
 };
 
 module.exports = {

--- a/tools/build-static/artwork.js
+++ b/tools/build-static/artwork.js
@@ -17,14 +17,16 @@ const {
 } = require('./xml.js');
 const { get_picture, validate_picture_attrs } = require('./parsing.js');
 const { build_museum_url } = require('./museums.js');
+const { mapLimit } = require('./concurrency.js');
 
 const readArtworkFile = async (personId, artworkFilename, collected) => {
   const artworksDoc = loadXMLDoc(artworkFilename);
   const onError = (message) => {
     throw `${artworkFilename}: ${message}`;
   };
-  return await Promise.all(
-    getElementsByTagName(artworksDoc, 'picture').map(async (picture) => {
+  return await mapLimit(
+    getElementsByTagName(artworksDoc, 'picture'),
+    async (picture) => {
       validate_picture_attrs(picture, onError);
 
       const pictureId = safeGetAttr(picture, 'id');
@@ -79,7 +81,7 @@ const readArtworkFile = async (personId, artworkFilename, collected) => {
         result.clipPath = clipPath;
       }
       return result;
-    })
+    }
   );
 };
 
@@ -89,12 +91,10 @@ const build_artwork = async (collected) => {
     : new Map(loadCachedJSON('collected.artwork') || []);
   const force_reload = collected_artwork.size == 0;
 
-  const promises = [];
-
-  await Promise.all(
-    Array.from(collected.poets.values()).map(async (person) => {
+  await mapLimit(
+    Array.from(collected.poets.values()),
+    async (person) => {
       const personId = person.id;
-      const personType = person.type;
       const artworkFilename = `fdirs/${personId}/artwork.xml`;
       const portraitsFile = `fdirs/${personId}/portraits.xml`;
 
@@ -127,35 +127,34 @@ const build_artwork = async (collected) => {
         // From portraits.xml
         const doc = loadXMLDoc(`fdirs/${personId}/portraits.xml`);
         if (doc != null) {
-          onError = (message) => {
+          const onError = (message) => {
             throw `fdirs/${personId}/portraits.xml: ${message}`;
           };
 
-          await Promise.all(
-            getElementsByTagName(doc, 'picture')
-              .filter((picture) => {
-                return (
-                  safeGetAttr(picture, 'artwork') == null &&
-                  safeGetAttr(picture, 'portrait') == null &&
-                  safeGetAttr(picture, 'ref') == null
+          await mapLimit(
+            getElementsByTagName(doc, 'picture').filter((picture) => {
+              return (
+                safeGetAttr(picture, 'artwork') == null &&
+                safeGetAttr(picture, 'portrait') == null &&
+                safeGetAttr(picture, 'ref') == null
+              );
+            }),
+            async (pictureNode) => {
+              const src = safeGetAttr(pictureNode, 'src');
+              const picture = await get_picture(
+                pictureNode,
+                `/images/${personId}`,
+                collected,
+                onError
+              );
+              if (picture == null) {
+                onError(
+                  'har et billede uden src-, artwork-, portrait- eller ref-attribut.'
                 );
-              })
-              .map(async (pictureNode) => {
-                const src = safeGetAttr(pictureNode, 'src');
-                const picture = await get_picture(
-                  pictureNode,
-                  `/images/${personId}`,
-                  collected,
-                  onError
-                );
-                if (picture == null) {
-                  onError(
-                    'har et billede uden src-, artwork-, portrait- eller ref-attribut.'
-                  );
-                }
-                const key = `portrait/${personId}/${src}`;
-                return { key, picture };
-              })
+              }
+              const key = `portrait/${personId}/${src}`;
+              return { key, picture };
+            }
           ).then((a) => {
             a.forEach((p) => {
               const { key, picture } = p;
@@ -165,15 +164,10 @@ const build_artwork = async (collected) => {
         }
       }
 
-      (await readArtworkFile('kunst', 'data/artwork.xml', collected)).forEach(
-        (artwork) => {
-          collected_artwork.set(artwork.id, artwork);
-        }
-      );
-
       // From works
-      await Promise.all(
-        collected.workids.get(personId).map(async (workId) => {
+      await mapLimit(
+        collected.workids.get(personId),
+        async (workId) => {
           const workFilename = `fdirs/${personId}/${workId}.xml`;
           if (force_reload || isFileModified(workFilename)) {
             // Fjern eksisterende work pictures fra cache
@@ -185,34 +179,33 @@ const build_artwork = async (collected) => {
 
             const doc = loadXMLDoc(workFilename);
             if (doc != null) {
-              onError = (message) => {
+              const onError = (message) => {
                 throw `${workFilename}: ${message}`;
               };
-              await Promise.all(
-                getElementsByTagName(doc, 'picture')
-                  .filter((picture) => {
-                    return (
-                      safeGetAttr(picture, 'artwork') == null &&
-                      safeGetAttr(picture, 'portrait') == null &&
-                      safeGetAttr(picture, 'ref') == null
+              await mapLimit(
+                getElementsByTagName(doc, 'picture').filter((picture) => {
+                  return (
+                    safeGetAttr(picture, 'artwork') == null &&
+                    safeGetAttr(picture, 'portrait') == null &&
+                    safeGetAttr(picture, 'ref') == null
+                  );
+                }),
+                async (pictureNode) => {
+                  const src = safeGetAttr(pictureNode, 'src');
+                  const picture = await get_picture(
+                    pictureNode,
+                    `/images/${personId}`,
+                    collected,
+                    onError
+                  );
+                  if (picture == null) {
+                    onError(
+                      'har et billede uden src-, artwork-, portrait- eller ref-attribut.'
                     );
-                  })
-                  .map(async (pictureNode) => {
-                    const src = safeGetAttr(pictureNode, 'src');
-                    const picture = await get_picture(
-                      pictureNode,
-                      `/images/${personId}`,
-                      collected,
-                      onError
-                    );
-                    if (picture == null) {
-                      onError(
-                        'har et billede uden src-, artwork-, portrait- eller ref-attribut.'
-                      );
-                    }
-                    const key = `work/${personId}/${workId}/${src}`;
-                    return { key, picture };
-                  })
+                  }
+                  const key = `work/${personId}/${workId}/${src}`;
+                  return { key, picture };
+                }
               ).then((a) => {
                 a.forEach((p) => {
                   const { key, picture } = p;
@@ -221,9 +214,15 @@ const build_artwork = async (collected) => {
               });
             }
           }
-        })
+        }
       );
-    })
+    }
+  );
+
+  (await readArtworkFile('kunst', 'data/artwork.xml', collected)).forEach(
+    (artwork) => {
+      collected_artwork.set(artwork.id, artwork);
+    }
   );
 
   writeCachedJSON('collected.artwork', Array.from(collected_artwork));

--- a/tools/build-static/benchmarking.js
+++ b/tools/build-static/benchmarking.js
@@ -1,25 +1,100 @@
 let b_keys = [];
 let b_millis = {};
+let b_memory = {};
+
+const megabytes = bytes => Math.round(bytes / 1024 / 1024);
+
+const memorySnapshot = () => {
+  const memory = process.memoryUsage();
+  return {
+    heapUsed: megabytes(memory.heapUsed),
+    external: megabytes(memory.external),
+    arrayBuffers: megabytes(memory.arrayBuffers),
+    rss: megabytes(memory.rss),
+  };
+};
+
+const collectGarbage = () => {
+  if (global.gc) {
+    global.gc();
+  }
+};
+
+const formatMemory = memory =>
+  `${memory.heapUsed}MB heap / ${memory.rss}MB rss`;
+
 // Benchmarking
 const b = async (name, f, args) => {
-  console.log(`${name}...`);
+  collectGarbage();
+  const beforeMemory = memorySnapshot();
+  console.log(`${name}... ${formatMemory(beforeMemory)}`);
   const beforeMillis = Date.now();
-  const result = f(args);
+  const result = await f(args);
   const afterMillis = Date.now();
+  collectGarbage();
+  const afterMemory = memorySnapshot();
   if (b_millis[name] == null) {
     b_keys.push(name);
     b_millis[name] = 0;
+    b_memory[name] = {
+      beforeHeapUsed: beforeMemory.heapUsed,
+      afterHeapUsed: afterMemory.heapUsed,
+      beforeExternal: beforeMemory.external,
+      afterExternal: afterMemory.external,
+      beforeArrayBuffers: beforeMemory.arrayBuffers,
+      afterArrayBuffers: afterMemory.arrayBuffers,
+      beforeRss: beforeMemory.rss,
+      afterRss: afterMemory.rss,
+      maxHeapUsed: afterMemory.heapUsed,
+      maxExternal: afterMemory.external,
+      maxArrayBuffers: afterMemory.arrayBuffers,
+      maxRss: afterMemory.rss,
+    };
   }
   b_millis[name] = b_millis[name] + afterMillis - beforeMillis;
+  b_memory[name].afterHeapUsed = afterMemory.heapUsed;
+  b_memory[name].afterExternal = afterMemory.external;
+  b_memory[name].afterArrayBuffers = afterMemory.arrayBuffers;
+  b_memory[name].afterRss = afterMemory.rss;
+  b_memory[name].maxHeapUsed = Math.max(
+    b_memory[name].maxHeapUsed,
+    beforeMemory.heapUsed,
+    afterMemory.heapUsed
+  );
+  b_memory[name].maxExternal = Math.max(
+    b_memory[name].maxExternal,
+    beforeMemory.external,
+    afterMemory.external
+  );
+  b_memory[name].maxArrayBuffers = Math.max(
+    b_memory[name].maxArrayBuffers,
+    beforeMemory.arrayBuffers,
+    afterMemory.arrayBuffers
+  );
+  b_memory[name].maxRss = Math.max(
+    b_memory[name].maxRss,
+    beforeMemory.rss,
+    afterMemory.rss
+  );
   return result;
 };
+
 const print_benchmarking_results = () => {
   let sum = 0;
   console.log('\nSTATS');
   b_keys.forEach(key => {
     const millis = b_millis[key];
+    const memory = b_memory[key];
     sum += millis;
-    console.log(`${key}: ${millis}ms`);
+    console.log(
+      `${key}: ${millis}ms, ` +
+        `${memory.beforeHeapUsed}->${memory.afterHeapUsed}MB heap, ` +
+        `${memory.beforeExternal}->${memory.afterExternal}MB ext, ` +
+        `${memory.beforeArrayBuffers}->${memory.afterArrayBuffers}MB buffers, ` +
+        `${memory.beforeRss}->${memory.afterRss}MB rss, ` +
+        `max ${memory.maxHeapUsed}MB heap / ${memory.maxExternal}MB ext / ` +
+        `${memory.maxArrayBuffers}MB buffers / ${memory.maxRss}MB rss`
+    );
   });
   console.log(`SUM: ${sum}ms`);
 };

--- a/tools/build-static/concurrency.js
+++ b/tools/build-static/concurrency.js
@@ -1,0 +1,20 @@
+const pLimit = require('p-limit');
+
+const DEFAULT_CONCURRENCY = 4;
+
+const buildConcurrency = Math.max(
+  1,
+  parseInt(process.env.KALLIOPE_BUILD_CONCURRENCY, 10) || DEFAULT_CONCURRENCY
+);
+
+const mapLimit = (items, mapper, concurrency = buildConcurrency) => {
+  const limit = pLimit(concurrency);
+  return Promise.all(
+    items.map((item, index) => limit(() => mapper(item, index)))
+  );
+};
+
+module.exports = {
+  buildConcurrency,
+  mapLimit,
+};

--- a/tools/build-static/keywords.js
+++ b/tools/build-static/keywords.js
@@ -13,6 +13,7 @@ const {
   safeGetAttr,
   getChildByTagName,
 } = require('./xml.js');
+const { mapLimit } = require('./concurrency.js');
 
 const build_keywords = async collected => {
   safeMkdir('public/api/keywords');
@@ -25,8 +26,9 @@ const build_keywords = async collected => {
   if (collected_keywords.size === 0 || isFileModified(...filenames)) {
     collected_keywords = new Map();
     let keywords_toc = new Array();
-    await Promise.all(
-      filenames.map(async path => {
+    await mapLimit(
+      filenames,
+      async path => {
         if (!path.endsWith('.xml')) {
           return;
         }
@@ -78,7 +80,7 @@ const build_keywords = async collected => {
         console.log(outFilename);
         writeJSON(outFilename, data);
         collected_keywords.set(id, { id, title });
-      })
+      }
     );
     writeCachedJSON('collected.keywords', Array.from(collected_keywords));
     const outFilename = `public/api/keywords.json`;

--- a/tools/build-static/parsing.js
+++ b/tools/build-static/parsing.js
@@ -13,6 +13,7 @@ const {
 } = require('./xml.js');
 const { poetName } = require('./formatting.js');
 const { imageSizeSync } = require('./image.js');
+const { mapLimit } = require('./concurrency.js');
 
 const publicPathFromSrc = src => `public${src}`;
 
@@ -254,10 +255,11 @@ const get_pictures = (head, srcPrefix, xmlFilename, collected) => {
   const onError = message => {
     throw `${xmlFilename}: ${message}`;
   };
-  return Promise.all(
-    getElementsByTagName(head, 'picture').map(async p => {
+  return mapLimit(
+    getElementsByTagName(head, 'picture'),
+    async p => {
       return await get_picture(p, srcPrefix, collected, onError);
-    })
+    }
   );
 };
 

--- a/tools/build-static/portraits.js
+++ b/tools/build-static/portraits.js
@@ -1,5 +1,6 @@
 const { get_picture } = require('./parsing.js');
 const { loadXMLDoc, getElementsByTagName } = require('./xml.js');
+const { mapLimit } = require('./concurrency.js');
 
 const build_portraits_json = async (poet, collected) => {
   let result = [];
@@ -11,8 +12,9 @@ const build_portraits_json = async (poet, collected) => {
     onError = message => {
       throw `fdirs/${poet.id}/portraits.xml: ${message}`;
     };
-    result = await Promise.all(
-      getElementsByTagName(doc, 'picture').map(async picture => {
+    result = await mapLimit(
+      getElementsByTagName(doc, 'picture'),
+      async picture => {
         picture = await get_picture(
           picture,
           `/images/${poet.id}`,
@@ -23,7 +25,7 @@ const build_portraits_json = async (poet, collected) => {
           onError('har et billede uden src- eller ref-attribut.');
         }
         return picture;
-      })
+      }
     );
     const primaries = result.filter(p => p.primary);
     if (primaries.length > 1) {

--- a/tools/build-static/timeline.js
+++ b/tools/build-static/timeline.js
@@ -12,6 +12,7 @@ const {
   getElementsByTagName,
 } = require('./xml.js');
 const { get_picture } = require('./parsing.js');
+const { mapLimit } = require('./concurrency.js');
 
 const normalize_timeline_date = normalizeTimelineDate;
 const compare_normalized_date = compareNormalizedDate;
@@ -27,8 +28,9 @@ const load_timeline = async (filename, collected) => {
   if (doc == null) {
     return [];
   }
-  return Promise.all(
-    getElementsByTagName(doc, 'entry').map(async (event) => {
+  return mapLimit(
+    getElementsByTagName(doc, 'entry'),
+    async (event) => {
       const type = safeGetAttr(event, 'type');
       const date = safeGetAttr(event, 'date');
       let data = {
@@ -61,7 +63,7 @@ const load_timeline = async (filename, collected) => {
         data.content_html = htmlToXml(safeGetInnerXML(html).trim(), collected);
       }
       return data;
-    })
+    }
   );
 };
 
@@ -109,56 +111,48 @@ const build_poet_timeline_json = async (poet, collected) => {
 
   let items = [];
   if (poet.type !== 'collection') {
-    const workItems = await Promise.all(
-      collected.workids
-        .get(poet.id)
-        .filter((workId) => {
-          // Vi vil ikke have underværkerne i tidslinjen
-          const work = collected.works.get(`${poet.id}/${workId}`);
-          return work.parent == null;
-        })
-        .map(async (workId) => {
-          const work = collected.works.get(`${poet.id}/${workId}`);
-          if (work.year != null) {
-            const workName = work.has_content
-              ? `<a work="${poet.id}/${workId}">${work.title}</a>`
-              : work.title;
-            const coverPicture = await cover_picture(
-              poet.id,
-              workId,
-              collected
-            );
-            const contentHtml = [
-              [`${poet.name.lastname}: ${workName}.`, { html: true }],
-            ];
-            const textItem = {
-              date: work.published,
-              normalized_date: normalize_timeline_date(work.published),
-              type: 'text',
-              content_lang: 'da',
-              is_history_item: false,
-              content_html: contentHtml,
-            };
-            if (coverPicture == null) {
-              return [textItem];
-            }
-            return [
-              {
-                date: work.published,
-                normalized_date: normalize_timeline_date(work.published),
-                type: 'image',
-                is_history_item: false,
-                src: coverPicture.src,
-                content_lang: coverPicture.content_lang,
-                lang: coverPicture.lang,
-                content_html: coverPicture.content_html,
-                miniature_content_html: contentHtml,
-              },
-            ];
-          }
-          return [];
-        })
-    );
+    const timelineWorkIds = collected.workids.get(poet.id).filter((workId) => {
+      // Vi vil ikke have underværkerne i tidslinjen
+      const work = collected.works.get(`${poet.id}/${workId}`);
+      return work.parent == null;
+    });
+    const workItems = await mapLimit(timelineWorkIds, async (workId) => {
+      const work = collected.works.get(`${poet.id}/${workId}`);
+      if (work.year != null) {
+        const workName = work.has_content
+          ? `<a work="${poet.id}/${workId}">${work.title}</a>`
+          : work.title;
+        const coverPicture = await cover_picture(poet.id, workId, collected);
+        const contentHtml = [
+          [`${poet.name.lastname}: ${workName}.`, { html: true }],
+        ];
+        const textItem = {
+          date: work.published,
+          normalized_date: normalize_timeline_date(work.published),
+          type: 'text',
+          content_lang: 'da',
+          is_history_item: false,
+          content_html: contentHtml,
+        };
+        if (coverPicture == null) {
+          return [textItem];
+        }
+        return [
+          {
+            date: work.published,
+            normalized_date: normalize_timeline_date(work.published),
+            type: 'image',
+            is_history_item: false,
+            src: coverPicture.src,
+            content_lang: coverPicture.content_lang,
+            lang: coverPicture.lang,
+            content_html: coverPicture.content_html,
+            miniature_content_html: contentHtml,
+          },
+        ];
+      }
+      return [];
+    });
     items = items.concat([].concat(...workItems));
     if (poet.period.born.date !== '?') {
       const place = (

--- a/tools/build-static/toc.js
+++ b/tools/build-static/toc.js
@@ -7,6 +7,7 @@ const {
   fileExists,
 } = require('../libs/helpers.js');
 const { collect_git_modified_dates } = require('./git.js');
+const { mapLimit } = require('./concurrency.js');
 const { extractTitle, get_notes, get_pictures } = require('./parsing.js');
 const { sortWorks } = require('../../common/worksort.js');
 const {
@@ -131,72 +132,54 @@ const build_works_toc = async (collected) => {
     return { lines, toc, subworks, notes, pictures };
   };
 
-  return Promise.all(
-    Array.from(collected.poets.entries()).map(async (entry) => {
-      const [poetId, poet] = entry;
-      safeMkdir(`public/api/${poetId}`);
-      const workFilenames = workFilesForPoet(poetId);
-      const poetWorksModified = isFileModified(
-        `fdirs/${poetId}/info.xml`,
-        ...workFilenames
-      );
-      const pageWorks = worksForPaging(poetId, poet);
+  const poetData = new Map();
+  const jobs = [];
+  collected.poets.forEach((poet, poetId) => {
+    safeMkdir(`public/api/${poetId}`);
+    const workFilenames = workFilesForPoet(poetId);
+    const poetWorksModified = isFileModified(
+      `fdirs/${poetId}/info.xml`,
+      ...workFilenames
+    );
+    const pageWorks = worksForPaging(poetId, poet);
+    poetData.set(poetId, { pageWorks, poet, poetWorksModified });
+    collected.workids.get(poetId).forEach((workId) => {
+      jobs.push({ poetId, workId });
+    });
+  });
 
-      return Promise.all(
-        collected.workids.get(poetId).map(async (workId) => {
-          const filename = `fdirs/${poetId}/${workId}.xml`;
-          if (!fileExists(filename)) {
-            return;
-          }
-          if (!poetWorksModified && !isFileModified(filename)) {
-            return;
-          }
-          let doc = loadXMLDoc(filename);
-          const work = getChildByTagName(doc, 'kalliopework');
-          const status = safeGetAttr(work, 'status');
-          const type = safeGetAttr(work, 'type');
-          const parentId = safeGetAttr(work, 'parent');
-          const head = getChildByTagName(work, 'workhead');
-          const title = safeGetText(head, 'title');
-          const toctitle = safeGetText(head, 'toctitle') || title;
-          const linktitle = safeGetText(head, 'linktitle') || title;
-          const breadcrumbtitle = safeGetText(head, 'breadcrumbtitle') || title;
-          const year = safeGetText(head, 'year');
-          const data = {
-            id: workId,
-            title,
-            toctitle,
-            breadcrumbtitle,
-            linktitle,
-            year,
-            status,
-            type,
-          };
-          const work_data = await extract_work_data(work);
-          const parentData = collected.works.get(parentId);
+  return mapLimit(jobs, async ({ poetId, workId }) => {
+    const { pageWorks, poet, poetWorksModified } = poetData.get(poetId);
+    const filename = `fdirs/${poetId}/${workId}.xml`;
+    if (!fileExists(filename)) {
+      return;
+    }
+    if (!poetWorksModified && !isFileModified(filename)) {
+      return;
+    }
+    let doc = loadXMLDoc(filename);
+    const work = getChildByTagName(doc, 'kalliopework');
+    const work_data = await extract_work_data(work);
 
-          if (work_data) {
-            const { prev, next } = resolvePrevNextWork(pageWorks, workId);
-            const toc_file_data = {
-              poet,
-              toc: work_data.toc,
-              subworks: work_data.subworks,
-              work: collected.works.get(`${poetId}/${workId}`),
-              notes: work_data.notes || [],
-              pictures: work_data.pictures || [],
-              modified: modifiedDates.get(filename),
-              prev,
-              next,
-            };
-            const tocFilename = `public/api/${poetId}/${workId}-toc.json`;
-            console.log(tocFilename);
-            writeJSON(tocFilename, toc_file_data);
-          }
-          doc = null;
-        })
-      );
-    })
-  );
+    if (work_data) {
+      const { prev, next } = resolvePrevNextWork(pageWorks, workId);
+      const toc_file_data = {
+        poet,
+        toc: work_data.toc,
+        subworks: work_data.subworks,
+        work: collected.works.get(`${poetId}/${workId}`),
+        notes: work_data.notes || [],
+        pictures: work_data.pictures || [],
+        modified: modifiedDates.get(filename),
+        prev,
+        next,
+      };
+      const tocFilename = `public/api/${poetId}/${workId}-toc.json`;
+      console.log(tocFilename);
+      writeJSON(tocFilename, toc_file_data);
+    }
+    doc = null;
+  });
 };
 
 module.exports = {


### PR DESCRIPTION
## Resumé
- tilføjer en fælles mapLimit-helper med konfigurerbar build-concurrency
- begrænser parallelisme i de tunge build-static trin, især works_second_pass og build_works_toc
- gør intern tekstbehandling i handle_work sekventiel for at undgå store samtidige JSON/XML-strenge
- udvider benchmark-output med heap, external, arrayBuffers og rss

Default concurrency er 4 og kan justeres med KALLIOPE_BUILD_CONCURRENCY.

Fixes #1154

## Målinger
Force reload med GC-måling:
- før: works_second_pass toppede omkring 1333MB rss hos Jesper
- efter: works_second_pass omkring 492MB rss hos Jesper
- concurrency 4 var hurtigere end 8 i lokal sammenligning: 57113ms vs 58298ms benchmark-sum

## Test
- node -c tools/build-static.js && node -c tools/build-static/concurrency.js && node -c tools/build-static/benchmarking.js && node -c tools/build-static/toc.js && node -c tools/build-static/artwork.js && node -c tools/build-static/parsing.js
- git diff --check
- npm run build-static
- node --expose-gc tools/build-static.js --force-reload