### PR TITLE
Gør valgt menupunkt klikbart ved sektionssider

### DIFF
--- a/components/menu.js
+++ b/components/menu.js
@@ -10,10 +10,12 @@ import { poetGenetiveLastName } from './poetname-helpers.js';
 
 const transitionDuration = '0.2s';
 
+const pathWithoutQuery = url => url.split(/[?#]/, 1)[0];
+
 const Tabs = (props) => {
   let searchField;
 
-  const { items, selected, poet, lang, query } = props;
+  const { items, selected, poet, lang, query, requestPath } = props;
   let country = props.country;
   if (country == null) {
     country = lang === 'da' ? 'dk' : 'gb';
@@ -160,14 +162,17 @@ const Tabs = (props) => {
     .map((item, i) => {
       const isSelected = item.id === selected;
       const className = isSelected ? 'tab selected' : 'tab';
+      const isCurrentPage =
+        pathWithoutQuery(item.url) === pathWithoutQuery(requestPath || '');
+      const isClickable = !isSelected || !isCurrentPage;
       return (
         <div className={className} key={item.url}>
-          {isSelected ? (
-            <h2>{item.title}</h2>
-          ) : (
+          {isClickable ? (
             <Link href={item.url}>
               <h2>{item.title}</h2>
             </Link>
+          ) : (
+            <h2>{item.title}</h2>
           )}
         </div>
       );

--- a/components/page.js
+++ b/components/page.js
@@ -95,6 +95,7 @@ const Page = (props) => {
           query={query}
           poet={poet}
           lang={lang}
+          requestPath={requestPath}
         />
         {children}
         <LangSelect lang={lang} path={requestPath} />


### PR DESCRIPTION
## Resumé
- sender sidens requestPath ned til menuen, så den kan skelne aktuel side fra valgt sektion
- bevarer selected styling på menupunktet
- gør menupunktet klikbart, når det peger på en anden side end den aktuelle

Eksempel: På /da/keyword/lejlighedsdigtning er "Nøgleord" valgt, men linker tilbage til /da/keywords. På /da/keywords er det stadig disabled.

## Test
- npm test -- __tests__/routes.test.js --runInBand
- manuelt via dev-server: /da/keyword/lejlighedsdigtning og /da/keywords returnerede 200, med/uden link som forventet