### PR TITLE
Tilføj agent- og billedkonventioner

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,9 @@
+# Agent Instructions
+
+Disse regler gælder for AI-agenter og automatiserede assistenter, der arbejder i dette repository.
+
+- Skriv altid GitHub issue-titler, issue-beskrivelser, PR-titler og PR-beskrivelser på dansk, medmindre brugeren eksplicit beder om et andet sprog.
+- Læg portræt- og kunstgrafik under `public/images/<id>/`. Læg aldrig billedfiler under `fdirs/`.
+- `fdirs/<id>/portraits.xml` må referere lokale portrætter med `src="..."` og `square-src="..."`, men filerne skal findes i `public/images/<id>/`.
+- Commit ikke lokale scratch-filer eller untracked arbejdsfiler, medmindre brugeren eksplicit beder om det.
+- Læs `docs/style-guide.md` før du opretter issues, PRs eller ændringer i data-/billedstrukturen.

--- a/__tests__/portrait-assets.test.js
+++ b/__tests__/portrait-assets.test.js
@@ -1,0 +1,65 @@
+const fs = require('fs');
+const path = require('path');
+
+const imageExtensionPattern = /\.(jpe?g|png|gif|webp)$/i;
+const pictureTagPattern = /<picture\b([^>]*)>/g;
+const pictureAssetPattern = /\b(src|square-src)="([^"]+)"/g;
+
+const walkFiles = dir => {
+  const files = [];
+  const visit = current => {
+    fs.readdirSync(current, { withFileTypes: true }).forEach(entry => {
+      const filename = path.join(current, entry.name);
+      if (entry.isDirectory()) {
+        visit(filename);
+      } else if (entry.isFile()) {
+        files.push(filename);
+      }
+    });
+  };
+  visit(dir);
+  return files;
+};
+
+describe('portrait asset conventions', () => {
+  it('keeps image files out of fdirs', () => {
+    const imageFiles = walkFiles('fdirs').filter(filename =>
+      imageExtensionPattern.test(filename)
+    );
+
+    expect(imageFiles).toEqual([]);
+  });
+
+  it('stores local portrait images under public/images/<poet-id>', () => {
+    const missing = [];
+    fs.readdirSync('fdirs', { withFileTypes: true })
+      .filter(entry => entry.isDirectory())
+      .map(entry => entry.name)
+      .forEach(poetId => {
+        const portraitsFile = path.join('fdirs', poetId, 'portraits.xml');
+        if (!fs.existsSync(portraitsFile)) {
+          return;
+        }
+
+        const xml = fs.readFileSync(portraitsFile, 'utf8');
+        Array.from(xml.matchAll(pictureTagPattern)).forEach(pictureMatch => {
+          Array.from(pictureMatch[1].matchAll(pictureAssetPattern)).forEach(
+            assetMatch => {
+              const attrName = assetMatch[1];
+              const value = assetMatch[2];
+              if (value.startsWith('/')) {
+                return;
+              }
+
+              const imagePath = path.join('public', 'images', poetId, value);
+              if (!fs.existsSync(imagePath)) {
+                missing.push(`${portraitsFile}: ${attrName}="${value}"`);
+              }
+            }
+          );
+        });
+      });
+
+    expect(missing).toEqual([]);
+  });
+});

--- a/docs/style-guide.md
+++ b/docs/style-guide.md
@@ -1,0 +1,28 @@
+# Kalliope Styleguide
+
+Denne guide samler projektets faste konventioner, især dem der er nemme at glemme i små ændringer.
+
+## GitHub
+
+- Issues, PR-titler og PR-beskrivelser skrives på dansk.
+- Skriv konkret hvad der er observeret, ændret og valideret.
+- Brug engelske navne eller citater, når de er kildens titel, personnavn eller egentlig terminologi.
+
+## Billeder
+
+- Portrætter og kunstgrafik ligger i `public/images/<id>/`.
+- Der må ikke ligge `.jpg`, `.jpeg`, `.png`, `.gif` eller `.webp` under `fdirs/`.
+- `fdirs/<id>/portraits.xml` refererer lokale filer med filnavn, fx `src="p1.jpg"` og `square-src="p1-square.jpg"`.
+- Den faktiske fil for `fdirs/<id>/portraits.xml` skal derfor være `public/images/<id>/p1.jpg`.
+- Square portraits er normalt manuelt beskårne kvadratiske billeder og skal også ligge i `public/images/<id>/`.
+
+## XML-data
+
+- Hold XML-beskrivelser korte, kildebaserede og i samme stil som omkringliggende filer.
+- Brug eksisterende attributter og formater; ukendte `<picture>`-attributter er build-fejl.
+- Se også `docs/xml-portraits-format.md` for detaljer om `portraits.xml`.
+
+## Arbejdsfiler
+
+- Lokale scratch-filer må gerne eksistere under arbejdet, men de skal ikke committes.
+- Tjek `git status --short` før commit og PR.

--- a/docs/xml-portraits-format.md
+++ b/docs/xml-portraits-format.md
@@ -4,6 +4,8 @@ Dette er et internt overblik over `fdirs/<id>/portraits.xml`.
 Filen beskriver portrætter, som vises på biografisider og bruges til kvadratiske social
 portraits. Portrætter kan også genbruges fra andre XML-filer via `portrait="digter/pN"`.
 
+Se også `docs/style-guide.md` for de generelle regler om billedplacering og GitHub-sprog.
+
 ## Grundstruktur
 
 ```xml


### PR DESCRIPTION
Tilføjer repo-lokale regler for AI-agenter og billedplacering, så projektkonventionerne ikke kun lever i chats.

Ændringer:
- Tilføjer `AGENTS.md` med korte instruktioner til agenter.
- Tilføjer `docs/style-guide.md` med regler for GitHub-sprog, billedplacering, XML-data og arbejdsfiler.
- Henviser fra `docs/xml-portraits-format.md` til den generelle styleguide.
- Tilføjer Jest-test, der sikrer at billedfiler ikke placeres under `fdirs/`, og at lokale `portraits.xml`-billeder findes under `public/images/<id>/`.

Validering:
- `npx jest __tests__/portrait-assets.test.js --runInBand`
- `git diff --check`