### PR TITLE
Udryd Latin-1 i tekstfiler

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -5,5 +5,6 @@ Disse regler gælder for AI-agenter og automatiserede assistenter, der arbejder 
 - Skriv altid GitHub issue-titler, issue-beskrivelser, PR-titler og PR-beskrivelser på dansk, medmindre brugeren eksplicit beder om et andet sprog.
 - Læg portræt- og kunstgrafik under `public/images/<id>/`. Læg aldrig billedfiler under `fdirs/`.
 - `fdirs/<id>/portraits.xml` må referere lokale portrætter med `src="..."` og `square-src="..."`, men filerne skal findes i `public/images/<id>/`.
+- Tekstfiler i repoet skal være UTF-8. Indfør ikke Latin-1/ISO-8859-1 encoded filer.
 - Commit ikke lokale scratch-filer eller untracked arbejdsfiler, medmindre brugeren eksplicit beder om det.
 - Læs `docs/style-guide.md` før du opretter issues, PRs eller ændringer i data-/billedstrukturen.

--- a/__tests__/encoding.test.js
+++ b/__tests__/encoding.test.js
@@ -1,0 +1,62 @@
+const fs = require('fs');
+const path = require('path');
+const { execFileSync } = require('child_process');
+const { TextDecoder } = require('util');
+
+const decoder = new TextDecoder('utf-8', { fatal: true });
+
+const binaryExtensions = new Set([
+  '.ai',
+  '.gif',
+  '.ico',
+  '.jpeg',
+  '.jpg',
+  '.pdf',
+  '.png',
+  '.tga',
+  '.traineddata',
+  '.ttf',
+  '.webp',
+  '.woff',
+  '.woff2',
+]);
+
+const gitFiles = () =>
+  execFileSync('git', ['ls-files'], { encoding: 'utf8' })
+    .split('\n')
+    .filter(Boolean);
+
+const looksBinary = buffer => {
+  const scanLength = Math.min(buffer.length, 8000);
+  for (let i = 0; i < scanLength; i++) {
+    if (buffer[i] === 0) {
+      return true;
+    }
+  }
+  return false;
+};
+
+describe('source encodings', () => {
+  it('keeps tracked text files encoded as UTF-8', () => {
+    const invalid = [];
+
+    gitFiles().forEach(filename => {
+      if (binaryExtensions.has(path.extname(filename).toLowerCase())) {
+        return;
+      }
+
+      const buffer = fs.readFileSync(filename);
+      if (looksBinary(buffer)) {
+        return;
+      }
+
+      try {
+        decoder.decode(buffer);
+      } catch (error) {
+        invalid.push(filename);
+      }
+    });
+
+    expect(invalid).toEqual([]);
+  });
+});

--- a/docs/style-guide.md
+++ b/docs/style-guide.md
@@ -20,6 +20,7 @@ Denne guide samler projektets faste konventioner, især dem der er nemme at glem
 
 - Hold XML-beskrivelser korte, kildebaserede og i samme stil som omkringliggende filer.
 - Brug eksisterende attributter og formater; ukendte `<picture>`-attributter er build-fejl.
+- Alle tekst- og XML-filer skal være UTF-8 encoded. Konvertér gamle Latin-1/ISO-8859-1-filer i stedet for at videreføre dem.
 - Se også `docs/xml-portraits-format.md` for detaljer om `portraits.xml`.
 
 ## Arbejdsfiler

--- a/fdirs/bibel/TODO
+++ b/fdirs/bibel/TODO
@@ -1,4 +1,4 @@
-profeter -> profetér hvis det er verbet.
+profeter -> profetÃ©r hvis det er verbet.
 Herren -> HERREN
 
 ---
@@ -9,7 +9,7 @@ Skal note til Eze.8,14 med?
 Skal note til Eze.17,5 med?
 Skal note til Eze.26,1 med?
 Skal note til Eze.32,17 med?
-Skal note til Eze.42,12 med? Vedrører v.1-12.
+Skal note til Eze.42,12 med? VedrÃ¸rer v.1-12.
 Skal note til Dan.1,21 med?
 Skal note til Dan.5,28 med?
 Skal note til 1.Sam.13,1 med?
@@ -19,7 +19,7 @@ Skal note til 1.Sam.28,12 med?
 ----
 
 1.Mos.46
-I dette kapitel er en del navne fremhævet (kursiveret) i de trykte udgaver,
+I dette kapitel er en del navne fremhÃ¦vet (kursiveret) i de trykte udgaver,
 og - formodentlig derfor - forskrevet i Kalliope. De rette former er:
 9. Rubens; 10. Simeons; 11. Levis; 12. Judas; 13. Issakars; 14. Zebulons;
 15. Leas; 16. Gads; 17. Asers; 18. Zilpa; 19. Rakels; 20. Josef; 21.
@@ -50,7 +50,7 @@ Overalt: Simon Peter -> Simeon Peter?
 
 Typiske fejl:
 
-navneord som begynder med især lille i eller lille k.
+navneord som begynder med isÃ¦r lille i eller lille k.
 F.eks. indbyggere -> Indbyggere, kobber -> Kobber.
 
 ---


### PR DESCRIPTION
Konverterer den sidste trackede Latin-1-tekstfil til UTF-8 og tilføjer en test, så problemet ikke kommer tilbage.

Ændringer:
- Konverterer `fdirs/bibel/TODO` fra ISO-8859-1 til UTF-8.
- Tilføjer `__tests__/encoding.test.js`, som validerer at trackede tekstfiler kan læses som UTF-8.
- Opdaterer `AGENTS.md` og `docs/style-guide.md` med UTF-8-reglen.

Ekstra tjek:
- Scene-/specialfiler blev tjekket eksplicit. Der er ingen trackede tekstlige scene-filer; søgningen fandt kun JPEG-filer med `scene` i filnavnet.
- `public/gfx/originaler/poet_reflect.ai` er binær (`application/pdf; charset=binary`) og er derfor undtaget som `.ai`.

Validering:
- `git ls-files -z | xargs -0 file -I | rg -i 'charset=(iso-8859|unknown|utf-16)'` gav ingen fund.
- `npx jest __tests__/encoding.test.js --runInBand`
- `git diff --check`