### PR TITLE
Vis mentions fra primære tekstvarianter

### DIFF
--- a/__tests__/mentions.test.js
+++ b/__tests__/mentions.test.js
@@ -1,0 +1,136 @@
+jest.mock('../tools/libs/caching.js', () => ({
+  isFileModified: () => false,
+  loadCachedJSON: () => null,
+  writeCachedJSON: () => {},
+  force_reload: false,
+}));
+
+jest.mock('../tools/libs/helpers.js', () => ({
+  safeMkdir: () => {},
+  writeJSON: () => {},
+  htmlToXml: (html) => html,
+  fileExists: () => false,
+}));
+
+jest.mock('../tools/build-static/xml.js', () => ({
+  loadXMLDoc: () => null,
+  safeGetText: () => null,
+  safeGetAttr: () => null,
+  getElementsByTagNames: () => [],
+  getElementsByTagName: () => [],
+  getChildrenByTagName: () => [],
+  getChildByTagName: () => null,
+  safeGetOuterXML: () => '',
+  safeGetInnerXML: () => '',
+}));
+
+const { build_mentions_data } = require('../tools/build-static/mentions.js');
+
+const poet = (id, firstname, lastname) => ({
+  id,
+  name: {
+    firstname,
+    lastname,
+  },
+});
+
+const text = (id, poetId, workId, title = id) => ({
+  id,
+  title,
+  poetId,
+  workId,
+});
+
+const work = (id, year) => ({
+  id,
+  year,
+  title: id,
+});
+
+describe('mentions data', () => {
+  const buildCollected = () => {
+    const reboul = poet('reboul', 'Jean', 'Reboul');
+    const aarestrup = poet('aarestrup', 'Emil', 'Aarestrup');
+    const lamartine = poet('lamartine', 'Alphonse de', 'Lamartine');
+
+    return {
+      poets: new Map([
+        ['reboul', reboul],
+        ['aarestrup', aarestrup],
+        ['lamartine', lamartine],
+      ]),
+      texts: new Map([
+        [
+          'aarestrup2018110521',
+          text('aarestrup2018110521', 'aarestrup', '1863', 'En Engel stod'),
+        ],
+        [
+          'aarestrup20190130175',
+          text('aarestrup20190130175', 'aarestrup', '1976-5', 'En Engel stod'),
+        ],
+        [
+          'reboul2019013101',
+          text('reboul2019013101', 'reboul', 'andre', "L'Ange et l'enfant"),
+        ],
+      ]),
+      works: new Map([
+        ['aarestrup/1863', work('1863', '1863')],
+        ['aarestrup/1976-5', work('1976-5', '1976')],
+        ['reboul/andre', work('andre', '1828')],
+      ]),
+      variants: new Map([
+        ['aarestrup2018110521', ['aarestrup20190130175']],
+        ['aarestrup20190130175', ['aarestrup2018110521']],
+      ]),
+      person_or_keyword_refs: new Map([
+        [
+          'reboul',
+          {
+            mention: [],
+            translation: [
+              {
+                translationPoemId: 'aarestrup20190130175',
+                translatedPoemId: 'reboul2019013101',
+              },
+            ],
+          },
+        ],
+        [
+          'lamartine',
+          {
+            mention: ['aarestrup20190130175'],
+            translation: [],
+          },
+        ],
+      ]),
+    };
+  };
+
+  it('viser oversættelser fra den primære variant', () => {
+    const collected = buildCollected();
+    const data = build_mentions_data(
+      collected.poets.get('reboul'),
+      'reboul',
+      collected,
+      (poemId) => [[poemId]]
+    );
+
+    expect(data.translations).toHaveLength(1);
+    expect(data.translations[0].translation.poem.id).toBe(
+      'aarestrup2018110521'
+    );
+    expect(data.translations[0].translated.poem.id).toBe('reboul2019013101');
+  });
+
+  it('viser mentions fra den primære variant', () => {
+    const collected = buildCollected();
+    const data = build_mentions_data(
+      collected.poets.get('lamartine'),
+      'lamartine',
+      collected,
+      (poemId) => [[poemId]]
+    );
+
+    expect(data.mentions).toEqual([[['aarestrup2018110521']]]);
+  });
+});

--- a/tools/build-static/mentions.js
+++ b/tools/build-static/mentions.js
@@ -189,6 +189,110 @@ const build_person_or_keyword_refs = (collected) => {
   collected.person_or_keyword_refs = person_or_keyword_refs;
 };
 
+const build_mentions_data = (poet, poetId, collected, build_html) => {
+  let data = {
+    poet,
+    mentions: [],
+    translations: [],
+    primary: [],
+    secondary: [],
+  };
+  const refs = collected.person_or_keyword_refs.get(poetId);
+  if (refs != null) {
+    const seenTranslations = new Set();
+    const seenTranslationKeys = new Set();
+    data.translations = refs.translation
+      .map((t) => {
+        const translationPoemId = primaryTextVariantId(
+          t.translationPoemId,
+          collected
+        );
+        const translatedPoemId =
+          t.translatedPoemId == null
+            ? null
+            : primaryTextVariantId(t.translatedPoemId, collected);
+        return {
+          translationPoemId,
+          translatedPoemId,
+        };
+      })
+      .filter((t) => {
+        const key = `${t.translationPoemId}:${t.translatedPoemId || ''}`;
+        if (seenTranslationKeys.has(key)) {
+          return false;
+        }
+        seenTranslationKeys.add(key);
+        return true;
+      })
+      .map((t) => {
+        const { translationPoemId, translatedPoemId } = t;
+        const translationPoem = collected.texts.get(translationPoemId);
+        let translatedPoem = null;
+        if (translatedPoemId != null) {
+          translatedPoem = collected.texts.get(translatedPoemId);
+          if (translatedPoem == null) {
+            throw `${translatedPoemId} not found in texts.`;
+          }
+          seenTranslations.add(translationPoemId);
+        }
+        const result = {
+          translation: {
+            poem: translationPoem,
+            work: collected.works.get(
+              `${translationPoem.poetId}/${translationPoem.workId}`
+            ),
+            poet: collected.poets.get(translationPoem.poetId),
+          },
+        };
+        if (translatedPoem != null) {
+          result.translated = {
+            poem: translatedPoem,
+            work: collected.works.get(
+              `${translatedPoem.poetId}/${translatedPoem.workId}`
+            ),
+          };
+        }
+        return result;
+      });
+    const seenMentionIds = new Set();
+    data.mentions = refs.mention
+      .map((id) => {
+        // Hvis en tekst har varianter som også henviser til denne,
+        // vil vi kun vise den ældste variant.
+        return primaryTextVariantId(id, collected);
+      })
+      .filter((id) => {
+        if (seenMentionIds.has(id)) {
+          return false;
+        }
+        seenMentionIds.add(id);
+        return true;
+      })
+      .filter((id) => {
+        const isAlsoTranslation = seenTranslations.has(id);
+        if (isAlsoTranslation) {
+          console.log(`Translation ${id} has superfluous mention.`);
+        }
+        return !isAlsoTranslation;
+      })
+      .map(build_html);
+  }
+
+  ['primary', 'secondary'].forEach((filename) => {
+    const biblioXmlPath = `fdirs/${poet.id}/bibliography-${filename}.xml`;
+    const doc = loadXMLDoc(biblioXmlPath);
+    if (doc != null) {
+      data[filename] = getElementsByTagName(doc, 'item').map((line) => {
+        return htmlToXml(safeGetInnerXML(line), collected);
+      });
+    } else {
+      data[filename] = [];
+    }
+  });
+
+  return data;
+};
+
 const build_mentions_json = (collected) => {
   const build_html = (poemId) => {
     const meta = collected.texts.get(poemId);
@@ -228,82 +332,7 @@ const build_mentions_json = (collected) => {
     }
 
     safeMkdir(`public/api/${poet.id}`);
-    let data = {
-      poet,
-      mentions: [],
-      translations: [],
-      primary: [],
-      secondary: [],
-    };
-    const refs = collected.person_or_keyword_refs.get(poetId);
-    if (refs != null) {
-      const seenTranslations = new Set();
-      data.translations = refs.translation
-        .filter((t) => {
-          // Fjern oversættelser som ikke er den ældste variant
-          const { translationPoemId, _ } = t;
-          return (
-            primaryTextVariantId(translationPoemId, collected) ===
-            translationPoemId
-          );
-        })
-        .map((t) => {
-          const { translationPoemId, translatedPoemId } = t;
-          const translationPoem = collected.texts.get(translationPoemId);
-          let translatedPoem = null;
-          if (translatedPoemId != null) {
-            translatedPoem = collected.texts.get(translatedPoemId);
-            if (translatedPoem == null) {
-              throw `${translatedPoemId} not found in texts.`;
-            }
-            seenTranslations.add(translationPoemId);
-          }
-          const result = {
-            translation: {
-              poem: translationPoem,
-              work: collected.works.get(
-                `${translationPoem.poetId}/${translationPoem.workId}`
-              ),
-              poet: collected.poets.get(translationPoem.poetId),
-            },
-          };
-          if (translatedPoem != null) {
-            result.translated = {
-              poem: translatedPoem,
-              work: collected.works.get(
-                `${translatedPoem.poetId}/${translatedPoem.workId}`
-              ),
-            };
-          }
-          return result;
-        });
-      data.mentions = refs.mention
-        .filter((id) => {
-          // Hvis en tekst har varianter som også henviser til denne,
-          // vil vi kun vise den ældste variant.
-          return primaryTextVariantId(id, collected) === id;
-        })
-        .filter((id) => {
-          const isAlsoTranslation = seenTranslations.has(id);
-          if (isAlsoTranslation) {
-            console.log(`Translation ${id} has superfluous mention.`);
-          }
-          return !isAlsoTranslation;
-        })
-        .map(build_html);
-    }
-
-    ['primary', 'secondary'].forEach((filename) => {
-      const biblioXmlPath = `fdirs/${poet.id}/bibliography-${filename}.xml`;
-      const doc = loadXMLDoc(biblioXmlPath);
-      if (doc != null) {
-        data[filename] = getElementsByTagName(doc, 'item').map((line) => {
-          return htmlToXml(safeGetInnerXML(line), collected);
-        });
-      } else {
-        data[filename] = [];
-      }
-    });
+    let data = build_mentions_data(poet, poetId, collected, build_html);
 
     const outFilename = `public/api/${poet.id}/mentions.json`;
     console.log(outFilename);
@@ -313,5 +342,6 @@ const build_mentions_json = (collected) => {
 
 module.exports = {
   build_person_or_keyword_refs,
+  build_mentions_data,
   build_mentions_json,
 };


### PR DESCRIPTION
Retter at henvisningssider kunne blive tomme, når en mention eller oversættelsesreference kun fandtes på en ikke-primær tekstvariant.

Problem:
- Reboul havde `has_mentions=true`, fordi Aarestrups variant `aarestrup20190130175` oversætter `reboul2019013101`.
- `build_mentions_json` filtrerede ikke-primære varianter væk i stedet for at vise den primære variant.
- Resultatet blev en tom `/da/mentions/reboul` trods menupunkt.

Ændringer:
- Normaliserer mentions og translations til `primaryTextVariantId(...)` før rendering.
- Deduplikerer efter normalisering, så flere varianter ikke giver dubletter.
- Tilføjer test for både translations og mentions fra en ikke-primær variant.

Validering:
- `npx jest __tests__/mentions.test.js --runInBand`
- `node --check tools/build-static/mentions.js`
- `git diff --check`

Lukker #1163.