### PR TITLE
Undgå falsk genbyg ved mtime-ændringer

### DIFF
--- a/__tests__/caching.test.js
+++ b/__tests__/caching.test.js
@@ -39,8 +39,11 @@ describe('caching', () => {
   test('treats mtime-only changes as unmodified content', () => {
     const { caching, writes } = loadCaching('same', 200, 'same', 100);
 
-    expect(caching.isFileModified(filename)).toBe(false);
-    expect(caching.isFileModified(filename)).toBe(false);
+    const firstConsumerSeesModified = caching.isFileModified(filename);
+    const nextConsumerSeesModified = caching.isFileModified(filename);
+
+    expect(firstConsumerSeesModified).toBe(false);
+    expect(nextConsumerSeesModified).toBe(false);
 
     caching.refreshFilesModifiedCache();
 
@@ -53,7 +56,10 @@ describe('caching', () => {
   test('keeps content changes marked modified during the same run', () => {
     const { caching } = loadCaching('changed', 200, 'original', 100);
 
-    expect(caching.isFileModified(filename)).toBe(true);
-    expect(caching.isFileModified(filename)).toBe(true);
+    const firstConsumerSeesModified = caching.isFileModified(filename);
+    const nextConsumerSeesModified = caching.isFileModified(filename);
+
+    expect(firstConsumerSeesModified).toBe(true);
+    expect(nextConsumerSeesModified).toBe(true);
   });
 });

--- a/__tests__/caching.test.js
+++ b/__tests__/caching.test.js
@@ -1,0 +1,59 @@
+const crypto = require('crypto');
+
+const filename = 'fdirs/poet/work.xml';
+
+const sha1 = data => {
+  const shasum = crypto.createHash('sha1');
+  shasum.update(data);
+  return shasum.digest('hex');
+};
+
+const loadCaching = (fileContent, fileMtime, cachedContent, cachedMtime) => {
+  jest.resetModules();
+
+  const files = new Map([[filename, { content: fileContent, mtime: fileMtime }]]);
+  const writes = [];
+  const cache = {
+    [filename]: {
+      sha: sha1(cachedContent),
+      mtime: cachedMtime,
+    },
+  };
+
+  jest.doMock('../tools/libs/helpers.js', () => ({
+    loadJSON: path => (path === './caches/files-sha.json' ? cache : null),
+    loadFile: path => files.get(path)?.content ?? null,
+    writeJSON: (path, data) => writes.push({ path, data }),
+    safeMkdir: jest.fn(),
+    fileExists: path => files.has(path),
+    fileModifiedTime: path => files.get(path).mtime,
+  }));
+
+  return {
+    caching: require('../tools/libs/caching.js'),
+    writes,
+  };
+};
+
+describe('caching', () => {
+  test('treats mtime-only changes as unmodified content', () => {
+    const { caching, writes } = loadCaching('same', 200, 'same', 100);
+
+    expect(caching.isFileModified(filename)).toBe(false);
+    expect(caching.isFileModified(filename)).toBe(false);
+
+    caching.refreshFilesModifiedCache();
+
+    expect(writes[0].data[filename]).toEqual({
+      sha: sha1('same'),
+      mtime: 200,
+    });
+  });
+
+  test('keeps content changes marked modified during the same run', () => {
+    const { caching } = loadCaching('changed', 200, 'original', 100);
+
+    expect(caching.isFileModified(filename)).toBe(true);
+    expect(caching.isFileModified(filename)).toBe(true);
+  });
+});

--- a/tools/libs/caching.js
+++ b/tools/libs/caching.js
@@ -13,6 +13,7 @@ const force_reload = process.argv.indexOf('--force-reload') !== -1;
 // Load caches
 let old_sha = loadJSON('./caches/files-sha.json') || {};
 let new_sha = {};
+let modified_files = new Set();
 let unmodified_files = new Set();
 let deleted_files = new Set();
 safeMkdir(`caches`);
@@ -31,6 +32,8 @@ const markFileDirty = (...filenames) => {
     if (filenames[i] != null) {
       //console.log('Marking file dirty: ' + filenames[i]);
       delete old_sha[filenames[i]];
+      delete new_sha[filenames[i]];
+      modified_files.delete(filenames[i]);
       unmodified_files.delete(filenames[i]);
     }
   }
@@ -40,15 +43,20 @@ const isFileModified = (...filenames) => {
   const _isFileModified = filename => {
     // For now remove the :id part of the filename
     filename = filename.split(':')[0];
-    if (new_sha[filename]) {
+    if (modified_files.has(filename)) {
       return true;
     }
     if (unmodified_files.has(filename)) {
       return false;
     }
+    if (new_sha[filename]) {
+      unmodified_files.add(filename);
+      return false;
+    }
     if (!fileExists(filename)) {
       if (old_sha[filename] != null) {
         deleted_files.add(filename);
+        modified_files.add(filename);
         return true;
       } else {
         return false;
@@ -71,13 +79,14 @@ const isFileModified = (...filenames) => {
       digest = 'NO-DATA';
     }
 
-    if (
-      old_sha[filename] == null ||
-      digest !== old_sha[filename].sha ||
-      mtime !== old_sha[filename].mtime
-    ) {
+    if (old_sha[filename] == null || digest !== old_sha[filename].sha) {
       new_sha[filename] = { sha: digest, mtime: mtime };
+      modified_files.add(filename);
       return true;
+    } else if (mtime !== old_sha[filename].mtime) {
+      new_sha[filename] = { sha: digest, mtime: mtime };
+      unmodified_files.add(filename);
+      return false;
     } else {
       unmodified_files.add(filename);
       return false;


### PR DESCRIPTION
## Observation

Bio-buildet skal fortsat afhænge af work XML-filerne, fordi de påvirker digterens tidslinje. Problemet var i stedet, at cache-laget behandlede ændret mtime som en reel filændring, selv når SHA'en var uændret. Det kan især ramme efter checkout eller Docker-kørsler, hvor mange mtimes ændrer sig uden indholdsændringer.

## Ændringer

- Adskiller reelt ændrede filer fra cache-opdateringer i `tools/libs/caching.js`.
- Opdaterer cache-mtime for uændret indhold uden at propagere filen som dirty senere i samme run.
- Tilføjer regressionstest for mtime-only ændringer og for reelle indholdsændringer.

## Validering

- `npm test -- caching.test.js`
- `node --check tools/libs/caching.js`
- `git diff --check`

Lukker #1165.
