### PR TITLE
Indekser kun ændrede værker i Elasticsearch

### DIFF
--- a/__tests__/elastic.test.js
+++ b/__tests__/elastic.test.js
@@ -1,47 +1,44 @@
-const fileContents = new Map();
-
 jest.mock('../tools/libs/helpers.js', () => ({
   htmlToXml: jest.fn(),
   replaceDashes: text => text,
-  loadFile: filename => fileContents.get(filename) || Buffer.from(filename),
 }));
 
 jest.mock('../tools/libs/caching.js', () => ({
-  loadCachedJSON: jest.fn(),
-  writeCachedJSON: jest.fn(),
+  isFileModified: jest.fn(),
   force_reload: false,
 }));
 
 jest.mock('../tools/libs/elasticsearch-client.js', () => ({
   create: jest.fn(),
   createIndex: jest.fn(),
+  deletePoet: jest.fn(),
+  deleteWork: jest.fn(),
   indexExists: jest.fn(),
 }));
 
 jest.mock('../tools/build-static/concurrency.js', () => ({
-  mapLimit: jest.fn(),
+  mapLimit: jest.fn(async (items, fn) => Promise.all(items.map(fn))),
 }));
 
 jest.mock('../tools/build-static/xml.js', () => ({
-  loadXMLDoc: jest.fn(),
-  safeGetText: jest.fn(),
-  safeGetAttr: jest.fn(),
-  getChildByTagName: jest.fn(),
-  getElementsByTagNames: jest.fn(),
-  getChildrenByTagName: jest.fn(),
-  getElementByTagName: jest.fn(),
-  safeGetInnerXML: jest.fn(),
+  loadXMLDoc: jest.fn(() => 'doc'),
+  safeGetText: jest.fn((element, tagName) => tagName),
+  safeGetAttr: jest.fn((element, attrName) => attrName),
+  getChildByTagName: jest.fn(() => 'head'),
+  getElementsByTagNames: jest.fn(() => []),
+  getChildrenByTagName: jest.fn(() => []),
+  getElementByTagName: jest.fn((element, tagName) =>
+    tagName === 'workbody' ? null : tagName
+  ),
+  safeGetInnerXML: jest.fn(() => null),
   tagName: jest.fn(),
 }));
 
 const elasticSearchClient = require('../tools/libs/elasticsearch-client.js');
+const { isFileModified } = require('../tools/libs/caching.js');
 const {
-  loadCachedJSON,
-  writeCachedJSON,
-} = require('../tools/libs/caching.js');
-const {
-  buildElasticsearchSourceSnapshot,
-  getElasticsearchSourceFiles,
+  getChangedElasticsearchWorkEntries,
+  getElasticsearchWorkEntries,
   update_elasticsearch,
 } = require('../tools/build-static/elastic.js');
 
@@ -53,31 +50,105 @@ const collected = {
 describe('Elasticsearch build-static step', () => {
   beforeEach(() => {
     jest.clearAllMocks();
-    fileContents.clear();
+    elasticSearchClient.indexExists.mockResolvedValue(true);
+    isFileModified.mockReturnValue(false);
   });
 
-  test('builds a stable source file list', () => {
-    expect(getElasticsearchSourceFiles(collected)).toEqual([
-      'fdirs/poet/first.xml',
-      'fdirs/poet/info.xml',
-      'fdirs/poet/second.xml',
-      'tools/build-static/elastic.js',
-      'tools/build-static/xml.js',
-      'tools/libs/elasticsearch-client.js',
-      'tools/libs/helpers.js',
+  test('builds stable work entries', () => {
+    expect(
+      getElasticsearchWorkEntries(collected).map(entry => ({
+        workKey: entry.workKey,
+        sourceFiles: entry.sourceFiles,
+      }))
+    ).toEqual([
+      {
+        workKey: 'poet-first',
+        sourceFiles: ['fdirs/poet/info.xml', 'fdirs/poet/first.xml'],
+      },
+      {
+        workKey: 'poet-second',
+        sourceFiles: ['fdirs/poet/info.xml', 'fdirs/poet/second.xml'],
+      },
     ]);
   });
 
-  test('skips Elasticsearch rebuild when sources are unchanged and index exists', async () => {
-    const snapshot = buildElasticsearchSourceSnapshot(collected);
+  test('finds changed works from the shared file cache', () => {
+    isFileModified.mockImplementation((...filenames) =>
+      filenames.includes('fdirs/poet/first.xml')
+    );
 
-    loadCachedJSON.mockReturnValue(snapshot);
-    elasticSearchClient.indexExists.mockResolvedValue(true);
+    const result = getChangedElasticsearchWorkEntries(
+      getElasticsearchWorkEntries(collected)
+    );
+
+    expect(result.modifiedPoetIds.size).toBe(0);
+    expect(result.entries.map(entry => entry.workKey)).toEqual(['poet-first']);
+  });
+
+  test('skips Elasticsearch when no works changed and index exists', async () => {
+    await update_elasticsearch(collected);
+
+    expect(elasticSearchClient.createIndex).not.toHaveBeenCalled();
+    expect(elasticSearchClient.deletePoet).not.toHaveBeenCalled();
+    expect(elasticSearchClient.deleteWork).not.toHaveBeenCalled();
+    expect(elasticSearchClient.create).not.toHaveBeenCalled();
+  });
+
+  test('indexes only changed works', async () => {
+    isFileModified.mockImplementation((...filenames) =>
+      filenames.includes('fdirs/poet/first.xml')
+    );
 
     await update_elasticsearch(collected);
 
     expect(elasticSearchClient.createIndex).not.toHaveBeenCalled();
-    expect(elasticSearchClient.create).not.toHaveBeenCalled();
-    expect(writeCachedJSON).not.toHaveBeenCalled();
+    expect(elasticSearchClient.deletePoet).not.toHaveBeenCalled();
+    expect(elasticSearchClient.deleteWork).toHaveBeenCalledTimes(1);
+    expect(elasticSearchClient.deleteWork).toHaveBeenCalledWith(
+      'kalliope',
+      'poet',
+      'first'
+    );
+    expect(elasticSearchClient.create).toHaveBeenCalledTimes(1);
+    expect(elasticSearchClient.create).toHaveBeenCalledWith(
+      'kalliope',
+      'text',
+      'poet-first',
+      expect.objectContaining({
+        poet: { id: 'poet' },
+        work: expect.objectContaining({ id: 'first' }),
+      })
+    );
+  });
+
+  test('reindexes all poet works when poet info changed', async () => {
+    isFileModified.mockImplementation((...filenames) =>
+      filenames.includes('fdirs/poet/info.xml')
+    );
+
+    await update_elasticsearch(collected);
+
+    expect(elasticSearchClient.deletePoet).toHaveBeenCalledTimes(1);
+    expect(elasticSearchClient.deletePoet).toHaveBeenCalledWith(
+      'kalliope',
+      'poet'
+    );
+    expect(elasticSearchClient.deleteWork).not.toHaveBeenCalled();
+    expect(elasticSearchClient.create).toHaveBeenCalledTimes(2);
+    expect(elasticSearchClient.create.mock.calls.map(call => call[2])).toEqual([
+      'poet-first',
+      'poet-second',
+    ]);
+  });
+
+  test('rebuilds the full index when the index is missing', async () => {
+    elasticSearchClient.indexExists.mockResolvedValue(false);
+
+    await update_elasticsearch(collected);
+
+    expect(elasticSearchClient.createIndex).toHaveBeenCalledWith('kalliope');
+    expect(elasticSearchClient.deletePoet).not.toHaveBeenCalled();
+    expect(elasticSearchClient.deleteWork).not.toHaveBeenCalled();
+    expect(elasticSearchClient.create).toHaveBeenCalledTimes(2);
   });
 });

--- a/__tests__/elastic.test.js
+++ b/__tests__/elastic.test.js
@@ -1,0 +1,83 @@
+const fileContents = new Map();
+
+jest.mock('../tools/libs/helpers.js', () => ({
+  htmlToXml: jest.fn(),
+  replaceDashes: text => text,
+  loadFile: filename => fileContents.get(filename) || Buffer.from(filename),
+}));
+
+jest.mock('../tools/libs/caching.js', () => ({
+  loadCachedJSON: jest.fn(),
+  writeCachedJSON: jest.fn(),
+  force_reload: false,
+}));
+
+jest.mock('../tools/libs/elasticsearch-client.js', () => ({
+  create: jest.fn(),
+  createIndex: jest.fn(),
+  indexExists: jest.fn(),
+}));
+
+jest.mock('../tools/build-static/concurrency.js', () => ({
+  mapLimit: jest.fn(),
+}));
+
+jest.mock('../tools/build-static/xml.js', () => ({
+  loadXMLDoc: jest.fn(),
+  safeGetText: jest.fn(),
+  safeGetAttr: jest.fn(),
+  getChildByTagName: jest.fn(),
+  getElementsByTagNames: jest.fn(),
+  getChildrenByTagName: jest.fn(),
+  getElementByTagName: jest.fn(),
+  safeGetInnerXML: jest.fn(),
+  tagName: jest.fn(),
+}));
+
+const elasticSearchClient = require('../tools/libs/elasticsearch-client.js');
+const {
+  loadCachedJSON,
+  writeCachedJSON,
+} = require('../tools/libs/caching.js');
+const {
+  buildElasticsearchSourceSnapshot,
+  getElasticsearchSourceFiles,
+  update_elasticsearch,
+} = require('../tools/build-static/elastic.js');
+
+const collected = {
+  poets: new Map([['poet', { id: 'poet' }]]),
+  workids: new Map([['poet', ['second', 'first']]]),
+};
+
+describe('Elasticsearch build-static step', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    fileContents.clear();
+  });
+
+  test('builds a stable source file list', () => {
+    expect(getElasticsearchSourceFiles(collected)).toEqual([
+      'fdirs/poet/first.xml',
+      'fdirs/poet/info.xml',
+      'fdirs/poet/second.xml',
+      'tools/build-static/elastic.js',
+      'tools/build-static/xml.js',
+      'tools/libs/elasticsearch-client.js',
+      'tools/libs/helpers.js',
+    ]);
+  });
+
+  test('skips Elasticsearch rebuild when sources are unchanged and index exists', async () => {
+    const snapshot = buildElasticsearchSourceSnapshot(collected);
+
+    loadCachedJSON.mockReturnValue(snapshot);
+    elasticSearchClient.indexExists.mockResolvedValue(true);
+
+    await update_elasticsearch(collected);
+
+    expect(elasticSearchClient.createIndex).not.toHaveBeenCalled();
+    expect(elasticSearchClient.create).not.toHaveBeenCalled();
+    expect(writeCachedJSON).not.toHaveBeenCalled();
+  });
+});

--- a/tools/build-static/elastic.js
+++ b/tools/build-static/elastic.js
@@ -1,10 +1,5 @@
-const crypto = require('crypto');
-const { htmlToXml, replaceDashes, loadFile } = require('../libs/helpers.js');
-const {
-  loadCachedJSON,
-  writeCachedJSON,
-  force_reload,
-} = require('../libs/caching.js');
+const { htmlToXml, replaceDashes } = require('../libs/helpers.js');
+const { isFileModified, force_reload } = require('../libs/caching.js');
 const {
   loadXMLDoc,
   safeGetText,
@@ -26,186 +21,234 @@ const elasticsearchConcurrency = Math.max(
 const elasticsearchForceRebuild = ['1', 'true', 'yes'].includes(
   (process.env.KALLIOPE_ELASTICSEARCH_FORCE_REBUILD || '').toLowerCase()
 );
-const elasticsearchCacheKey = 'elasticsearch-sources';
+const elasticsearchCodeSourceFiles = [
+  'tools/build-static/elastic.js',
+  'tools/build-static/xml.js',
+  'tools/libs/elasticsearch-client.js',
+  'tools/libs/helpers.js',
+];
 
-const getElasticsearchSourceFiles = collected => {
-  const sourceFiles = new Set([
-    'tools/build-static/elastic.js',
-    'tools/build-static/xml.js',
-    'tools/libs/elasticsearch-client.js',
-    'tools/libs/helpers.js',
-  ]);
+const getElasticsearchWorkKey = (poetId, workId) => `${poetId}-${workId}`;
+
+const getElasticsearchWorkSourceFiles = (poetId, workId) => [
+  `fdirs/${poetId}/info.xml`,
+  `fdirs/${poetId}/${workId}.xml`,
+];
+
+const getElasticsearchWorkEntries = collected => {
+  const entries = [];
 
   collected.poets.forEach((poet, poetId) => {
-    sourceFiles.add(`fdirs/${poetId}/info.xml`);
     collected.workids.get(poetId).forEach(workId => {
-      sourceFiles.add(`fdirs/${poetId}/${workId}.xml`);
+      entries.push({
+        poet,
+        poetId,
+        workId,
+        workKey: getElasticsearchWorkKey(poetId, workId),
+        sourceFiles: getElasticsearchWorkSourceFiles(poetId, workId),
+      });
     });
   });
 
-  return Array.from(sourceFiles).sort();
+  return entries.sort((a, b) => a.workKey.localeCompare(b.workKey));
 };
 
-const buildElasticsearchSourceSnapshot = collected => {
-  const sourceFiles = getElasticsearchSourceFiles(collected);
-  const shasum = crypto.createHash('sha1');
+const getChangedElasticsearchWorkEntries = workEntries => {
+  const modifiedPoetIds = new Set();
+  const modifiedWorkKeys = new Set();
 
-  sourceFiles.forEach(filename => {
-    shasum.update(filename);
-    shasum.update('\0');
-    shasum.update(loadFile(filename) || 'NO-DATA');
-    shasum.update('\0');
+  workEntries.forEach(entry => {
+    if (isFileModified(`fdirs/${entry.poetId}/info.xml`)) {
+      modifiedPoetIds.add(entry.poetId);
+    } else if (isFileModified(`fdirs/${entry.poetId}/${entry.workId}.xml`)) {
+      modifiedWorkKeys.add(entry.workKey);
+    }
   });
 
   return {
-    digest: shasum.digest('hex'),
-    sourceFiles,
+    modifiedPoetIds,
+    entries: workEntries.filter(
+      entry =>
+        modifiedPoetIds.has(entry.poetId) || modifiedWorkKeys.has(entry.workKey)
+    ),
   };
 };
 
-const update_elasticsearch = async collected => {
-  const inner_update_elasticsearch = async () => {
-    const tasks = [];
+const buildElasticsearchWorkDocuments = (collected, entry) => {
+  const { poet, poetId, workId, workKey } = entry;
+  const filename = `fdirs/${poetId}/${workId}.xml`;
+  let doc = loadXMLDoc(filename);
+  const work = getElementByTagName(doc, 'kalliopework');
+  const workBody = getElementByTagName(work, 'workbody');
+  const status = safeGetAttr(work, 'status');
+  const type = safeGetAttr(work, 'type');
+  const head = getChildByTagName(work, 'workhead');
+  const title = safeGetText(head, 'title');
+  const year = safeGetText(head, 'year');
+  const workData = {
+    id: workId,
+    title,
+    year,
+    status,
+    type,
+  };
+  const documents = [
+    {
+      id: workKey,
+      data: {
+        poet,
+        work: workData,
+      },
+    },
+  ];
 
-    collected.poets.forEach((poet, poetId) => {
-      collected.workids.get(poetId).forEach(workId => {
-        const filename = `fdirs/${poetId}/${workId}.xml`;
-        let doc = loadXMLDoc(filename);
-        const work = getElementByTagName(doc, 'kalliopework');
-        const workBody = getElementByTagName(work, 'workbody');
-        const status = safeGetAttr(work, 'status');
-        const type = safeGetAttr(work, 'type');
-        const head = getChildByTagName(work, 'workhead');
-        const title = safeGetText(head, 'title');
-        const year = safeGetText(head, 'year');
-        const workData = {
-          id: workId,
-          title,
-          year,
-          status,
-          type,
-        };
-        const data = {
-          poet,
-          work: workData,
-        };
+  if (workBody == null) {
+    return documents;
+  }
 
-        console.log(`Updating work ${poetId}-${workId} in elasticsearch`);
-        tasks.push(() =>
-          elasticSearchClient.create(
-            'kalliope',
-            'text',
-            `${poetId}-${workId}`,
-            data
-          )
+  getElementsByTagNames(workBody, ['text', 'section']).forEach(text => {
+    const textId = safeGetAttr(text, 'id');
+    if (tagName(text) === 'section' && textId == null) {
+      return;
+    }
+    const head = getChildByTagName(text, 'head');
+    const body = getChildByTagName(text, 'body');
+    const title = (
+      safeGetInnerXML(getChildByTagName(head, 'linktitle')) ||
+      safeGetInnerXML(getChildByTagName(head, 'title')) ||
+      safeGetInnerXML(getChildByTagName(head, 'firstline'))
+    ).replace(/<num>.*<\/num>/, '');
+    const keywords = safeGetText(head, 'keywords');
+    let subtitles = null;
+    const subtitle = getChildByTagName(head, 'subtitle');
+    if (subtitle && getChildrenByTagName(subtitle, 'line').length > 0) {
+      subtitles = getChildrenByTagName(subtitle, 'line').map(s =>
+        replaceDashes(safeGetInnerXML(s))
+      );
+    } else if (subtitle) {
+      const subtitleString = safeGetInnerXML(subtitle);
+      if (subtitleString.indexOf('<subtitle/>') === -1) {
+        subtitles = [replaceDashes(subtitleString)];
+      }
+    }
+    let keywordsArray = null;
+    if (keywords) {
+      keywordsArray = keywords.split(',');
+    }
+
+    const textData = {
+      id: textId,
+      title: replaceDashes(title),
+      subtitles,
+      keywords: keywordsArray,
+      content_html: htmlToXml(
+        (safeGetInnerXML(body) || '')
+          .replace(/<note>.*?<\/note>/g, '')
+          .replace(/<footnote>.*?<\/footnote>/g, '')
+          .replace(/<.*?>/g, ' '),
+        collected,
+        false
+      )
+        .map(line => line[0])
+        .join(' ')
+        .replace(/<.*?>/g, ' '),
+    };
+    const data = {
+      poet,
+      work: workData,
+      text: textData,
+    };
+    documents.push({
+      id: textId,
+      data,
+    });
+  });
+
+  return documents;
+};
+
+const writeElasticsearchDocuments = async documents => {
+  console.log(
+    `Writing ${documents.length} Elasticsearch documents with concurrency ${elasticsearchConcurrency}`
+  );
+  let completed = 0;
+  await mapLimit(
+    documents,
+    async document => {
+      const result = await elasticSearchClient.create(
+        'kalliope',
+        'text',
+        document.id,
+        document.data
+      );
+      completed += 1;
+      if (completed % 100 === 0 || completed === documents.length) {
+        console.log(
+          `Wrote ${completed}/${documents.length} Elasticsearch documents`
         );
-        if (workBody == null) {
-          return;
-        }
-        getElementsByTagNames(workBody, ['text', 'section']).forEach(text => {
-          const textId = safeGetAttr(text, 'id');
-          if (tagName(text) === 'section' && textId == null) {
-            return;
-          }
-          const head = getChildByTagName(text, 'head');
-          const body = getChildByTagName(text, 'body');
-          const title = (
-            safeGetInnerXML(getChildByTagName(head, 'linktitle')) ||
-            safeGetInnerXML(getChildByTagName(head, 'title')) ||
-            safeGetInnerXML(getChildByTagName(head, 'firstline'))
-          ).replace(/<num>.*<\/num>/, '');
-          const keywords = safeGetText(head, 'keywords');
-          let subtitles = null;
-          const subtitle = getChildByTagName(head, 'subtitle');
-          if (subtitle && getChildrenByTagName(subtitle, 'line').length > 0) {
-            subtitles = getChildrenByTagName(subtitle, 'line').map(s =>
-              replaceDashes(safeGetInnerXML(s))
-            );
-          } else if (subtitle) {
-            const subtitleString = safeGetInnerXML(subtitle);
-            if (subtitleString.indexOf('<subtitle/>') === -1) {
-              subtitles = [replaceDashes(subtitleString)];
-            }
-          }
-          let keywordsArray = null;
-          if (keywords) {
-            keywordsArray = keywords.split(',');
-          }
+      }
+      return result;
+    },
+    elasticsearchConcurrency
+  );
+};
 
-          const textData = {
-            id: textId,
-            title: replaceDashes(title),
-            subtitles,
-            keywords: keywordsArray,
-            content_html: htmlToXml(
-              (safeGetInnerXML(body) || '')
-                .replace(/<note>.*?<\/note>/g, '')
-                .replace(/<footnote>.*?<\/footnote>/g, '')
-                .replace(/<.*?>/g, ' '),
-              collected,
-              false
-            )
-              .map(line => line[0])
-              .join(' ')
-              .replace(/<.*?>/g, ' '),
-          };
-          const data = {
-            poet,
-            work: workData,
-            text: textData,
-          };
-          //console.log(`Putting textId ${textId}: ${title}`);
-          tasks.push(() =>
-            elasticSearchClient.create('kalliope', 'text', textId, data)
-          );
-        });
-      });
+const update_elasticsearch = async collected => {
+  const indexWorks = async entries => {
+    const documents = [];
+
+    entries.forEach(entry => {
+      console.log(`Updating work ${entry.workKey} in elasticsearch`);
+      const workDocuments = buildElasticsearchWorkDocuments(collected, entry);
+      documents.push(...workDocuments);
     });
 
-    console.log(
-      `Writing ${tasks.length} Elasticsearch documents with concurrency ${elasticsearchConcurrency}`
-    );
-    let completed = 0;
-    await mapLimit(
-      tasks,
-      async task => {
-        const result = await task();
-        completed += 1;
-        if (completed % 100 === 0 || completed === tasks.length) {
-          console.log(
-            `Wrote ${completed}/${tasks.length} Elasticsearch documents`
-          );
-        }
-        return result;
-      },
-      elasticsearchConcurrency
-    );
+    await writeElasticsearchDocuments(documents);
   };
 
   try {
-    const sourceSnapshot = buildElasticsearchSourceSnapshot(collected);
-    const cachedSourceSnapshot = loadCachedJSON(elasticsearchCacheKey);
-    const sourceSnapshotChanged =
-      cachedSourceSnapshot == null ||
-      cachedSourceSnapshot.digest !== sourceSnapshot.digest;
+    const workEntries = getElasticsearchWorkEntries(collected);
     const indexExists = await elasticSearchClient.indexExists('kalliope');
+    const codeModified = isFileModified(...elasticsearchCodeSourceFiles);
+    const needsFullRebuild =
+      force_reload ||
+      elasticsearchForceRebuild ||
+      !indexExists ||
+      codeModified;
 
-    if (
-      !force_reload &&
-      !elasticsearchForceRebuild &&
-      !sourceSnapshotChanged &&
-      indexExists
-    ) {
-      console.log('Skipping Elasticsearch update; source snapshot unchanged');
+    if (needsFullRebuild) {
+      await elasticSearchClient.createIndex('kalliope');
+      await indexWorks(workEntries);
       return;
     }
 
-    await elasticSearchClient.createIndex('kalliope');
-    await inner_update_elasticsearch();
-    writeCachedJSON(elasticsearchCacheKey, {
-      ...sourceSnapshot,
-      updatedAt: new Date().toISOString(),
-    });
+    const {
+      modifiedPoetIds,
+      entries: changedWorkEntries,
+    } = getChangedElasticsearchWorkEntries(workEntries);
+
+    if (changedWorkEntries.length === 0) {
+      console.log('Skipping Elasticsearch update; no changed works');
+      return;
+    }
+
+    await mapLimit(
+      Array.from(modifiedPoetIds),
+      poetId => elasticSearchClient.deletePoet('kalliope', poetId),
+      elasticsearchConcurrency
+    );
+    await mapLimit(
+      changedWorkEntries.filter(entry => !modifiedPoetIds.has(entry.poetId)),
+      entry =>
+        elasticSearchClient.deleteWork(
+          'kalliope',
+          entry.poetId,
+          entry.workId
+        ),
+      elasticsearchConcurrency
+    );
+
+    await indexWorks(changedWorkEntries);
   } catch (error) {
     console.log('Elasticsearch update failed.');
     console.log(error);
@@ -214,7 +257,7 @@ const update_elasticsearch = async collected => {
 };
 
 module.exports = {
-  buildElasticsearchSourceSnapshot,
-  getElasticsearchSourceFiles,
+  getChangedElasticsearchWorkEntries,
+  getElasticsearchWorkEntries,
   update_elasticsearch,
 };

--- a/tools/build-static/elastic.js
+++ b/tools/build-static/elastic.js
@@ -1,4 +1,10 @@
-const { htmlToXml, replaceDashes } = require('../libs/helpers.js');
+const crypto = require('crypto');
+const { htmlToXml, replaceDashes, loadFile } = require('../libs/helpers.js');
+const {
+  loadCachedJSON,
+  writeCachedJSON,
+  force_reload,
+} = require('../libs/caching.js');
 const {
   loadXMLDoc,
   safeGetText,
@@ -17,6 +23,45 @@ const elasticsearchConcurrency = Math.max(
   1,
   parseInt(process.env.KALLIOPE_ELASTICSEARCH_CONCURRENCY, 10) || 1
 );
+const elasticsearchForceRebuild = ['1', 'true', 'yes'].includes(
+  (process.env.KALLIOPE_ELASTICSEARCH_FORCE_REBUILD || '').toLowerCase()
+);
+const elasticsearchCacheKey = 'elasticsearch-sources';
+
+const getElasticsearchSourceFiles = collected => {
+  const sourceFiles = new Set([
+    'tools/build-static/elastic.js',
+    'tools/build-static/xml.js',
+    'tools/libs/elasticsearch-client.js',
+    'tools/libs/helpers.js',
+  ]);
+
+  collected.poets.forEach((poet, poetId) => {
+    sourceFiles.add(`fdirs/${poetId}/info.xml`);
+    collected.workids.get(poetId).forEach(workId => {
+      sourceFiles.add(`fdirs/${poetId}/${workId}.xml`);
+    });
+  });
+
+  return Array.from(sourceFiles).sort();
+};
+
+const buildElasticsearchSourceSnapshot = collected => {
+  const sourceFiles = getElasticsearchSourceFiles(collected);
+  const shasum = crypto.createHash('sha1');
+
+  sourceFiles.forEach(filename => {
+    shasum.update(filename);
+    shasum.update('\0');
+    shasum.update(loadFile(filename) || 'NO-DATA');
+    shasum.update('\0');
+  });
+
+  return {
+    digest: shasum.digest('hex'),
+    sourceFiles,
+  };
+};
 
 const update_elasticsearch = async collected => {
   const inner_update_elasticsearch = async () => {
@@ -138,8 +183,29 @@ const update_elasticsearch = async collected => {
   };
 
   try {
+    const sourceSnapshot = buildElasticsearchSourceSnapshot(collected);
+    const cachedSourceSnapshot = loadCachedJSON(elasticsearchCacheKey);
+    const sourceSnapshotChanged =
+      cachedSourceSnapshot == null ||
+      cachedSourceSnapshot.digest !== sourceSnapshot.digest;
+    const indexExists = await elasticSearchClient.indexExists('kalliope');
+
+    if (
+      !force_reload &&
+      !elasticsearchForceRebuild &&
+      !sourceSnapshotChanged &&
+      indexExists
+    ) {
+      console.log('Skipping Elasticsearch update; source snapshot unchanged');
+      return;
+    }
+
     await elasticSearchClient.createIndex('kalliope');
     await inner_update_elasticsearch();
+    writeCachedJSON(elasticsearchCacheKey, {
+      ...sourceSnapshot,
+      updatedAt: new Date().toISOString(),
+    });
   } catch (error) {
     console.log('Elasticsearch update failed.');
     console.log(error);
@@ -148,5 +214,7 @@ const update_elasticsearch = async collected => {
 };
 
 module.exports = {
+  buildElasticsearchSourceSnapshot,
+  getElasticsearchSourceFiles,
   update_elasticsearch,
 };

--- a/tools/libs/elasticsearch-client.js
+++ b/tools/libs/elasticsearch-client.js
@@ -34,6 +34,24 @@ const requestWithRetry = async (URL, options, attempts = 15) => {
 };
 
 class ElasticSearchClient {
+  async indexExists(index) {
+    const URL = `${URLPrefix}/${index}`;
+    const res = await fetch(URL, {
+      method: 'HEAD',
+      timeout: requestTimeout,
+    });
+    if (res.ok) {
+      return true;
+    }
+    if (res.status === 404) {
+      return false;
+    }
+    const text = await res.text();
+    throw new Error(
+      `Elasticsearch HEAD ${URL} failed: ${res.status} ${text}`
+    );
+  }
+
   async createIndex(index) {
     const URL = `${URLPrefix}/${index}`;
     const deleteRes = await fetch(URL, {

--- a/tools/libs/elasticsearch-client.js
+++ b/tools/libs/elasticsearch-client.js
@@ -91,6 +91,45 @@ class ElasticSearchClient {
     return res.json();
   }
 
+  async deleteByQuery(index, query) {
+    const URL = `${URLPrefix}/${index}/_delete_by_query?conflicts=proceed&refresh=true`;
+    const res = await requestWithRetry(URL, {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+      },
+      body: JSON.stringify({ query }),
+    });
+    return res.json();
+  }
+
+  deletePoet(index, poetId) {
+    return this.deleteByQuery(index, {
+      term: {
+        'poet.id': poetId,
+      },
+    });
+  }
+
+  deleteWork(index, poetId, workId) {
+    return this.deleteByQuery(index, {
+      bool: {
+        filter: [
+          {
+            term: {
+              'poet.id': poetId,
+            },
+          },
+          {
+            term: {
+              'work.id': workId,
+            },
+          },
+        ],
+      },
+    });
+  }
+
   // Returns the raw JSON as (a promise of) text, not as an object.
   search(index, type, country, poetId, query, page = 0) {
     const URL = `${URLPrefix}/${index}/_search`;


### PR DESCRIPTION
## Observation

`docker compose --profile build run --rm static-builder` persisterer allerede både `./caches` og Elasticsearch-volumenet. Problemet var derfor ikke primært Docker-volumenerne.

Det underlige var, at `update_elasticsearch` altid kaldte `createIndex('kalliope')`, og `createIndex` sletter indexet før det oprettes igen. Dermed blev Elasticsearch genbygget fra bunden ved hvert static-builder-run, selv om `caches/files-sha.json` allerede kan fortælle hvilke kildefiler der er ændret.

## Ændringer

- Bruger den eksisterende `isFileModified()`/`caches/files-sha.json` til at finde ændrede værker.
- Skipper Elasticsearch-trinnet, når ingen værker er ændret og indexet findes.
- Sletter og genindekserer kun ændrede værker.
- Hvis `info.xml` for en digter ændres, slettes digterens ES-dokumenter og alle digterens aktuelle værker genindekseres, fordi poet-data ligger i hvert dokument.
- Beholder fuld rebuild når indexet mangler, ved `--force-reload`, ved `KALLIOPE_ELASTICSEARCH_FORCE_REBUILD=1`, eller når ES-buildkoden ændres.
- Tilføjer `_delete_by_query`-helpers til at slette dokumenter for en digter eller et værk før genindeksering.

## Validering

- `npm test -- elastic.test.js caching.test.js`
- `node --check tools/build-static/elastic.js`
- `node --check tools/libs/elasticsearch-client.js`
- `git diff --check`

Lukker #1164.
