### PR TITLE
Gør Docker build-flow mere robust

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,7 +48,8 @@ docker compose --profile build run --rm static-builder
 docker compose up --build app
 ```
 
-Det starter appen på `http://localhost:3000` og Elasticsearch på `http://localhost:9200`.
+Det starter appen på `http://localhost:3001`. Elasticsearch kører kun på
+Docker-netværket og er ikke eksponeret på hosten.
 
 Efter ændringer i XML-filer under `data/` eller `fdirs/` skal builderen køres igen:
 

--- a/tools/libs/elasticsearch-client.js
+++ b/tools/libs/elasticsearch-client.js
@@ -7,7 +7,12 @@ const requestTimeout = Math.max(
 );
 const wait = ms => new Promise(resolve => setTimeout(resolve, ms));
 
-const requestWithRetry = async (URL, options, attempts = 15) => {
+const requestWithRetry = async (
+  URL,
+  options,
+  attempts = 15,
+  acceptedStatuses = []
+) => {
   let lastError = null;
   const requestOptions = {
     timeout: requestTimeout,
@@ -16,7 +21,7 @@ const requestWithRetry = async (URL, options, attempts = 15) => {
   for (let attempt = 1; attempt <= attempts; attempt++) {
     try {
       const res = await fetch(URL, requestOptions);
-      if (res.ok) {
+      if (res.ok || acceptedStatuses.includes(res.status)) {
         return res;
       }
       const text = await res.text();
@@ -54,16 +59,15 @@ class ElasticSearchClient {
 
   async createIndex(index) {
     const URL = `${URLPrefix}/${index}`;
-    const deleteRes = await fetch(URL, {
-      method: 'DELETE',
-      timeout: requestTimeout,
-    });
-    const deleteText = await deleteRes.text();
-    if (!deleteRes.ok && deleteRes.status !== 404) {
-      throw new Error(
-        `Elasticsearch DELETE ${URL} failed: ${deleteRes.status} ${deleteText}`
-      );
-    }
+    const deleteRes = await requestWithRetry(
+      URL,
+      {
+        method: 'DELETE',
+      },
+      15,
+      [404]
+    );
+    await deleteRes.text();
     const putRes = await requestWithRetry(URL, {
       method: 'PUT',
       headers: {

--- a/tools/wait-for-elasticsearch.js
+++ b/tools/wait-for-elasticsearch.js
@@ -12,10 +12,13 @@ const waitForElasticsearch = async () => {
     try {
       const response = await fetch(healthUrl);
       if (response.ok) {
-        return;
+        const health = await response.json();
+        if (health.status === 'yellow' || health.status === 'green') {
+          return;
+        }
       }
     } catch (error) {
-      // Ignore connection errors while Elasticsearch is booting.
+      // Ignore connection and parse errors while Elasticsearch is booting.
     }
 
     await sleep(1000);


### PR DESCRIPTION
## Ændringer
- Venter på at Elasticsearch bliver `yellow` eller `green`, før app/builder fortsætter.
- Bruger retry ved sletning af Elasticsearch-index før genoprettelse.
- Retter README, så Docker-URL’en matcher compose-porten og Elasticsearch-beskrivelsen.

## Validering
- Static build i Docker gennemførte og indekserede Elasticsearch.
- Appen svarede `200 OK` på `http://127.0.0.1:3001/`.
- Søgning på `sol` gav hits.