### PR TITLE
Skip eksisterende thumbnails for uændrede billeder

### DIFF
--- a/__tests__/sharp-images.test.js
+++ b/__tests__/sharp-images.test.js
@@ -3,19 +3,23 @@ const os = require('os');
 const path = require('path');
 const sharp = require('sharp');
 
-const { resizeImage } = require('../tools/libs/helpers.js');
+const { buildThumbnails, resizeImage } = require('../tools/libs/helpers.js');
 const { imageSizeSync } = require('../tools/build-static/image.js');
+const ImagePaths = require('../common/imagepaths.js');
 
 describe('sharp image helpers', () => {
   let tmpdir;
+  let cwd;
   let logSpy;
 
   beforeEach(() => {
     tmpdir = fs.mkdtempSync(path.join(os.tmpdir(), 'kalliope-images-'));
+    cwd = process.cwd();
     logSpy = jest.spyOn(console, 'log').mockImplementation(() => {});
   });
 
   afterEach(() => {
+    process.chdir(cwd);
     logSpy.mockRestore();
     fs.rmSync(tmpdir, { recursive: true, force: true });
   });
@@ -66,5 +70,54 @@ describe('sharp image helpers', () => {
       width: 123,
       height: 45,
     });
+  });
+
+  it('keeps existing thumbnails when the source mtime changes without content changes', async () => {
+    process.chdir(tmpdir);
+    fs.mkdirSync('public/images/poet', { recursive: true });
+    await createJpeg('public/images/poet/p1.jpg', 320, 180);
+
+    await buildThumbnails('public/images', () => true);
+
+    const output = `public${ImagePaths.thumbnailSrc(
+      '/images/poet/p1.jpg',
+      100,
+      'jpg'
+    )}`;
+    const outputMtime = fs.statSync(output).mtimeMs;
+    const future = new Date(Date.now() + 60000);
+    fs.utimesSync('public/images/poet/p1.jpg', future, future);
+
+    await buildThumbnails('public/images', () => false);
+
+    expect(fs.statSync(output).mtimeMs).toBe(outputMtime);
+  });
+
+  it('creates missing thumbnails even when the source content is unchanged', async () => {
+    process.chdir(tmpdir);
+    fs.mkdirSync('public/images/poet', { recursive: true });
+    await createJpeg('public/images/poet/p1.jpg', 320, 180);
+
+    await buildThumbnails('public/images', () => true);
+
+    const missingOutput = `public${ImagePaths.thumbnailSrc(
+      '/images/poet/p1.jpg',
+      100,
+      'jpg'
+    )}`;
+    const existingOutput = `public${ImagePaths.thumbnailSrc(
+      '/images/poet/p1.jpg',
+      150,
+      'jpg'
+    )}`;
+    const existingOutputMtime = fs.statSync(existingOutput).mtimeMs;
+    fs.unlinkSync(missingOutput);
+    const future = new Date(Date.now() + 60000);
+    fs.utimesSync('public/images/poet/p1.jpg', future, future);
+
+    await buildThumbnails('public/images', () => false);
+
+    expect(fs.existsSync(missingOutput)).toBe(true);
+    expect(fs.statSync(existingOutput).mtimeMs).toBe(existingOutputMtime);
   });
 });

--- a/tools/libs/helpers.js
+++ b/tools/libs/helpers.js
@@ -305,6 +305,9 @@ const buildThumbnails = async (topFolder, isFileModifiedMethod) => {
         filename.endsWith('.jpg') &&
         !skipRegExps.test(filename)
       ) {
+        const hasModificationCache = isFileModifiedMethod != null;
+        const sourceModified =
+          hasModificationCache && isFileModifiedMethod(fullFilename);
         const sourceMtime = fileModifiedTime(fullFilename);
         CommonData.availableImageFormats.forEach((ext, i) => {
           CommonData.availableImageWidths.forEach(width => {
@@ -315,7 +318,12 @@ const buildThumbnails = async (topFolder, isFileModifiedMethod) => {
             )}`;
             safeMkdir(outputfile.replace(/\/[^\/]+?$/, ''));
             const outputMtime = fileModifiedTime(outputfile);
-            if (outputMtime == null || sourceMtime > outputMtime) {
+            if (
+              outputMtime == null ||
+              (hasModificationCache
+                ? sourceModified
+                : sourceMtime > outputMtime)
+            ) {
               tasks.push(
                 limit(() => {
                   return resizeImage(fullFilename, outputfile, width);


### PR DESCRIPTION
## Observation

Thumbnail-genereringen kiggede kun på kildebilledets og outputfilens mtime. Hvis kildebilleder fik nye mtimes efter checkout/cache-uro, blev eksisterende thumbnails derfor regenereret, selv om billedindholdet var uændret og outputfilerne allerede fandtes.

## Ændringer

- `buildThumbnails` bruger nu den eksisterende `isFileModified`-funktion, når den gives fra `build-static`.
- For uændrede kildebilleder genereres kun manglende thumbnail-filer.
- For ændrede kildebilleder regenereres thumbnails stadig.
- Kald uden cachefunktion bevarer den gamle mtime-baserede adfærd.
- Tilføjer test for eksisterende thumbnails med ændret source-mtime og for manglende thumbnail-output.

## Validering

- `npm test -- sharp-images.test.js`
- `node --check tools/libs/helpers.js`
- `git diff --check`
