### PR TITLE
Lad SidebarPictures rendere billeder

### DIFF
--- a/components/sidebarpictures.js
+++ b/components/sidebarpictures.js
@@ -1,6 +1,42 @@
-const SidebarPictures = ({ children }) => {
+import Picture from './picture.js';
+
+const pictureKey = (picture, index) => {
+  if (picture.key != null) {
+    return picture.key;
+  }
+  const firstPicture =
+    picture.pictures != null
+      ? picture.pictures[picture.startIndex || 0]
+      : picture;
+  return firstPicture.id || firstPicture.src || index;
+};
+
+const pictureProps = (picture, defaultProps) => {
+  if (picture.pictures != null) {
+    const { key, ...props } = picture;
+    return { ...defaultProps, ...props };
+  }
+  return {
+    ...defaultProps,
+    pictures: [picture],
+    contentLang: picture.content_lang || 'da',
+  };
+};
+
+const SidebarPictures = ({ children, pictures = [], lang, ...defaultProps }) => {
+  const renderedPictures = pictures.map((picture, index) => {
+    return (
+      <Picture
+        key={pictureKey(picture, index)}
+        lang={lang}
+        {...pictureProps(picture, defaultProps)}
+      />
+    );
+  });
+
   return (
     <div className="sidebar-pictures">
+      {renderedPictures}
       {children}
       <style jsx>{`
         div.sidebar-pictures {

--- a/pages/about.js
+++ b/pages/about.js
@@ -6,7 +6,6 @@ import * as Links from '../components/links';
 import { kalliopeMenu } from '../components/menu.js';
 import Note from '../components/note.js';
 import Page from '../components/page.js';
-import Picture from '../components/picture.js';
 import SidebarPictures from '../components/sidebarpictures.js';
 import SidebarSplit from '../components/sidebarsplit.js';
 import SubHeading from '../components/subheading.js';
@@ -24,20 +23,14 @@ const About = (props) => {
     return <ErrorPage error={error} lang={lang} message="Ukendt nøgleord" />;
   }
 
-  const pictures = keyword.pictures.map((p, i) => {
-    return (
-      <Picture
-        key={'pic' + i}
-        pictures={[p]}
-        contentLang={p.content_lang || 'da'}
-        showDropShadow={aboutItemId !== 'kalliope'}
-        clickToZoom={aboutItemId !== 'kalliope'}
-        lang={lang}
-      />
-    );
-  });
   const renderedPictures = (
-    <SidebarPictures key="pictures">{pictures}</SidebarPictures>
+    <SidebarPictures
+      key="pictures"
+      pictures={keyword.pictures}
+      showDropShadow={aboutItemId !== 'kalliope'}
+      clickToZoom={aboutItemId !== 'kalliope'}
+      lang={lang}
+    />
   );
   const renderedNotes = keyword.notes.map((note, i) => {
     return (

--- a/pages/keyword.js
+++ b/pages/keyword.js
@@ -6,7 +6,6 @@ import { FootnoteContainer, FootnoteList } from '../components/footnotes.js';
 import * as Links from '../components/links';
 import { kalliopeMenu } from '../components/menu.js';
 import Page from '../components/page.js';
-import Picture from '../components/picture.js';
 import SidebarPictures from '../components/sidebarpictures.js';
 import SidebarSplit from '../components/sidebarsplit.js';
 import SubHeading from '../components/subheading.js';
@@ -22,17 +21,9 @@ const KeywordPage = (props) => {
 
   const requestPath = `/${lang}/keyword/${keyword.id}`;
 
-  const pictures = keyword.pictures.map((p, i) => {
-    return (
-      <Picture
-        key={i}
-        pictures={[p]}
-        contentLang={p.content_lang || 'da'}
-        lang={lang}
-      />
-    );
-  });
-  const renderedPictures = <SidebarPictures>{pictures}</SidebarPictures>;
+  const renderedPictures = (
+    <SidebarPictures pictures={keyword.pictures} lang={lang} />
+  );
 
   let sidebar = [];
 

--- a/pages/text.js
+++ b/pages/text.js
@@ -13,7 +13,6 @@ import * as Links from '../components/links';
 import { poetMenu } from '../components/menu.js';
 import Note from '../components/note.js';
 import Page from '../components/page.js';
-import Picture from '../components/picture.js';
 import { poetNameString } from '../components/poetname-helpers.js';
 import PoetName from '../components/poetname.js';
 import SidebarPictures from '../components/sidebarpictures.js';
@@ -334,16 +333,7 @@ const TextPage = (props) => {
     renderedNotes = <div style={{ marginBottom: '30px' }}>{notes}</div>;
   }
 
-  let textPictures = text.pictures.map((p, i) => {
-    return (
-      <Picture
-        key={'textpicture' + i}
-        pictures={[p]}
-        contentLang={p.content_lang || 'da'}
-        lang={lang}
-      />
-    );
-  });
+  let textPictures = [...text.pictures];
 
   if (text.source != null && text.source.facsimilePages != null) {
     function pad(num, size) {
@@ -361,20 +351,18 @@ const TextPage = (props) => {
         content_lang: 'da',
       });
     }
-    textPictures.push(
-      <Picture
-        key={'facsimile' + firstPageNumber}
-        pictures={facsimilePictures}
-        startIndex={firstPageNumber - 1}
-        lang="da"
-        contentLang="da"
-      />
-    );
+    textPictures.push({
+      key: 'facsimile' + firstPageNumber,
+      pictures: facsimilePictures,
+      startIndex: firstPageNumber - 1,
+      lang: 'da',
+      contentLang: 'da',
+    });
   }
 
   const renderedPictures = (
     <div style={{ marginTop: '30px' }}>
-      <SidebarPictures>{textPictures}</SidebarPictures>
+      <SidebarPictures pictures={textPictures} lang={lang} />
     </div>
   );
 

--- a/pages/work.js
+++ b/pages/work.js
@@ -7,7 +7,6 @@ import * as Links from '../components/links.js';
 import { poetMenu } from '../components/menu.js';
 import Note from '../components/note.js';
 import Page from '../components/page.js';
-import Picture from '../components/picture.js';
 import { poetNameString } from '../components/poetname-helpers.js';
 import PoetName from '../components/poetname.js';
 import SidebarPictures from '../components/sidebarpictures.js';
@@ -51,17 +50,7 @@ const WorkPage = (props) => {
     );
   });
 
-  const workPictures = pictures.map((p, i) => {
-    return (
-      <Picture
-        pictures={[p]}
-        key={'picture' + i}
-        contentLang={p.content_lang || 'da'}
-        lang={lang}
-      />
-    );
-  });
-  const renderedPictures = <SidebarPictures>{workPictures}</SidebarPictures>;
+  const renderedPictures = <SidebarPictures pictures={pictures} lang={lang} />;
   const completedStatus =
     work.status === 'incomplete' && work.id !== 'andre' ? (
       <div>


### PR DESCRIPTION
## Ændringer

- Lader `SidebarPictures` tage en `pictures`-prop og selv rendere `<Picture>`.
- Fjerner gentaget `pictures.map(...<Picture />...)` fra `work`, `text`, `keyword` og `about`.
- Bevarer tekstsidens facsimile-visning ved at lade `SidebarPictures` acceptere entries med egne `pictures`, `startIndex` og øvrige `Picture`-props.

## Validering

- `npm test -- strings.test.js textname.test.js variants.test.js`
- `npm run build`
- `git diff --check`
