### PR TITLE
Udvid ejefald for digternavne

### DIFF
--- a/__tests__/poetname.test.js
+++ b/__tests__/poetname.test.js
@@ -116,7 +116,7 @@ describe('String method', () => {
     expect(poetLastNameString({ name: {} })).toEqual('Ukendt');
   });
 
-  it('formats genitive last names in Danish and English', () => {
+  it('formats genitive last names', () => {
     expect(poetGenetiveLastName({ name: { lastname: 'Petersen' } }, 'da')).toBe(
       'Petersens'
     );
@@ -126,11 +126,29 @@ describe('String method', () => {
     expect(poetGenetiveLastName({ name: { lastname: 'Petersen' } }, 'en')).toBe(
       'Petersen’s'
     );
-    expect(poetGenetiveLastName({ name: { lastname: 'S' } }, 'en')).toBe(
-      'S’s'
+    expect(poetGenetiveLastName({ name: { lastname: 'Dickens' } }, 'en')).toBe(
+      'Dickens’'
     );
-    expect(() => poetGenetiveLastName({ name: {} }, 'fr')).toThrow(
-      'Ukendt sprog: fr'
+    expect(poetGenetiveLastName({ name: { lastname: 'Marx' } }, 'en')).toBe(
+      'Marx’s'
+    );
+    expect(poetGenetiveLastName({ name: { lastname: 'Berlioz' } }, 'en')).toBe(
+      'Berlioz’s'
+    );
+    expect(poetGenetiveLastName({ name: { lastname: 'Goethe' } }, 'de')).toBe(
+      'von Goethe'
+    );
+    expect(poetGenetiveLastName({ name: { lastname: 'Reboul' } }, 'fr')).toBe(
+      'de Reboul'
+    );
+    expect(
+      poetGenetiveLastName({ name: { lastname: 'Aarestrup' } }, 'fr')
+    ).toBe('d’Aarestrup');
+    expect(poetGenetiveLastName({ name: { lastname: "d'Urfé" } }, 'fr')).toBe(
+      'd’Urfé'
+    );
+    expect(() => poetGenetiveLastName({ name: {} }, 'it')).toThrow(
+      'Ukendt sprog: it'
     );
   });
 });

--- a/__tests__/translations.test.js
+++ b/__tests__/translations.test.js
@@ -16,5 +16,11 @@ describe('translations helper', () => {
     expect(_('Søg i {genetiveLastName} værker', 'en', {
       genetiveLastName: 'Aarestrup',
     })).toBe('Search Aarestrup works');
+    expect(_('Søg i {genetiveLastName} værker', 'de', {
+      genetiveLastName: 'von Goethe',
+    })).toBe('In den Werken von Goethe suchen');
+    expect(_('Søg i {genetiveLastName} værker', 'fr', {
+      genetiveLastName: 'de Reboul',
+    })).toBe('Rechercher dans les œuvres de Reboul');
   });
 });

--- a/common/translations.js
+++ b/common/translations.js
@@ -56,9 +56,13 @@ const translations = {
   'en*knytter sig til samme dato.': 'are associated with the same date.',
 
   'de*og': 'und',
+  'de*Søg i {genetiveLastName} værker':
+    'In den Werken {genetiveLastName} suchen',
   'de*knytter sig til samme dato.': 'beziehen sich auf dasselbe Datum.',
 
   'fr*og': 'et',
+  'fr*Søg i {genetiveLastName} værker':
+    'Rechercher dans les œuvres {genetiveLastName}',
   'fr*knytter sig til samme dato.': 'se rapportent à la même date.',
 };
 

--- a/components/poetname-helpers.js
+++ b/components/poetname-helpers.js
@@ -76,18 +76,44 @@ export function poetLastNameString(poet) {
 export function poetGenetiveLastName(poet, lang) {
   const { firstname, lastname } = poet.name;
   let name = nvl(lastname, nvl(firstname, 'Ukendt'));
+
+  const danskEjefald = (navn) => {
+    if (navn.match(/[szx]$/)) {
+      return `${navn}’`;
+    }
+    return `${navn}s`;
+  };
+
+  const engelskEjefald = (navn) => {
+    if (navn.match(/s$/i)) {
+      return `${navn}’`;
+    }
+    return `${navn}’s`;
+  };
+
+  const tyskEjefald = (navn) => {
+    return `von ${navn}`;
+  };
+
+  const franskEjefald = (navn) => {
+    const leadingElision = navn.match(/^d['’](.+)$/i);
+    if (leadingElision != null) {
+      return `d’${leadingElision[1]}`;
+    }
+    if (navn.match(/^[aeiouyàâäéèêëîïôöùûüÿæœ]/i)) {
+      return `d’${navn}`;
+    }
+    return `de ${navn}`;
+  };
+
   if (lang === 'da') {
-    if (name.match(/[szx]$/)) {
-      return `${name}’`;
-    } else {
-      return `${name}s`;
-    }
+    return danskEjefald(name);
   } else if (lang === 'en') {
-    if (name.match(/s$/)) {
-      return `${name}’`;
-    } else {
-      return `${name}’s`;
-    }
+    return engelskEjefald(name);
+  } else if (lang === 'de') {
+    return tyskEjefald(name);
+  } else if (lang === 'fr') {
+    return franskEjefald(name);
   } else {
     throw `Ukendt sprog: ${lang}`;
   }


### PR DESCRIPTION
## Ændringer

- Udvider `poetGenetiveLastName` til fransk og tysk.
- Bevarer engelsk `’s` ved `x`/`z`-endelser, men bruger apostrof ved `s`.
- Gør fransk form robust for navne som `d'Urfé`, så formen bliver `d’Urfé` og ikke `de d'Urfé`.
- Tilføjer tyske og franske oversættelser af søge-placeholderen.

## Validering

- `npm test -- poetname.test.js translations.test.js`
- `npm run build`
- `git diff --check`
