### PR TITLE
Udvid testdækning for sortering

### DIFF
--- a/__tests__/sorting.test.js
+++ b/__tests__/sorting.test.js
@@ -2,6 +2,15 @@ import * as Sorting from '../common/sorting.js';
 
 //const Sorting = require('./sorting.js');
 
+describe('locale lookup', () => {
+  it('returns known locales and falls back to Danish', () => {
+    expect(Sorting.localeForLang('fr')).toBe('fr-FR');
+    expect(Sorting.localeForLang('unknown')).toBe('da-DK');
+    expect(Sorting.localeForCountry('us')).toBe('en-US');
+    expect(Sorting.localeForCountry('unknown')).toBe('da-DK');
+  });
+});
+
 describe('sectionsByTitle', () => {
   it('sorts ÆØÅ correctly', () => {
     const data = ['Ø', 'A', 'Æ', 'B', 'Å', 'C'].map(x => {
@@ -29,6 +38,37 @@ describe('sectionsByTitle', () => {
   });
 });
 
+describe('poetsByLastname', () => {
+  it('uses sortname before lastname and firstname', () => {
+    const data = [
+      { name: { firstname: 'Jens', lastname: 'Baggesen' } },
+      {
+        name: {
+          firstname: 'Adam',
+          lastname: 'Oehlenschläger',
+          sortname: 'Adam Oehlenschläger',
+        },
+      },
+      { name: { firstname: 'Johan Ludvig', lastname: 'Heiberg' } },
+    ];
+    const sorted = data.sort(Sorting.poetsByLastname).map((x) => {
+      return x.name.lastname;
+    });
+    expect(sorted).toEqual(['Oehlenschläger', 'Baggesen', 'Heiberg']);
+  });
+
+  it('falls back to firstname when lastname is missing', () => {
+    const data = [
+      { name: { firstname: 'Zacharias' } },
+      { name: { firstname: 'Ambrosius' } },
+    ];
+    const sorted = data.sort(Sorting.poetsByLastname).map((x) => {
+      return x.name.firstname;
+    });
+    expect(sorted).toEqual(['Ambrosius', 'Zacharias']);
+  });
+});
+
 describe('poetsByLastnameForCountry', () => {
   it('sorts German poet names by German collation', () => {
     const data = ['Müller', 'Mörike', 'Mozart', 'Meyer'].map((lastname) => {
@@ -50,6 +90,80 @@ describe('poetsByLastnameForCountry', () => {
       .sort(Sorting.poetsByLastnameForCountry('un'))
       .map((x) => x.name.lastname);
     expect(sorted).toEqual(['Andersen', 'Blicher', 'Øster', 'Aagesen']);
+  });
+});
+
+describe('poetsByBirthDate', () => {
+  it('sorts poets by birth date', () => {
+    const data = [
+      {
+        name: { lastname: 'Middle' },
+        period: { born: { date: '1850-01-01' } },
+      },
+      {
+        name: { lastname: 'Late' },
+        period: { born: { date: '1900-01-01' } },
+      },
+      {
+        name: { lastname: 'Early' },
+        period: { born: { date: '1800-01-01' } },
+      },
+      {
+        name: { lastname: 'Later' },
+        period: { born: { date: '1920-01-01' } },
+      },
+    ];
+    const sorted = data.sort(Sorting.poetsByBirthDate).map((x) => {
+      return x.name.lastname;
+    });
+    expect(sorted).toEqual(['Early', 'Middle', 'Late', 'Later']);
+  });
+
+  it('sorts equal birth dates by lastname', () => {
+    const data = [
+      {
+        name: { lastname: 'Ørsted' },
+        period: { born: { date: '1782-10-11' } },
+      },
+      {
+        name: { lastname: 'Blicher' },
+        period: { born: { date: '1782-10-11' } },
+      },
+      {
+        name: { lastname: 'Aarestrup' },
+        period: { born: { date: '1782-10-11' } },
+      },
+    ];
+    const sorted = data.sort(Sorting.poetsByBirthDate).map((x) => {
+      return x.name.lastname;
+    });
+    expect(sorted).toEqual(['Blicher', 'Ørsted', 'Aarestrup']);
+  });
+
+  it('falls back to lastname when period data is missing', () => {
+    const data = [
+      { name: { lastname: 'Ørsted' } },
+      { name: { lastname: 'Blicher' } },
+      { name: { lastname: 'Aarestrup' } },
+      { name: { lastname: 'Andersen' } },
+    ];
+    const sorted = data.sort(Sorting.poetsByBirthDate).map((x) => {
+      return x.name.lastname;
+    });
+    expect(sorted).toEqual(['Andersen', 'Blicher', 'Ørsted', 'Aarestrup']);
+  });
+
+  it('uses country collation when birth dates are equal', () => {
+    const data = ['Müller', 'Meyer', 'Mörike', 'Mozart'].map((lastname) => {
+      return {
+        name: { lastname },
+        period: { born: { date: '1800-01-01' } },
+      };
+    });
+    const sorted = data
+      .sort(Sorting.poetsByBirthDateForCountry('de'))
+      .map((x) => x.name.lastname);
+    expect(sorted).toEqual(['Meyer', 'Mörike', 'Mozart', 'Müller']);
   });
 });
 
@@ -143,9 +257,23 @@ describe('linesPairsByLineForLang', () => {
   });
 });
 
+describe('linesPairsByLine', () => {
+  it('sorts lines by Danish collation', () => {
+    const data = ['Ø', 'A', 'Æ', 'B', 'Aa'].map((x) => {
+      return { sortBy: x };
+    });
+    const sorted = data.sort(Sorting.linesPairsByLine).map((x) => x.sortBy);
+    expect(sorted).toEqual(['A', 'B', 'Æ', 'Ø', 'Aa']);
+  });
+});
+
 describe('lineSectionTitleForLang', () => {
   it('groups Danish Aa as Å', () => {
     expect(Sorting.lineSectionTitleForLang('Aarets tider', 'da')).toEqual('Å');
+  });
+
+  it('groups Danish Ö as Ø', () => {
+    expect(Sorting.lineSectionTitleForLang('Örnens flugt', 'da')).toEqual('Ø');
   });
 
   it('groups German umlauts by their base letters', () => {
@@ -160,6 +288,24 @@ describe('lineSectionTitleForLang', () => {
 
   it('groups accented letters by their base letters outside Danish', () => {
     expect(Sorting.lineSectionTitleForLang('Ève', 'fr')).toEqual('E');
+  });
+});
+
+describe('title sorters', () => {
+  it('sorts keywords by Danish title collation', () => {
+    const data = ['Ømhed', 'Almue', 'Ånd'].map((title) => {
+      return { title };
+    });
+    const sorted = data.sort(Sorting.keywordsByTitle).map((x) => x.title);
+    expect(sorted).toEqual(['Almue', 'Ømhed', 'Ånd']);
+  });
+
+  it('sorts dict items by Danish title collation', () => {
+    const data = ['Ørn', 'Aand', 'Æble'].map((title) => {
+      return { title };
+    });
+    const sorted = data.sort(Sorting.dictItemsByTitle).map((x) => x.title);
+    expect(sorted).toEqual(['Æble', 'Ørn', 'Aand']);
   });
 });
 
@@ -186,5 +332,15 @@ describe('poetYearSectionsByTitle', () => {
       '100 - 124',
       'Ukendt fødeår',
     ]);
+  });
+
+  it('sorts numeric BCE-style negative intervals before CE intervals', () => {
+    const data = ['1 - 24', '-50 - -26', '-25 - -1'].map((x) => {
+      return { title: x };
+    });
+    const sorted = data
+      .sort(Sorting.poetYearSectionsByTitle)
+      .map((x) => x.title);
+    expect(sorted).toEqual(['-50 - -26', '-25 - -1', '1 - 24']);
   });
 });


### PR DESCRIPTION
## Resumé
- tilføjer tests for locale fallback, sortname og birthdate-sortering
- dækker basislinjesortering, keyword/dict-sortering og dansk Ö-gruppering
- udvider årstalssektion-tests med negative intervaller

## Test
- npm test -- __tests__/sorting.test.js --runInBand