### PR TITLE
Gør søgning accent-insensitiv

### DIFF
--- a/__tests__/elasticsearch-client.test.js
+++ b/__tests__/elasticsearch-client.test.js
@@ -1,0 +1,41 @@
+jest.mock('node-fetch', () => jest.fn());
+
+const fetch = require('node-fetch');
+const elasticSearchClient = require('../tools/libs/elasticsearch-client.js');
+
+const response = {
+  ok: true,
+  text: jest.fn(async () => ''),
+};
+
+describe('Elasticsearch client', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    response.text.mockClear();
+    fetch.mockResolvedValue(response);
+  });
+
+  test('creates an accent-insensitive text index', async () => {
+    await elasticSearchClient.createIndex('kalliope');
+
+    const putCall = fetch.mock.calls.find(([, options]) => {
+      return options.method === 'PUT';
+    });
+    const body = JSON.parse(putCall[1].body);
+
+    expect(body.settings.analysis.analyzer.kalliope_text).toEqual({
+      tokenizer: 'standard',
+      filter: ['lowercase', 'asciifolding'],
+    });
+    expect(body.mappings.properties.text.properties.content_html).toEqual({
+      type: 'text',
+      analyzer: 'kalliope_text',
+    });
+    expect(body.mappings.properties.text.properties.title.analyzer).toBe(
+      'kalliope_text'
+    );
+    expect(body.mappings.properties.text.properties.subtitles.analyzer).toBe(
+      'kalliope_text'
+    );
+  });
+});

--- a/tools/libs/elasticsearch-client.js
+++ b/tools/libs/elasticsearch-client.js
@@ -74,8 +74,36 @@ class ElasticSearchClient {
         'Content-Type': 'application/json',
       },
       body: JSON.stringify({
+        settings: {
+          analysis: {
+            analyzer: {
+              kalliope_text: {
+                tokenizer: 'standard',
+                filter: ['lowercase', 'asciifolding'],
+              },
+            },
+          },
+        },
         mappings: {
           date_detection: false,
+          properties: {
+            text: {
+              properties: {
+                title: {
+                  type: 'text',
+                  analyzer: 'kalliope_text',
+                },
+                content_html: {
+                  type: 'text',
+                  analyzer: 'kalliope_text',
+                },
+                subtitles: {
+                  type: 'text',
+                  analyzer: 'kalliope_text',
+                },
+              },
+            },
+          },
         },
       }),
     });


### PR DESCRIPTION
## Ændringer

- Opretter Elasticsearch-indekset med en `kalliope_text` analyzer.
- Analyzeren bruger `lowercase` og `asciifolding`, så søgning efter fx `ekbatana` kan matche `Ekbátana`.
- Sætter analyzeren på de tekstfelter, som søgningen bruger: titel, undertitler og brødtekst.
- Tilføjer unit-test for index-settings, så `asciifolding` ikke forsvinder igen.

Ændringen i `tools/libs/elasticsearch-client.js` er allerede med i build-static cache-listen, så næste build laver fuld Elasticsearch-reindex.

## Validering

- `npm test -- elasticsearch-client.test.js elastic.test.js`
- `npm run build`
- `git diff --check`

Fixes #1180.
