### PR TITLE
Indekser digtere til søgning

### DIFF
--- a/__tests__/elastic.test.js
+++ b/__tests__/elastic.test.js
@@ -37,13 +37,26 @@ jest.mock('../tools/build-static/xml.js', () => ({
 const elasticSearchClient = require('../tools/libs/elasticsearch-client.js');
 const { isFileModified } = require('../tools/libs/caching.js');
 const {
+  buildElasticsearchPoetDocuments,
   getChangedElasticsearchWorkEntries,
   getElasticsearchWorkEntries,
   update_elasticsearch,
 } = require('../tools/build-static/elastic.js');
 
 const collected = {
-  poets: new Map([['poet', { id: 'poet' }]]),
+  poets: new Map([
+    [
+      'poet',
+      {
+        id: 'poet',
+        name: {
+          firstname: 'Emil',
+          lastname: 'Aarestrup',
+          fullname: 'Carl Ludvig Emil Aarestrup',
+        },
+      },
+    ],
+  ]),
   workids: new Map([['poet', ['second', 'first']]]),
 };
 
@@ -85,6 +98,19 @@ describe('Elasticsearch build-static step', () => {
     expect(result.entries.map(entry => entry.workKey)).toEqual(['poet-first']);
   });
 
+  test('builds searchable poet documents', () => {
+    expect(buildElasticsearchPoetDocuments(collected)).toEqual([
+      {
+        id: 'poet-poet',
+        data: {
+          result_type: 'poet',
+          poet: collected.poets.get('poet'),
+          poet_search: 'Emil Aarestrup Carl Ludvig Emil Aarestrup',
+        },
+      },
+    ]);
+  });
+
   test('skips Elasticsearch when no works changed and index exists', async () => {
     await update_elasticsearch(collected);
 
@@ -115,7 +141,7 @@ describe('Elasticsearch build-static step', () => {
       'text',
       'poet-first',
       expect.objectContaining({
-        poet: { id: 'poet' },
+        poet: collected.poets.get('poet'),
         work: expect.objectContaining({ id: 'first' }),
       })
     );
@@ -134,8 +160,9 @@ describe('Elasticsearch build-static step', () => {
       'poet'
     );
     expect(elasticSearchClient.deleteWork).not.toHaveBeenCalled();
-    expect(elasticSearchClient.create).toHaveBeenCalledTimes(2);
+    expect(elasticSearchClient.create).toHaveBeenCalledTimes(3);
     expect(elasticSearchClient.create.mock.calls.map(call => call[2])).toEqual([
+      'poet-poet',
       'poet-first',
       'poet-second',
     ]);
@@ -149,6 +176,11 @@ describe('Elasticsearch build-static step', () => {
     expect(elasticSearchClient.createIndex).toHaveBeenCalledWith('kalliope');
     expect(elasticSearchClient.deletePoet).not.toHaveBeenCalled();
     expect(elasticSearchClient.deleteWork).not.toHaveBeenCalled();
-    expect(elasticSearchClient.create).toHaveBeenCalledTimes(2);
+    expect(elasticSearchClient.create).toHaveBeenCalledTimes(3);
+    expect(elasticSearchClient.create.mock.calls.map(call => call[2])).toEqual([
+      'poet-poet',
+      'poet-first',
+      'poet-second',
+    ]);
   });
 });

--- a/__tests__/elasticsearch-client.test.js
+++ b/__tests__/elasticsearch-client.test.js
@@ -39,10 +39,11 @@ describe('Elasticsearch client', () => {
     );
   });
 
-  test('searches both texts and poet names', async () => {
+  test('searches poet names across countries and texts in selected country', async () => {
     await elasticSearchClient.search('kalliope', 'text', 'dk', '', 'aarestrup');
 
     const body = JSON.parse(fetch.mock.calls[0][1].body);
+    const resultTypeFilter = body.query.bool.filter[0].bool;
 
     expect(body.query.bool.must[0].multi_match.fields).toEqual([
       'poet_search^4',
@@ -50,7 +51,20 @@ describe('Elasticsearch client', () => {
       'text.subtitles^2',
       'text.content_html',
     ]);
-    expect(body.query.bool.filter).toEqual([{ term: { 'poet.country': 'dk' } }]);
+    expect(resultTypeFilter).toEqual({
+      should: [
+        { term: { result_type: 'poet' } },
+        {
+          bool: {
+            filter: [
+              { term: { result_type: 'text' } },
+              { term: { 'poet.country': 'dk' } },
+            ],
+          },
+        },
+      ],
+      minimum_should_match: 1,
+    });
   });
 
   test('searches only texts when scoped to a poet', async () => {
@@ -65,9 +79,9 @@ describe('Elasticsearch client', () => {
     const body = JSON.parse(fetch.mock.calls[0][1].body);
 
     expect(body.query.bool.filter).toEqual([
-      { term: { 'poet.country': 'dk' } },
       { term: { 'poet.id': 'aarestrup' } },
       { term: { result_type: 'text' } },
+      { term: { 'poet.country': 'dk' } },
     ]);
   });
 });

--- a/__tests__/elasticsearch-client.test.js
+++ b/__tests__/elasticsearch-client.test.js
@@ -38,4 +38,36 @@ describe('Elasticsearch client', () => {
       'kalliope_text'
     );
   });
+
+  test('searches both texts and poet names', async () => {
+    await elasticSearchClient.search('kalliope', 'text', 'dk', '', 'aarestrup');
+
+    const body = JSON.parse(fetch.mock.calls[0][1].body);
+
+    expect(body.query.bool.must[0].multi_match.fields).toEqual([
+      'poet_search^4',
+      'text.title^3',
+      'text.subtitles^2',
+      'text.content_html',
+    ]);
+    expect(body.query.bool.filter).toEqual([{ term: { 'poet.country': 'dk' } }]);
+  });
+
+  test('searches only texts when scoped to a poet', async () => {
+    await elasticSearchClient.search(
+      'kalliope',
+      'text',
+      'dk',
+      'aarestrup',
+      'rose'
+    );
+
+    const body = JSON.parse(fetch.mock.calls[0][1].body);
+
+    expect(body.query.bool.filter).toEqual([
+      { term: { 'poet.country': 'dk' } },
+      { term: { 'poet.id': 'aarestrup' } },
+      { term: { result_type: 'text' } },
+    ]);
+  });
 });

--- a/pages/search.js
+++ b/pages/search.js
@@ -24,23 +24,31 @@ const RenderedHits = ({ hits }) => {
   const lang = useContext(LangContext);
 
   return hits
-    .filter((x) => x._source.text != null)
+    .filter((x) => ['poet', 'text'].includes(x._source.result_type))
     .map((hit, i) => {
       const { poet, work, text } = hit._source;
       const { highlight } = hit;
       let item = null;
-      if (text == null) {
-        const workURL = Links.textURL(lang, work.id);
+      if (hit._source.result_type === 'poet') {
+        const poetURL = Links.poetURL(lang, poet.id);
         item = (
           <div>
-            <div>
-              <Link href={workURL}>
-                <WorkName work={work} lang={lang} />
+            <div className="title">
+              <Link href={poetURL}>
+                <PoetName poet={poet} includePeriod />
               </Link>
             </div>
-            <div>
-              <PoetName poet={poet} />:{' '}
+            <div className="poet-and-work">
+              {_('Digter', lang)}
             </div>
+            <style jsx>{`
+              .title {
+                font-size: 1.15em;
+              }
+              .poet-and-work {
+                color: ${CommonData.lightTextColor};
+              }
+            `}</style>
           </div>
         );
       } else {

--- a/tools/build-static/elastic.js
+++ b/tools/build-static/elastic.js
@@ -74,6 +74,32 @@ const getChangedElasticsearchWorkEntries = workEntries => {
   };
 };
 
+const getPoetSearchText = poet => {
+  const name = poet.name || {};
+  return [
+    name.firstname,
+    name.lastname,
+    name.fullname,
+    name.pseudonym,
+    name.christened,
+    name.realname,
+    name.sortname,
+  ]
+    .filter(Boolean)
+    .join(' ');
+};
+
+const buildElasticsearchPoetDocuments = collected => {
+  return Array.from(collected.poets.values()).map(poet => ({
+    id: `poet-${poet.id}`,
+    data: {
+      result_type: 'poet',
+      poet,
+      poet_search: getPoetSearchText(poet),
+    },
+  }));
+};
+
 const buildElasticsearchWorkDocuments = (collected, entry) => {
   const { poet, poetId, workId, workKey } = entry;
   const filename = `fdirs/${poetId}/${workId}.xml`;
@@ -96,6 +122,7 @@ const buildElasticsearchWorkDocuments = (collected, entry) => {
     {
       id: workKey,
       data: {
+        result_type: 'work',
         poet,
         work: workData,
       },
@@ -160,7 +187,10 @@ const buildElasticsearchWorkDocuments = (collected, entry) => {
     };
     documents.push({
       id: textId,
-      data,
+      data: {
+        result_type: 'text',
+        ...data,
+      },
     });
   });
 
@@ -208,6 +238,7 @@ const update_elasticsearch = async collected => {
 
   try {
     const workEntries = getElasticsearchWorkEntries(collected);
+    const poetDocuments = buildElasticsearchPoetDocuments(collected);
     const indexExists = await elasticSearchClient.indexExists('kalliope');
     const codeModified = isFileModified(...elasticsearchCodeSourceFiles);
     const needsFullRebuild =
@@ -218,6 +249,7 @@ const update_elasticsearch = async collected => {
 
     if (needsFullRebuild) {
       await elasticSearchClient.createIndex('kalliope');
+      await writeElasticsearchDocuments(poetDocuments);
       await indexWorks(workEntries);
       return;
     }
@@ -248,6 +280,12 @@ const update_elasticsearch = async collected => {
       elasticsearchConcurrency
     );
 
+    const changedPoetDocuments = poetDocuments.filter(document =>
+      modifiedPoetIds.has(document.data.poet.id)
+    );
+    if (changedPoetDocuments.length > 0) {
+      await writeElasticsearchDocuments(changedPoetDocuments);
+    }
     await indexWorks(changedWorkEntries);
   } catch (error) {
     console.log('Elasticsearch update failed.');
@@ -257,6 +295,7 @@ const update_elasticsearch = async collected => {
 };
 
 module.exports = {
+  buildElasticsearchPoetDocuments,
   getChangedElasticsearchWorkEntries,
   getElasticsearchWorkEntries,
   update_elasticsearch,

--- a/tools/libs/elasticsearch-client.js
+++ b/tools/libs/elasticsearch-client.js
@@ -174,7 +174,12 @@ class ElasticSearchClient {
             {
               multi_match: {
                 query: query,
-                fields: ['text.title', 'text.content_html', 'text.subtitles'],
+                fields: [
+                  'poet_search^4',
+                  'text.title^3',
+                  'text.subtitles^2',
+                  'text.content_html',
+                ],
               },
             },
           ],
@@ -190,6 +195,9 @@ class ElasticSearchClient {
     if (poetId != null && poetId.length > 0) {
       body.query.bool.filter.push({
         term: { 'poet.id': poetId },
+      });
+      body.query.bool.filter.push({
+        term: { result_type: 'text' },
       });
     }
 

--- a/tools/libs/elasticsearch-client.js
+++ b/tools/libs/elasticsearch-client.js
@@ -183,7 +183,7 @@ class ElasticSearchClient {
               },
             },
           ],
-          filter: [{ term: { 'poet.country': country } }],
+          filter: [],
         },
       },
       highlight: {
@@ -198,6 +198,26 @@ class ElasticSearchClient {
       });
       body.query.bool.filter.push({
         term: { result_type: 'text' },
+      });
+      body.query.bool.filter.push({
+        term: { 'poet.country': country },
+      });
+    } else {
+      body.query.bool.filter.push({
+        bool: {
+          should: [
+            { term: { result_type: 'poet' } },
+            {
+              bool: {
+                filter: [
+                  { term: { result_type: 'text' } },
+                  { term: { 'poet.country': country } },
+                ],
+              },
+            },
+          ],
+          minimum_should_match: 1,
+        },
       });
     }
 


### PR DESCRIPTION
## Ændringer

- Indekserer hver digter som eget Elasticsearch-dokument med `result_type: "poet"`.
- Søger i et separat `poet_search`-felt, så navnematch ikke får alle digterens tekster til at matche.
- Lader global søgning søge i digternavne på tværs af samlinger.
- Lader teksthits i global søgning fortsat følge den valgte samling.
- Begrænser søgning inde på en digters side til teksthits.
- Viser digterhits på søgeresultatsiden som links til digterens biografi.

Ændringen i `tools/build-static/elastic.js` er med i build-static cache-listen, så næste build laver fuld Elasticsearch-reindex.

## Validering

- `npm test -- elastic.test.js elasticsearch-client.test.js`
- `npm run build`
- `git diff --check`

Fixes #1182.
