### PR TITLE
Skriv manglende mentions-json

### DIFF
--- a/__tests__/mentions.test.js
+++ b/__tests__/mentions.test.js
@@ -141,8 +141,13 @@ describe('mentions data', () => {
   it('skriver manglende mentions-json fra eksisterende refs', () => {
     const collected = buildCollected();
     collected.poets.get('reboul').has_mentions = true;
+    const consoleLogSpy = jest.spyOn(console, 'log').mockImplementation(() => {});
 
-    build_mentions_json(collected);
+    try {
+      build_mentions_json(collected);
+    } finally {
+      consoleLogSpy.mockRestore();
+    }
 
     expect(writeJSON).toHaveBeenCalledWith(
       'public/api/reboul/mentions.json',

--- a/__tests__/mentions.test.js
+++ b/__tests__/mentions.test.js
@@ -7,7 +7,7 @@ jest.mock('../tools/libs/caching.js', () => ({
 
 jest.mock('../tools/libs/helpers.js', () => ({
   safeMkdir: () => {},
-  writeJSON: () => {},
+  writeJSON: jest.fn(),
   htmlToXml: (html) => html,
   fileExists: () => false,
 }));
@@ -24,7 +24,11 @@ jest.mock('../tools/build-static/xml.js', () => ({
   safeGetInnerXML: () => '',
 }));
 
-const { build_mentions_data } = require('../tools/build-static/mentions.js');
+const { writeJSON } = require('../tools/libs/helpers.js');
+const {
+  build_mentions_data,
+  build_mentions_json,
+} = require('../tools/build-static/mentions.js');
 
 const poet = (id, firstname, lastname) => ({
   id,
@@ -132,5 +136,25 @@ describe('mentions data', () => {
     );
 
     expect(data.mentions).toEqual([[['aarestrup2018110521']]]);
+  });
+
+  it('skriver manglende mentions-json fra eksisterende refs', () => {
+    const collected = buildCollected();
+    collected.poets.get('reboul').has_mentions = true;
+
+    build_mentions_json(collected);
+
+    expect(writeJSON).toHaveBeenCalledWith(
+      'public/api/reboul/mentions.json',
+      expect.objectContaining({
+        translations: expect.arrayContaining([
+          expect.objectContaining({
+            translation: expect.objectContaining({
+              poem: expect.objectContaining({ id: 'aarestrup2018110521' }),
+            }),
+          }),
+        ]),
+      })
+    );
   });
 });

--- a/tools/build-static/mentions.js
+++ b/tools/build-static/mentions.js
@@ -324,17 +324,21 @@ const build_mentions_json = (collected) => {
     if (!poet.has_mentions) {
       return;
     }
+    const outFilename = `public/api/${poet.id}/mentions.json`;
     const biblioFilesAreModifed =
       isFileModified(`fdirs/${poet.id}/bibliography-primary.xml`) ||
       isFileModified(`fdirs/${poet.id}/bibliography-secondary.xml`);
-    if (!biblioFilesAreModifed && !person_mentions_dirty.has(poet.id)) {
+    const shouldRebuild =
+      biblioFilesAreModifed ||
+      person_mentions_dirty.has(poet.id) ||
+      !fileExists(outFilename);
+    if (!shouldRebuild) {
       return;
     }
 
     safeMkdir(`public/api/${poet.id}`);
     let data = build_mentions_data(poet, poetId, collected, build_html);
 
-    const outFilename = `public/api/${poet.id}/mentions.json`;
     console.log(outFilename);
     writeJSON(outFilename, data);
   });


### PR DESCRIPTION
## Observation

Reboul har ikke almindelige omtaler, men har en oversættelseshenvisning. Den lokale `mentions.json` kan derfor godt have `mentions: []`, men stadig have renderbart indhold under `translations`.

Problemet kan opstå i incremental build, hvis `person_or_keyword_refs` allerede kommer fra cache og `public/api/<id>/mentions.json` mangler eller er forældet. Så kan `build_mentions_json` springe skrivningen over, selv om `poet.has_mentions` er sand.

## Ændringer

- `build_mentions_json` skriver nu også `mentions.json`, når outputfilen mangler.
- Tilføjer test, der dækker Reboul-lignende data: cached refs med en oversættelse skal stadig skrive `public/api/reboul/mentions.json`.

## Validering

- `npm test -- mentions.test.js`
- `npm run build`
- `git diff --check`

Fixes #1163.
