### PR TITLE
Ignorer manglende Elasticsearch under build-static

### DIFF
--- a/__tests__/elastic.test.js
+++ b/__tests__/elastic.test.js
@@ -120,6 +120,25 @@ describe('Elasticsearch build-static step', () => {
     expect(elasticSearchClient.create).not.toHaveBeenCalled();
   });
 
+  test('skips Elasticsearch when the local server is unavailable', async () => {
+    const error = new Error('connect ECONNREFUSED 127.0.0.1:9200');
+    error.code = 'ECONNREFUSED';
+    elasticSearchClient.indexExists.mockRejectedValue(error);
+    const consoleLog = jest.spyOn(console, 'log').mockImplementation(() => {});
+
+    await expect(update_elasticsearch(collected)).resolves.toBeUndefined();
+
+    expect(elasticSearchClient.createIndex).not.toHaveBeenCalled();
+    expect(elasticSearchClient.deletePoet).not.toHaveBeenCalled();
+    expect(elasticSearchClient.deleteWork).not.toHaveBeenCalled();
+    expect(elasticSearchClient.create).not.toHaveBeenCalled();
+    expect(consoleLog).toHaveBeenCalledWith(
+      'Elasticsearch server not available; skipping search index update.'
+    );
+
+    consoleLog.mockRestore();
+  });
+
   test('indexes only changed works', async () => {
     isFileModified.mockImplementation((...filenames) =>
       filenames.includes('fdirs/poet/first.xml')

--- a/tools/build-static/elastic.js
+++ b/tools/build-static/elastic.js
@@ -223,6 +223,36 @@ const writeElasticsearchDocuments = async documents => {
   );
 };
 
+const isElasticsearchUnavailable = error => {
+  const unavailableCodes = new Set([
+    'ECONNREFUSED',
+    'ECONNRESET',
+    'ENOTFOUND',
+    'EHOSTUNREACH',
+    'ETIMEDOUT',
+  ]);
+  let current = error;
+
+  while (current != null) {
+    if (
+      unavailableCodes.has(current.code) ||
+      unavailableCodes.has(current.errno)
+    ) {
+      return true;
+    }
+    if (
+      /\b(ECONNREFUSED|ECONNRESET|ENOTFOUND|EHOSTUNREACH|ETIMEDOUT)\b/.test(
+        current.message || ''
+      )
+    ) {
+      return true;
+    }
+    current = current.cause;
+  }
+
+  return false;
+};
+
 const update_elasticsearch = async collected => {
   const indexWorks = async entries => {
     const documents = [];
@@ -288,6 +318,13 @@ const update_elasticsearch = async collected => {
     }
     await indexWorks(changedWorkEntries);
   } catch (error) {
+    if (isElasticsearchUnavailable(error)) {
+      console.log(
+        'Elasticsearch server not available; skipping search index update.'
+      );
+      console.log(error.message);
+      return;
+    }
     console.log('Elasticsearch update failed.');
     console.log(error);
     throw error;


### PR DESCRIPTION
## Resumé
- springer Elasticsearch-opdateringen over, når den lokale server ikke er tilgængelig
- tilføjer regressionstest for ECONNREFUSED på localhost:9200

## Test
- npm test -- __tests__/elastic.test.js --runInBand

Fixes #1186