### PR TITLE
Brug bulk requests til Elasticsearch-indeksering

### DIFF
--- a/__tests__/elastic.test.js
+++ b/__tests__/elastic.test.js
@@ -9,11 +9,13 @@ jest.mock('../tools/libs/caching.js', () => ({
 }));
 
 jest.mock('../tools/libs/elasticsearch-client.js', () => ({
+  bulkCreate: jest.fn(),
   create: jest.fn(),
   createIndex: jest.fn(),
   deletePoet: jest.fn(),
   deleteWork: jest.fn(),
   indexExists: jest.fn(),
+  refreshIndex: jest.fn(),
 }));
 
 jest.mock('../tools/build-static/concurrency.js', () => ({
@@ -59,6 +61,11 @@ const collected = {
   ]),
   workids: new Map([['poet', ['second', 'first']]]),
 };
+
+const bulkDocumentIds = () =>
+  elasticSearchClient.bulkCreate.mock.calls.flatMap(call =>
+    call[1].map(document => document.id)
+  );
 
 describe('Elasticsearch build-static step', () => {
   beforeEach(() => {
@@ -117,7 +124,8 @@ describe('Elasticsearch build-static step', () => {
     expect(elasticSearchClient.createIndex).not.toHaveBeenCalled();
     expect(elasticSearchClient.deletePoet).not.toHaveBeenCalled();
     expect(elasticSearchClient.deleteWork).not.toHaveBeenCalled();
-    expect(elasticSearchClient.create).not.toHaveBeenCalled();
+    expect(elasticSearchClient.bulkCreate).not.toHaveBeenCalled();
+    expect(elasticSearchClient.refreshIndex).not.toHaveBeenCalled();
   });
 
   test('indexes only changed works', async () => {
@@ -135,16 +143,20 @@ describe('Elasticsearch build-static step', () => {
       'poet',
       'first'
     );
-    expect(elasticSearchClient.create).toHaveBeenCalledTimes(1);
-    expect(elasticSearchClient.create).toHaveBeenCalledWith(
+    expect(elasticSearchClient.bulkCreate).toHaveBeenCalledTimes(1);
+    expect(elasticSearchClient.bulkCreate).toHaveBeenCalledWith(
       'kalliope',
-      'text',
-      'poet-first',
-      expect.objectContaining({
-        poet: collected.poets.get('poet'),
-        work: expect.objectContaining({ id: 'first' }),
-      })
+      [
+        expect.objectContaining({
+          id: 'poet-first',
+          data: expect.objectContaining({
+            poet: collected.poets.get('poet'),
+            work: expect.objectContaining({ id: 'first' }),
+          }),
+        }),
+      ]
     );
+    expect(elasticSearchClient.refreshIndex).toHaveBeenCalledWith('kalliope');
   });
 
   test('reindexes all poet works when poet info changed', async () => {
@@ -160,12 +172,12 @@ describe('Elasticsearch build-static step', () => {
       'poet'
     );
     expect(elasticSearchClient.deleteWork).not.toHaveBeenCalled();
-    expect(elasticSearchClient.create).toHaveBeenCalledTimes(3);
-    expect(elasticSearchClient.create.mock.calls.map(call => call[2])).toEqual([
+    expect(bulkDocumentIds()).toEqual([
       'poet-poet',
       'poet-first',
       'poet-second',
     ]);
+    expect(elasticSearchClient.refreshIndex).toHaveBeenCalledWith('kalliope');
   });
 
   test('rebuilds the full index when the index is missing', async () => {
@@ -176,11 +188,11 @@ describe('Elasticsearch build-static step', () => {
     expect(elasticSearchClient.createIndex).toHaveBeenCalledWith('kalliope');
     expect(elasticSearchClient.deletePoet).not.toHaveBeenCalled();
     expect(elasticSearchClient.deleteWork).not.toHaveBeenCalled();
-    expect(elasticSearchClient.create).toHaveBeenCalledTimes(3);
-    expect(elasticSearchClient.create.mock.calls.map(call => call[2])).toEqual([
+    expect(bulkDocumentIds()).toEqual([
       'poet-poet',
       'poet-first',
       'poet-second',
     ]);
+    expect(elasticSearchClient.refreshIndex).toHaveBeenCalledWith('kalliope');
   });
 });

--- a/__tests__/elasticsearch-client.test.js
+++ b/__tests__/elasticsearch-client.test.js
@@ -5,12 +5,14 @@ const elasticSearchClient = require('../tools/libs/elasticsearch-client.js');
 
 const response = {
   ok: true,
+  json: jest.fn(async () => ({ errors: false, items: [] })),
   text: jest.fn(async () => ''),
 };
 
 describe('Elasticsearch client', () => {
   beforeEach(() => {
     jest.clearAllMocks();
+    response.json.mockClear();
     response.text.mockClear();
     fetch.mockResolvedValue(response);
   });
@@ -37,6 +39,38 @@ describe('Elasticsearch client', () => {
     expect(body.mappings.properties.text.properties.subtitles.analyzer).toBe(
       'kalliope_text'
     );
+  });
+
+  test('writes documents through the bulk API as newline-delimited JSON', async () => {
+    await elasticSearchClient.bulkCreate('kalliope', [
+      {
+        id: 'poet-first',
+        data: {
+          result_type: 'work',
+        },
+      },
+      {
+        id: 'text-id',
+        data: {
+          result_type: 'text',
+          title: 'Første linje',
+        },
+      },
+    ]);
+
+    const [url, options] = fetch.mock.calls[0];
+    const lines = options.body.split('\n');
+
+    expect(url).toBe('http://localhost:9200/kalliope/_bulk');
+    expect(options.method).toBe('POST');
+    expect(options.headers['Content-Type']).toBe('application/x-ndjson');
+    expect(lines).toEqual([
+      JSON.stringify({ index: { _id: 'poet-first' } }),
+      JSON.stringify({ result_type: 'work' }),
+      JSON.stringify({ index: { _id: 'text-id' } }),
+      JSON.stringify({ result_type: 'text', title: 'Første linje' }),
+      '',
+    ]);
   });
 
   test('searches poet names across countries and texts in selected country', async () => {

--- a/tools/build-static/elastic.js
+++ b/tools/build-static/elastic.js
@@ -18,6 +18,10 @@ const elasticsearchConcurrency = Math.max(
   1,
   parseInt(process.env.KALLIOPE_ELASTICSEARCH_CONCURRENCY, 10) || 1
 );
+const elasticsearchBulkSize = Math.max(
+  1,
+  parseInt(process.env.KALLIOPE_ELASTICSEARCH_BULK_SIZE, 10) || 500
+);
 const elasticsearchForceRebuild = ['1', 'true', 'yes'].includes(
   (process.env.KALLIOPE_ELASTICSEARCH_FORCE_REBUILD || '').toLowerCase()
 );
@@ -197,22 +201,34 @@ const buildElasticsearchWorkDocuments = (collected, entry) => {
   return documents;
 };
 
+const chunkDocuments = documents => {
+  const chunks = [];
+
+  for (let i = 0; i < documents.length; i += elasticsearchBulkSize) {
+    chunks.push(documents.slice(i, i + elasticsearchBulkSize));
+  }
+
+  return chunks;
+};
+
 const writeElasticsearchDocuments = async documents => {
+  const chunks = chunkDocuments(documents);
+
   console.log(
-    `Writing ${documents.length} Elasticsearch documents with concurrency ${elasticsearchConcurrency}`
+    `Writing ${documents.length} Elasticsearch documents in ` +
+      `${chunks.length} bulk request(s) with concurrency ` +
+      elasticsearchConcurrency
   );
   let completed = 0;
   await mapLimit(
-    documents,
-    async document => {
-      const result = await elasticSearchClient.create(
-        'kalliope',
-        'text',
-        document.id,
-        document.data
-      );
-      completed += 1;
-      if (completed % 100 === 0 || completed === documents.length) {
+    chunks,
+    async chunk => {
+      const result = await elasticSearchClient.bulkCreate('kalliope', chunk);
+      completed += chunk.length;
+      if (
+        completed % elasticsearchBulkSize === 0 ||
+        completed === documents.length
+      ) {
         console.log(
           `Wrote ${completed}/${documents.length} Elasticsearch documents`
         );
@@ -251,6 +267,7 @@ const update_elasticsearch = async collected => {
       await elasticSearchClient.createIndex('kalliope');
       await writeElasticsearchDocuments(poetDocuments);
       await indexWorks(workEntries);
+      await elasticSearchClient.refreshIndex('kalliope');
       return;
     }
 
@@ -287,6 +304,7 @@ const update_elasticsearch = async collected => {
       await writeElasticsearchDocuments(changedPoetDocuments);
     }
     await indexWorks(changedWorkEntries);
+    await elasticSearchClient.refreshIndex('kalliope');
   } catch (error) {
     console.log('Elasticsearch update failed.');
     console.log(error);

--- a/tools/libs/elasticsearch-client.js
+++ b/tools/libs/elasticsearch-client.js
@@ -123,6 +123,55 @@ class ElasticSearchClient {
     return res.json();
   }
 
+  async bulkCreate(index, documents) {
+    if (documents.length === 0) {
+      return { errors: false, items: [] };
+    }
+
+    const URL = `${URLPrefix}/${index}/_bulk`;
+    const body =
+      documents
+        .map(document =>
+          [
+            JSON.stringify({
+              index: {
+                _id: document.id,
+              },
+            }),
+            JSON.stringify(document.data),
+          ].join('\n')
+        )
+        .join('\n') + '\n';
+    const res = await requestWithRetry(URL, {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/x-ndjson',
+      },
+      body,
+    });
+    const result = await res.json();
+
+    if (result.errors) {
+      const failedItem = result.items.find(item => {
+        const action = item.index || item.create || item.update;
+        return action && action.error;
+      });
+      throw new Error(
+        `Elasticsearch bulk ${URL} failed: ${JSON.stringify(failedItem)}`
+      );
+    }
+
+    return result;
+  }
+
+  async refreshIndex(index) {
+    const URL = `${URLPrefix}/${index}/_refresh`;
+    const res = await requestWithRetry(URL, {
+      method: 'POST',
+    });
+    return res.json();
+  }
+
   async deleteByQuery(index, query) {
     const URL = `${URLPrefix}/${index}/_delete_by_query?conflicts=proceed&refresh=true`;
     const res = await requestWithRetry(URL, {


### PR DESCRIPTION
## Resumé
- skriver Elasticsearch-dokumenter med bulk API i stedet for én PUT per dokument
- tilføjer konfigurerbar bulk-størrelse via KALLIOPE_ELASTICSEARCH_BULK_SIZE
- refresher indekset efter opdatering
- udvider tests for bulk-skrivning og NDJSON-format

## Test
- npm test -- __tests__/elastic.test.js __tests__/elasticsearch-client.test.js --runInBand

Fixes #1162