### PR TITLE
Optimer mobil fontindlæsning

### DIFF
--- a/components/head.js
+++ b/components/head.js
@@ -7,9 +7,7 @@ const defaultOGURL = urlPrefix;
 const defaultOGImage = `${urlPrefix}/touch-icon.png`;
 const criticalFonts = [
   '/fonts/alegreya-sans/alegreya-sans-normal-400-latin.woff2',
-  '/fonts/alegreya-sans/alegreya-sans-normal-700-latin.woff2',
   '/fonts/alegreya-sans/alegreya-sans-normal-100-latin.woff2',
-  '/fonts/alegreya-sans/alegreya-sans-normal-300-latin.woff2',
 ];
 
 const Head = ({

--- a/pages/_document.js
+++ b/pages/_document.js
@@ -24,7 +24,7 @@ export default class MyDocument extends Document {
         <body>
           <Main />
           <NextScript />
-          <script src="/register-sw.js" />
+          <script src="/register-sw.js" defer />
         </body>
       </Html>
     );


### PR DESCRIPTION
## Ændringer

- Reducerer font-preload til de snit, der bruges tidligt på siden.
- Indlæser service worker-registrering med `defer`.

## Validering

- `npm run build`