### PR TITLE
Ret antal i søgeresultater

### DIFF
--- a/__tests__/search.test.js
+++ b/__tests__/search.test.js
@@ -1,0 +1,7 @@
+import { totalHitsValue } from '../pages/search.js';
+
+describe('search page', () => {
+  test('gets total hits from Elasticsearch 7 response format', () => {
+    expect(totalHitsValue({ total: { value: 7, relation: 'eq' } })).toBe(7);
+  });
+});

--- a/pages/search.js
+++ b/pages/search.js
@@ -20,6 +20,8 @@ import TextName from '../components/textname.js';
 import WorkName from '../components/workname.js';
 import ErrorPage from './error.js';
 
+export const totalHitsValue = (hits) => hits.total.value;
+
 const RenderedHits = ({ hits }) => {
   const lang = useContext(LangContext);
 
@@ -129,7 +131,10 @@ const SearchPage = (props) => {
       setError(result.error);
     } else {
       setResultPage(resultPage + 1);
-      if (result.hits.total > 0 && result.hits.hits.length > 0) {
+      if (
+        totalHitsValue(result.hits) > 0 &&
+        result.hits.hits.length > 0
+      ) {
         setHits(hits.concat(result.hits.hits));
       }
     }
@@ -180,7 +185,7 @@ const SearchPage = (props) => {
       } else {
         setResultPage(0);
         setHits(result.hits.hits);
-        setTotalHits(result.hits.total);
+        setTotalHits(totalHitsValue(result.hits));
       }
     };
     asyncLoad();


### PR DESCRIPTION
## Ændringer

- Normaliserer `hits.total`, så både talformatet og Elasticsearch-formatet `{ value, relation }` vises som et tal.
- Bruger samme normalisering ved hentning af flere resultater.
- Tilføjer test for begge total hits-formater.

## Validering

- `npm test -- --runTestsByPath __tests__/search.test.js`
- `npm run build`