### PR TITLE
Fjern fetch-polyfills

### DIFF
--- a/__tests__/elasticsearch-client.test.js
+++ b/__tests__/elasticsearch-client.test.js
@@ -1,6 +1,3 @@
-jest.mock('node-fetch', () => jest.fn());
-
-const fetch = require('node-fetch');
 const elasticSearchClient = require('../tools/libs/elasticsearch-client.js');
 
 const response = {
@@ -10,17 +7,23 @@ const response = {
 };
 
 describe('Elasticsearch client', () => {
+  const originalFetch = global.fetch;
+
   beforeEach(() => {
     jest.clearAllMocks();
     response.json.mockClear();
     response.text.mockClear();
-    fetch.mockResolvedValue(response);
+    global.fetch = jest.fn().mockResolvedValue(response);
+  });
+
+  afterAll(() => {
+    global.fetch = originalFetch;
   });
 
   test('creates an accent-insensitive text index', async () => {
     await elasticSearchClient.createIndex('kalliope');
 
-    const putCall = fetch.mock.calls.find(([, options]) => {
+    const putCall = global.fetch.mock.calls.find(([, options]) => {
       return options.method === 'PUT';
     });
     const body = JSON.parse(putCall[1].body);
@@ -62,7 +65,7 @@ describe('Elasticsearch client', () => {
       },
     ]);
 
-    const [url, options] = fetch.mock.calls[0];
+    const [url, options] = global.fetch.mock.calls[0];
     const lines = options.body.split('\n');
 
     expect(url).toBe('http://localhost:9200/kalliope/_bulk');
@@ -80,7 +83,7 @@ describe('Elasticsearch client', () => {
   test('searches poet names across countries and works/texts in selected country', async () => {
     await elasticSearchClient.search('kalliope', 'text', 'dk', '', 'aarestrup');
 
-    const body = JSON.parse(fetch.mock.calls[0][1].body);
+    const body = JSON.parse(global.fetch.mock.calls[0][1].body);
     const resultTypeFilter = body.query.bool.filter[0].bool;
 
     expect(body.query.bool.must).toEqual([]);
@@ -157,7 +160,7 @@ describe('Elasticsearch client', () => {
       'rose'
     );
 
-    const body = JSON.parse(fetch.mock.calls[0][1].body);
+    const body = JSON.parse(global.fetch.mock.calls[0][1].body);
 
     expect(body.query.bool.filter).toEqual([
       { term: { 'poet.id': 'aarestrup' } },

--- a/common/client.js
+++ b/common/client.js
@@ -1,4 +1,3 @@
-import 'isomorphic-fetch';
 import * as Paths from './paths.js';
 
 export const createURL = (path) => {

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,8 +9,6 @@
       "version": "1.0.0",
       "license": "MIT",
       "dependencies": {
-        "global": "^4.3.2",
-        "isomorphic-fetch": "^2.2.1",
         "react": "^18.3.1",
         "react-dom": "^18.3.1"
       },
@@ -23,7 +21,6 @@
         "jest": "^30.4.2",
         "mkdirp": "^0.5.1",
         "next": "^16.2.9",
-        "node-fetch": "^1.7.1",
         "p-limit": "^2.2.2",
         "regenerator-runtime": "^0.13.1",
         "sharp": "^0.34.5"
@@ -2923,9 +2920,6 @@
         "node": ">=8"
       }
     },
-    "node_modules/dom-walk": {
-      "version": "0.1.2"
-    },
     "node_modules/eastasianwidth": {
       "version": "0.2.0",
       "resolved": "https://registry.npmjs.org/eastasianwidth/-/eastasianwidth-0.2.0.tgz",
@@ -2957,13 +2951,6 @@
       "integrity": "sha512-L18DaJsXSUk2+42pv8mLs5jJT2hqFkFE4j21wOmgbUqsZ2hL72NsUU785g9RXgo3s0ZNgVl42TiHp3ZtOv/Vyg==",
       "dev": true,
       "license": "MIT"
-    },
-    "node_modules/encoding": {
-      "version": "0.1.13",
-      "license": "MIT",
-      "dependencies": {
-        "iconv-lite": "^0.6.2"
-      }
     },
     "node_modules/entities": {
       "version": "1.1.2",
@@ -3213,14 +3200,6 @@
         "url": "https://github.com/sponsors/isaacs"
       }
     },
-    "node_modules/global": {
-      "version": "4.4.0",
-      "license": "MIT",
-      "dependencies": {
-        "min-document": "^2.19.0",
-        "process": "^0.11.10"
-      }
-    },
     "node_modules/graceful-fs": {
       "version": "4.2.11",
       "dev": true,
@@ -3251,16 +3230,6 @@
       "license": "Apache-2.0",
       "engines": {
         "node": ">=10.17.0"
-      }
-    },
-    "node_modules/iconv-lite": {
-      "version": "0.6.3",
-      "license": "MIT",
-      "dependencies": {
-        "safer-buffer": ">= 2.1.2 < 3.0.0"
-      },
-      "engines": {
-        "node": ">=0.10.0"
       }
     },
     "node_modules/ics": {
@@ -3345,27 +3314,12 @@
         "node": ">=6"
       }
     },
-    "node_modules/is-stream": {
-      "version": "1.1.0",
-      "license": "MIT",
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
     "node_modules/isexe": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
       "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==",
       "dev": true,
       "license": "ISC"
-    },
-    "node_modules/isomorphic-fetch": {
-      "version": "2.2.1",
-      "license": "MIT",
-      "dependencies": {
-        "node-fetch": "^1.0.1",
-        "whatwg-fetch": ">=0.10.0"
-      }
     },
     "node_modules/istanbul-lib-report": {
       "version": "3.0.1",
@@ -4425,13 +4379,6 @@
         "node": ">=6"
       }
     },
-    "node_modules/min-document": {
-      "version": "2.19.2",
-      "license": "MIT",
-      "dependencies": {
-        "dom-walk": "^0.1.0"
-      }
-    },
     "node_modules/minimatch": {
       "version": "9.0.9",
       "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.9.tgz",
@@ -4579,14 +4526,6 @@
         "sass": {
           "optional": true
         }
-      }
-    },
-    "node_modules/node-fetch": {
-      "version": "1.7.3",
-      "license": "MIT",
-      "dependencies": {
-        "encoding": "^0.1.11",
-        "is-stream": "^1.0.1"
       }
     },
     "node_modules/node-int64": {
@@ -4866,13 +4805,6 @@
         "url": "https://github.com/chalk/ansi-styles?sponsor=1"
       }
     },
-    "node_modules/process": {
-      "version": "0.11.10",
-      "license": "MIT",
-      "engines": {
-        "node": ">= 0.6.0"
-      }
-    },
     "node_modules/property-expr": {
       "version": "2.0.6",
       "dev": true,
@@ -4971,10 +4903,6 @@
       "engines": {
         "node": ">=8"
       }
-    },
-    "node_modules/safer-buffer": {
-      "version": "2.1.2",
-      "license": "MIT"
     },
     "node_modules/scheduler": {
       "version": "0.23.2",
@@ -5526,10 +5454,6 @@
       "dependencies": {
         "makeerror": "1.0.12"
       }
-    },
-    "node_modules/whatwg-fetch": {
-      "version": "3.6.20",
-      "license": "MIT"
     },
     "node_modules/which": {
       "version": "2.0.2",
@@ -7552,9 +7476,6 @@
       "integrity": "sha512-TLz+x/vEXm/Y7P7wn1EJFNLxYpUD4TgMosxY6fAVJUnJMbupHBOncxyWUG9OpTaH9EBD7uFI5LfEgmMOc54DsA==",
       "dev": true
     },
-    "dom-walk": {
-      "version": "0.1.2"
-    },
     "eastasianwidth": {
       "version": "0.2.0",
       "resolved": "https://registry.npmjs.org/eastasianwidth/-/eastasianwidth-0.2.0.tgz",
@@ -7576,12 +7497,6 @@
       "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-9.2.2.tgz",
       "integrity": "sha512-L18DaJsXSUk2+42pv8mLs5jJT2hqFkFE4j21wOmgbUqsZ2hL72NsUU785g9RXgo3s0ZNgVl42TiHp3ZtOv/Vyg==",
       "dev": true
-    },
-    "encoding": {
-      "version": "0.1.13",
-      "requires": {
-        "iconv-lite": "^0.6.2"
-      }
     },
     "entities": {
       "version": "1.1.2",
@@ -7745,13 +7660,6 @@
         "path-scurry": "^1.11.1"
       }
     },
-    "global": {
-      "version": "4.4.0",
-      "requires": {
-        "min-document": "^2.19.0",
-        "process": "^0.11.10"
-      }
-    },
     "graceful-fs": {
       "version": "4.2.11",
       "dev": true
@@ -7773,12 +7681,6 @@
       "resolved": "https://registry.npmjs.org/human-signals/-/human-signals-2.1.0.tgz",
       "integrity": "sha512-B4FFZ6q/T2jhhksgkbEW3HBvWIfDW85snkQgawt07S7J5QXTk6BkNV+0yAeZrM5QpMAdYlocGoljn0sJ/WQkFw==",
       "dev": true
-    },
-    "iconv-lite": {
-      "version": "0.6.3",
-      "requires": {
-        "safer-buffer": ">= 2.1.2 < 3.0.0"
-      }
     },
     "ics": {
       "version": "2.44.0",
@@ -7836,21 +7738,11 @@
       "integrity": "sha512-cTIB4yPYL/Grw0EaSzASzg6bBy9gqCofvWN8okThAYIxKJZC+udlRAmGbM0XLeniEJSs8uEgHPGuHSe1XsOLSQ==",
       "dev": true
     },
-    "is-stream": {
-      "version": "1.1.0"
-    },
     "isexe": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
       "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==",
       "dev": true
-    },
-    "isomorphic-fetch": {
-      "version": "2.2.1",
-      "requires": {
-        "node-fetch": "^1.0.1",
-        "whatwg-fetch": ">=0.10.0"
-      }
     },
     "istanbul-lib-report": {
       "version": "3.0.1",
@@ -8603,12 +8495,6 @@
       "integrity": "sha512-OqbOk5oEQeAZ8WXWydlu9HJjz9WVdEIvamMCcXmuqUYjTknH/sqsWvhQ3vgwKFRR1HpjvNBKQ37nbJgYzGqGcg==",
       "dev": true
     },
-    "min-document": {
-      "version": "2.19.2",
-      "requires": {
-        "dom-walk": "^0.1.0"
-      }
-    },
     "minimatch": {
       "version": "9.0.9",
       "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.9.tgz",
@@ -8680,13 +8566,6 @@
         "postcss": "8.4.31",
         "sharp": "^0.34.5",
         "styled-jsx": "5.1.6"
-      }
-    },
-    "node-fetch": {
-      "version": "1.7.3",
-      "requires": {
-        "encoding": "^0.1.11",
-        "is-stream": "^1.0.1"
       }
     },
     "node-int64": {
@@ -8871,9 +8750,6 @@
         }
       }
     },
-    "process": {
-      "version": "0.11.10"
-    },
     "property-expr": {
       "version": "2.0.6",
       "dev": true
@@ -8937,9 +8813,6 @@
       "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-5.0.0.tgz",
       "integrity": "sha512-qYg9KP24dD5qka9J47d0aVky0N+b4fTU89LN9iDnjB5waksiC49rvMB0PrUJQGoTmH50XPiqOvAjDfaijGxYZw==",
       "dev": true
-    },
-    "safer-buffer": {
-      "version": "2.1.2"
     },
     "scheduler": {
       "version": "0.23.2",
@@ -9307,9 +9180,6 @@
       "requires": {
         "makeerror": "1.0.12"
       }
-    },
-    "whatwg-fetch": {
-      "version": "3.6.20"
     },
     "which": {
       "version": "2.0.2",

--- a/package.json
+++ b/package.json
@@ -29,8 +29,6 @@
     "build-facsimiles-old": "node tools/build-facsimiles-old.js"
   },
   "dependencies": {
-    "global": "^4.3.2",
-    "isomorphic-fetch": "^2.2.1",
     "react": "^18.3.1",
     "react-dom": "^18.3.1"
   },
@@ -43,7 +41,6 @@
     "jest": "^30.4.2",
     "mkdirp": "^0.5.1",
     "next": "^16.2.9",
-    "node-fetch": "^1.7.1",
     "p-limit": "^2.2.2",
     "regenerator-runtime": "^0.13.1",
     "sharp": "^0.34.5"

--- a/pages/index.js
+++ b/pages/index.js
@@ -1,4 +1,3 @@
-import 'isomorphic-fetch';
 import { useContext } from 'react';
 import { createURL } from '../common/client.js';
 import LangContext from '../common/LangContext.js';

--- a/pages/keywords.js
+++ b/pages/keywords.js
@@ -1,4 +1,3 @@
-import 'isomorphic-fetch';
 import { useContext } from 'react';
 import { createURL } from '../common/client.js';
 import LangContext from '../common/LangContext.js';

--- a/pages/museum.js
+++ b/pages/museum.js
@@ -1,4 +1,3 @@
-import 'isomorphic-fetch';
 import * as Client from '../common/client.js';
 import _ from '../common/translations.js';
 import { kalliopeCrumbs } from '../components/breadcrumbs.js';

--- a/pages/poets-looks.js
+++ b/pages/poets-looks.js
@@ -1,4 +1,3 @@
-import 'isomorphic-fetch';
 import Link from 'next/link';
 import { createURL } from '../common/client.js';
 import CommonData from '../common/commondata.js';

--- a/pages/works.js
+++ b/pages/works.js
@@ -1,4 +1,3 @@
-import 'isomorphic-fetch';
 import Router from 'next/router';
 import { useEffect } from 'react';
 import * as Client from '../common/client.js';

--- a/tools/libs/elasticsearch-client.js
+++ b/tools/libs/elasticsearch-client.js
@@ -1,11 +1,13 @@
-const fetch = require('node-fetch');
-
 const URLPrefix = process.env.ELASTICSEARCH_URL || 'http://localhost:9200';
 const requestTimeout = Math.max(
   1000,
   parseInt(process.env.KALLIOPE_ELASTICSEARCH_REQUEST_TIMEOUT_MS, 10) || 60000
 );
 const wait = ms => new Promise(resolve => setTimeout(resolve, ms));
+const withRequestTimeout = options => ({
+  ...options,
+  signal: options.signal || AbortSignal.timeout(requestTimeout),
+});
 
 const requestWithRetry = async (
   URL,
@@ -14,11 +16,8 @@ const requestWithRetry = async (
   acceptedStatuses = []
 ) => {
   let lastError = null;
-  const requestOptions = {
-    timeout: requestTimeout,
-    ...options,
-  };
   for (let attempt = 1; attempt <= attempts; attempt++) {
+    const requestOptions = withRequestTimeout(options);
     try {
       const res = await fetch(URL, requestOptions);
       if (res.ok || acceptedStatuses.includes(res.status)) {
@@ -41,10 +40,9 @@ const requestWithRetry = async (
 class ElasticSearchClient {
   async indexExists(index) {
     const URL = `${URLPrefix}/${index}`;
-    const res = await fetch(URL, {
+    const res = await fetch(URL, withRequestTimeout({
       method: 'HEAD',
-      timeout: requestTimeout,
-    });
+    }));
     if (res.ok) {
       return true;
     }


### PR DESCRIPTION
## Ændringer

- Fjerner de direkte dependencies `global`, `isomorphic-fetch` og `node-fetch`.
- Bruger native `fetch` i browser/Node 20 i stedet for fetch-polyfills.
- Bevarer timeout på Elasticsearch-kald med `AbortSignal.timeout(...)`.
- Opdaterer Elasticsearch-klienttesten til at mocke `global.fetch`.

## Validering

- `npm test -- --runTestsByPath __tests__/elasticsearch-client.test.js`
- `npm test`
- `npm run build`
- `npm audit --omit=dev --json`