### PR TITLE
Kør build-static smoke i CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,3 +29,31 @@ jobs:
         run: npm run test-ci
         env:
           CI: true
+
+  build-static:
+    name: Run build-static smoke
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        node-version: [20.x]
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Use Node.js ${{ matrix.node-version }}
+        uses: actions/setup-node@v4
+        with:
+          node-version: ${{ matrix.node-version }}
+          cache: 'npm'
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Build static data
+        run: npm run build-static
+        env:
+          CI: true
+          KALLIOPE_SKIP_ELASTICSEARCH: true
+          KALLIOPE_SKIP_IMAGE_THUMBNAILS: true
+          KALLIOPE_SHARP_CACHE_MEMORY: 64
+          KALLIOPE_SHARP_CONCURRENCY: 1

--- a/tools/build-static.js
+++ b/tools/build-static.js
@@ -101,6 +101,15 @@ const {
   build_poet_timeline_json,
 } = require('./build-static/timeline.js');
 
+const envFlag = (name) => {
+  return ['1', 'true', 'yes'].includes(
+    (process.env[name] || '').toLowerCase(),
+  );
+};
+
+const skipImageThumbnails = envFlag('KALLIOPE_SKIP_IMAGE_THUMBNAILS');
+const skipElasticsearch = envFlag('KALLIOPE_SKIP_ELASTICSEARCH');
+
 let collected = {
   texts: new Map(),
   works: new Map(),
@@ -1139,8 +1148,16 @@ const main = async () => {
   await b('build_sitemap_xml', build_sitemap_xml, collected);
   await b('build_anniversaries_ical', build_anniversaries_ical, collected);
   refreshFilesModifiedCache();
-  await b('build_image_thumbnails', build_image_thumbnails);
-  await b('update_elasticsearch', update_elasticsearch, collected);
+  if (skipImageThumbnails) {
+    console.log('Skipping image thumbnail build.');
+  } else {
+    await b('build_image_thumbnails', build_image_thumbnails);
+  }
+  if (skipElasticsearch) {
+    console.log('Skipping Elasticsearch update.');
+  } else {
+    await b('update_elasticsearch', update_elasticsearch, collected);
+  }
   refreshFilesModifiedCache();
   flushImageSizeCache();
   print_benchmarking_results();


### PR DESCRIPTION
## Hvad

- Tilføjer env flags til at springe de tungeste side effects i `build-static` over:
  - `KALLIOPE_SKIP_IMAGE_THUMBNAILS`
  - `KALLIOPE_SKIP_ELASTICSEARCH`
- Tilføjer en CI-check, der kører `npm run build-static` med disse flags slået til.

## Hvorfor

PR #1203 viste, at de eksisterende grønne checks ikke fangede runtime-fejl i `build-static`. Denne smoke-check kører hele den globale build-pipeline uden at filtrere digtere, men undgår thumbnail-generering og Elasticsearch-opdatering, så checken bliver væsentligt lettere.

## Validering

- `KALLIOPE_SKIP_ELASTICSEARCH=true KALLIOPE_SKIP_IMAGE_THUMBNAILS=true KALLIOPE_SHARP_CACHE_MEMORY=64 KALLIOPE_SHARP_CONCURRENCY=1 npm run build-static`
- `npm test`
