### PR TITLE
Opdater README om udvikling og produktion

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,117 +1,97 @@
 [![CI](https://github.com/thabz/Kalliope/actions/workflows/ci.yml/badge.svg?branch=master)](https://github.com/thabz/Kalliope/actions/workflows/ci.yml)
 
-## Kalliope installation lokalt
+# Kalliope
 
-1. Installer [NodeJS](https://nodejs.org/en/).
-2. Hent din kopi af Kalliope på [GitHub](https://github.com/thabz/Kalliope.git) enten som zip-fil eller, bedre, som en git-clone.
-3. Åbn en terminal (Terminal.app på Mac, PowerShell på Windows eller hvad som helst på Linux) og find mappen med din kopi af Kalliope.
-4. Udfør derefter følgende trin (hvoraf nogle kan tage lang tid)
+## Udvikling og tekstredigering lokalt
+
+Brug denne arbejdsgang når du udvikler på appen eller redigerer tekster i
+`fdirs/` og `data/`.
+
+Krav:
+
+- Node.js 20 eller nyere
+- Docker, hvis Elasticsearch skal køres lokalt via Compose
+
+Installer afhængigheder:
 
 ```shell
 npm install
-npm run build
-npm run build-static
-npm run start
 ```
 
-Hvis alt lykkes, kan din egen kopi af Kalliope nu ses på http://localhost:3000/.
-
-Hvis du nu retter i en XML-fil, f.eks. under `/fdirs/`, skal `npm run build-static` udføres igen, hvorefter ændringen kan ses i browseren. `npm run build-static` udføres meget hurtigt anden gang man kører den, da kun ændrede xml-filer behandles.
-
-### Docker
-
-Du kan også køre Kalliope med Docker og Elasticsearch:
-
-Først skal `docker` være installeret og tilgængelig i din terminal:
-
-- På Mac kan du installere [Docker Desktop](https://www.docker.com/products/docker-desktop/)
-  eller bruge [Colima](https://github.com/abiosoft/colima) sammen med Docker CLI:
-  `brew install colima docker docker-compose`.
-- På Linux skal du installere Docker Engine og Compose-plugin'et via din distributions
-  pakkehåndtering eller Dockers installationsvejledning.
-
-Start derefter Docker-daemonen:
-
-- Med Docker Desktop: åbn Docker Desktop og vent til Docker kører.
-- Med Colima:
+Start Elasticsearch på `localhost:9200`:
 
 ```shell
-colima start
+docker compose -f docker-compose.yml -f docker-compose.dev.yml up -d elasticsearch
 ```
 
-Første gang skal de statiske data bygges, før appen startes:
+Byg de statiske data og start appen:
+
+```shell
+npm run build-static
+npm run dev
+```
+
+Appen kører på http://localhost:3000/.
+
+Når du ændrer XML-filer i `fdirs/` eller `data/`, skal de statiske data bygges
+igen:
+
+```shell
+npm run build-static
+```
+
+Hvis cachede build-data driller, kan hele static-buildet tvinges igennem:
+
+```shell
+npm run build-static-force-reload
+```
+
+Kør testene før større ændringer eller pull requests:
+
+```shell
+npm test
+```
+
+## Deploy på prod og opdatering af prod
+
+Produktionen køres med Docker Compose. Prod-serveren bygger appen, bygger de
+statiske data og opdaterer Elasticsearch.
+
+Log ind på prod-serveren og gå til repoet:
+
+```shell
+ssh jec@10.0.0.5
+cd ~/Sites/kalliope
+```
+
+Hent seneste kode:
+
+```shell
+git pull --ff-only
+```
+
+Byg og kør static-builderen:
 
 ```shell
 docker compose up -d elasticsearch
 docker compose --profile build build static-builder
 docker compose --profile build run --rm static-builder
-docker compose up --build app
 ```
 
-Det starter appen på `http://localhost:3001`. Elasticsearch kører kun på
-Docker-netværket og er ikke eksponeret på hosten.
-
-Hvis du udvikler direkte på hosten med `npm run dev`, men gerne vil bruge
-Elasticsearch fra Docker på `localhost:9200`, så start kun Elasticsearch med
-dev-override:
+Byg og genstart appen:
 
 ```shell
-docker compose -f docker-compose.yml -f docker-compose.dev.yml up -d elasticsearch
-npm run build-static
-npm run dev
+docker compose up --build -d app
 ```
 
-`docker-compose.dev.yml` eksponerer kun Elasticsearch-porten, når override-filen
-bruges. Den almindelige Docker-opsætning holder stadig Elasticsearch internt på
-Docker-netværket.
-
-Efter ændringer i XML-filer under `data/` eller `fdirs/` skal builderen køres igen:
+Tjek at containerne kører:
 
 ```shell
-docker compose --profile build run --rm static-builder
+docker compose ps
 ```
 
-På Colima kan første statiske build godt kræve mere RAM end standardopsætningen, især under thumbnail-generering. Docker-opsætningen kører fire thumbnails ad gangen som standard (`KALLIOPE_THUMBNAIL_CONCURRENCY=4`), men holder sharp/libvips per-billede concurrency lav (`KALLIOPE_SHARP_CONCURRENCY=1`) og bruger en lille sharp-cache (`KALLIOPE_SHARP_CACHE_MEMORY=64`) for at spare hukommelse. Hvis containeren alligevel bliver killed under `build-static`, så prøv at starte Colima med mere hukommelse og kør builderen igen:
+Ved større dataændringer kan static-buildet køres med fuld reload:
 
 ```shell
-colima stop
-colima start --cpu 4 --memory 8 --disk 60
-docker compose --profile build run --rm static-builder
-```
-
-Hvis du vil bygge thumbnails hurtigere og har rigeligt RAM, kan concurrency hæves:
-
-```shell
-KALLIOPE_THUMBNAIL_CONCURRENCY=8 docker compose --profile build run --rm static-builder
-```
-
-`KALLIOPE_THUMBNAIL_CONCURRENCY` styrer hvor mange billeder der behandles samtidig. `KALLIOPE_SHARP_CONCURRENCY` styrer hvor mange libvips worker-tråde sharp bruger per billede.
-
-### Faksimile generering
-
-Kræver `pdfimages` som er del af `poppler` pakken.
-
-## Kalliope installation på server
-
-### Install
-
-```shell
-mkdir ~/home/jec/Sites
-cd ~/home/jec/Sites
-git checkout ...
-npm run build
-```
-
-### systemd
-
-```shell
-sudo cp ~/home/jec/Sites/tools/kalliope.service /etc/systemd/system
-sudo systemctl daemon-reload
-sudo systemctl enable kalliope.service
-```
-
-Now Kalliope should start on system start (after nginx). Test with
-
-```
-sudo systemctl start kalliope # To et
+docker compose --profile build run --rm static-builder npm run build-static-force-reload
 ```

--- a/README.md
+++ b/README.md
@@ -57,12 +57,7 @@ npm test
 Produktionen køres med Docker Compose. Prod-serveren bygger appen, bygger de
 statiske data og opdaterer Elasticsearch.
 
-Log ind på prod-serveren og gå til repoet:
-
-```shell
-ssh jec@10.0.0.5
-cd ~/Sites/kalliope
-```
+Log ind på prod-serveren og gå til repoet.
 
 Hent seneste kode:
 


### PR DESCRIPTION
## Ændringer

- Omskriver README, så den fokuserer på lokal udvikling/tekstredigering og produktion.
- Dokumenterer lokal brug af `npm run dev` med Elasticsearch på `localhost:9200`.
- Dokumenterer den enkle Docker Compose-baserede prod-opdatering.
- Fjerner forældet omtale af systemd, faksimile-generering og thumbnail-concurrency.

## Validering

- Ikke kørt tests; ændringen er kun dokumentation.