### PR TITLE
Brug mindre thumbnails i sidebars

### DIFF
--- a/components/picture.js
+++ b/components/picture.js
@@ -88,6 +88,7 @@ const Picture = ({
   showDropShadow = true,
   clickToZoom = true,
   startIndex = 0,
+  sizes = '(max-width: 767px) 47vw, 250px',
 }) => {
   const [overlayShown, showOverlay] = useState(false);
   const picture = pictures[startIndex];
@@ -96,7 +97,6 @@ const Picture = ({
     src,
     CommonData.fallbackImagePostfix
   );
-  const sizes = '(max-width: 700px) 250px, 48vw';
   let srcsets = {};
   const sources = CommonData.availableImageFormats.map((ext) => {
     const srcset = CommonData.availableImageWidths

--- a/components/picturesgrid.js
+++ b/components/picturesgrid.js
@@ -36,6 +36,9 @@ const PicturesGrid = ({ lang, poet, artwork, hideArtist, hideMuseum }) => {
     return height;
   };
 
+  // Fortæl browseren hvor bredt billedet faktisk vises: i små viewports er
+  // bredden en procentdel af viewporten, mens den på desktop er bundet af
+  // hovedkolonnens maksimale bredde.
   const imageSizesForWidth = (widthPercent) => {
     return `(max-width: ${mainBreakpointPx}px) ${widthPercent.toFixed(
       2

--- a/components/picturesgrid.js
+++ b/components/picturesgrid.js
@@ -1,5 +1,9 @@
 import Picture from '../components/picture.js';
 
+const mainMaxWidthPx = 880;
+const mainHorizontalPaddingPx = 40;
+const mainBreakpointPx = mainMaxWidthPx + mainHorizontalPaddingPx;
+
 const PicturesGrid = ({ lang, poet, artwork, hideArtist, hideMuseum }) => {
   if (artwork.length === 0) {
     return null;
@@ -30,6 +34,14 @@ const PicturesGrid = ({ lang, poet, artwork, hideArtist, hideMuseum }) => {
       }
     });
     return height;
+  };
+
+  const imageSizesForWidth = (widthPercent) => {
+    return `(max-width: ${mainBreakpointPx}px) ${widthPercent.toFixed(
+      2
+    )}vw, ${Math.ceil(
+      (widthPercent / 100) * mainMaxWidthPx
+    )}px`;
   };
 
   const sortedArtworks = sortArtworks(artwork);
@@ -91,7 +103,7 @@ const PicturesGrid = ({ lang, poet, artwork, hideArtist, hideMuseum }) => {
       const renderedList = row.items.map((item, i) => {
         const picture = item.picture;
 
-        const width = item.width;
+        const widthPercent = item.width;
         let pictureRendered = null;
         if (picture != null) {
           pictureRendered = (
@@ -102,11 +114,12 @@ const PicturesGrid = ({ lang, poet, artwork, hideArtist, hideMuseum }) => {
               pictures={[picture]}
               contentLang={picture.content_lang || 'da'}
               lang={lang}
+              sizes={imageSizesForWidth(widthPercent)}
             />
           );
         }
         return (
-          <div key={'container-' + i} style={{ flexBasis: width + '%' }}>
+          <div key={'container-' + i} style={{ flexBasis: widthPercent + '%' }}>
             {pictureRendered}
           </div>
         );


### PR DESCRIPTION
## Ændringer

- Ændrer standard-`sizes` for `Picture`, så sidebar-, forside- og biografibilleder ikke annonceres som `48vw` på desktop.
- Gør `sizes` konfigurerbar for `Picture`.
- Giver kunst-/billedgridet egne layoutbaserede `sizes`, så større gridbilleder stadig kan hente passende varianter.

Fixes #1194

## Validering

- `npm test`
- `npm run build`