### PR TITLE
Udelad testafhængigheder fra Docker-build

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,7 +5,7 @@ ENV NPM_CONFIG_UPDATE_NOTIFIER=false
 WORKDIR /app
 
 COPY package*.json ./
-RUN npm ci --legacy-peer-deps
+RUN npm ci --omit=dev --legacy-peer-deps
 
 COPY next.config.js routes.js server.js ./
 COPY common ./common

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,21 +9,19 @@
       "version": "1.0.0",
       "license": "MIT",
       "dependencies": {
-        "react": "^18.3.1",
-        "react-dom": "^18.3.1"
-      },
-      "devDependencies": {
         "@xmldom/xmldom": "^0.9.10",
         "async": "^2.5.0",
         "entities": "^1.1.1",
-        "full-icu": "^1.2.1",
         "ics": "^2.4.1",
-        "jest": "^30.4.2",
         "mkdirp": "^0.5.1",
         "next": "^16.2.9",
         "p-limit": "^2.2.2",
-        "regenerator-runtime": "^0.13.1",
+        "react": "^18.3.1",
+        "react-dom": "^18.3.1",
         "sharp": "^0.34.5"
+      },
+      "devDependencies": {
+        "jest": "^30.4.2"
       },
       "engines": {
         "node": ">=20.18.1"
@@ -453,7 +451,6 @@
     },
     "node_modules/@babel/runtime": {
       "version": "7.28.4",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=6.9.0"
@@ -527,7 +524,6 @@
       "version": "1.11.1",
       "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.11.1.tgz",
       "integrity": "sha512-vgj7R3y3Wgx24IQaGPA/R6YFXLHVMOZ0uVEyIQPaWs+rd1AzfEMXlAC22FYwO1XkKR6NPsq7mUandH8oIRdZFw==",
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "dependencies": {
@@ -549,7 +545,6 @@
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/@img/colour/-/colour-1.1.0.tgz",
       "integrity": "sha512-Td76q7j57o/tLVdgS746cYARfSyxk8iEfRxewL9h4OMzYhbW4TAcppl0mT4eyqXddh6L/jwoM75mo7ixa/pCeQ==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=18"
@@ -562,7 +557,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -585,7 +579,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -608,7 +601,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -625,7 +617,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -641,10 +632,6 @@
       "integrity": "sha512-bFI7xcKFELdiNCVov8e44Ia4u2byA+l3XtsAj+Q8tfCwO6BQ8iDojYdvoPMqsKDkuoOo+X6HZA0s0q11ANMQ8A==",
       "cpu": [
         "arm"
-      ],
-      "dev": true,
-      "libc": [
-        "glibc"
       ],
       "license": "LGPL-3.0-or-later",
       "optional": true,
@@ -662,10 +649,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -681,10 +664,6 @@
       "integrity": "sha512-FMuvGijLDYG6lW+b/UvyilUWu5Ayu+3r2d1S8notiGCIyYU/76eig1UfMmkZ7vwgOrzKzlQbFSuQfgm7GYUPpA==",
       "cpu": [
         "ppc64"
-      ],
-      "dev": true,
-      "libc": [
-        "glibc"
       ],
       "license": "LGPL-3.0-or-later",
       "optional": true,
@@ -702,10 +681,6 @@
       "cpu": [
         "riscv64"
       ],
-      "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -721,10 +696,6 @@
       "integrity": "sha512-qmp9VrzgPgMoGZyPvrQHqk02uyjA0/QrTO26Tqk6l4ZV0MPWIW6LTkqOIov+J1yEu7MbFQaDpwdwJKhbJvuRxQ==",
       "cpu": [
         "s390x"
-      ],
-      "dev": true,
-      "libc": [
-        "glibc"
       ],
       "license": "LGPL-3.0-or-later",
       "optional": true,
@@ -742,10 +713,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -761,10 +728,6 @@
       "integrity": "sha512-FVQHuwx1IIuNow9QAbYUzJ+En8KcVm9Lk5+uGUQJHaZmMECZmOlix9HnH7n1TRkXMS0pGxIJokIVB9SuqZGGXw==",
       "cpu": [
         "arm64"
-      ],
-      "dev": true,
-      "libc": [
-        "musl"
       ],
       "license": "LGPL-3.0-or-later",
       "optional": true,
@@ -782,10 +745,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -801,10 +760,6 @@
       "integrity": "sha512-9dLqsvwtg1uuXBGZKsxem9595+ujv0sJ6Vi8wcTANSFpwV/GONat5eCkzQo/1O6zRIkh0m/8+5BjrRr7jDUSZw==",
       "cpu": [
         "arm"
-      ],
-      "dev": true,
-      "libc": [
-        "glibc"
       ],
       "license": "Apache-2.0",
       "optional": true,
@@ -828,10 +783,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -853,10 +804,6 @@
       "integrity": "sha512-7zznwNaqW6YtsfrGGDA6BRkISKAAE1Jo0QdpNYXNMHu2+0dTrPflTLNkpc8l7MUP5M16ZJcUvysVWWrMefZquA==",
       "cpu": [
         "ppc64"
-      ],
-      "dev": true,
-      "libc": [
-        "glibc"
       ],
       "license": "Apache-2.0",
       "optional": true,
@@ -880,10 +827,6 @@
       "cpu": [
         "riscv64"
       ],
-      "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -905,10 +848,6 @@
       "integrity": "sha512-nQtCk0PdKfho3eC5MrbQoigJ2gd1CgddUMkabUj+rBevs8tZ2cULOx46E7oyX+04WGfABgIwmMC0VqieTiR4jg==",
       "cpu": [
         "s390x"
-      ],
-      "dev": true,
-      "libc": [
-        "glibc"
       ],
       "license": "Apache-2.0",
       "optional": true,
@@ -932,10 +871,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -957,10 +892,6 @@
       "integrity": "sha512-fprJR6GtRsMt6Kyfq44IsChVZeGN97gTD331weR1ex1c1rypDEABN6Tm2xa1wE6lYb5DdEnk03NZPqA7Id21yg==",
       "cpu": [
         "arm64"
-      ],
-      "dev": true,
-      "libc": [
-        "musl"
       ],
       "license": "Apache-2.0",
       "optional": true,
@@ -984,10 +915,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -1010,7 +937,6 @@
       "cpu": [
         "wasm32"
       ],
-      "dev": true,
       "license": "Apache-2.0 AND LGPL-3.0-or-later AND MIT",
       "optional": true,
       "dependencies": {
@@ -1030,7 +956,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "Apache-2.0 AND LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -1050,7 +975,6 @@
       "cpu": [
         "ia32"
       ],
-      "dev": true,
       "license": "Apache-2.0 AND LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -1070,7 +994,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "Apache-2.0 AND LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -1753,7 +1676,6 @@
       "version": "16.2.9",
       "resolved": "https://registry.npmjs.org/@next/env/-/env-16.2.9.tgz",
       "integrity": "sha512-ki5VxxXfzD/9TDe13wyeTKIjQTAwBVpnr8KhRDUr8ltMUq1/NBpWNT5tiPoxiGl+PHM4X2ahSOiPk6iAimIzPg==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/@next/swc-darwin-arm64": {
@@ -1763,7 +1685,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1780,7 +1701,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1797,7 +1717,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1814,7 +1733,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1831,7 +1749,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1848,7 +1765,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1865,7 +1781,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1882,7 +1797,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1947,7 +1861,6 @@
       "version": "0.5.15",
       "resolved": "https://registry.npmjs.org/@swc/helpers/-/helpers-0.5.15.tgz",
       "integrity": "sha512-JQ5TuMi45Owi4/BIMAJBoSQoOJu12oOk/gADqlcUL9JEdHB8vyjUSsxqeNXnmXHjYKMi2WcYtezGEEhqUI/E2g==",
-      "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
         "tslib": "^2.8.0"
@@ -2038,7 +1951,6 @@
     },
     "node_modules/@types/lodash": {
       "version": "4.17.20",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/@types/node": {
@@ -2410,7 +2322,6 @@
       "version": "0.9.10",
       "resolved": "https://registry.npmjs.org/@xmldom/xmldom/-/xmldom-0.9.10.tgz",
       "integrity": "sha512-A9gOqLdi6cV4ibazAjcQufGj0B1y/vDqYrcuP6d/6x8P27gRS8643Dj9o1dEKtB6O7fwxb2FgBmJS2mX7gpvdw==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=14.6"
@@ -2497,7 +2408,6 @@
     },
     "node_modules/async": {
       "version": "2.6.4",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "lodash": "^4.17.14"
@@ -2541,7 +2451,6 @@
       "version": "2.10.37",
       "resolved": "https://registry.npmjs.org/baseline-browser-mapping/-/baseline-browser-mapping-2.10.37.tgz",
       "integrity": "sha512-girxaJ7WZssDOFhzCGZTDKoTa1gk6A1TbflaYTpykLJ4UU9Fz9kx1aREM8JCuoVHbL8X8T/mJg7w2oYSq72Oig==",
-      "dev": true,
       "license": "Apache-2.0",
       "bin": {
         "baseline-browser-mapping": "dist/cli.cjs"
@@ -2602,14 +2511,6 @@
         "node-int64": "^0.4.0"
       }
     },
-    "node_modules/buffer-crc32": {
-      "version": "0.2.13",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": "*"
-      }
-    },
     "node_modules/buffer-from": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/buffer-from/-/buffer-from-1.1.2.tgz",
@@ -2642,7 +2543,6 @@
     },
     "node_modules/caniuse-lite": {
       "version": "1.0.30001755",
-      "dev": true,
       "funding": [
         {
           "type": "opencollective",
@@ -2713,7 +2613,6 @@
       "version": "0.0.1",
       "resolved": "https://registry.npmjs.org/client-only/-/client-only-0.0.1.tgz",
       "integrity": "sha512-IV3Ou0jSMzZrd3pZ48nLkT9DA7Ag1pnPzaiQhpW7c3RbcqqzvzzVu+L8gfqMp/8IM2MQtSiqaCxrrcfu8I8rMA==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/cliui": {
@@ -2904,7 +2803,6 @@
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-2.1.2.tgz",
       "integrity": "sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ==",
-      "dev": true,
       "license": "Apache-2.0",
       "engines": {
         "node": ">=8"
@@ -2954,7 +2852,6 @@
     },
     "node_modules/entities": {
       "version": "1.1.2",
-      "dev": true,
       "license": "BSD-2-Clause"
     },
     "node_modules/error-ex": {
@@ -3077,14 +2974,6 @@
         "bser": "2.1.1"
       }
     },
-    "node_modules/fd-slicer": {
-      "version": "1.1.0",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "pend": "~1.2.0"
-      }
-    },
     "node_modules/foreground-child": {
       "version": "3.3.1",
       "resolved": "https://registry.npmjs.org/foreground-child/-/foreground-child-3.3.1.tgz",
@@ -3122,19 +3011,6 @@
       ],
       "engines": {
         "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
-      }
-    },
-    "node_modules/full-icu": {
-      "version": "1.5.0",
-      "dev": true,
-      "hasInstallScript": true,
-      "license": "Unicode-DFS-2016",
-      "dependencies": {
-        "yauzl": "^2.10.0"
-      },
-      "bin": {
-        "full-icu": "node-full-icu.js",
-        "node-full-icu-path": "node-icu-data.js"
       }
     },
     "node_modules/gensync": {
@@ -3234,7 +3110,6 @@
     },
     "node_modules/ics": {
       "version": "2.44.0",
-      "dev": true,
       "license": "ISC",
       "dependencies": {
         "nanoid": "^3.1.23",
@@ -4297,12 +4172,10 @@
     },
     "node_modules/lodash": {
       "version": "4.17.21",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/lodash-es": {
       "version": "4.17.21",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/loose-envify": {
@@ -4397,7 +4270,6 @@
     },
     "node_modules/minimist": {
       "version": "1.2.8",
-      "dev": true,
       "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
@@ -4415,7 +4287,6 @@
     },
     "node_modules/mkdirp": {
       "version": "0.5.6",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "minimist": "^1.2.6"
@@ -4431,12 +4302,10 @@
     },
     "node_modules/nanoclone": {
       "version": "0.2.1",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/nanoid": {
       "version": "3.3.11",
-      "dev": true,
       "funding": [
         {
           "type": "github",
@@ -4478,7 +4347,6 @@
       "version": "16.2.9",
       "resolved": "https://registry.npmjs.org/next/-/next-16.2.9.tgz",
       "integrity": "sha512-MEOJiq/UvuezAdqVSceHbqDgZt1kDw2tpGVOlsdIoJsQdbN2JY2hpVG4xnXGkbdJUOEWhnRfiu/O4Hpc9Juwww==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@next/env": "16.2.9",
@@ -4581,7 +4449,6 @@
     },
     "node_modules/p-limit": {
       "version": "2.3.0",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "p-try": "^2.0.0"
@@ -4595,7 +4462,6 @@
     },
     "node_modules/p-limit/node_modules/p-try": {
       "version": "2.2.0",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=6"
@@ -4652,14 +4518,8 @@
       "dev": true,
       "license": "ISC"
     },
-    "node_modules/pend": {
-      "version": "1.2.0",
-      "dev": true,
-      "license": "MIT"
-    },
     "node_modules/picocolors": {
       "version": "1.1.1",
-      "dev": true,
       "license": "ISC"
     },
     "node_modules/picomatch": {
@@ -4752,7 +4612,6 @@
       "version": "8.4.31",
       "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.4.31.tgz",
       "integrity": "sha512-PS08Iboia9mts/2ygV3eLpY5ghnUcfLV/EXTOW1E2qYxJKGGBUtNjN76FYHnMs36RmARn41bC0AZmn+rR0OVpQ==",
-      "dev": true,
       "funding": [
         {
           "type": "opencollective",
@@ -4807,7 +4666,6 @@
     },
     "node_modules/property-expr": {
       "version": "2.0.6",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/pure-rand": {
@@ -4866,11 +4724,6 @@
       "dev": true,
       "license": "MIT"
     },
-    "node_modules/regenerator-runtime": {
-      "version": "0.13.11",
-      "dev": true,
-      "license": "MIT"
-    },
     "node_modules/require-directory": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/require-directory/-/require-directory-2.1.1.tgz",
@@ -4924,7 +4777,6 @@
       "version": "0.34.5",
       "resolved": "https://registry.npmjs.org/sharp/-/sharp-0.34.5.tgz",
       "integrity": "sha512-Ou9I5Ft9WNcCbXrU9cMgPBcCK8LiwLqcbywW3t4oDV37n1pzpuNLsYiAV8eODnjbtQlSDwZ2cUEeQz4E54Hltg==",
-      "dev": true,
       "hasInstallScript": true,
       "license": "Apache-2.0",
       "dependencies": {
@@ -4969,7 +4821,6 @@
       "version": "7.8.5",
       "resolved": "https://registry.npmjs.org/semver/-/semver-7.8.5.tgz",
       "integrity": "sha512-Y7/KDsb8LjooZpwaqGyulO6DQlksgCncchHGk+sZIY4SBvUocMBEFH5Ur1fI4dV+Jvl0w6cjvucaIi40puRioA==",
-      "dev": true,
       "license": "ISC",
       "bin": {
         "semver": "bin/semver.js"
@@ -5028,7 +4879,6 @@
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.1.tgz",
       "integrity": "sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==",
-      "dev": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -5265,7 +5115,6 @@
       "version": "5.1.6",
       "resolved": "https://registry.npmjs.org/styled-jsx/-/styled-jsx-5.1.6.tgz",
       "integrity": "sha512-qSVyDTeMotdvQYoHWLNGwRFJHC+i+ZvdBRYosOFgC+Wg1vx4frN2/RG/NA7SYqqvKNLf39P2LSRA2pu6n0XYZA==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "client-only": "0.0.1"
@@ -5323,14 +5172,12 @@
     },
     "node_modules/toposort": {
       "version": "2.0.2",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/tslib": {
       "version": "2.8.1",
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
       "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
-      "dev": true,
       "license": "0BSD"
     },
     "node_modules/type-detect": {
@@ -5676,15 +5523,6 @@
         "node": ">=8"
       }
     },
-    "node_modules/yauzl": {
-      "version": "2.10.0",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "buffer-crc32": "~0.2.3",
-        "fd-slicer": "~1.1.0"
-      }
-    },
     "node_modules/yocto-queue": {
       "version": "0.1.0",
       "resolved": "https://registry.npmjs.org/yocto-queue/-/yocto-queue-0.1.0.tgz",
@@ -5700,7 +5538,6 @@
     },
     "node_modules/yup": {
       "version": "0.32.11",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@babel/runtime": "^7.15.4",
@@ -5995,8 +5832,7 @@
       }
     },
     "@babel/runtime": {
-      "version": "7.28.4",
-      "dev": true
+      "version": "7.28.4"
     },
     "@babel/template": {
       "version": "7.29.7",
@@ -6055,7 +5891,6 @@
       "version": "1.11.1",
       "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.11.1.tgz",
       "integrity": "sha512-vgj7R3y3Wgx24IQaGPA/R6YFXLHVMOZ0uVEyIQPaWs+rd1AzfEMXlAC22FYwO1XkKR6NPsq7mUandH8oIRdZFw==",
-      "dev": true,
       "optional": true,
       "requires": {
         "tslib": "^2.4.0"
@@ -6074,14 +5909,12 @@
     "@img/colour": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/@img/colour/-/colour-1.1.0.tgz",
-      "integrity": "sha512-Td76q7j57o/tLVdgS746cYARfSyxk8iEfRxewL9h4OMzYhbW4TAcppl0mT4eyqXddh6L/jwoM75mo7ixa/pCeQ==",
-      "dev": true
+      "integrity": "sha512-Td76q7j57o/tLVdgS746cYARfSyxk8iEfRxewL9h4OMzYhbW4TAcppl0mT4eyqXddh6L/jwoM75mo7ixa/pCeQ=="
     },
     "@img/sharp-darwin-arm64": {
       "version": "0.34.5",
       "resolved": "https://registry.npmjs.org/@img/sharp-darwin-arm64/-/sharp-darwin-arm64-0.34.5.tgz",
       "integrity": "sha512-imtQ3WMJXbMY4fxb/Ndp6HBTNVtWCUI0WdobyheGf5+ad6xX8VIDO8u2xE4qc/fr08CKG/7dDseFtn6M6g/r3w==",
-      "dev": true,
       "optional": true,
       "requires": {
         "@img/sharp-libvips-darwin-arm64": "1.2.4"
@@ -6091,7 +5924,6 @@
       "version": "0.34.5",
       "resolved": "https://registry.npmjs.org/@img/sharp-darwin-x64/-/sharp-darwin-x64-0.34.5.tgz",
       "integrity": "sha512-YNEFAF/4KQ/PeW0N+r+aVVsoIY0/qxxikF2SWdp+NRkmMB7y9LBZAVqQ4yhGCm/H3H270OSykqmQMKLBhBJDEw==",
-      "dev": true,
       "optional": true,
       "requires": {
         "@img/sharp-libvips-darwin-x64": "1.2.4"
@@ -6101,77 +5933,66 @@
       "version": "1.2.4",
       "resolved": "https://registry.npmjs.org/@img/sharp-libvips-darwin-arm64/-/sharp-libvips-darwin-arm64-1.2.4.tgz",
       "integrity": "sha512-zqjjo7RatFfFoP0MkQ51jfuFZBnVE2pRiaydKJ1G/rHZvnsrHAOcQALIi9sA5co5xenQdTugCvtb1cuf78Vf4g==",
-      "dev": true,
       "optional": true
     },
     "@img/sharp-libvips-darwin-x64": {
       "version": "1.2.4",
       "resolved": "https://registry.npmjs.org/@img/sharp-libvips-darwin-x64/-/sharp-libvips-darwin-x64-1.2.4.tgz",
       "integrity": "sha512-1IOd5xfVhlGwX+zXv2N93k0yMONvUlANylbJw1eTah8K/Jtpi15KC+WSiaX/nBmbm2HxRM1gZ0nSdjSsrZbGKg==",
-      "dev": true,
       "optional": true
     },
     "@img/sharp-libvips-linux-arm": {
       "version": "1.2.4",
       "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-arm/-/sharp-libvips-linux-arm-1.2.4.tgz",
       "integrity": "sha512-bFI7xcKFELdiNCVov8e44Ia4u2byA+l3XtsAj+Q8tfCwO6BQ8iDojYdvoPMqsKDkuoOo+X6HZA0s0q11ANMQ8A==",
-      "dev": true,
       "optional": true
     },
     "@img/sharp-libvips-linux-arm64": {
       "version": "1.2.4",
       "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-arm64/-/sharp-libvips-linux-arm64-1.2.4.tgz",
       "integrity": "sha512-excjX8DfsIcJ10x1Kzr4RcWe1edC9PquDRRPx3YVCvQv+U5p7Yin2s32ftzikXojb1PIFc/9Mt28/y+iRklkrw==",
-      "dev": true,
       "optional": true
     },
     "@img/sharp-libvips-linux-ppc64": {
       "version": "1.2.4",
       "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-ppc64/-/sharp-libvips-linux-ppc64-1.2.4.tgz",
       "integrity": "sha512-FMuvGijLDYG6lW+b/UvyilUWu5Ayu+3r2d1S8notiGCIyYU/76eig1UfMmkZ7vwgOrzKzlQbFSuQfgm7GYUPpA==",
-      "dev": true,
       "optional": true
     },
     "@img/sharp-libvips-linux-riscv64": {
       "version": "1.2.4",
       "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-riscv64/-/sharp-libvips-linux-riscv64-1.2.4.tgz",
       "integrity": "sha512-oVDbcR4zUC0ce82teubSm+x6ETixtKZBh/qbREIOcI3cULzDyb18Sr/Wcyx7NRQeQzOiHTNbZFF1UwPS2scyGA==",
-      "dev": true,
       "optional": true
     },
     "@img/sharp-libvips-linux-s390x": {
       "version": "1.2.4",
       "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-s390x/-/sharp-libvips-linux-s390x-1.2.4.tgz",
       "integrity": "sha512-qmp9VrzgPgMoGZyPvrQHqk02uyjA0/QrTO26Tqk6l4ZV0MPWIW6LTkqOIov+J1yEu7MbFQaDpwdwJKhbJvuRxQ==",
-      "dev": true,
       "optional": true
     },
     "@img/sharp-libvips-linux-x64": {
       "version": "1.2.4",
       "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-x64/-/sharp-libvips-linux-x64-1.2.4.tgz",
       "integrity": "sha512-tJxiiLsmHc9Ax1bz3oaOYBURTXGIRDODBqhveVHonrHJ9/+k89qbLl0bcJns+e4t4rvaNBxaEZsFtSfAdquPrw==",
-      "dev": true,
       "optional": true
     },
     "@img/sharp-libvips-linuxmusl-arm64": {
       "version": "1.2.4",
       "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linuxmusl-arm64/-/sharp-libvips-linuxmusl-arm64-1.2.4.tgz",
       "integrity": "sha512-FVQHuwx1IIuNow9QAbYUzJ+En8KcVm9Lk5+uGUQJHaZmMECZmOlix9HnH7n1TRkXMS0pGxIJokIVB9SuqZGGXw==",
-      "dev": true,
       "optional": true
     },
     "@img/sharp-libvips-linuxmusl-x64": {
       "version": "1.2.4",
       "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linuxmusl-x64/-/sharp-libvips-linuxmusl-x64-1.2.4.tgz",
       "integrity": "sha512-+LpyBk7L44ZIXwz/VYfglaX/okxezESc6UxDSoyo2Ks6Jxc4Y7sGjpgU9s4PMgqgjj1gZCylTieNamqA1MF7Dg==",
-      "dev": true,
       "optional": true
     },
     "@img/sharp-linux-arm": {
       "version": "0.34.5",
       "resolved": "https://registry.npmjs.org/@img/sharp-linux-arm/-/sharp-linux-arm-0.34.5.tgz",
       "integrity": "sha512-9dLqsvwtg1uuXBGZKsxem9595+ujv0sJ6Vi8wcTANSFpwV/GONat5eCkzQo/1O6zRIkh0m/8+5BjrRr7jDUSZw==",
-      "dev": true,
       "optional": true,
       "requires": {
         "@img/sharp-libvips-linux-arm": "1.2.4"
@@ -6181,7 +6002,6 @@
       "version": "0.34.5",
       "resolved": "https://registry.npmjs.org/@img/sharp-linux-arm64/-/sharp-linux-arm64-0.34.5.tgz",
       "integrity": "sha512-bKQzaJRY/bkPOXyKx5EVup7qkaojECG6NLYswgktOZjaXecSAeCWiZwwiFf3/Y+O1HrauiE3FVsGxFg8c24rZg==",
-      "dev": true,
       "optional": true,
       "requires": {
         "@img/sharp-libvips-linux-arm64": "1.2.4"
@@ -6191,7 +6011,6 @@
       "version": "0.34.5",
       "resolved": "https://registry.npmjs.org/@img/sharp-linux-ppc64/-/sharp-linux-ppc64-0.34.5.tgz",
       "integrity": "sha512-7zznwNaqW6YtsfrGGDA6BRkISKAAE1Jo0QdpNYXNMHu2+0dTrPflTLNkpc8l7MUP5M16ZJcUvysVWWrMefZquA==",
-      "dev": true,
       "optional": true,
       "requires": {
         "@img/sharp-libvips-linux-ppc64": "1.2.4"
@@ -6201,7 +6020,6 @@
       "version": "0.34.5",
       "resolved": "https://registry.npmjs.org/@img/sharp-linux-riscv64/-/sharp-linux-riscv64-0.34.5.tgz",
       "integrity": "sha512-51gJuLPTKa7piYPaVs8GmByo7/U7/7TZOq+cnXJIHZKavIRHAP77e3N2HEl3dgiqdD/w0yUfiJnII77PuDDFdw==",
-      "dev": true,
       "optional": true,
       "requires": {
         "@img/sharp-libvips-linux-riscv64": "1.2.4"
@@ -6211,7 +6029,6 @@
       "version": "0.34.5",
       "resolved": "https://registry.npmjs.org/@img/sharp-linux-s390x/-/sharp-linux-s390x-0.34.5.tgz",
       "integrity": "sha512-nQtCk0PdKfho3eC5MrbQoigJ2gd1CgddUMkabUj+rBevs8tZ2cULOx46E7oyX+04WGfABgIwmMC0VqieTiR4jg==",
-      "dev": true,
       "optional": true,
       "requires": {
         "@img/sharp-libvips-linux-s390x": "1.2.4"
@@ -6221,7 +6038,6 @@
       "version": "0.34.5",
       "resolved": "https://registry.npmjs.org/@img/sharp-linux-x64/-/sharp-linux-x64-0.34.5.tgz",
       "integrity": "sha512-MEzd8HPKxVxVenwAa+JRPwEC7QFjoPWuS5NZnBt6B3pu7EG2Ge0id1oLHZpPJdn3OQK+BQDiw9zStiHBTJQQQQ==",
-      "dev": true,
       "optional": true,
       "requires": {
         "@img/sharp-libvips-linux-x64": "1.2.4"
@@ -6231,7 +6047,6 @@
       "version": "0.34.5",
       "resolved": "https://registry.npmjs.org/@img/sharp-linuxmusl-arm64/-/sharp-linuxmusl-arm64-0.34.5.tgz",
       "integrity": "sha512-fprJR6GtRsMt6Kyfq44IsChVZeGN97gTD331weR1ex1c1rypDEABN6Tm2xa1wE6lYb5DdEnk03NZPqA7Id21yg==",
-      "dev": true,
       "optional": true,
       "requires": {
         "@img/sharp-libvips-linuxmusl-arm64": "1.2.4"
@@ -6241,7 +6056,6 @@
       "version": "0.34.5",
       "resolved": "https://registry.npmjs.org/@img/sharp-linuxmusl-x64/-/sharp-linuxmusl-x64-0.34.5.tgz",
       "integrity": "sha512-Jg8wNT1MUzIvhBFxViqrEhWDGzqymo3sV7z7ZsaWbZNDLXRJZoRGrjulp60YYtV4wfY8VIKcWidjojlLcWrd8Q==",
-      "dev": true,
       "optional": true,
       "requires": {
         "@img/sharp-libvips-linuxmusl-x64": "1.2.4"
@@ -6251,7 +6065,6 @@
       "version": "0.34.5",
       "resolved": "https://registry.npmjs.org/@img/sharp-wasm32/-/sharp-wasm32-0.34.5.tgz",
       "integrity": "sha512-OdWTEiVkY2PHwqkbBI8frFxQQFekHaSSkUIJkwzclWZe64O1X4UlUjqqqLaPbUpMOQk6FBu/HtlGXNblIs0huw==",
-      "dev": true,
       "optional": true,
       "requires": {
         "@emnapi/runtime": "^1.7.0"
@@ -6261,21 +6074,18 @@
       "version": "0.34.5",
       "resolved": "https://registry.npmjs.org/@img/sharp-win32-arm64/-/sharp-win32-arm64-0.34.5.tgz",
       "integrity": "sha512-WQ3AgWCWYSb2yt+IG8mnC6Jdk9Whs7O0gxphblsLvdhSpSTtmu69ZG1Gkb6NuvxsNACwiPV6cNSZNzt0KPsw7g==",
-      "dev": true,
       "optional": true
     },
     "@img/sharp-win32-ia32": {
       "version": "0.34.5",
       "resolved": "https://registry.npmjs.org/@img/sharp-win32-ia32/-/sharp-win32-ia32-0.34.5.tgz",
       "integrity": "sha512-FV9m/7NmeCmSHDD5j4+4pNI8Cp3aW+JvLoXcTUo0IqyjSfAZJ8dIUmijx1qaJsIiU+Hosw6xM5KijAWRJCSgNg==",
-      "dev": true,
       "optional": true
     },
     "@img/sharp-win32-x64": {
       "version": "0.34.5",
       "resolved": "https://registry.npmjs.org/@img/sharp-win32-x64/-/sharp-win32-x64-0.34.5.tgz",
       "integrity": "sha512-+29YMsqY2/9eFEiW93eqWnuLcWcufowXewwSNIT6UwZdUUCrM3oFjMWH/Z6/TMmb4hlFenmfAVbpWeup2jryCw==",
-      "dev": true,
       "optional": true
     },
     "@isaacs/cliui": {
@@ -6762,63 +6572,54 @@
     "@next/env": {
       "version": "16.2.9",
       "resolved": "https://registry.npmjs.org/@next/env/-/env-16.2.9.tgz",
-      "integrity": "sha512-ki5VxxXfzD/9TDe13wyeTKIjQTAwBVpnr8KhRDUr8ltMUq1/NBpWNT5tiPoxiGl+PHM4X2ahSOiPk6iAimIzPg==",
-      "dev": true
+      "integrity": "sha512-ki5VxxXfzD/9TDe13wyeTKIjQTAwBVpnr8KhRDUr8ltMUq1/NBpWNT5tiPoxiGl+PHM4X2ahSOiPk6iAimIzPg=="
     },
     "@next/swc-darwin-arm64": {
       "version": "16.2.9",
       "resolved": "https://registry.npmjs.org/@next/swc-darwin-arm64/-/swc-darwin-arm64-16.2.9.tgz",
       "integrity": "sha512-HkfxNYUCmcct0Xsqib5KxqMSHV4AHJq857BNRchyBDs4YS19aHzVfn1kDuBYKqLLQBjXgnkIsjV2Kd4d2wzYhw==",
-      "dev": true,
       "optional": true
     },
     "@next/swc-darwin-x64": {
       "version": "16.2.9",
       "resolved": "https://registry.npmjs.org/@next/swc-darwin-x64/-/swc-darwin-x64-16.2.9.tgz",
       "integrity": "sha512-7IAtK4MeybpqRV9GRABWEhJ62mOS+rzWOzOTFie4cSEtm12xsoOMJRcECoZx3FHPzFAqN/IJtHqWAFOLfl152w==",
-      "dev": true,
       "optional": true
     },
     "@next/swc-linux-arm64-gnu": {
       "version": "16.2.9",
       "resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-gnu/-/swc-linux-arm64-gnu-16.2.9.tgz",
       "integrity": "sha512-hBD75iWpUtkL9SmQmcRhmLomn9jgkPzCEkbOcLgHymPEKzv+6ONy13RRiIEz/iEObjkS2Jlb5gYS2XGoS3X4rw==",
-      "dev": true,
       "optional": true
     },
     "@next/swc-linux-arm64-musl": {
       "version": "16.2.9",
       "resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-musl/-/swc-linux-arm64-musl-16.2.9.tgz",
       "integrity": "sha512-qZTI3pf9SGc/obr8NkQAekBxmp1QK+kVm+VAf3BALLfFAj+1kUhkTxmrWpVos9R/UYIA8AWX2p6cGI5WdwzVUA==",
-      "dev": true,
       "optional": true
     },
     "@next/swc-linux-x64-gnu": {
       "version": "16.2.9",
       "resolved": "https://registry.npmjs.org/@next/swc-linux-x64-gnu/-/swc-linux-x64-gnu-16.2.9.tgz",
       "integrity": "sha512-xm0HfRNX+UkH4R3c18ynswjj5o5uEj/7iI9p9omdtTSIsRCzQqkGMA+10nzJ4EHnYC3as65IMhbbl5fWRUWHYg==",
-      "dev": true,
       "optional": true
     },
     "@next/swc-linux-x64-musl": {
       "version": "16.2.9",
       "resolved": "https://registry.npmjs.org/@next/swc-linux-x64-musl/-/swc-linux-x64-musl-16.2.9.tgz",
       "integrity": "sha512-QumimHkGEG6vM3PfEDWKyKen03NcqLOkeKB1EfcPe7VxzmEiCa4jNnMyBn/US5zcd/VE1CI+O8Ovb3lfjVHfGw==",
-      "dev": true,
       "optional": true
     },
     "@next/swc-win32-arm64-msvc": {
       "version": "16.2.9",
       "resolved": "https://registry.npmjs.org/@next/swc-win32-arm64-msvc/-/swc-win32-arm64-msvc-16.2.9.tgz",
       "integrity": "sha512-hzQpKZvw8rAwI6A2uQh6SacCSvNAXaIkPNsWwzqqfRiIMiXMfH936skDhz1OO6KpvdKkJrgHHtqQOq5PIXOvdQ==",
-      "dev": true,
       "optional": true
     },
     "@next/swc-win32-x64-msvc": {
       "version": "16.2.9",
       "resolved": "https://registry.npmjs.org/@next/swc-win32-x64-msvc/-/swc-win32-x64-msvc-16.2.9.tgz",
       "integrity": "sha512-qr2VL3Ce5QrwgO2yh1ujSBawrimjVKX8FGF/cOynmdYKJY0BdHpGVNIRK1tqONB10Vkm25Ub1BD2bkjWs4+96w==",
-      "dev": true,
       "optional": true
     },
     "@pkgjs/parseargs": {
@@ -6862,7 +6663,6 @@
       "version": "0.5.15",
       "resolved": "https://registry.npmjs.org/@swc/helpers/-/helpers-0.5.15.tgz",
       "integrity": "sha512-JQ5TuMi45Owi4/BIMAJBoSQoOJu12oOk/gADqlcUL9JEdHB8vyjUSsxqeNXnmXHjYKMi2WcYtezGEEhqUI/E2g==",
-      "dev": true,
       "requires": {
         "tslib": "^2.8.0"
       }
@@ -6943,8 +6743,7 @@
       }
     },
     "@types/lodash": {
-      "version": "4.17.20",
-      "dev": true
+      "version": "4.17.20"
     },
     "@types/node": {
       "version": "25.9.3",
@@ -7156,8 +6955,7 @@
     "@xmldom/xmldom": {
       "version": "0.9.10",
       "resolved": "https://registry.npmjs.org/@xmldom/xmldom/-/xmldom-0.9.10.tgz",
-      "integrity": "sha512-A9gOqLdi6cV4ibazAjcQufGj0B1y/vDqYrcuP6d/6x8P27gRS8643Dj9o1dEKtB6O7fwxb2FgBmJS2mX7gpvdw==",
-      "dev": true
+      "integrity": "sha512-A9gOqLdi6cV4ibazAjcQufGj0B1y/vDqYrcuP6d/6x8P27gRS8643Dj9o1dEKtB6O7fwxb2FgBmJS2mX7gpvdw=="
     },
     "ansi-escapes": {
       "version": "4.3.2",
@@ -7212,7 +7010,6 @@
     },
     "async": {
       "version": "2.6.4",
-      "dev": true,
       "requires": {
         "lodash": "^4.17.14"
       }
@@ -7249,8 +7046,7 @@
     "baseline-browser-mapping": {
       "version": "2.10.37",
       "resolved": "https://registry.npmjs.org/baseline-browser-mapping/-/baseline-browser-mapping-2.10.37.tgz",
-      "integrity": "sha512-girxaJ7WZssDOFhzCGZTDKoTa1gk6A1TbflaYTpykLJ4UU9Fz9kx1aREM8JCuoVHbL8X8T/mJg7w2oYSq72Oig==",
-      "dev": true
+      "integrity": "sha512-girxaJ7WZssDOFhzCGZTDKoTa1gk6A1TbflaYTpykLJ4UU9Fz9kx1aREM8JCuoVHbL8X8T/mJg7w2oYSq72Oig=="
     },
     "brace-expansion": {
       "version": "2.1.1",
@@ -7281,10 +7077,6 @@
         "node-int64": "^0.4.0"
       }
     },
-    "buffer-crc32": {
-      "version": "0.2.13",
-      "dev": true
-    },
     "buffer-from": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/buffer-from/-/buffer-from-1.1.2.tgz",
@@ -7304,8 +7096,7 @@
       "dev": true
     },
     "caniuse-lite": {
-      "version": "1.0.30001755",
-      "dev": true
+      "version": "1.0.30001755"
     },
     "chalk": {
       "version": "4.1.2",
@@ -7338,8 +7129,7 @@
     "client-only": {
       "version": "0.0.1",
       "resolved": "https://registry.npmjs.org/client-only/-/client-only-0.0.1.tgz",
-      "integrity": "sha512-IV3Ou0jSMzZrd3pZ48nLkT9DA7Ag1pnPzaiQhpW7c3RbcqqzvzzVu+L8gfqMp/8IM2MQtSiqaCxrrcfu8I8rMA==",
-      "dev": true
+      "integrity": "sha512-IV3Ou0jSMzZrd3pZ48nLkT9DA7Ag1pnPzaiQhpW7c3RbcqqzvzzVu+L8gfqMp/8IM2MQtSiqaCxrrcfu8I8rMA=="
     },
     "cliui": {
       "version": "8.0.1",
@@ -7467,8 +7257,7 @@
     "detect-libc": {
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-2.1.2.tgz",
-      "integrity": "sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ==",
-      "dev": true
+      "integrity": "sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ=="
     },
     "detect-newline": {
       "version": "3.1.0",
@@ -7499,8 +7288,7 @@
       "dev": true
     },
     "entities": {
-      "version": "1.1.2",
-      "dev": true
+      "version": "1.1.2"
     },
     "error-ex": {
       "version": "1.3.4",
@@ -7587,13 +7375,6 @@
         "bser": "2.1.1"
       }
     },
-    "fd-slicer": {
-      "version": "1.1.0",
-      "dev": true,
-      "requires": {
-        "pend": "~1.2.0"
-      }
-    },
     "foreground-child": {
       "version": "3.3.1",
       "resolved": "https://registry.npmjs.org/foreground-child/-/foreground-child-3.3.1.tgz",
@@ -7616,13 +7397,6 @@
       "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
       "dev": true,
       "optional": true
-    },
-    "full-icu": {
-      "version": "1.5.0",
-      "dev": true,
-      "requires": {
-        "yauzl": "^2.10.0"
-      }
     },
     "gensync": {
       "version": "1.0.0-beta.2",
@@ -7684,7 +7458,6 @@
     },
     "ics": {
       "version": "2.44.0",
-      "dev": true,
       "requires": {
         "nanoid": "^3.1.23",
         "yup": "^0.32.9"
@@ -8437,12 +8210,10 @@
       "dev": true
     },
     "lodash": {
-      "version": "4.17.21",
-      "dev": true
+      "version": "4.17.21"
     },
     "lodash-es": {
-      "version": "4.17.21",
-      "dev": true
+      "version": "4.17.21"
     },
     "loose-envify": {
       "version": "1.4.0",
@@ -8505,8 +8276,7 @@
       }
     },
     "minimist": {
-      "version": "1.2.8",
-      "dev": true
+      "version": "1.2.8"
     },
     "minipass": {
       "version": "7.1.3",
@@ -8516,7 +8286,6 @@
     },
     "mkdirp": {
       "version": "0.5.6",
-      "dev": true,
       "requires": {
         "minimist": "^1.2.6"
       }
@@ -8526,12 +8295,10 @@
       "dev": true
     },
     "nanoclone": {
-      "version": "0.2.1",
-      "dev": true
+      "version": "0.2.1"
     },
     "nanoid": {
-      "version": "3.3.11",
-      "dev": true
+      "version": "3.3.11"
     },
     "napi-postinstall": {
       "version": "0.3.4",
@@ -8549,7 +8316,6 @@
       "version": "16.2.9",
       "resolved": "https://registry.npmjs.org/next/-/next-16.2.9.tgz",
       "integrity": "sha512-MEOJiq/UvuezAdqVSceHbqDgZt1kDw2tpGVOlsdIoJsQdbN2JY2hpVG4xnXGkbdJUOEWhnRfiu/O4Hpc9Juwww==",
-      "dev": true,
       "requires": {
         "@next/env": "16.2.9",
         "@next/swc-darwin-arm64": "16.2.9",
@@ -8607,14 +8373,12 @@
     },
     "p-limit": {
       "version": "2.3.0",
-      "dev": true,
       "requires": {
         "p-try": "^2.0.0"
       },
       "dependencies": {
         "p-try": {
-          "version": "2.2.0",
-          "dev": true
+          "version": "2.2.0"
         }
       }
     },
@@ -8654,13 +8418,8 @@
         }
       }
     },
-    "pend": {
-      "version": "1.2.0",
-      "dev": true
-    },
     "picocolors": {
-      "version": "1.1.1",
-      "dev": true
+      "version": "1.1.1"
     },
     "picomatch": {
       "version": "4.0.4",
@@ -8723,7 +8482,6 @@
       "version": "8.4.31",
       "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.4.31.tgz",
       "integrity": "sha512-PS08Iboia9mts/2ygV3eLpY5ghnUcfLV/EXTOW1E2qYxJKGGBUtNjN76FYHnMs36RmARn41bC0AZmn+rR0OVpQ==",
-      "dev": true,
       "requires": {
         "nanoid": "^3.3.6",
         "picocolors": "^1.0.0",
@@ -8751,8 +8509,7 @@
       }
     },
     "property-expr": {
-      "version": "2.0.6",
-      "dev": true
+      "version": "2.0.6"
     },
     "pure-rand": {
       "version": "7.0.1",
@@ -8787,10 +8544,6 @@
       "version": "npm:react-is@19.2.7",
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-19.2.7.tgz",
       "integrity": "sha512-kZFnouyVv7eP/Phmrlo9FK+zcAdriZJvzxXHF1Sl1P377WSGe2G/JxVolhTrB/jeV47lKImhNUsijjHAAbcl/A==",
-      "dev": true
-    },
-    "regenerator-runtime": {
-      "version": "0.13.11",
       "dev": true
     },
     "require-directory": {
@@ -8830,7 +8583,6 @@
       "version": "0.34.5",
       "resolved": "https://registry.npmjs.org/sharp/-/sharp-0.34.5.tgz",
       "integrity": "sha512-Ou9I5Ft9WNcCbXrU9cMgPBcCK8LiwLqcbywW3t4oDV37n1pzpuNLsYiAV8eODnjbtQlSDwZ2cUEeQz4E54Hltg==",
-      "dev": true,
       "requires": {
         "@img/colour": "^1.0.0",
         "@img/sharp-darwin-arm64": "0.34.5",
@@ -8864,8 +8616,7 @@
         "semver": {
           "version": "7.8.5",
           "resolved": "https://registry.npmjs.org/semver/-/semver-7.8.5.tgz",
-          "integrity": "sha512-Y7/KDsb8LjooZpwaqGyulO6DQlksgCncchHGk+sZIY4SBvUocMBEFH5Ur1fI4dV+Jvl0w6cjvucaIi40puRioA==",
-          "dev": true
+          "integrity": "sha512-Y7/KDsb8LjooZpwaqGyulO6DQlksgCncchHGk+sZIY4SBvUocMBEFH5Ur1fI4dV+Jvl0w6cjvucaIi40puRioA=="
         }
       }
     },
@@ -8899,8 +8650,7 @@
     "source-map-js": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.1.tgz",
-      "integrity": "sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==",
-      "dev": true
+      "integrity": "sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA=="
     },
     "source-map-support": {
       "version": "0.5.13",
@@ -9065,7 +8815,6 @@
       "version": "5.1.6",
       "resolved": "https://registry.npmjs.org/styled-jsx/-/styled-jsx-5.1.6.tgz",
       "integrity": "sha512-qSVyDTeMotdvQYoHWLNGwRFJHC+i+ZvdBRYosOFgC+Wg1vx4frN2/RG/NA7SYqqvKNLf39P2LSRA2pu6n0XYZA==",
-      "dev": true,
       "requires": {
         "client-only": "0.0.1"
       }
@@ -9095,14 +8844,12 @@
       "dev": true
     },
     "toposort": {
-      "version": "2.0.2",
-      "dev": true
+      "version": "2.0.2"
     },
     "tslib": {
       "version": "2.8.1",
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
-      "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
-      "dev": true
+      "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w=="
     },
     "type-detect": {
       "version": "4.0.8",
@@ -9335,14 +9082,6 @@
       "integrity": "sha512-tVpsJW7DdjecAiFpbIB1e3qxIQsE6NoPc5/eTdrbbIC4h0LVsWhnoa3g+m2HclBIujHzsxZ4VJVA+GUuc2/LBw==",
       "dev": true
     },
-    "yauzl": {
-      "version": "2.10.0",
-      "dev": true,
-      "requires": {
-        "buffer-crc32": "~0.2.3",
-        "fd-slicer": "~1.1.0"
-      }
-    },
     "yocto-queue": {
       "version": "0.1.0",
       "resolved": "https://registry.npmjs.org/yocto-queue/-/yocto-queue-0.1.0.tgz",
@@ -9351,7 +9090,6 @@
     },
     "yup": {
       "version": "0.32.11",
-      "dev": true,
       "requires": {
         "@babel/runtime": "^7.15.4",
         "@types/lodash": "^4.14.175",

--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
     "start": "NODE_ENV=production LOCALE=da_DK.UTF_8 node server.js",
     "test": "jest",
     "test-watch": "jest --watch",
-    "test-ci": "NODE_ICU_DATA=./node_modules/full-icu jest",
+    "test-ci": "jest",
     "test2": "next test",
     "build-static": "node tools/build-static.js",
     "build-graph": "node tools/build-graph.js",
@@ -29,21 +29,19 @@
     "build-facsimiles-old": "node tools/build-facsimiles-old.js"
   },
   "dependencies": {
-    "react": "^18.3.1",
-    "react-dom": "^18.3.1"
-  },
-  "devDependencies": {
     "@xmldom/xmldom": "^0.9.10",
     "async": "^2.5.0",
     "entities": "^1.1.1",
-    "full-icu": "^1.2.1",
     "ics": "^2.4.1",
-    "jest": "^30.4.2",
     "mkdirp": "^0.5.1",
     "next": "^16.2.9",
     "p-limit": "^2.2.2",
-    "regenerator-runtime": "^0.13.1",
+    "react": "^18.3.1",
+    "react-dom": "^18.3.1",
     "sharp": "^0.34.5"
+  },
+  "devDependencies": {
+    "jest": "^30.4.2"
   },
   "author": "Jesper Christensen",
   "license": "MIT",


### PR DESCRIPTION
## Resumé

- flytter build- og runtime-afhængigheder fra devDependencies til dependencies
- lader Jest blive som test-only devDependency
- fjerner full-icu, fordi både lokal Node 20 og node:20-bullseye-slim allerede har fuld ICU
- fjerner ubrugt regenerator-runtime
- bruger `npm ci --omit=dev --legacy-peer-deps` i Docker-buildet, så static-builder ikke installerer Jest-kæden med glob/inflight warnings

## Validering

- `npm ls jest glob inflight --omit=dev`
- `npm test -- __tests__/routes.test.js --runInBand`
- `npm test -- __tests__/icu.js --runInBand`
- `npm run test-ci -- __tests__/icu.js --runInBand`
- `npm test -- __tests__/icu.js __tests__/routes.test.js --runInBand`
- `docker run --rm node:20-bullseye-slim node -p "JSON.stringify({node: process.versions.node, icu: process.versions.icu, da: new Intl.Collator('da').resolvedOptions().locale, esJanuary: new Intl.DateTimeFormat('es', {month:'long'}).format(new Date(9e8))})"`
- `docker build --target runtime .`
- `docker build --target static-builder .`

Fixes #1205
Relateret: #1212