### PR TITLE
Gør facsimile-udtræk robust

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,6 +77,12 @@ Kør hele kæden med udtrækning og thumbnails:
 docker compose --profile facsimiles run --rm --build facsimile-builder npm run build-facsimiles -- all
 ```
 
+PDF-udtræk bruger som standard `KALLIOPE_FACSIMILE_EXTRACTOR=auto`, som
+udtrækker sikre indlejrede JPEG-sidebilleder med `pdfimages` og renderer resten
+med `pdftoppm`. Sæt `KALLIOPE_FACSIMILE_EXTRACTOR=pdftoppm` for kun at rendere
+med `pdftoppm`, eller justér fallback-opløsningen med
+`KALLIOPE_FACSIMILE_RENDER_DPI` (default `300`).
+
 Upload derefter fra hosten til `jec@10.0.0.5:/Volumes/Alma/Faksimiler`:
 
 ```shell

--- a/__tests__/build-facsimiles.test.js
+++ b/__tests__/build-facsimiles.test.js
@@ -1,0 +1,124 @@
+import fs from 'fs';
+import os from 'os';
+import path from 'path';
+
+import {
+  extractWithAuto,
+  parsePdfImagesList,
+  parsePdfInfoPageCount,
+  safePdfImagePages,
+  validateExtractedPages,
+} from '../tools/build-facsimiles.js';
+
+describe('facsimile PDF extraction helpers', () => {
+  let tmpdir;
+
+  beforeEach(() => {
+    tmpdir = fs.mkdtempSync(path.join(os.tmpdir(), 'kalliope-facsimiles-'));
+  });
+
+  afterEach(() => {
+    fs.rmSync(tmpdir, { recursive: true, force: true });
+  });
+
+  const pdfImagesList = `
+page   num  type   width height color comp bpc  enc interp  object ID x-ppi y-ppi size ratio
+--------------------------------------------------------------------------------------------
+   1     0 image     311   386  icc     3   8  image  no       463  0   139   139  371B 0.1%
+   1     1 smask     311   386  gray    1   8  image  no       463  0   139   139 5477B 4.6%
+   2     2 image    1624  2339  icc     3   8  jpeg   no       171  0   300   300  328K 3.0%
+   3     3 image    1566  2312  icc     3   8  jpeg   no       173  0   300   300  182K 1.7%
+   3     4 image    1534  2276  icc     3   8  jpeg   no       175  0   300   300  135K 1.3%
+   4     5 image    1535  2301  icc     3   8  jp2    no       177  0   300   300  139K 1.3%
+`;
+
+  it('parses pdfinfo page counts', () => {
+    expect(parsePdfInfoPageCount('Title: Test\nPages:           145\n')).toBe(
+      145
+    );
+  });
+
+  it('selects only pages with one large JPEG image as safe pdfimages pages', () => {
+    const images = parsePdfImagesList(pdfImagesList);
+
+    expect(images).toEqual([
+      expect.objectContaining({ page: 1, type: 'image', encoding: 'image' }),
+      expect.objectContaining({ page: 1, type: 'smask', encoding: 'image' }),
+      expect.objectContaining({ page: 2, width: 1624, encoding: 'jpeg' }),
+      expect.objectContaining({ page: 3, encoding: 'jpeg' }),
+      expect.objectContaining({ page: 3, encoding: 'jpeg' }),
+      expect.objectContaining({ page: 4, encoding: 'jp2' }),
+    ]);
+    expect([...safePdfImagePages(images, 4, 1000)]).toEqual([2]);
+  });
+
+  it('uses pdfimages for safe pages and pdftoppm for unsafe pages', async () => {
+    const imagesDir = path.join(tmpdir, 'images');
+    fs.mkdirSync(imagesDir);
+    const calls = [];
+    const command = async (cmd, args) => {
+      calls.push({ cmd, args });
+
+      if (cmd === 'pdfinfo') {
+        return { stdout: 'Pages:           3\n' };
+      }
+
+      if (cmd === 'pdfimages' && args.includes('-list')) {
+        return {
+          stdout: `
+page   num  type   width height color comp bpc  enc interp  object ID x-ppi y-ppi size ratio
+--------------------------------------------------------------------------------------------
+   1     0 image     311   386  icc     3   8  image  no       463  0   139   139  371B 0.1%
+   2     1 image    1624  2339  icc     3   8  jpeg   no       171  0   300   300  328K 3.0%
+   3     2 image    1566  2312  icc     3   8  jpeg   no       173  0   300   300  182K 1.7%
+   3     3 image    1534  2276  icc     3   8  jpeg   no       175  0   300   300  135K 1.3%
+`,
+        };
+      }
+
+      if (cmd === 'pdfimages') {
+        const prefix = args[args.length - 1];
+        const filename = `${prefix}-002-001.jpg`;
+        fs.writeFileSync(filename, 'safe page 2');
+        return { stdout: '' };
+      }
+
+      if (cmd === 'pdftoppm') {
+        const outputPrefix = args[args.length - 1];
+        fs.writeFileSync(`${outputPrefix}.jpg`, `rendered ${outputPrefix}`);
+        return { stdout: '' };
+      }
+
+      throw new Error(`Unexpected command ${cmd}`);
+    };
+
+    await extractWithAuto(
+      { fullFilename: path.join(tmpdir, 'test.pdf') },
+      imagesDir,
+      { command }
+    );
+
+    expect(fs.readdirSync(imagesDir).sort()).toEqual([
+      '000.jpg',
+      '001.jpg',
+      '002.jpg',
+    ]);
+    expect(fs.readFileSync(path.join(imagesDir, '001.jpg'), 'utf8')).toBe(
+      'safe page 2'
+    );
+    expect(
+      calls.filter(call => call.cmd === 'pdftoppm').map(call => call.args)
+    ).toEqual([
+      expect.arrayContaining(['-f', '1', '-l', '1']),
+      expect.arrayContaining(['-f', '3', '-l', '3']),
+    ]);
+  });
+
+  it('validates stable page output names', () => {
+    fs.writeFileSync(path.join(tmpdir, '000.jpg'), '');
+    fs.writeFileSync(path.join(tmpdir, '001.jpg'), '');
+
+    expect(() => validateExtractedPages(tmpdir, 2)).not.toThrow();
+    expect(() => validateExtractedPages(tmpdir, 3)).toThrow(/3 sider/);
+  });
+});

--- a/tools/build-facsimiles.js
+++ b/tools/build-facsimiles.js
@@ -1,18 +1,26 @@
 import { execFile } from 'child_process';
 import fs from 'fs';
+import os from 'os';
 import path from 'path';
+import { fileURLToPath } from 'url';
 import { promisify } from 'util';
 import plimit from 'p-limit';
-import { safeMkdir, buildThumbnails } from './libs/helpers.js';
+import { buildThumbnails } from './libs/helpers.js';
 
 const execFileAsync = promisify(execFile);
 
 const facsimilesDir = process.env.KALLIOPE_FACSIMILE_DIR || 'facsimiles';
+const extractor = process.env.KALLIOPE_FACSIMILE_EXTRACTOR || 'auto';
+const renderDpi =
+  parseInt(process.env.KALLIOPE_FACSIMILE_RENDER_DPI, 10) || 300;
+const safeImageMinDimension =
+  parseInt(process.env.KALLIOPE_FACSIMILE_MIN_IMAGE_DIMENSION, 10) || 1000;
 const extractConcurrency = Math.max(
   1,
   parseInt(process.env.KALLIOPE_FACSIMILE_EXTRACT_CONCURRENCY, 10) || 2
 );
 const commands = new Set(['extract', 'reextract', 'thumbnails', 'all']);
+const extractors = new Set(['auto', 'pdftoppm', 'pdfimages']);
 
 const usage = () => {
   console.error(
@@ -26,29 +34,254 @@ const facsimileThumbnailOutputPath = (fullFilename, width, ext) => {
     .replace(/\/([^/]+)$/, '/t/$1');
 };
 
-const pageNumber = filename => {
-  const match = filename.match(/(\d+)(?=\.jpg$)/);
-  return match == null ? 0 : parseInt(match[1], 10);
+const pageFilename = pageIndex => {
+  return (
+    pageIndex.toLocaleString('en-US', {
+      minimumIntegerDigits: 3,
+      useGrouping: false,
+    }) + '.jpg'
+  );
 };
 
-// pdftoppm names files from its output prefix. Rename to Kalliopes stable
-// page format: 000.jpg, 001.jpg, ...
-const renameImages = imagesDir => {
-  fs
-    .readdirSync(imagesDir)
-    .filter(f => f.endsWith('.jpg'))
-    .sort((a, b) => pageNumber(a) - pageNumber(b))
-    .forEach((srcFilename, i) => {
-      const destFilename =
-        i.toLocaleString('en-US', {
-          minimumIntegerDigits: 3,
-          useGrouping: false,
-        }) + '.jpg';
-      fs.renameSync(
-        path.join(imagesDir, srcFilename),
-        path.join(imagesDir, destFilename)
+const stablePagePath = (imagesDir, page) => {
+  return path.join(imagesDir, pageFilename(page - 1));
+};
+
+const parsePdfInfoPageCount = stdout => {
+  const match = stdout.match(/^Pages:\s+(\d+)\s*$/m);
+  if (match == null) {
+    throw new Error('Kunne ikke læse sidetal fra pdfinfo.');
+  }
+  return parseInt(match[1], 10);
+};
+
+const parsePdfImagesList = stdout => {
+  return stdout
+    .split(/\r?\n/)
+    .map(line => line.trim())
+    .filter(line => line !== '' && /^\d+\s+/.test(line))
+    .map(line => {
+      const parts = line.split(/\s+/);
+      return {
+        page: parseInt(parts[0], 10),
+        type: parts[2],
+        width: parseInt(parts[3], 10),
+        height: parseInt(parts[4], 10),
+        encoding: parts[8],
+      };
+    })
+    .filter(image => {
+      return (
+        Number.isInteger(image.page) &&
+        Number.isInteger(image.width) &&
+        Number.isInteger(image.height)
       );
     });
+};
+
+const safePdfImagePages = (images, pageCount, minDimension) => {
+  const pages = new Set();
+  for (let page = 1; page <= pageCount; page++) {
+    const largeJpegs = images.filter(image => {
+      return (
+        image.page === page &&
+        image.type === 'image' &&
+        image.encoding === 'jpeg' &&
+        image.width >= minDimension &&
+        image.height >= minDimension
+      );
+    });
+    if (largeJpegs.length === 1) {
+      pages.add(page);
+    }
+  }
+  return pages;
+};
+
+const pdfImagesPageNumber = filename => {
+  const match = path.basename(filename).match(/-(\d+)-\d+\.jpg$/);
+  return match == null ? null : parseInt(match[1], 10);
+};
+
+const validateExtractedPages = (imagesDir, pageCount) => {
+  const jpgs = fs
+    .readdirSync(imagesDir)
+    .filter(filename => filename.toLowerCase().endsWith('.jpg'))
+    .sort();
+
+  if (jpgs.length !== pageCount) {
+    throw new Error(
+      `${imagesDir} har ${jpgs.length} jpg-filer, men PDF'en har ${pageCount} sider.`
+    );
+  }
+
+  for (let page = 1; page <= pageCount; page++) {
+    const filename = pageFilename(page - 1);
+    if (!fs.existsSync(path.join(imagesDir, filename))) {
+      throw new Error(`${imagesDir} mangler ${filename}.`);
+    }
+  }
+};
+
+const getPageCount = async (fullFilename, command = execFileAsync) => {
+  const { stdout } = await command('pdfinfo', [fullFilename]);
+  return parsePdfInfoPageCount(stdout);
+};
+
+const renderPageWithPdftoppm = async (
+  fullFilename,
+  imagesDir,
+  page,
+  command = execFileAsync
+) => {
+  const outputPrefix = path.join(imagesDir, `pdftoppm-page-${page}`);
+  try {
+    await command('pdftoppm', [
+      '-jpeg',
+      '-f',
+      String(page),
+      '-l',
+      String(page),
+      '-singlefile',
+      '-r',
+      String(renderDpi),
+      fullFilename,
+      outputPrefix,
+    ]);
+  } catch (err) {
+    throw new Error(
+      `Kunne ikke rendere ${fullFilename} side ${page} med pdftoppm: ${
+        err.message || err
+      }`
+    );
+  }
+
+  const outputFilename = `${outputPrefix}.jpg`;
+  if (!fs.existsSync(outputFilename)) {
+    throw new Error(
+      `pdftoppm oprettede ikke ${outputFilename} for ${fullFilename} side ${page}.`
+    );
+  }
+  fs.renameSync(outputFilename, stablePagePath(imagesDir, page));
+};
+
+const extractWithPdftoppm = async (task, imagesDir, command = execFileAsync) => {
+  const pageCount = await getPageCount(task.fullFilename, command);
+  for (let page = 1; page <= pageCount; page++) {
+    await renderPageWithPdftoppm(task.fullFilename, imagesDir, page, command);
+  }
+  validateExtractedPages(imagesDir, pageCount);
+};
+
+const extractPdfImages = async (
+  task,
+  tempDir,
+  safePages,
+  command = execFileAsync
+) => {
+  const prefix = path.join(tempDir, 'pdfimages');
+  await command('pdfimages', [
+    '-j',
+    '-p',
+    task.fullFilename,
+    prefix,
+  ]);
+
+  const extracted = new Map();
+  fs
+    .readdirSync(tempDir)
+    .map(filename => path.join(tempDir, filename))
+    .filter(line => line.toLowerCase().endsWith('.jpg'))
+    .forEach(filename => {
+      const page = pdfImagesPageNumber(filename);
+      if (page == null || !safePages.has(page)) {
+        return;
+      }
+      if (!extracted.has(page)) {
+        extracted.set(page, []);
+      }
+      extracted.get(page).push(filename);
+    });
+
+  return extracted;
+};
+
+const extractWithAuto = async (
+  task,
+  imagesDir,
+  { pdfimagesOnly = false, command = execFileAsync } = {}
+) => {
+  const pageCount = await getPageCount(task.fullFilename, command);
+  let safePages = new Set();
+  try {
+    const { stdout } = await command('pdfimages', [
+      '-list',
+      task.fullFilename,
+    ]);
+    safePages = safePdfImagePages(
+      parsePdfImagesList(stdout),
+      pageCount,
+      safeImageMinDimension
+    );
+  } catch (err) {
+    if (pdfimagesOnly) {
+      throw err;
+    }
+    console.warn(
+      `pdfimages -list fejlede for ${task.fullFilename}, bruger pdftoppm for alle sider.`
+    );
+  }
+  const pdfImagesTempDir = fs.mkdtempSync(
+    path.join(os.tmpdir(), 'kalliope-pdfimages-')
+  );
+
+  try {
+    let extractedPages = new Map();
+    if (safePages.size > 0) {
+      try {
+        extractedPages = await extractPdfImages(
+          task,
+          pdfImagesTempDir,
+          safePages,
+          command
+        );
+      } catch (err) {
+        if (pdfimagesOnly) {
+          throw err;
+        }
+        console.warn(
+          `pdfimages fejlede for ${task.fullFilename}, bruger pdftoppm for alle sider.`
+        );
+      }
+    }
+
+    for (let page = 1; page <= pageCount; page++) {
+      const candidates = extractedPages.get(page) || [];
+      if (safePages.has(page) && candidates.length === 1) {
+        fs.copyFileSync(candidates[0], stablePagePath(imagesDir, page));
+      } else if (pdfimagesOnly) {
+        throw new Error(
+          `pdfimages kunne ikke levere én sikker JPEG for ${task.fullFilename} side ${page}.`
+        );
+      } else {
+        await renderPageWithPdftoppm(
+          task.fullFilename,
+          imagesDir,
+          page,
+          command
+        );
+      }
+    }
+  } finally {
+    fs.rmSync(pdfImagesTempDir, { recursive: true, force: true });
+  }
+
+  validateExtractedPages(imagesDir, pageCount);
+};
+
+const moveCompletedImagesDir = (tempImagesDir, imagesDir) => {
+  fs.rmSync(imagesDir, { recursive: true, force: true });
+  fs.renameSync(tempImagesDir, imagesDir);
 };
 
 const findPdfTasks = () => {
@@ -71,7 +304,6 @@ const findPdfTasks = () => {
           return {
             fullFilename,
             imagesDir: path.join(poetDir, workId),
-            imagesPrefix: path.join(poetDir, workId, workId),
           };
         });
     });
@@ -83,23 +315,27 @@ const extractPdf = async (task, force) => {
       console.log(`${task.imagesDir} findes allerede, springer over.`);
       return;
     }
-    fs.rmSync(task.imagesDir, { recursive: true, force: true });
   }
 
-  safeMkdir(task.imagesDir);
+  const tempImagesDir = fs.mkdtempSync(
+    path.join(path.dirname(task.imagesDir), `.${path.basename(task.imagesDir)}-`)
+  );
   console.log(`Extracting from ${task.fullFilename}`);
   try {
-    await execFileAsync('pdftoppm', [
-      '-jpeg',
-      '-r',
-      '300',
-      task.fullFilename,
-      task.imagesPrefix,
-    ]);
-    renameImages(task.imagesDir);
+    if (extractor === 'pdftoppm') {
+      await extractWithPdftoppm(task, tempImagesDir);
+    } else if (extractor === 'pdfimages') {
+      await extractWithAuto(task, tempImagesDir, { pdfimagesOnly: true });
+    } else {
+      await extractWithAuto(task, tempImagesDir);
+    }
+    moveCompletedImagesDir(tempImagesDir, task.imagesDir);
   } catch (err) {
+    fs.rmSync(tempImagesDir, { recursive: true, force: true });
     console.error(`Kunne ikke udtrække ${task.fullFilename}`);
-    console.error("Installer poppler/pdftoppm, fx via facsimile-containeren.");
+    console.error(
+      'Installer poppler-utils med pdfinfo, pdfimages og pdftoppm, fx via facsimile-containeren.'
+    );
     throw err;
   }
 };
@@ -147,12 +383,29 @@ const run = async command => {
 
 const command = process.argv[2] || 'all';
 
-if (!commands.has(command)) {
-  usage();
-  process.exit(1);
+if (fileURLToPath(import.meta.url) === process.argv[1]) {
+  if (!commands.has(command)) {
+    usage();
+    process.exit(1);
+  }
+
+  if (!extractors.has(extractor)) {
+    console.error(
+      `Ukendt KALLIOPE_FACSIMILE_EXTRACTOR=${extractor}. Brug auto, pdftoppm eller pdfimages.`
+    );
+    process.exit(1);
+  }
+
+  run(command).catch(err => {
+    console.error(err.message || err);
+    process.exit(1);
+  });
 }
 
-run(command).catch(err => {
-  console.error(err.message || err);
-  process.exit(1);
-});
+export {
+  parsePdfInfoPageCount,
+  parsePdfImagesList,
+  safePdfImagePages,
+  extractWithAuto,
+  validateExtractedPages,
+};


### PR DESCRIPTION
## Resumé
- tilføjer guarded auto-udtræk, der bruger pdfimages for sikre JPEG-sidebilleder og pdftoppm som fallback
- gør extractor og fallback-DPI konfigurerbare via miljøvariabler
- dokumenterer indstillingerne og dækker parsing/fallback med tests

## Validering
- npm test -- __tests__/build-facsimiles.test.js
- npm test
- isoleret container-test på hanseno/130025479964-color.pdf med 145 genererede jpg-sider