### PR TITLE
Tilføj editor-syntax til old2kalliope

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,7 +1,4 @@
 {
-  "files.associations": {
-    "efterklang.txt": "kalliope-old"
-  },
   "editor.tokenColorCustomizations": {
     "textMateRules": [
       {

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,34 @@
+{
+  "files.associations": {
+    "efterklang.txt": "kalliope-old"
+  },
+  "editor.tokenColorCustomizations": {
+    "textMateRules": [
+      {
+        "scope": "keyword.other.header.text.kalliope",
+        "settings": {
+          "foreground": "#6A9955"
+        }
+      },
+      {
+        "scope": "keyword.other.header.work.kalliope",
+        "settings": {
+          "foreground": "#C586C0"
+        }
+      },
+      {
+        "scope": "keyword.other.header.todo.kalliope",
+        "settings": {
+          "foreground": "#D7BA7D",
+          "fontStyle": "bold"
+        }
+      },
+      {
+        "scope": "invalid.trailing-space-before-punctuation.kalliope, invalid.space-before-period.kalliope, invalid.escape.kalliope, invalid.leading-period.kalliope",
+        "settings": {
+          "foreground": "#F44747"
+        }
+      }
+    ]
+  }
+}

--- a/tools/install-vscode-kalliope-syntax.sh
+++ b/tools/install-vscode-kalliope-syntax.sh
@@ -1,0 +1,17 @@
+#!/bin/sh
+set -eu
+
+extension_source=$(CDPATH= cd -- "$(dirname -- "$0")/vscode-kalliope-syntax" && pwd)
+extension_target="$HOME/.vscode/extensions/thabz.kalliope-syntax"
+
+if [ -e "$extension_target" ] && [ ! -L "$extension_target" ]; then
+  echo "Refusing to replace existing non-symlink: $extension_target" >&2
+  exit 1
+fi
+
+mkdir -p "$(dirname -- "$extension_target")"
+ln -sfn "$extension_source" "$extension_target"
+
+echo "Installed Kalliope VS Code syntax extension:"
+echo "$extension_target -> $extension_source"
+echo "Restart VS Code to load it."

--- a/tools/vim-kalliope-syntax/README.md
+++ b/tools/vim-kalliope-syntax/README.md
@@ -17,10 +17,9 @@ Enable it for a buffer with:
 :set syntax=kalliope
 ```
 
-To enable it automatically for the current Kalliope conversion file, add an autocmd to `~/.vim/ftdetect/kalliope.vim`:
+To enable it automatically for Kalliope conversion files, add an autocmd to
+`~/.vim/ftdetect/kalliope.vim`:
 
 ```vim
-autocmd BufRead,BufNewFile */kalliope/efterklang.txt setfiletype kalliope
+autocmd BufRead,BufNewFile *.txt if getline(1) =~# '^KILDE:' | setfiletype kalliope | endif
 ```
-
-If you use other `old2kalliope` input filenames, add them to the same autocmd pattern.

--- a/tools/vim-kalliope-syntax/README.md
+++ b/tools/vim-kalliope-syntax/README.md
@@ -4,22 +4,18 @@ Syntax highlighting for Kalliope `old2kalliope` input files.
 
 ## Install
 
-Copy or symlink `kalliope.vim` into Vim's syntax directory:
+Copy or symlink `kalliope.vim` into Vim's syntax directory and the filetype
+detection file into Vim's `ftdetect` directory:
 
 ```sh
 mkdir -p ~/.vim/syntax
+mkdir -p ~/.vim/ftdetect
 ln -sfn "$PWD/tools/vim-kalliope-syntax/kalliope.vim" ~/.vim/syntax/kalliope.vim
+ln -sfn "$PWD/tools/vim-kalliope-syntax/ftdetect/kalliope.vim" ~/.vim/ftdetect/kalliope.vim
 ```
 
 Enable it for a buffer with:
 
 ```vim
 :set syntax=kalliope
-```
-
-To enable it automatically for Kalliope conversion files, add an autocmd to
-`~/.vim/ftdetect/kalliope.vim`:
-
-```vim
-autocmd BufRead,BufNewFile *.txt if getline(1) =~# '^KILDE:' | setfiletype kalliope | endif
 ```

--- a/tools/vim-kalliope-syntax/README.md
+++ b/tools/vim-kalliope-syntax/README.md
@@ -1,0 +1,26 @@
+# Kalliope Syntax for Vim
+
+Syntax highlighting for Kalliope `old2kalliope` input files.
+
+## Install
+
+Copy or symlink `kalliope.vim` into Vim's syntax directory:
+
+```sh
+mkdir -p ~/.vim/syntax
+ln -sfn "$PWD/tools/vim-kalliope-syntax/kalliope.vim" ~/.vim/syntax/kalliope.vim
+```
+
+Enable it for a buffer with:
+
+```vim
+:set syntax=kalliope
+```
+
+To enable it automatically for the current Kalliope conversion file, add an autocmd to `~/.vim/ftdetect/kalliope.vim`:
+
+```vim
+autocmd BufRead,BufNewFile */kalliope/efterklang.txt setfiletype kalliope
+```
+
+If you use other `old2kalliope` input filenames, add them to the same autocmd pattern.

--- a/tools/vim-kalliope-syntax/ftdetect/kalliope.vim
+++ b/tools/vim-kalliope-syntax/ftdetect/kalliope.vim
@@ -1,0 +1,1 @@
+autocmd BufRead,BufNewFile *.txt if getline(1) =~# '^KILDE:' | setfiletype kalliope | endif

--- a/tools/vim-kalliope-syntax/kalliope.vim
+++ b/tools/vim-kalliope-syntax/kalliope.vim
@@ -1,0 +1,97 @@
+" Vim syntax file
+" Language: Kalliope Text Format
+" Maintainer: Jesper Christensen
+" Latest Revision: 30 April 2020
+
+if exists("b:current_syntax")
+  finish
+endif
+
+syn match sideText contained '\d\+-\d\+$'
+syn match sideText contained '[IVX]\+-[IVX]\+$'
+syn match talText contained '\d\+$'
+syn match sideFejlText contained '\d\+-$'
+syn match layoutStyle contained '[wcsib]\+:'
+syn match hrStyle '^---\+$'
+
+syn match textCommand contained 'T:'
+syn match textCommand contained 'LINKTITEL:'
+syn match textCommand contained 'INDEXTITEL:'
+syn match textCommand contained 'TOCTITEL:'
+syn match textCommand contained 'U:'
+syn match textCommand contained 'F:'
+syn match textCommand contained 'TYPE:'
+syn match textCommand contained 'DIGTER:'
+syn match textCommand contained 'VARIANT:'
+syn match textCommand contained 'CREDITS:'
+syn match textCommand contained 'FREMFØRT:'
+syn match textCommand contained 'BEGIVENHED:'
+syn match textCommand contained 'SKREVET:'
+syn match textCommand contained 'SIDE:'
+syn match textCommand contained 'NOTE:'
+syn match textCommand contained 'N:'
+syn match todoCommand contained 'TODO:'
+
+syn match workCommand contained 'KILDE:'
+syn match workCommand contained 'DIGTER:'
+syn match workCommand contained 'FACSIMILE:'
+syn match workCommand contained 'FACSIMILE-SIDER:'
+syn match workCommand contained 'TITELBLAD:'
+syn match workCommand contained 'SEKTION:'
+syn match workCommand contained 'SLUT'
+syn match workCommand contained 'SLUTSEKTION'
+
+syn match commonError ' ? *$'
+syn match commonError ' ! *$'
+syn match commonError ' ; *$'
+syn match commonError '[^\.] \. *$'
+syn match commonError '\\'
+syn match commonError '^\. *[a-zA-ZæøåÆØÅ]'
+
+syn sync fromstart
+syn region workHeadBlock start='^KILDE:' end='^\s*$' contains=workHeadLine keepend
+
+syn region textHeadLine display oneline start='^T:' end='$' contains=textCommand
+syn region textHeadLine display oneline start='^LINKTITEL:' end='$' contains=textCommand
+syn region textHeadLine display oneline start='^INDEXTITEL:' end='$' contains=textCommand
+syn region textHeadLine display oneline start='^TOCTITEL:' end='$' contains=textCommand
+syn region textHeadLine display oneline start='^U:' end='$' contains=textCommand
+syn region textHeadLine display oneline start='^F:' end='$' contains=textCommand
+syn region textHeadLine display oneline start='^TYPE:' end='$' contains=textCommand
+syn region textHeadLine display oneline start='^VARIANT:' end='$' contains=textCommand
+syn region textHeadLine display oneline start='^CREDITS:' end='$' contains=textCommand
+syn region textHeadLine display oneline start='^FREMFØRT:' end='$' contains=textCommand
+syn region textHeadLine display oneline start='^BEGIVENHED:' end='$' contains=textCommand
+syn region textHeadLine display oneline start='^SKREVET:' end='$' contains=textCommand
+syn region textHeadLine display oneline start='^SIDE:' end='$' contains=textCommand,sideText,talText,sideFejlText
+syn region textHeadLine display oneline start='^TODO:' end='$' contains=todoCommand
+syn region textHeadLine display oneline start='^NOTE:' end='$' contains=textCommand
+syn region textHeadLine display oneline start='^N:' end='$' contains=textCommand
+
+syn region workHeadLine display oneline start='^KILDE:' end='$' contains=workCommand contained
+syn region workHeadLine display oneline start='^DIGTER:' end='$' contains=workCommand contained
+syn region workHeadLine display oneline start='^FACSIMILE:' end='$' contains=workCommand contained
+syn region workHeadLine display oneline start='^FACSIMILE-SIDER:' end='$' contains=workCommand,talText contained
+syn region workHeadLine display oneline start='^TITELBLAD:' end='$' contains=workCommand contained
+syn region workHeadLine display oneline start='^SEKTION:' end='$' contains=workCommand
+syn region workHeadLine display oneline start='^SLUT' end='$' contains=workCommand
+syn region workHeadLine display oneline start='^SLUTSEKTION' end='$' contains=workCommand
+syn region textHeadLine display oneline start='^DIGTER:' end='$' contains=textCommand
+
+syn region layoutLine   display oneline start='^{' end='}' contains=layoutStyle
+
+let b:current_syntax = "kalliope"
+
+hi def link sideText            Constant
+hi def link talText             Constant
+hi def link todoCommand         Todo
+hi def link textCommand         Type
+hi def link workCommand         Statement
+hi def link workHeadBlock       PreProc
+hi def link textHeadLine        PreProc
+hi def link workHeadLine        PreProc
+hi def link sideFejlText        WarningMsg
+hi def link layoutLine          PreProc
+hi def link layoutStyle         Identifier
+hi def link commonError         Error
+hi def link hrStyle             PreProc

--- a/tools/vscode-kalliope-syntax/README.md
+++ b/tools/vscode-kalliope-syntax/README.md
@@ -2,7 +2,8 @@
 
 Syntax highlighting for Kalliope `old2kalliope` input files.
 
-The language is selected automatically for files whose first line starts with `KILDE:`. It also associates `efterklang.txt`, `.old2kalliope`, and `.kalliope` files with the language.
+The language is selected automatically for `.txt` files whose first line starts
+with `KILDE:`.
 
 ## Install
 

--- a/tools/vscode-kalliope-syntax/README.md
+++ b/tools/vscode-kalliope-syntax/README.md
@@ -1,0 +1,19 @@
+# Kalliope Syntax for VS Code
+
+Syntax highlighting for Kalliope `old2kalliope` input files.
+
+The language is selected automatically for files whose first line starts with `KILDE:`. It also associates `efterklang.txt`, `.old2kalliope`, and `.kalliope` files with the language.
+
+## Install
+
+Install the workspace copy as a symlink in VS Code's extension directory:
+
+```sh
+tools/install-vscode-kalliope-syntax.sh
+```
+
+Restart VS Code after installing.
+
+The Kalliope workspace also contains `.vscode/settings.json` with token colors for this grammar. In that setup, text-header commands such as `T:`, `F:`, and text-level `DIGTER:` use the green `keyword.other.header.text.kalliope` scope, while work-header commands use `keyword.other.header.work.kalliope`.
+
+VS Code does not load arbitrary extensions directly from a workspace folder. The install script is therefore needed once per machine; after that, starting VS Code in this source tree will use the workspace settings automatically.

--- a/tools/vscode-kalliope-syntax/extension.js
+++ b/tools/vscode-kalliope-syntax/extension.js
@@ -1,0 +1,48 @@
+const path = require('path');
+const vscode = require('vscode');
+
+const languageId = 'kalliope-old';
+
+const isKalliopeOldText = document => {
+  if (document.uri.scheme !== 'file') {
+    return false;
+  }
+  if (path.extname(document.fileName).toLowerCase() !== '.txt') {
+    return false;
+  }
+  return document.lineCount > 0 && /^KILDE:/.test(document.lineAt(0).text);
+};
+
+const updateLanguage = async document => {
+  const shouldUseKalliopeSyntax = isKalliopeOldText(document);
+  if (shouldUseKalliopeSyntax && document.languageId !== languageId) {
+    await vscode.languages.setTextDocumentLanguage(document, languageId);
+  } else if (!shouldUseKalliopeSyntax && document.languageId === languageId) {
+    await vscode.languages.setTextDocumentLanguage(document, 'plaintext');
+  }
+};
+
+const activate = context => {
+  vscode.workspace.textDocuments.forEach(document => {
+    updateLanguage(document);
+  });
+
+  context.subscriptions.push(
+    vscode.workspace.onDidOpenTextDocument(document => {
+      updateLanguage(document);
+    }),
+    vscode.workspace.onDidChangeTextDocument(event => {
+      if (
+        event.contentChanges.some(change => {
+          return change.range.start.line === 0 || change.range.end.line === 0;
+        })
+      ) {
+        updateLanguage(event.document);
+      }
+    })
+  );
+};
+
+module.exports = {
+  activate,
+};

--- a/tools/vscode-kalliope-syntax/language-configuration/kalliope-old.json
+++ b/tools/vscode-kalliope-syntax/language-configuration/kalliope-old.json
@@ -1,0 +1,19 @@
+{
+  "comments": {
+    "lineComment": "REM "
+  },
+  "brackets": [
+    ["{", "}"],
+    ["<", ">"]
+  ],
+  "autoClosingPairs": [
+    { "open": "{", "close": "}" },
+    { "open": "<", "close": ">" },
+    { "open": "\"", "close": "\"" }
+  ],
+  "surroundingPairs": [
+    { "open": "{", "close": "}" },
+    { "open": "<", "close": ">" },
+    { "open": "\"", "close": "\"" }
+  ]
+}

--- a/tools/vscode-kalliope-syntax/package.json
+++ b/tools/vscode-kalliope-syntax/package.json
@@ -1,0 +1,40 @@
+{
+  "name": "kalliope-syntax",
+  "displayName": "Kalliope Syntax",
+  "description": "Syntax highlighting for Kalliope old2kalliope text files.",
+  "version": "0.0.1",
+  "publisher": "thabz",
+  "engines": {
+    "vscode": "^1.90.0"
+  },
+  "categories": [
+    "Programming Languages"
+  ],
+  "contributes": {
+    "languages": [
+      {
+        "id": "kalliope-old",
+        "aliases": [
+          "Kalliope Old Text",
+          "kalliope-old"
+        ],
+        "extensions": [
+          ".old2kalliope",
+          ".kalliope"
+        ],
+        "filenames": [
+          "efterklang.txt"
+        ],
+        "firstLine": "^KILDE:",
+        "configuration": "./language-configuration/kalliope-old.json"
+      }
+    ],
+    "grammars": [
+      {
+        "language": "kalliope-old",
+        "scopeName": "source.kalliope.old",
+        "path": "./syntaxes/kalliope-old.tmLanguage.json"
+      }
+    ]
+  }
+}

--- a/tools/vscode-kalliope-syntax/package.json
+++ b/tools/vscode-kalliope-syntax/package.json
@@ -7,6 +7,12 @@
   "engines": {
     "vscode": "^1.90.0"
   },
+  "main": "./extension.js",
+  "activationEvents": [
+    "onStartupFinished",
+    "onLanguage:plaintext",
+    "onLanguage:kalliope-old"
+  ],
   "categories": [
     "Programming Languages"
   ],
@@ -18,14 +24,6 @@
           "Kalliope Old Text",
           "kalliope-old"
         ],
-        "extensions": [
-          ".old2kalliope",
-          ".kalliope"
-        ],
-        "filenames": [
-          "efterklang.txt"
-        ],
-        "firstLine": "^KILDE:",
         "configuration": "./language-configuration/kalliope-old.json"
       }
     ],

--- a/tools/vscode-kalliope-syntax/syntaxes/kalliope-old.tmLanguage.json
+++ b/tools/vscode-kalliope-syntax/syntaxes/kalliope-old.tmLanguage.json
@@ -1,0 +1,181 @@
+{
+  "$schema": "https://raw.githubusercontent.com/martinring/tmlanguage/master/tmlanguage.json",
+  "name": "Kalliope Old Text",
+  "scopeName": "source.kalliope.old",
+  "patterns": [
+    {
+      "include": "#work-head"
+    },
+    {
+      "include": "#section-line"
+    },
+    {
+      "include": "#text-head-line"
+    },
+    {
+      "include": "#layout-line"
+    },
+    {
+      "include": "#horizontal-rule"
+    },
+    {
+      "include": "#inline-markup"
+    },
+    {
+      "include": "#common-error"
+    }
+  ],
+  "repository": {
+    "work-head": {
+      "name": "meta.header.work.kalliope",
+      "begin": "^(KILDE:)",
+      "beginCaptures": {
+        "1": {
+          "name": "keyword.other.header.work.kalliope"
+        }
+      },
+      "end": "^\\s*$",
+      "patterns": [
+        {
+          "include": "#work-head-line"
+        },
+        {
+          "include": "#inline-markup"
+        },
+        {
+          "include": "#common-error"
+        }
+      ]
+    },
+    "work-head-line": {
+      "patterns": [
+        {
+          "name": "meta.header.work.kalliope",
+          "match": "^(DIGTER:|FACSIMILE:|FACSIMILE-SIDER:|FACSIMILE-OFFSET:|TITELBLAD:|ID:|NOTE:|TODO:|DATO:)(.*)$",
+          "captures": {
+            "1": {
+              "name": "keyword.other.header.work.kalliope"
+            },
+            "2": {
+              "patterns": [
+                {
+                  "include": "#inline-markup"
+                }
+              ]
+            }
+          }
+        }
+      ]
+    },
+    "section-line": {
+      "name": "meta.section.kalliope",
+      "match": "^(SEKTION\\d*:|SLUTSEKTION|SEKTIONSLUT|SLUT)(.*)$",
+      "captures": {
+        "1": {
+          "name": "keyword.other.section.kalliope"
+        }
+      }
+    },
+    "text-head-line": {
+      "patterns": [
+        {
+          "name": "meta.header.text.kalliope",
+          "match": "^(SIDE:)(\\s*)(\\d+-$|\\d+-\\d+$|[IVXivx]+-[IVXivx]+$|\\d+$|[IVXivx]+$)?(.*)$",
+          "captures": {
+            "1": {
+              "name": "keyword.other.header.text.kalliope"
+            },
+            "3": {
+              "name": "constant.numeric.page.kalliope"
+            },
+            "4": {
+              "patterns": [
+                {
+                  "include": "#inline-markup"
+                }
+              ]
+            }
+          }
+        },
+        {
+          "name": "meta.header.text.kalliope",
+          "match": "^(T:|LINKTITEL:|INDEXTITEL:|TOCTITEL:|U:|F:|TYPE:|DIGTER:|VARIANT:|CREDITS:|FREMFØRT:|BEGIVENHED:|SKREVET:|FACSIMILE-SIDE:|NOTE:|N:|ID:|SPROG:)(.*)$",
+          "captures": {
+            "1": {
+              "name": "keyword.other.header.text.kalliope"
+            },
+            "2": {
+              "patterns": [
+                {
+                  "include": "#inline-markup"
+                }
+              ]
+            }
+          }
+        },
+        {
+          "name": "meta.header.todo.kalliope",
+          "match": "^(TODO:)(.*)$",
+          "captures": {
+            "1": {
+              "name": "keyword.other.header.todo.kalliope"
+            }
+          }
+        }
+      ]
+    },
+    "layout-line": {
+      "name": "meta.layout.kalliope",
+      "match": "^\\{([wcsibrp]+:)(.*)\\}$",
+      "captures": {
+        "1": {
+          "name": "support.function.layout.kalliope"
+        }
+      }
+    },
+    "horizontal-rule": {
+      "name": "meta.separator.kalliope",
+      "match": "^---+$"
+    },
+    "inline-markup": {
+      "patterns": [
+        {
+          "name": "markup.italic.kalliope",
+          "match": "_[^_]+_"
+        },
+        {
+          "name": "markup.bold.kalliope",
+          "match": "\\*[^*]+\\*"
+        },
+        {
+          "name": "markup.other.word.kalliope",
+          "match": "=[^=]+="
+        },
+        {
+          "name": "entity.name.tag.xml.kalliope",
+          "match": "</?[a-zA-Z][^>]*>"
+        }
+      ]
+    },
+    "common-error": {
+      "patterns": [
+        {
+          "name": "invalid.trailing-space-before-punctuation.kalliope",
+          "match": " [?!;] *$"
+        },
+        {
+          "name": "invalid.space-before-period.kalliope",
+          "match": "[^.] \\. *$"
+        },
+        {
+          "name": "invalid.escape.kalliope",
+          "match": "\\\\"
+        },
+        {
+          "name": "invalid.leading-period.kalliope",
+          "match": "^\\. *[a-zA-ZæøåÆØÅ]"
+        }
+      ]
+    }
+  }
+}


### PR DESCRIPTION
## Ændringer
- Tilføjer en lokal VS Code-extension med TextMate-grammar for old2kalliope-input.
- Begrænser automatisk VS Code-match til lokale .txt-filer, hvor første linje begynder med KILDE:.
- Tilføjer workspace settings, så Kalliope-tekstheaders kan få egen farve i VS Code.
- Lægger Vim-syntaxfil og ftdetect-fil i repoet, så Vim kun auto-detekterer .txt-filer med KILDE: som første linje.
- Tilføjer et install-script til at symlinke VS Code-extensionen ind i brugerens extension-mappe.

## Validering
- JSON-filerne er parse-valideret med Node.
- VS Code-extensionens JavaScript er syntakstjekket med node --check.
- Vim filetype-detektion er testet med en .txt-fil med KILDE: og en almindelig .txt-fil.
- Vim-syntaxen er testet med en lille buffer, hvor work-header DIGTER: rammer workCommand og text-header DIGTER: rammer textCommand.