### PR TITLE
Tilføj manglende digtere fra 1850-bibliografien

### DIFF
--- a/fdirs/andersen-carl/1857.xml
+++ b/fdirs/andersen-carl/1857.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE kalliopework SYSTEM "../../data/kalliopework.dtd">
+<kalliopework id="1857" author="andersen-carl" status="incomplete" type="poetry">
+<workhead>
+   <title>En Krands paa en Arbeiders Kiste: Nogle Digte</title>
+   <year>1857</year>
+</workhead>
+</kalliopework>

--- a/fdirs/andersen-carl/1860.xml
+++ b/fdirs/andersen-carl/1860.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE kalliopework SYSTEM "../../data/kalliopework.dtd">
+<kalliopework id="1860" author="andersen-carl" status="incomplete" type="poetry">
+<workhead>
+   <title>Ingolfs og Hjørleifs Saga</title>
+   <year>1860</year>
+</workhead>
+</kalliopework>

--- a/fdirs/andersen-carl/1862.xml
+++ b/fdirs/andersen-carl/1862.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE kalliopework SYSTEM "../../data/kalliopework.dtd">
+<kalliopework id="1862" author="andersen-carl" status="incomplete" type="poetry">
+<workhead>
+   <title>Tonens Veie</title>
+   <year>1862</year>
+</workhead>
+</kalliopework>

--- a/fdirs/andersen-carl/1863.xml
+++ b/fdirs/andersen-carl/1863.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE kalliopework SYSTEM "../../data/kalliopework.dtd">
+<kalliopework id="1863" author="andersen-carl" status="incomplete" type="poetry">
+<workhead>
+   <title>Lyriske Smaadigte</title>
+   <year>1863</year>
+</workhead>
+</kalliopework>

--- a/fdirs/andersen-carl/1865.xml
+++ b/fdirs/andersen-carl/1865.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE kalliopework SYSTEM "../../data/kalliopework.dtd">
+<kalliopework id="1865" author="andersen-carl" status="incomplete" type="poetry">
+<workhead>
+   <title>Ved Arno og ved Ganges</title>
+   <year>1865</year>
+</workhead>
+</kalliopework>

--- a/fdirs/andersen-carl/1868.xml
+++ b/fdirs/andersen-carl/1868.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE kalliopework SYSTEM "../../data/kalliopework.dtd">
+<kalliopework id="1868" author="andersen-carl" status="incomplete" type="poetry">
+<workhead>
+   <title>Lys og Skygge</title>
+   <year>1868</year>
+</workhead>
+</kalliopework>

--- a/fdirs/andersen-carl/1870.xml
+++ b/fdirs/andersen-carl/1870.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE kalliopework SYSTEM "../../data/kalliopework.dtd">
+<kalliopework id="1870" author="andersen-carl" status="incomplete" type="poetry">
+<workhead>
+   <title>Poesier</title>
+   <year>1870</year>
+</workhead>
+</kalliopework>

--- a/fdirs/andersen-carl/1873.xml
+++ b/fdirs/andersen-carl/1873.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE kalliopework SYSTEM "../../data/kalliopework.dtd">
+<kalliopework id="1873" author="andersen-carl" status="incomplete" type="poetry">
+<workhead>
+   <title>Liv i Lænker</title>
+   <year>1873</year>
+</workhead>
+</kalliopework>

--- a/fdirs/andersen-carl/1878.xml
+++ b/fdirs/andersen-carl/1878.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE kalliopework SYSTEM "../../data/kalliopework.dtd">
+<kalliopework id="1878" author="andersen-carl" status="incomplete" type="poetry">
+<workhead>
+   <title>Massudith</title>
+   <year>1878</year>
+</workhead>
+</kalliopework>

--- a/fdirs/andersen-carl/1880.xml
+++ b/fdirs/andersen-carl/1880.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE kalliopework SYSTEM "../../data/kalliopework.dtd">
+<kalliopework id="1880" author="andersen-carl" status="incomplete" type="poetry">
+<workhead>
+   <title>Romancer og Sange</title>
+   <year>1880</year>
+</workhead>
+</kalliopework>

--- a/fdirs/andersen-carl/info.xml
+++ b/fdirs/andersen-carl/info.xml
@@ -1,0 +1,23 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<person id="andersen-carl" country="dk" lang="da" type="poet">
+  <name>
+    <firstname>Carl</firstname>
+    <lastname>Andersen</lastname>
+    <fullname>Carl Christian Thorvald Andersen</fullname>
+  </name>
+  <period>
+    <born>
+      <date>1828-10-26</date>
+    </born>
+    <dead>
+      <date>1883-09-13</date>
+    </dead>
+  </period>
+  <literary-periods>romantik-og-praeromantik</literary-periods>
+  <identifiers>
+    <wikidata>Q15873738</wikidata>
+    <viaf>47597627</viaf>
+    <litteraturpriser-dk>ACarlAndersen</litteraturpriser-dk>
+    <runeberg-org>andercar</runeberg-org>
+  </identifiers>
+</person>

--- a/fdirs/andersen-carl/info.xml
+++ b/fdirs/andersen-carl/info.xml
@@ -4,6 +4,7 @@
     <firstname>Carl</firstname>
     <lastname>Andersen</lastname>
     <fullname>Carl Christian Thorvald Andersen</fullname>
+    <pseudonym>Christian Adam</pseudonym>
   </name>
   <period>
     <born>
@@ -14,6 +15,7 @@
     </dead>
   </period>
   <literary-periods>romantik-og-praeromantik</literary-periods>
+  <works>1857,1860,1862,1863,1865,1868,1870,1873,1878,1880</works>
   <identifiers>
     <wikidata>Q15873738</wikidata>
     <viaf>47597627</viaf>

--- a/fdirs/fibiger-ilia/1867.xml
+++ b/fdirs/fibiger-ilia/1867.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE kalliopework SYSTEM "../../data/kalliopework.dtd">
+<kalliopework id="1867" author="fibiger-ilia" status="incomplete" type="poetry">
+<workhead>
+   <title>Digtninger</title>
+   <year>1867</year>
+</workhead>
+</kalliopework>

--- a/fdirs/fibiger-ilia/info.xml
+++ b/fdirs/fibiger-ilia/info.xml
@@ -1,0 +1,28 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<person id="fibiger-ilia" country="dk" lang="da" type="poet">
+  <name>
+    <firstname>Ilia</firstname>
+    <lastname>Fibiger</lastname>
+    <fullname>Ilia Marie Fibiger</fullname>
+  </name>
+  <period>
+    <born>
+      <date>1817-10-05</date>
+      <place>København</place>
+    </born>
+    <dead>
+      <date>1867-06-10</date>
+      <place>København</place>
+    </dead>
+  </period>
+  <literary-periods>romantik-og-praeromantik</literary-periods>
+  <identifiers>
+    <wikidata>Q4947977</wikidata>
+    <gravsted-dk>iliafibiger</gravsted-dk>
+    <viaf>46455706</viaf>
+    <lex-dk>Ilia_Fibiger</lex-dk>
+    <biografisk-leksikon-lex-dk>Ilia_Fibiger</biografisk-leksikon-lex-dk>
+    <litteraturpriser-dk>FIliaFibiger</litteraturpriser-dk>
+    <runeberg-org>fibigili</runeberg-org>
+  </identifiers>
+</person>

--- a/fdirs/fibiger-ilia/info.xml
+++ b/fdirs/fibiger-ilia/info.xml
@@ -16,6 +16,7 @@
     </dead>
   </period>
   <literary-periods>romantik-og-praeromantik</literary-periods>
+  <works>1867</works>
   <identifiers>
     <wikidata>Q4947977</wikidata>
     <gravsted-dk>iliafibiger</gravsted-dk>


### PR DESCRIPTION
## Resumé

- tilføjer `info.xml` for Carl Christian Thorvald Andersen
- tilføjer `info.xml` for Ilia Marie Fibiger
- medtager sikre autoritets-id’er fra Wikidata, VIAF, Runeberg, Litteraturpriser og lex.dk, hvor de findes

## Validering

- `xmllint --noout fdirs/andersen-carl/info.xml fdirs/fibiger-ilia/info.xml`
- `npm test -- __tests__/poets.test.js`

Fixes #1223