### PR TITLE
Tilføj Wikidata-id’er til billeder

### DIFF
--- a/data/artwork.xml
+++ b/data/artwork.xml
@@ -6,8 +6,7 @@
     <picture id="rafael-leone-x-1518" wikidata="Q2610729" year="1518 ca.">
         Rafael: <i>Papa Leone X con i cugini, i cardinali Giulio de' Medici e Luigi de' Rossi.</i>, mellem 1518 og 1519, olie på panel. Uffizierne, Firenze.
     </picture>
-    <picture id="loeffler-anna-nielsen-1836"  year="1836" museum="smk" invnr="KMS8660">Carl Løffler: <i>Skuespilleren Anna Nielsen</i>, ca. 1836, olie på lærred, 23,3 × 20,7 cm.</picture>
+    <picture id="loeffler-anna-nielsen-1836" wikidata="Q20415264" year="1836" museum="smk" invnr="KMS8660">Carl Løffler: <i>Skuespilleren Anna Nielsen</i>, ca. 1836, olie på lærred, 23,3 × 20,7 cm.</picture>
     <picture id="tizian-amor-sacro-e-amor-profano-1515">Tizian: <i>L'Amor sacro e Amor profano</i>, ca. 1515, olie på træ, 118×279 cm. Galleria Borghese, Rom.</picture> <!-- https://en.wikipedia.org/wiki/Sacred_and_Profane_Love --> 
     <picture id="rivett-carnac-edward-fitzgerald-oval" museum="npg" year="1873">Eva Rivett-Carnac: <i>Edward Fitzgerald</i>, miniature efter et fotografi fra 1873.</picture>
 </pictures>
-

--- a/data/artwork.xml
+++ b/data/artwork.xml
@@ -7,6 +7,6 @@
         Rafael: <i>Papa Leone X con i cugini, i cardinali Giulio de' Medici e Luigi de' Rossi.</i>, mellem 1518 og 1519, olie på panel. Uffizierne, Firenze.
     </picture>
     <picture id="loeffler-anna-nielsen-1836" wikidata="Q20415264" year="1836" museum="smk" invnr="KMS8660">Carl Løffler: <i>Skuespilleren Anna Nielsen</i>, ca. 1836, olie på lærred, 23,3 × 20,7 cm.</picture>
-    <picture id="tizian-amor-sacro-e-amor-profano-1515">Tizian: <i>L'Amor sacro e Amor profano</i>, ca. 1515, olie på træ, 118×279 cm. Galleria Borghese, Rom.</picture> <!-- https://en.wikipedia.org/wiki/Sacred_and_Profane_Love --> 
+    <picture id="tizian-amor-sacro-e-amor-profano-1515" wikidata="Q794077">Tizian: <i>L'Amor sacro e Amor profano</i>, ca. 1515, olie på træ, 118×279 cm. Galleria Borghese, Rom.</picture> <!-- https://en.wikipedia.org/wiki/Sacred_and_Profane_Love -->
     <picture id="rivett-carnac-edward-fitzgerald-oval" museum="npg" year="1873">Eva Rivett-Carnac: <i>Edward Fitzgerald</i>, miniature efter et fotografi fra 1873.</picture>
 </pictures>

--- a/data/keywords/romantismen.xml
+++ b/data/keywords/romantismen.xml
@@ -5,7 +5,7 @@
     <pictures>
         <picture src="friedrich7.jpg">Den romantiske udlængsel ifølge Caspar David Friedrich: <i>View from the Artist's Studio, Right Window</i>, 1805-1806. 31 × 24 cm. Sepia på papir. Wien Kunsthistorisches Museum.</picture>
     <picture portrait="hugo/p3" />
-    <picture src="ingres8.jpg">Jean Auguste Dominique Ingres: <i>Grande Odalisque</i>, 1814. Musée du Louvre.</picture>
+    <picture src="ingres8.jpg" wikidata="Q1978815">Jean Auguste Dominique Ingres: <i>Grande Odalisque</i>, 1814. Musée du Louvre.</picture>
     <picture portrait="heine/p3" />
     </pictures>
     <related>romantikken</related>

--- a/fdirs/abildgaard/artwork.xml
+++ b/fdirs/abildgaard/artwork.xml
@@ -1,9 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <pictures>
-    <picture id="1778-hamlet" year="1778" museum="smk" invnr="KMS1019" >
+    <picture id="1778-hamlet" wikidata="Q20406826" year="1778" museum="smk" invnr="KMS1019" >
         <i>Hamlet hos sin moder</i>, ca. 1778, olie på lærred, 50,5×64cm.
     </picture>
-    <picture id="1782-christian4" year="1782" museum="smk" invnr="KMS1139d" >
+    <picture id="1782-christian4" wikidata="Q20277436" year="1782" museum="smk" invnr="KMS1139d" >
         <i>Christian IV på "Trefoldigheden" i slaget på Kolberger Heide 1644</i>, 1782, olie på lærred, 61×37cm.
 
 Skitse til vægbillede i riddersalen på Christiansborg, der brændte med slottet i 1794.

--- a/fdirs/ahlmann/1907.xml
+++ b/fdirs/ahlmann/1907.xml
@@ -946,7 +946,7 @@ Hellere glemt — end en bitter Dag
     <firstline>Dit Smil er som en Sejersfærd</firstline>
     <source pages="51"/>
     <pictures>
-        <picture src="ahlmann2022051823-p1.jpg">Leonardo da Vinci: <i>Ritratto di Monna Lisa del Giocondo</i>, 1503-06, olie på panel, 77 × 53 cm. Louvre.</picture>
+        <picture src="ahlmann2022051823-p1.jpg" wikidata="Q12418">Leonardo da Vinci: <i>Ritratto di Monna Lisa del Giocondo</i>, 1503-06, olie på panel, 77 × 53 cm. Louvre.</picture>
     </pictures>
     <quality>korrektur1,kilde,side</quality>
 </head>

--- a/fdirs/arnold/portraits.xml
+++ b/fdirs/arnold/portraits.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <pictures>
-  <picture src="p1.jpg" primary="true" square-src="p1-square.jpg"  objid="mw00185" invnr="NPG 1000" museum="npg" year="1880">
+  <picture src="p1.jpg" wikidata="Q28050353" primary="true" square-src="p1-square.jpg"  objid="mw00185" invnr="NPG 1000" museum="npg" year="1880">
     George Frederic Watts: <i>Matthew Arnold</i>, 1880, olie på lærred, 66 × 52 cm.
   </picture>
 </pictures>

--- a/fdirs/bache/artwork.xml
+++ b/fdirs/bache/artwork.xml
@@ -6,7 +6,7 @@
   <picture id="1887-christian4-kroningstog" year="1887" museum="fnm">
     <i>Christian IVs kroningstog</i>, 1887, olie på lærred.
   </picture>
-  <picture id="1886-sankelmark" year="1886" museum="ribe" invnr="RKMm0009">
+  <picture id="1886-sankelmark" wikidata="Q38713295" year="1886" museum="ribe" invnr="RKMm0009">
     <i>Oberst Max Müller ved Sankelmark Sø den 6. februar 1864</i>, 1886, olie på lærred, 84 × 60 cm.
   </picture>
   <picture id="1894-soldaternes-hjemkomst" year="1894" museum="fnm">

--- a/fdirs/bering/portraits.xml
+++ b/fdirs/bering/portraits.xml
@@ -3,7 +3,7 @@
   <picture src="p1.jpg" primary="true" square-src="p1-square.jpg">
     Ukendt maler: <i>Vitus Bering</i>, midten af 1700-tallet. Marinemuseet (Центральный военно-морской музей), St. Petersburg.
   </picture>
-  <picture src="p2.jpg" museum="fnm" invnr="a-4969">
+  <picture src="p2.jpg" wikidata="Q51190752" museum="fnm" invnr="a-4969">
     Abraham Vuchters: <i>Vitus Bering</i>, omkr. 1600.
   </picture>
 </pictures>

--- a/fdirs/blake/portraits.xml
+++ b/fdirs/blake/portraits.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <pictures>
-  <picture src="p1.jpg" primary="true" square-src="p1-square.jpg" objid="mw00609" invnr="NPG212" museum="npg" year="1807">
+  <picture src="p1.jpg" wikidata="Q28048651" primary="true" square-src="p1-square.jpg" objid="mw00609" invnr="NPG212" museum="npg" year="1807">
     Thomas Phillips: <i>William Blake</i>, 1807, olie på lærred,  921 mm x 720 mm.
   </picture>
   <picture src="p2.jpg">

--- a/fdirs/blicher/portraits.xml
+++ b/fdirs/blicher/portraits.xml
@@ -4,7 +4,7 @@
   </picture>
   <picture artwork="gertner/1845-blicher" primary="true" square-src="p2-square.jpg">
   </picture>
-  <picture src="p3.jpg" museum="fnm" invnr="a-4566" year="1866">
+  <picture src="p3.jpg" wikidata="Q51260369" museum="fnm" invnr="a-4566" year="1866">
       Christen Dalsgaard: <i>Blicher paa Heden</i>, 1866, olie på lærred.
   </picture>
 </pictures>

--- a/fdirs/bloch/artwork.xml
+++ b/fdirs/bloch/artwork.xml
@@ -6,7 +6,7 @@
   <picture id="fiskerstue-1858" year="1858">
       <i>Scene i en Fiskerstue. En Dreng der slaar ud efter en And. Fa'er skal sove</i>, 1858, olie på lærred, 73×91cm. <!-- http://www.artnet.com/artists/carl-heinrich-bloch/scene-i-en-fiskerstue-en-dreng-der-slaar-ud-efter-Dn_kg27bieXgbZ3dA3u16g2 -->
   </picture>
-  <picture id="prometheus-1864" year="1864" museum="ribe" invnr="RKMm0671">
+  <picture id="prometheus-1864" wikidata="Q39411868" year="1864" museum="ribe" invnr="RKMm0671">
       <i>Prometheus' befrielse</i>, 1864, olie på papir, opklæbet på lærred, 46×38cm.
   </picture>
   <picture id="marstrand-1867" subject="marstrand" year="1867" museum="hirschsprungske">
@@ -15,11 +15,10 @@
   <picture id="andersen-1869" subject="andersen" year="1869" museum="nivaagaard">
       <i>H.C. Andersen</i>, 1869, olie på lærred. Privateje, deponeret.
   </picture>
-  <picture id="christian2-1871" subject="christian2" year="1871" museum="smk" invnr="KMS985">
+  <picture id="christian2-1871" wikidata="Q20537509" subject="christian2" year="1871" museum="smk" invnr="KMS985">
       <i>Christian II i fængslet på Sønderborg Slot</i>, 1872, olie på lærred, 294.5×1234.5.
   </picture>
   <picture id="bloch-1886" subject="bloch" year="1886" museum="fnm">
       <i>Selvportræt</i>, 1886.
   </picture>
 </pictures>
-

--- a/fdirs/boennelycke/portraits.xml
+++ b/fdirs/boennelycke/portraits.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <pictures>
-  <picture src="p1.jpg" primary="true" square-src="p1-square.jpg" museum="smk" year="1921" invnr="KMS8760">
+  <picture src="p1.jpg" wikidata="Q104637574" primary="true" square-src="p1-square.jpg" museum="smk" year="1921" invnr="KMS8760">
       Vilhelm Lundstrøm: <i>Portræt af Emil Bønnelycke</i>, 1921, olie på lærred, 166 × 100,7 cm.
   </picture>
 </pictures>

--- a/fdirs/brorson/portraits.xml
+++ b/fdirs/brorson/portraits.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <pictures>
-  <picture src="p1.jpg" primary="true" square-src="p1-square.jpg" museum="fnm" invnr="r-21">
+  <picture src="p1.jpg" wikidata="Q131586023" primary="true" square-src="p1-square.jpg" museum="fnm" invnr="r-21">
     Johan Hørner: <i>H.A. Brorson</i>, 1756.
   </picture>
   <picture src="p2.jpg">

--- a/fdirs/browningeb/portraits.xml
+++ b/fdirs/browningeb/portraits.xml
@@ -2,7 +2,7 @@
 <pictures>
   <picture src="p1.jpg">
   </picture>
-  <picture src="p2.jpg" primary="true" square-src="p2-square.jpg" objid="mw00856" invnr="NPG1899" museum="npg" year="1858">
+  <picture src="p2.jpg" wikidata="Q28050108" primary="true" square-src="p2-square.jpg" objid="mw00856" invnr="NPG1899" museum="npg" year="1858">
     Michele Gordigiani: <i>Elizabeth Barrett Browning</i>, 1858, olie på lærred.
   </picture>
 </pictures>

--- a/fdirs/byron/portraits.xml
+++ b/fdirs/byron/portraits.xml
@@ -1,11 +1,11 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <pictures>
-  <picture src="p1.jpg" objid="mw00991" invnr="NPG 142" museum="npg" year="1835">
+  <picture src="p1.jpg" wikidata="Q28048739" objid="mw00991" invnr="NPG 142" museum="npg" year="1835">
     Thomas Phillips: <i>Lord Byron in Albanian dress</i>, ca. 1835.
   </picture>
   <picture src="p2.jpg">
   </picture>
-  <picture src="p3.jpg" primary="true" square-src="p3-square.jpg" objid="mw00989" invnr="NPG 4243" museum="npg" year="1813">
+  <picture src="p3.jpg" wikidata="Q28048735" primary="true" square-src="p3-square.jpg" objid="mw00989" invnr="NPG 4243" museum="npg" year="1813">
     Richard Westall: <i>George Gordon Byron, 6th Baron Byron</i>, 1813.
   </picture>
 </pictures>

--- a/fdirs/campbell/portraits.xml
+++ b/fdirs/campbell/portraits.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <pictures>
-  <picture src="p1.jpg" primary="true" square-src="p1-square.jpg" objid="mw01033" invnr="NPG 198" museum="npg" year="1820">
+  <picture src="p1.jpg" wikidata="Q28048827" primary="true" square-src="p1-square.jpg" objid="mw01033" invnr="NPG 198" museum="npg" year="1820">
       Sir Thomas Lawrence: <i>Thomas Campbell</i>, c. 1820, olie på lærred, 914 × 711 mm.
   </picture>
 </pictures>

--- a/fdirs/churchill/portraits.xml
+++ b/fdirs/churchill/portraits.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <pictures>
-  <picture src="p1.jpg" primary="true" square-src="p1-square.jpg" museum="npg" year="1763" objid="mw01295" invnr="NPG 162">
+  <picture src="p1.jpg" wikidata="Q28047720" primary="true" square-src="p1-square.jpg" museum="npg" year="1763" objid="mw01295" invnr="NPG 162">
       J.S.C. Schaak: <i>Charles Churchill</i>, ca. 1763-1764, olie på lærred, 73,0×62,2cm.
   </picture>
 </pictures>

--- a/fdirs/clare/portraits.xml
+++ b/fdirs/clare/portraits.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <pictures>
-  <picture src="p1.jpg" primary="true" square-src="p1-square.jpg" objid="mw01307" invnr="NPG 1469" museum="npg" year="1820">
+  <picture src="p1.jpg" wikidata="Q28048833" primary="true" square-src="p1-square.jpg" objid="mw01307" invnr="NPG 1469" museum="npg" year="1820">
       William Hilton: <i>John Clare</i>, 1820, olie på lærred, 76,2 × 64,5 cm.
   </picture>
   <picture src="p2.jpg" objid="mw113260" invnr="NPG P1101" museum="npg" year="1862">

--- a/fdirs/coleridge/portraits.xml
+++ b/fdirs/coleridge/portraits.xml
@@ -1,9 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <pictures>
-  <picture src="p1.jpg" primary="true" square-src="p1-square.jpg" objid="mw01398" invnr="NPG 184" museum="npg" year="1814">
+  <picture src="p1.jpg" wikidata="Q28048744" primary="true" square-src="p1-square.jpg" objid="mw01398" invnr="NPG 184" museum="npg" year="1814">
       Washington Allston (1779-1843): <i>Portrait of Samuel Taylor Coleridge</i>, 1814, olie på lærred, 114,3 × 87,6 cm.
   </picture>
-  <picture src="p2.jpg" objid="mw01396" invnr="NPG 192" museum="npg" year="1795">
+  <picture src="p2.jpg" wikidata="Q28048420" objid="mw01396" invnr="NPG 192" museum="npg" year="1795">
       Peter Vandyke: <i>Samuel Taylor Coleridge</i>, 1795, olie på lærred, 55,9 × 45,7 cm.
   </picture>
 </pictures>

--- a/fdirs/cunningham/portraits.xml
+++ b/fdirs/cunningham/portraits.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <pictures>
-  <picture src="p1.jpg" primary="true" square-src="p1-square.jpg" objid="mw01673" invnr="NPG 1823" museum="npg" year="1840">
+  <picture src="p1.jpg" wikidata="Q28049608" primary="true" square-src="p1-square.jpg" objid="mw01673" invnr="NPG 1823" museum="npg" year="1840">
       Henry Room: <i>Allan Cunningham</i>, ca. 1840, olie på lærred, 914 × 711 mm.
   </picture>
 </pictures>

--- a/fdirs/daugaard/portraits.xml
+++ b/fdirs/daugaard/portraits.xml
@@ -1,9 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <pictures>
-  <picture src="p1.jpg" primary="true" square-src="p1-square.jpg" year="1900" museum="ribe" invnr="RKMm0235">
+  <picture src="p1.jpg" wikidata="Q40237114" primary="true" square-src="p1-square.jpg" year="1900" museum="ribe" invnr="RKMm0235">
       Carl Thomsen: <i>Frk. Daugård i sit hjem i Ribe</i>, 1900, olie på lærred, 56×47cm.
   </picture>
-  <picture src="p2.jpg" year="1906" museum="ribe" invnr="RKMm0162">
+  <picture src="p2.jpg" wikidata="Q40288635" year="1906" museum="ribe" invnr="RKMm0162">
       Caja Prytz (1877-1916): <i>Forfatterinden frk. Christine Daugaard</i>, 1906, olie på lærred, 27 × 26,5 cm.
   </picture>
 </pictures>

--- a/fdirs/donne/portraits.xml
+++ b/fdirs/donne/portraits.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <pictures>
 <!-- Interessant artiklen om restaureringen på NPG: http://www.npg.org.uk/research/conservation/john-donne-and-his-picture -->
-  <picture src="p1.jpg" primary="true" square-src="p1-square.jpg" objid="mw111844" invnr="NPG 6790" museum="npg" year="1595">
+  <picture src="p1.jpg" wikidata="Q28042968" primary="true" square-src="p1-square.jpg" objid="mw111844" invnr="NPG 6790" museum="npg" year="1595">
     Ukendt kunstner: <i>John Donne</i>, ca. 1595.
 
 Dette portræt havde Donne selv hængende og omtaler det som det "picture of myne w[hi]ch is taken in the shaddowes".

--- a/fdirs/eckersberg/artwork.xml
+++ b/fdirs/eckersberg/artwork.xml
@@ -7,14 +7,14 @@
   <picture id="apistemplet-1809" year="1809" museum="smk" invnr="KKSgb4236">
     <i>Prospekt fra Frederiksberg have ved slottet og Apistemplet</i>, 1809, vandfarve, 265 × 324 mm.
   </picture>
-  <picture id="1812-odysseus-hjemkomst" year="1812" invnr="KMS7256" museum="smk">
+  <picture id="1812-odysseus-hjemkomst" wikidata="Q20354438" year="1812" invnr="KMS7256" museum="smk">
       <i>Odysseus' hjemkomst. Motiv fra Odysséen XIX sang</i>, 1812, olie på lærred, 60 × 72 cm.
   </picture>
   <picture id="thorvaldsen-1814" year="1814" subject="thorvaldsen">
     <i>Bertel Thorvaldsen</i>, 1814, 90 × 74 cm. Kunstakademiet.
     <!-- Findes i tre versioner: 1. Nærværende på Kunstakademiet. 2. Nationalmuseum, Stockholm. https://digitaltmuseum.se/021046502180/den-danske-skulptoren-bertel-thorvaldsen og 3. Glyptoteket. https://artsandculture.google.com/asset/bertel-thorvaldsen/ygFcme7z95CiAg -->
   </picture>
-  <picture id="udsigt-gennem-tre-buer-i-colosseum-1815" year="1815" invnr="KMS3123" museum="smk">
+  <picture id="udsigt-gennem-tre-buer-i-colosseum-1815" wikidata="Q3079004" year="1815" invnr="KMS3123" museum="smk">
       <i>Udsigt gennem tre buer i Colosseums tredje stokværk</i>, 1815, olie på lærred, 32 × 49,5 cm.
   </picture>
   <picture id="1816-ingemann" year="1816-18 ca." subject="ingemann" museum="fnm" invnr="a-4570">
@@ -23,26 +23,26 @@
   <picture id="brunf-1816" year="1816 ca." subject="brunf">
     <i>Friederike Brun</i>, ca. 1816.
   </picture>
-  <picture id="familien-nathanson-1818" year="1818" museum="smk" invnr="KMS1241">
+  <picture id="familien-nathanson-1818" wikidata="Q20354137" year="1818" museum="smk" invnr="KMS1241">
       <i>Familien Nathanson</i>, 1818, olie på lærred, 126 × 172,5 cm.
   </picture>
   <picture id="nathanson-1819" year="1819">
       <i>Mendel Levin Nathanson</i>, 1819.
   </picture>
-  <picture id="1820-thorvaldsen" year="1820" subject="thorvaldsen" museum="thorvaldsens" invnr="B454">
+  <picture id="1820-thorvaldsen" wikidata="Q115697387" year="1820" subject="thorvaldsen" museum="thorvaldsens" invnr="B454">
     <i>Portræt af Thorvaldsen</i>, 1820, 49,8 × 40 cm.
   </picture>
-  <picture id="bella-hanna-1820" year="1820" museum="smk" invnr="KMS3498">
+  <picture id="bella-hanna-1820" wikidata="Q4883392" year="1820" museum="smk" invnr="KMS3498">
       <i>Mendel Levin Nathansons ældste døtre, Bella og Hanna</i>, 1820, olie på lærred, 125 × 85,5 cm.
   </picture>
-  <picture id="as-oersted-1821" year="1821" museum="smk" invnr="KMS1495">
+  <picture id="as-oersted-1821" wikidata="Q20355827" year="1821" museum="smk" invnr="KMS1495">
       <i>Juristen og statsmanden Anders Sandøe Ørsted</i>, 1821, olie på lærred, 53,5 × 43 cm.
   </picture>
   <!-- TODO: Find Oehlenschläger-portrættet https://dnm.dk/kunstvaerk/a-7555/ -->
   <picture id="frederik3-kongeloven-1824" year="1824" subject="frederik3">
       <i>Frederik III, som lader udfærdige kongeloven ved Peder Schumacher sidenhen bekjendt under navnet <a poet="griffenfeld">Griffenfeldt</a></i>, 1824. Skitse til de store billeder malet til trongemakket på Christiansborg Slot.
   </picture>
-  <picture id="frederik6-1825" year="1825" subject="frederik6" museum="fnm" invnr="a-626">
+  <picture id="frederik6-1825" wikidata="Q55413030" year="1825" subject="frederik6" museum="fnm" invnr="a-626">
       <i>Kong Frederik VI af Danmark</i>, 1825, olie på lærred.
   </picture>
   <picture id="jomfruen-fra-afar-1830" year="1830" museum="hirschsprungske">

--- a/fdirs/eliot/portraits.xml
+++ b/fdirs/eliot/portraits.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <pictures>
-  <picture src="p1.jpg" primary="true" square-src="p1-square.jpg" invnr="NPG 1405" museum="npg" year="1849">
+  <picture src="p1.jpg" wikidata="Q28049877" primary="true" square-src="p1-square.jpg" invnr="NPG 1405" museum="npg" year="1849">
       Alexandre-Louis-François d'Albert-Durade: <i>George Eliot</i>, 1849, olie på lærred.
   </picture>
 </pictures>

--- a/fdirs/faber/portraits.xml
+++ b/fdirs/faber/portraits.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <pictures>
-    <picture src="p1.jpg" primary="true" square-src="p1-square.jpg" museum="fnm" invnr="a-1834">
+    <picture src="p1.jpg" wikidata="Q24056784" primary="true" square-src="p1-square.jpg" museum="fnm" invnr="a-1834">
         Jørgen Luplau Janssen (1869-1927): <i>Peter Faber</i>, 1903, olie på lærred.
     </picture>
 </pictures>

--- a/fdirs/fonss/1896.xml
+++ b/fdirs/fonss/1896.xml
@@ -877,7 +877,7 @@ bliver Du maaske selv engang i Tiden.
     <firstline>Har vi vel mere Vidnesbyrd behov</firstline>
     <source pages="37"/>
     <pictures>
-        <picture src="fonss2019101510-p1.jpg">Leonardo da Vinci: <i>Den sidste nadver</i>, 1895-98, tempera, 460 × 880 cm. Santa Maria delle Grazie, Milano.</picture>
+        <picture src="fonss2019101510-p1.jpg" wikidata="Q128910">Leonardo da Vinci: <i>Den sidste nadver</i>, 1895-98, tempera, 460 × 880 cm. Santa Maria delle Grazie, Milano.</picture>
     </pictures>
     <keywords>sonnet</keywords>
     <quality>korrektur1,kilde,side</quality>

--- a/fdirs/gertner/artwork.xml
+++ b/fdirs/gertner/artwork.xml
@@ -9,7 +9,7 @@
   <picture id="1845-blicher" subject="blicher" year="1845" museum="kb">
     <i>St. St. Blicher</i>, 23. Maj 1845.
   </picture>
-  <picture id="1847-oehlenschlaeger" subject="oehlenschlaeger" year="1847" museum="fnm" invnr="a-841">
+  <picture id="1847-oehlenschlaeger" wikidata="Q51214358" subject="oehlenschlaeger" year="1847" museum="fnm" invnr="a-841">
       <i>Portræt af Adam Oehlenschläger</i>, 1847-48, olie på lærred.
   </picture>
   <picture id="1850-eckersberg" subject="eckersberg" year="1850">

--- a/fdirs/hansenc/artwork.xml
+++ b/fdirs/hansenc/artwork.xml
@@ -1,18 +1,18 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <pictures>
-    <picture id="selvportraet-1825" subject="hansenc" museum="smk" invnr="KMS3982" year="1825">
+    <picture id="selvportraet-1825" wikidata="Q20468253" subject="hansenc" museum="smk" invnr="KMS3982" year="1825">
       <i>Selvportræt</i>, 1825, olie på lærred, 63×50 cm.
     </picture>
-    <picture id="tre-unge-piger-1827" year="1827" invnr="KMS125" museum="smk">
+    <picture id="tre-unge-piger-1827" wikidata="Q20354726" year="1827" invnr="KMS125" museum="smk">
         <i>Tre unge piger. Kunstnerens søstre Alvilde, Ida og Henriette</i>, 1827, olie på lærred, 62,5 × 81 cm.
     </picture>
-    <picture id="slottet-kronborg-1834" year="1834" invnr="KMS6815" museum="smk">
+    <picture id="slottet-kronborg-1834" wikidata="Q20354987" year="1834" invnr="KMS6815" museum="smk">
         <i>Slottet Kronborg</i>, 1834, olie på lærred, 28,5 × 42,5 cm.
     </picture>
-    <picture id="kuchler-1837" invnr="KMS4961" year="1837" museum="smk">
+    <picture id="kuchler-1837" wikidata="Q20440649" invnr="KMS4961" year="1837" museum="smk">
         <i>Maleren Albert Küchler</i>, 1837, olie på papir opsat på lærred.
     </picture>
-    <picture id="et-selskab-af-danske-kunstnere-i-rom-1837" year="1837" invnr="KMS3236" museum="smk">
+    <picture id="et-selskab-af-danske-kunstnere-i-rom-1837" wikidata="Q2015484" year="1837" invnr="KMS3236" museum="smk">
         <i>Et Selskab af danske Kunstnere i Rom</i>, 1837, olie på lærred, 62 × 74 cm.
     </picture>
     <picture id="monrad-1846" year="1846">
@@ -30,7 +30,7 @@
     <picture id="ploug-1863" year="1863" subject="plough">
         <i>Portræt af Carl Ploug</i>, 1863, olie på lærred, 47×59cm.<!-- http://www.artnet.com/artists/carl-christian-constantin-hansen/portræt-af-carl-ploug-JFiTB7ce33jGcbkBzennjg2 -->
     </picture>
-    <picture id="tegner-1866" year="1866" subject="tegner,oehlenschlaeger" museum="fnm" invnr="a-1846">
+    <picture id="tegner-1866" wikidata="Q105606652" year="1866" subject="tegner,oehlenschlaeger" museum="fnm" invnr="a-1846">
         <i>Oehlenschläger digterkrones af Tegnér i Lunds Domkirke</i>, 1866.
         <!-- 1829/06/30	Oehlenschläger laurbærkranses af Tegnér i Lund Domkirke -->
     </picture>
@@ -40,7 +40,7 @@
     <picture id="winther-1857" year="1857" subject="winther" museum="fnm" invnr="a-5555">
         <i>Christian Winther</i>, 1857.
     </picture>
-    <picture id="jessen-1830" year="1830" invnr="KMS1788" museum="smk">
+    <picture id="jessen-1830" wikidata="Q20422143" year="1830" invnr="KMS1788" museum="smk">
         <i>Forfatterinden Juliane Marie Jessen</i>, ca. 1830, olie på lærred, 31 × 25.5 cm.
     </picture>
 </pictures>

--- a/fdirs/hardy/portraits.xml
+++ b/fdirs/hardy/portraits.xml
@@ -1,9 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <pictures>
-  <picture src="p1.jpg" objid="mw02926" invnr="NPG 2929" museum="npg" year="1893">
+  <picture src="p1.jpg" wikidata="Q28050637" objid="mw02926" invnr="NPG 2929" museum="npg" year="1893">
     William Strang: <i>Thomas Hardy</i>, 1893, olie på panel, 432×381mm.
   </picture>
-  <picture src="p2.jpg" primary="true" square-src="p2-square.jpg" objid="mw02937" invnr="NPG 2498" museum="npg" year="1923">
+  <picture src="p2.jpg" wikidata="Q28051348" primary="true" square-src="p2-square.jpg" objid="mw02937" invnr="NPG 2498" museum="npg" year="1923">
     Reginald Grenville Eves: <i>Thomas Hardy</i>, 1923, olie på lærred, 508×406mm.
   </picture>
 </pictures>

--- a/fdirs/heibergjl/portraits.xml
+++ b/fdirs/heibergjl/portraits.xml
@@ -3,7 +3,7 @@
   <picture src="p1.jpg">
   </picture>
   <picture artwork="bissen/heibergjl-1860" />
-  <picture src="p3.jpg" primary="true" square-src="p3-square.jpg" museum="fnm" invnr="a-2533">
+  <picture src="p3.jpg" wikidata="Q104177493" primary="true" square-src="p3-square.jpg" museum="fnm" invnr="a-2533">
     Sophus Schack: <i>Johan Ludvig Heiberg</i>.
   </picture>
   <picture src="p4.jpg">

--- a/fdirs/hornc/portraits.xml
+++ b/fdirs/hornc/portraits.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <pictures>
-  <picture src="p1.jpg" primary="true" square-src="p1-square.jpg" museum="smk" year="1783" invnr="KMS4083">
+  <picture src="p1.jpg" wikidata="Q20276037" primary="true" square-src="p1-square.jpg" museum="smk" year="1783" invnr="KMS4083">
       Carl Fredric von Breda: <i>Portræt af Claes Fredrik Horn</i>, 1783, olie på lærred, 64.5 × 54,5 cm.
   </picture>
 </pictures>

--- a/fdirs/hunt/portraits.xml
+++ b/fdirs/hunt/portraits.xml
@@ -1,9 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <pictures>
-  <picture src="p1.jpg" primary="true" square-src="p1-square.jpg" year="1811" objid="mw03305" invnr="NPG 293" museum="npg">
+  <picture src="p1.jpg" wikidata="Q28048706" primary="true" square-src="p1-square.jpg" year="1811" objid="mw03305" invnr="NPG 293" museum="npg">
       Benjamin Robert Haydon: <i>Leigh Hunt</i>, ca. 1811, olie på lærred, 610 × 502 mm.
   </picture>
-  <picture src="p2.jpg" objid="mw03307" invnr="NPG 2508" year="1837" museum="npg">
+  <picture src="p2.jpg" wikidata="Q28049430" objid="mw03307" invnr="NPG 2508" year="1837" museum="npg">
       Samuel Laurence: <i>Leigh Hunt</i>, ca. 1837, olie på lærred, 1118 × 905 mm.
   </picture>
 </pictures>

--- a/fdirs/jensenca/artwork.xml
+++ b/fdirs/jensenca/artwork.xml
@@ -18,10 +18,10 @@
   <picture id="weyse-1832" subject="weyse" year="1832 ca." museum="fnm" invnr="a-4593">
     <i>Christoph Ernst Friedrich Weyse</i>, ca. 1832.
   </picture>
-  <picture id="eckersberg-1832" subject="eckersberg" year="1832" invnr="KMS1762" museum="smk">
+  <picture id="eckersberg-1832" wikidata="Q20428331" subject="eckersberg" year="1832" invnr="KMS1762" museum="smk">
       <i>Maleren C.W. Eckersberg</i>, 1832, olie på lærred, 25×22cm.
   </picture>
-  <picture id="oersted-1832" subject="oersted" year="1832" invnr="KMS8176" museum="smk">
+  <picture id="oersted-1832" wikidata="Q20355578" subject="oersted" year="1832" invnr="KMS8176" museum="smk">
       <i>Portræt af naturvidenskabsmanden H.C. Ørsted</i>, 1832-33, olie på lærred, 67,8×51cm.
   </picture>
   <picture id="sophie-hansen-1832" year="1832">
@@ -33,7 +33,7 @@
   <picture id="bissen-1835" subject="bissen" year="1835">
       <i>Herman Wilhelm Bissen</i>, 1835, olie på lærred, 25×21 cm. Ny Carlsberg Glyptotek. <!-- invnr. 1734 -->
   </picture>
-  <picture id="herholdt-1835" year="1835" museum="smk" invnr="KMS3129">
+  <picture id="herholdt-1835" wikidata="Q20354175" year="1835" museum="smk" invnr="KMS3129">
     <i>Professor dr. med. J.D. Herholdt</i>, 1835, olie på lærred. 23,5 × 19 cm.
   </picture>
   <picture id="andersen-1836" subject="andersen" year="1836">
@@ -42,13 +42,13 @@
   <picture id="boedtcher-1836" subject="boedtcher" year="1836" invnr="B444" museum="thorvaldsens">
     <i>Ludvig Bødtcher</i>, 1836, olie på lærred, 36×28,8 cm.
   </picture>
-  <picture id="jensenca-1836" subject="jensenca" year="1836" museum="smk" invnr="KMS1825">
+  <picture id="jensenca-1836" wikidata="Q20544246" subject="jensenca" year="1836" museum="smk" invnr="KMS1825">
     <i>Selvportræt</i>, 1836, olie på lærred. 34×27 cm.
   </picture>
   <picture id="1839-thorvaldsen" subject="thorvaldsen" year="1839" museum="thorvaldsens" invnr="B433">
       <i>Portræt af Thorvaldsen</i>, 1839, olie på lærred. 28,8×22,8 cm. <!-- Skitse til https://digitaltmuseum.se/021046502315/den-danske-bildhuggaren-bertel-thorvaldsen -->
   </picture>
-  <picture id="oehlenschlaeger-1842" subject="oehlenschlaeger" year="1842" museum="fnm" invnr="r-51">
+  <picture id="oehlenschlaeger-1842" wikidata="Q131586287" subject="oehlenschlaeger" year="1842" museum="fnm" invnr="r-51">
     <i>Adam Oehlenschläger</i>, 1842.
     <!-- TODO: Find en bedre kopi - gerne i farver. -->
   </picture>
@@ -58,13 +58,11 @@
   <picture id="grundtvig-1843" subject="grundtvig" year="1843" museum="hirschsprungske">
     <i>N.F.S. Grundtvig</i>, 1843, olie på lærred. 66,7×53 cm.
   </picture>
-  <picture id="ingemann-1844" subject="ingemann" year="1844" museum="fnm" invnr="r-54"> 
+  <picture id="ingemann-1844" wikidata="Q28088498" subject="ingemann" year="1844" museum="fnm" invnr="r-54">
     <i>B.S. Ingemann</i>, 1844.
   </picture>
   <picture id="ingemann-2">
     <i>B.S. Ingemann</i>, u.å.
   </picture>
 </pictures>
-
-
 

--- a/fdirs/jonson/portraits.xml
+++ b/fdirs/jonson/portraits.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <pictures>
-  <picture src="p1.jpg" primary="true" square-src="p1-square.jpg" objid="mw03528" invnr="NPG 2752" museum="npg" year="1617">
+  <picture src="p1.jpg" wikidata="Q28043338" primary="true" square-src="p1-square.jpg" objid="mw03528" invnr="NPG 2752" museum="npg" year="1617">
       Abraham van Blyenberch: <i>Ben Jonson</i>, ca. 1617, olie på lærred, 47 × 42 cm.
   </picture>
 </pictures>

--- a/fdirs/juel/artwork.xml
+++ b/fdirs/juel/artwork.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <pictures>
-    <picture id="juel-1" year="1767 ca." subject="juel" museum="fnm" invnr="a-377">
+    <picture id="juel-1" wikidata="Q111836293" year="1767 ca." subject="juel" museum="fnm" invnr="a-377">
         <i>Selvportræt</i>, ca. 1767-68, olie på lærred, 48×40cm.
     </picture>
     <picture id="1767-selvportraet" year="1767" subject="juel">
@@ -12,7 +12,7 @@
     <picture id="1772-abildgaard" year="1772" museum="fnm" invnr="a-730">
         <i>Nicolai Abildgaard</i>, 1772.
     </picture>
-    <picture id="1773-selvportraet" year="1773-74" subject="juel" museum="smk" invnr="KMS3275">
+    <picture id="1773-selvportraet" wikidata="Q20433666" year="1773-74" subject="juel" museum="smk" invnr="KMS3275">
         <i>Selvportræt</i>, 1773-74, olie på lærred, 56,5×44,5cm.
     </picture>
     <picture id="klopstock-oval" year="1779 ca." subject="klopstock">
@@ -42,8 +42,7 @@
     <picture id="klopstock-oval" year="1779 ca." subject="klopstock" museum="fnm" invnr="a-2569">
         <i>Friedrich Gottlieb Klopstock</i>, ca. 1779.
     </picture>
-    <picture id="heibergpa" year="1790 ca." museum="fnm" invnr="a-553">
+    <picture id="heibergpa" wikidata="Q55411525" year="1790 ca." museum="fnm" invnr="a-553">
       <i>Forfatteren Peter Andreas Heiberg</i>, ca. 1790-1799, olie på lærred.
   </picture>
 </pictures>
-

--- a/fdirs/keats/portraits.xml
+++ b/fdirs/keats/portraits.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <pictures>
-  <picture src="p1.jpg" primary="true" square-src="p1-square.jpg" objid="mw03555" invnr="NPG194" museum="npg" year="1822">
+  <picture src="p1.jpg" wikidata="Q28048922" primary="true" square-src="p1-square.jpg" objid="mw03555" invnr="NPG194" museum="npg" year="1822">
     William Hilton: <i>Portrait of John Keats</i> efter Joseph Severn, ca. 1822.
   </picture>
   <picture src="p2.jpg">

--- a/fdirs/kipling/portraits.xml
+++ b/fdirs/kipling/portraits.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <pictures>
-  <picture src="p2.jpg" objid="mw03660" invnr="NPG 1863" museum="npg" year="1899">
+  <picture src="p2.jpg" wikidata="Q28050799" objid="mw03660" invnr="NPG 1863" museum="npg" year="1899">
     Sir Philip Burne-Jones, 2nd Bt: <i>Rudyard Kipling</i>, 1899, olie på lærred, 749×622mm.
   </picture>
   <picture src="p1.jpg" primary="true" square-src="p1-square.jpg" objid="mw58084" invnr="NPG x11811" museum="npg" year="1920">

--- a/fdirs/koebke/artwork.xml
+++ b/fdirs/koebke/artwork.xml
@@ -3,26 +3,25 @@
     <picture id="1832-soedring" museum="hirschsprungske" subject="soedring" year="1832">
         <i>Landskabsmaleren Frederik Sødring</i>, 1832, olie på lærred, 42,2×38,9cm.
     </picture>
-    <picture id="1832-ida-thiele" museum="smk" invnr="KMS3136" year="1832">
+    <picture id="1832-ida-thiele" wikidata="Q20380158" museum="smk" invnr="KMS3136" year="1832">
         <i>Ida Thiele, senere gift Wilde, som barn</i>, 1832, olie på lærred, 22,5×20cm.
     </picture>
-    <picture id="1833-christian-petersen" year="1833-05-22" museum="smk" invnr="KMS3159">
+    <picture id="1833-christian-petersen" wikidata="Q20354582" year="1833-05-22" museum="smk" invnr="KMS3159">
         <i>Urtekræmmer Christian F. Petersen, kunstnerens fætter og svoger</i>, 22/5 1833, olie på lærred,  31,5 × 27 cm.
     </picture>
-    <picture id="1833-selvportraet" subject="koebke" year="1833" museum="smk" invnr="KMS3150">
+    <picture id="1833-selvportraet" wikidata="Q20267373" subject="koebke" year="1833" museum="smk" invnr="KMS3150">
         <i>Selvportræt</i>, ca. 1833, olie på lærred,  42 × 35,5 cm.
     </picture>
     <picture id="1834-hansenc" subject="hansenc" year="1834" museum="ribe" invnr="RKMm0118">
         <i>Portræt af maleren Constantin Hansen</i>, 1834-35, olie på lærred, 107,5 × 87,5 cm.
     </picture>
-    <picture id="1835-grethe-petersen" year="1835" museum="smk" invnr="KMS3160">
+    <picture id="1835-grethe-petersen" wikidata="Q20440852" year="1835" museum="smk" invnr="KMS3160">
         <i>Cecilie Margrethe Petersen, født Købke, kunstnerens søster</i>, 1835, olie på lærred,  94 × 74 cm.
     </picture>
-    <picture id="1836-marstrand" subject="marstrand" year="1836" museum="smk" invnr="KMS1348">
+    <picture id="1836-marstrand" wikidata="Q20268310" subject="marstrand" year="1836" museum="smk" invnr="KMS1348">
         <i>Maleren Wilhelm Marstrand</i>, 1836, olie på lærred, 18,5 × 15 cm.
     </picture>
     <picture id="1846-krohn" subject="krohn" year="1846" museum="natmus.se" objid="160037">
         <i>Skolebestyrer J. Krohn som barn, kunstnerens søstersøn</i>, 1846, olie på lærred, 30 × 25 cm.
     </picture>
 </pictures>
-

--- a/fdirs/kroyer/artwork.xml
+++ b/fdirs/kroyer/artwork.xml
@@ -1,9 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <pictures>
-    <picture id="1879-sardineri" year="1879" museum="smk" invnr="KMS3108">
+    <picture id="1879-sardineri" wikidata="Q20496956" year="1879" museum="smk" invnr="KMS3108">
         <i>Et sardineri i Concarneau</i>, 1879, olie på lærred, 101,5 × 140,5 cm.
     </picture>
-    <picture id="1879-franske-arbejdere" year="1879" museum="ribe" invnr="RKMm0492">
+    <picture id="1879-franske-arbejdere" wikidata="Q20440119" year="1879" museum="ribe" invnr="RKMm0492">
         <i>Franske arbejdere i hulvej</i>, 1879, olie på lærred, 80 × 100 cm.
     </picture>
     <picture id="1880-hattemagere" year="1880" museum="hirschsprungske">
@@ -48,7 +48,7 @@
     <picture id="schandorph-2" subject="schandorph" year="1895" museum="hirschsprungske">
         <i>Forfatteren Sophus Schandorph</i>, 1895. Skitse til maleri tilhørende Statens Museum for Kunst.
     </picture>
-    <picture id="schandorph-3" subject="schandorph" invnr="KMS6858" museum="smk" year="1895">
+    <picture id="schandorph-3" wikidata="Q20354292" subject="schandorph" invnr="KMS6858" museum="smk" year="1895">
         <i>Sophus Schandorph</i>, 1895.
     </picture>
     <picture id="gjellerup-2" subject="schandorph" year="1897">

--- a/fdirs/kuchler/artwork.xml
+++ b/fdirs/kuchler/artwork.xml
@@ -1,19 +1,19 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <pictures>
-    <picture id="boedtcher-1830" year="1830 ca." subject="boedtcher" museum="fnm" invnr="a-702">
+    <picture id="boedtcher-1830" wikidata="Q119072202" year="1830 ca." subject="boedtcher" museum="fnm" invnr="a-702">
        <i>Ludvig Bødtcher</i>, ca. 1830.
     </picture>
     <picture id="1831-italienerinde" year="1831" museum="glyptoteket">
         <description><i>Italienerinde</i>, 1831, olie på lærred, 45×37cm.</description>
         <picture-note>Også kendt med titlen <i>Albanerinde</i>. <a poet="winther">Christian Winther</a> bestilte dette maleri af sin italienske kæreste. <!--  inv. nr. MIN 0914 --> <!-- https://www.kulturarv.dk/kid/VisVaerk.do?vaerkId=105077 --> <!-- »Albanerinde«, som i en kvinde fra Albanosøen ved Rom og ikke fra Albanien. --></picture-note>
     </picture>
-    <picture id="en-romersk-gadescene-1833" year="1833" invnr="KMS3317" museum="smk">
+    <picture id="en-romersk-gadescene-1833" wikidata="Q20538366" year="1833" invnr="KMS3317" museum="smk">
         <i>En romersk gadescene</i>, 1833, olie på lærred, 60,5×51 cm.
     </picture>
-    <picture id="andersen-1834" year="1834" museum="fnm" invnr="a-701">
+    <picture id="andersen-1834" wikidata="Q119716534" year="1834" museum="fnm" invnr="a-701">
         <i>H.C. Andersen</i>, januar 1834, Rom, olie på lærred.
     </picture>
-    <picture id="hansenc-1837" year="1837" invnr="KMS4964" museum="smk">
+    <picture id="hansenc-1837" wikidata="Q20267924" year="1837" invnr="KMS4964" museum="smk">
         <i>Maleren Constantin Hansen</i>, 1837, olie på papir opsat på lærred, 28 × 20 cm.
     </picture>
 </pictures>

--- a/fdirs/landor/portraits.xml
+++ b/fdirs/landor/portraits.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <pictures>
-  <picture src="p1.jpg" primary="true" square-src="p1-square.jpg" objid="mw03735" invnr="NPG 236" museum="npg">
+  <picture src="p1.jpg" wikidata="Q28049552" primary="true" square-src="p1-square.jpg" objid="mw03735" invnr="NPG 236" museum="npg">
       William Fisher († 1895): <i>Walter Savage Landor</i>, før 1895, olie på lærred, 89,5 × 69,9 cm.
   </picture>
 </pictures>

--- a/fdirs/lund/artwork.xml
+++ b/fdirs/lund/artwork.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <pictures>
-    <picture id="1803-andromache" year="1803" museum="smk" invnr="KMS7455">
+    <picture id="1803-andromache" wikidata="Q20355703" year="1803" museum="smk" invnr="KMS7455">
         <i>Andromache i afmagt ved synet af Hektors lig</i>, 1803/04, olie på lærred, 49,2 × 62,7 cm.
   </picture>
   <picture id="1809-oehlenschlaeger" year="1809" subject="oehlenschlaeger" museum="fnm" invnr="a-50">

--- a/fdirs/lundbye/artwork.xml
+++ b/fdirs/lundbye/artwork.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <pictures>
-  <picture id="1841-malkescene" year="1841" museum="smk" invnr="KMS431">
+  <picture id="1841-malkescene" wikidata="Q20440210" year="1841" museum="smk" invnr="KMS431">
       <i>Malkescene. Fra Christian Winther: Aftenmøde</i>, 1841, olie på lærred, 84.5 × 95 cm.
   </picture>
   <picture id="1841-selvportraet" year="1841" museum="glyptoteket">

--- a/fdirs/lyttelton/portraits.xml
+++ b/fdirs/lyttelton/portraits.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <pictures>
-  <picture src="p1.jpg" primary="true" square-src="p1-square.jpg" museum="npg" objid="mw04071" invnr="NPG 128" year="1756">
+  <picture src="p1.jpg" wikidata="Q28047664" primary="true" square-src="p1-square.jpg" museum="npg" objid="mw04071" invnr="NPG 128" year="1756">
       Ukendt kunstner: <i>George Lyttelton, 1st Baron Lyttelton</i>, ca. 1756?, olie på lærred, 749×629mm.
   </picture>
 </pictures>

--- a/fdirs/macpherson/portraits.xml
+++ b/fdirs/macpherson/portraits.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <pictures>
-  <picture src="p1.jpg" primary="true" square-src="p1-square.jpg" invnr="NPG 5804">
+  <picture src="p1.jpg" wikidata="Q28048060" primary="true" square-src="p1-square.jpg" invnr="NPG 5804">
       George Romney: <i>James Macpherson</i>, 1779-1780, olie på lærred, 75,9×63cm.
   </picture>
 </pictures>

--- a/fdirs/marstrand/artwork.xml
+++ b/fdirs/marstrand/artwork.xml
@@ -9,22 +9,22 @@
   <picture id="thiele" subject="thiele" museum="thorvaldsens" invnr="B421">
     <i>Portræt af Just Mathias Thiele</i>, ukendt år, olie på lærred, 87,3×70,5 cm.
   </picture>
-  <picture id="koebke-1839" subject="koebke" year="1839" museum="smk" invnr="KMS3615" >
+  <picture id="koebke-1839" wikidata="Q20354392" subject="koebke" year="1839" museum="smk" invnr="KMS3615" >
       <i>Maleren Christen Købke</i>, 1839, olie på lærred, 233×20cm.
   </picture>
   <picture id="christian8-1843" subject="christian8" year="1843">
     <i>Christian VIII - Det Dansk-Tyske Monarkis Konge</i>, 1843, olie på lærred. Rosenborg Slot.
   </picture>
-  <picture id="carstensen-1844" year="1844" museum="fnm" invnr="a-5694">
+  <picture id="carstensen-1844" wikidata="Q51272986" year="1844" museum="fnm" invnr="a-5694">
     <i>Portræt af Georg Carstensen</i>, 1844, olie på lærred.
   </picture>
-  <picture id="piazza-barberini-1840erne" year="1845" museum="smk" invnr="KMS3770">
+  <picture id="piazza-barberini-1840erne" wikidata="Q20404534" year="1845" museum="smk" invnr="KMS3770">
       <i>En charlatan sælger blanksværte på Piazza Barberini i Rom</i>, 1840'erne, olie på lærred, 37×47,5cm. <!-- Omkr. dateringen skriver SMK: baseret på et fagligt skøn. Formodentlig malet under kunstnerens andet Rom-ophold 1845-48. -->
   </picture>
   <picture id="heibergjohanne-1859" subject="heibergjohanne" year="1859" museum="fnm" invnr="a-251">
     <i>Portræt af Johanne Louise Heiberg</i>, 1859, olie på lærred, 196×102cm.
   </picture>
-  <picture id="hansenc-1862" subject="hansenc" year="1862" museum="smk" invnr="KMS823">
+  <picture id="hansenc-1862" wikidata="Q20276620" subject="hansenc" year="1862" museum="smk" invnr="KMS823">
       <i>Maleren Constantin Hansen</i>, 1862, olie på lærred, 158×109cm.
   </picture>
   <picture id="ewald-1864" subject="ewald" year="1864" museum="fnm" invnr="a-6615">

--- a/fdirs/michaelis/1900.xml
+++ b/fdirs/michaelis/1900.xml
@@ -1979,7 +1979,7 @@ tyst i Natten sine Spor.
     <firstline>Porten gaar op. Under klingende Spil</firstline>
     <source pages="89-90"/>
     <pictures>
-        <picture src="michaelis2017091538-p1.jpg">Rembrandt: <i>Nattevagten</i>, 1712, olie på lærred, 363×437cm. Rijksmuseum, Amsterdam.</picture>
+        <picture src="michaelis2017091538-p1.jpg" wikidata="Q219831">Rembrandt: <i>Nattevagten</i>, 1712, olie på lærred, 363×437cm. Rijksmuseum, Amsterdam.</picture>
     </pictures>
     <quality>korrektur1,kilde,side</quality>
 </head>
@@ -2028,7 +2028,7 @@ Hjerterne vaagne bag Skærf og bag Panser.
     <firstline>Tæt skal jeg Tonerne slynge</firstline>
     <source pages="91-92"/>
     <pictures>
-        <picture src="michaelis2017091540-p1.jpg">Rembrandt: <i>Saul and David</i>, ca. 1651-1654 og ca. 1655-1658, olie på lærred, 130 × 165,5 cm. Mauritshuis, Den Haag.</picture>
+        <picture src="michaelis2017091540-p1.jpg" wikidata="Q9074913">Rembrandt: <i>Saul and David</i>, ca. 1651-1654 og ca. 1655-1658, olie på lærred, 130 × 165,5 cm. Mauritshuis, Den Haag.</picture>
     </pictures>
     <quality>korrektur1,kilde,side</quality>
 </head>
@@ -2084,7 +2084,7 @@ i Øjets bundløse Sø.
     <firstline>Den sidste tunge Strid er stridt</firstline>
     <source pages="93-94"/>
     <pictures>
-        <picture src="michaelis2017091542-p1.jpg">Rembrandt: <i>The anatomy lesson of Dr. Joan Deyman</i>, ca. 1666, olie på lærred, 100 × 134 cm. Rijksmuseum, Amsterdam.</picture>
+        <picture src="michaelis2017091542-p1.jpg" wikidata="Q2252345">Rembrandt: <i>The anatomy lesson of Dr. Joan Deyman</i>, ca. 1666, olie på lærred, 100 × 134 cm. Rijksmuseum, Amsterdam.</picture>
     </pictures>
     <quality>korrektur1,kilde,side</quality>
 </head>
@@ -2140,7 +2140,7 @@ jeg læser alt, hvad du har lidt.
     <firstline>Der aander fra dit Ansigt</firstline>
     <source pages="95-96"/>
     <pictures>
-        <picture src="michaelis2017091544-p1.jpg">Rembrandt: <i>Portrait of Hendrikje Stoffels</i>, c.1654-6, oile på lærred, 101,9 × 83,7 cm. The National Gallery, London.</picture>
+        <picture src="michaelis2017091544-p1.jpg" wikidata="Q21500197">Rembrandt: <i>Portrait of Hendrikje Stoffels</i>, c.1654-6, oile på lærred, 101,9 × 83,7 cm. The National Gallery, London.</picture>
     </pictures>
     <quality>korrektur1,kilde,side</quality>
 </head>

--- a/fdirs/michaelis/1900.xml
+++ b/fdirs/michaelis/1900.xml
@@ -2140,7 +2140,7 @@ jeg læser alt, hvad du har lidt.
     <firstline>Der aander fra dit Ansigt</firstline>
     <source pages="95-96"/>
     <pictures>
-        <picture src="michaelis2017091544-p1.jpg" wikidata="Q21500197">Rembrandt: <i>Portrait of Hendrikje Stoffels</i>, c.1654-6, oile på lærred, 101,9 × 83,7 cm. The National Gallery, London.</picture>
+        <picture src="michaelis2017091544-p1.jpg" wikidata="Q21500197">Rembrandt: <i>Portrait of Hendrikje Stoffels</i>, c.1654-6, olie på lærred, 101,9 × 83,7 cm. The National Gallery, London.</picture>
     </pictures>
     <quality>korrektur1,kilde,side</quality>
 </head>

--- a/fdirs/milton/portraits.xml
+++ b/fdirs/milton/portraits.xml
@@ -6,7 +6,7 @@
   </picture>
   <picture src="p3.jpg">
   </picture>
-  <picture src="p4.jpg" primary="true" square-src="p4-square.jpg" objid="mw04437" invnr="NPG 4222" museum="npg" year="1629">
+  <picture src="p4.jpg" wikidata="Q28043565" primary="true" square-src="p4-square.jpg" objid="mw04437" invnr="NPG 4222" museum="npg" year="1629">
     Ukendt kunstner: <i>John Milton</i>, ca. 1629.
   </picture>
 </pictures>

--- a/fdirs/oehlenschlaeger/portraits.xml
+++ b/fdirs/oehlenschlaeger/portraits.xml
@@ -1,11 +1,11 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <pictures>
-  <picture src="p7.jpg" museum="fnm" invnr="a-551">
+  <picture src="p7.jpg" wikidata="Q119415814" museum="fnm" invnr="a-551">
     Peder Faxøe (1761-1840): <i>Adam Oehlenschläger som 6-årig</i>, 1785.
   </picture>
   <picture src="p6.jpg">Brdr. Riepenhausen: Portræt af Adam Oehlenschläger, 1809, [Udsnit]. Bakkehusmuseet.</picture>
   <picture artwork="lund/1809-oehlenschlaeger" primary="true" square-src="p1-square.jpg" />
-  <picture src="p8.jpg" museum="fnm" invnr="a-2620" year="1815">
+  <picture src="p8.jpg" wikidata="Q104177546" museum="fnm" invnr="a-2620" year="1815">
     F.C. Gröger: <i>Adam Oehlenschläger</i>, 1815.
   </picture>
   <picture artwork="jensenca/oehlenschlaeger-1832" />

--- a/fdirs/opie/portraits.xml
+++ b/fdirs/opie/portraits.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <pictures>
-  <picture src="p1.jpg" primary="true" square-src="p1-square.jpg" museum="npg" objid="mw04749" invnr="NPG 765" year="1798">
+  <picture src="p1.jpg" wikidata="Q28048497" primary="true" square-src="p1-square.jpg" museum="npg" objid="mw04749" invnr="NPG 765" year="1798">
       John Opie: <i>Amelia Opie</i>, 1798, olie på lærred, 743 × 622 mm.
   </picture>
 </pictures>

--- a/fdirs/prior/portraits.xml
+++ b/fdirs/prior/portraits.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <pictures>
-  <picture src="p1.jpg" primary="true" square-src="p1-square.jpg" objid="mw05152" invnr="NPG 562" museum="npg" year="1779">
+  <picture src="p1.jpg" wikidata="Q28045116" primary="true" square-src="p1-square.jpg" objid="mw05152" invnr="NPG 562" museum="npg" year="1779">
       Thomas Hudson: <i>Matthew Prior</i>, 1779 (efter et værk fra 1718 af Jonathan Richardson), olie på lærred, 1022×872mm.
   </picture>
 </pictures>

--- a/fdirs/rimestad/1908.xml
+++ b/fdirs/rimestad/1908.xml
@@ -976,7 +976,7 @@ En Hjemvé mod svundne Lyster har fyldt hendes Blik!
     <subtitle>Til Otto Rung</subtitle>
     <firstline>Det Smil blev til i en Mesters Drøm</firstline>
     <pictures>
-        <picture src="rimestad2019030614-p1.jpg">Leonardo da Vinci: <i>Johannes Døberen</i>, 1513-1516, olie på træ, 69 × 57 cm. Louvre.</picture>
+        <picture src="rimestad2019030614-p1.jpg" wikidata="Q783215">Leonardo da Vinci: <i>Johannes Døberen</i>, 1513-1516, olie på træ, 69 × 57 cm. Louvre.</picture>
     </pictures>
     <notes>
         <note>Otto Rung (1874-1945), jurist, embedsmands, forfatter og især kendt som produktiv manuskriptforfatter.</note>

--- a/fdirs/shakespeare/portraits.xml
+++ b/fdirs/shakespeare/portraits.xml
@@ -6,7 +6,7 @@
   <picture src="p2.jpg">
     Gerard Soest: <i>William Shakespeare</i>, ca. 1650-60.
   </picture>
-  <picture src="p3.jpg" primary="true" square-src="p3-square.jpg" objid="mw11574" invnr="NPG1" museum="npg" year="1600">
+  <picture src="p3.jpg" wikidata="Q1061759" primary="true" square-src="p3-square.jpg" objid="mw11574" invnr="NPG1" museum="npg" year="1600">
 John Tayler (formodentligt): <i>William Shakespeare</i>, ca. 1600-10.
 
 Maleriet er kendt som <i>The Chandos Portrait</i>.

--- a/fdirs/shelley/portraits.xml
+++ b/fdirs/shelley/portraits.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <pictures>
-  <picture src="p1.jpg" primary="true" square-src="p1-square.jpg" objid="mw05764" invnr="NPG 1271" museum="npg" year="1829">
+  <picture src="p1.jpg" wikidata="Q28048817" primary="true" square-src="p1-square.jpg" objid="mw05764" invnr="NPG 1271" museum="npg" year="1829">
     Alfred Clint: <i>Percy Bysshe Shelley</i>, 1829, baseret på et værk fra 1819.
   </picture>
 </pictures>

--- a/fdirs/sidney/portraits.xml
+++ b/fdirs/sidney/portraits.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <pictures>
-  <picture src="p1.jpg" primary="true" square-src="p1-square.jpg" objid="mw07877" invnr="NPG 5732" museum="npg" year="1576">
+  <picture src="p1.jpg" wikidata="Q28042661" primary="true" square-src="p1-square.jpg" objid="mw07877" invnr="NPG 5732" museum="npg" year="1576">
       Ukendt kunstner: <i>Sir Philip Sidney</i>, ca. 1576, olie på panel, 114×84cm.
   </picture>
 </pictures>

--- a/fdirs/southey/portraits.xml
+++ b/fdirs/southey/portraits.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <pictures>
-  <picture src="p1.jpg" primary="true" square-src="p1-square.jpg" objid="mw05925" invnr="NPG 193" museum="npg" year="1785">
+  <picture src="p1.jpg" wikidata="Q28048469" primary="true" square-src="p1-square.jpg" objid="mw05925" invnr="NPG 193" museum="npg" year="1785">
       Peter Vandyke: <i>Robert Southey</i>, 1785, olie på lærred, 546 mm x 445 mm.
   </picture>
 </pictures>

--- a/fdirs/staffeldt/andre.xml
+++ b/fdirs/staffeldt/andre.xml
@@ -51,7 +51,7 @@ Gierne jeg for Kiephest og for Dukke
       <note>Trykt i Poulsens <i>Nytaarsgave</i> for 1802.</note>
    </notes>
    <pictures>
-      <picture src="staffeldt1999030406.jpg">Vecellio Tiziano (1490-1576): »Venere di Urbino« (1538), oliemaleri, 119 × 165 cm, Galleria degli Uffizi, Firenze.</picture>
+      <picture src="staffeldt1999030406.jpg" wikidata="Q727875">Vecellio Tiziano (1490-1576): »Venere di Urbino« (1538), oliemaleri, 119 × 165 cm, Galleria degli Uffizi, Firenze.</picture>
    </pictures>
    <quality>korrektur1</quality>
    <keywords>sonnet</keywords>

--- a/fdirs/swain/portraits.xml
+++ b/fdirs/swain/portraits.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <pictures>
-  <picture src="p1.jpg" primary="true" square-src="p1-square.jpg" objid="mw06167" invnr="NPG 4014" museum="npg" year="1833">
+  <picture src="p1.jpg" wikidata="Q28049199" primary="true" square-src="p1-square.jpg" objid="mw06167" invnr="NPG 4014" museum="npg" year="1833">
       William Bradley: <i>Charles Swain</i>, ca. 1833, olie på panel, 329mm x 244mm.
   </picture>
 </pictures>

--- a/fdirs/swift/portraits.xml
+++ b/fdirs/swift/portraits.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <pictures>
-  <picture src="p1.jpg" primary="true" square-src="p1-square.jpg" invnr="NPG 4407" museum="npg" year="1709">
+  <picture src="p1.jpg" wikidata="Q28044968" primary="true" square-src="p1-square.jpg" invnr="NPG 4407" museum="npg" year="1709">
       Charles Jervas (studio): <i>Jonathan Swift</i>, baseret på et værk fra 1709-1710, olie på lærred, 76,2×63,5cm.
   </picture>
   <picture src="p2.jpg">

--- a/fdirs/thorvaldsen/artwork.xml
+++ b/fdirs/thorvaldsen/artwork.xml
@@ -3,7 +3,7 @@
   <picture id="thaarup-oval" subject="thaarup" year="1790 ca.">
       <i>Thomas Thaarup</i>, blyant og vandfarve, 1790'erne, 10,6×8,9 cm. Teatermuseet i Hofteatret.<!-- https://arkivet.thorvaldsensmuseum.dk/personer/thaarup-thomas -->
   </picture>
-  <picture id="1803-jason" year="1803" museum="thorvaldsens" invnr="A822" >
+  <picture id="1803-jason" wikidata="Q4563532" year="1803" museum="thorvaldsens" invnr="A822" >
       <i>Jason med det gyldne skind</i>, 1803, marmor, 242cm.
   </picture>
   <picture id="1805-tiedge" subject="tiedge" year="1805" museum="thorvaldsens" invnr="A851" >
@@ -33,7 +33,7 @@
   <picture id="1812-alexander-triumfvognen" year="1812" museum="thorvaldsens" invnr="A713" >
       <i>Alexander den Store på triumfvognen</i>, efter 1812, gips, 115×105cm.
   </picture>
-  <picture id="1815-natten" year="1815" museum="thorvaldsens" invnr="A901" >
+  <picture id="1815-natten" wikidata="Q21570161" year="1815" museum="thorvaldsens" invnr="A901" >
       <i>Natten</i>, 1815, marmor, ⌀ 80,5 cm.
   </picture>
   <picture id="1815-dagen" year="1815" museum="thorvaldsens" invnr="A902" >

--- a/fdirs/tode/portraits.xml
+++ b/fdirs/tode/portraits.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <pictures>
-  <picture src="p1.jpg" primary="true" square-src="p1-square.jpg" museum="fnm" invnr="a-6176">
+  <picture src="p1.jpg" wikidata="Q51225498" primary="true" square-src="p1-square.jpg" museum="fnm" invnr="a-6176">
     Jens Juels værksted: <i>Johan Clemens Tode</i>, omkr. 1700. Frederiksborg.
   </picture>
   <picture src="p2.jpg">

--- a/fdirs/waller/portraits.xml
+++ b/fdirs/waller/portraits.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <pictures>
-  <picture src="p1.jpg" primary="true" square-src="p1-square.jpg" objid="mw06555" invnr="NPG 144" museum="npg" year="1691">
+  <picture src="p1.jpg" wikidata="Q28044730" primary="true" square-src="p1-square.jpg" objid="mw06555" invnr="NPG 144" museum="npg" year="1691">
       John Riley: <i>Edmund Waller</i>, før 1691, olie på lærred, 521×406mm.
   </picture>
 </pictures>

--- a/fdirs/white/portraits.xml
+++ b/fdirs/white/portraits.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <pictures>
-  <picture src="p1.jpg" primary="true" square-src="p1-square.jpg" objid="mw06749" invnr="NPG 3248" museum="npg" year="1805">
+  <picture src="p1.jpg" wikidata="Q28048636" primary="true" square-src="p1-square.jpg" objid="mw06749" invnr="NPG 3248" museum="npg" year="1805">
     Sylvanus Redgate (efter Thomas Barber): <i>Henry Kirke White</i>, baseret på værk fra ca. 1805, olie på træ, 241 mm x 178 mm.
   </picture>
 </pictures>

--- a/fdirs/wordsworth/portraits.xml
+++ b/fdirs/wordsworth/portraits.xml
@@ -10,7 +10,7 @@
   <picture src="p4.jpg" year="1831">
     <i>William Wordsworth</i>, stik fra 1831 af et portræt af Benjamin Robert Haydon.
   </picture>
-  <picture src="p5.jpg" primary="true" square-src="p5-square.jpg" objid="mw06936" invnr="NPG 1857" museum="npg" year="1842">
+  <picture src="p5.jpg" wikidata="Q28049687" primary="true" square-src="p5-square.jpg" objid="mw06936" invnr="NPG 1857" museum="npg" year="1842">
     Benjamin Robert Haydon: <i>William Wordsworth</i>, 1842.
   </picture>
 </pictures>


### PR DESCRIPTION
## Resumé

- tilføjer `wikidata`-attributter til 107 kunstværker og portrætter
- matcher hovedparten på Wikidata `P217` ud fra eksisterende inventarnumre
- supplerer med sikre titel-/kunstnermatches for kendte værker som Leonardo da Vincis `Mona Lisa`, `Johannes Døberen` og `Den sidste nadver`
- springer flertydige eller manglende matches over

Refs #1224

## Validering

- `git diff --check`
- XML-parse af de senest ændrede XML-filer med `@xmldom/xmldom`
- tidligere XML-parse af 527 relevante `artwork.xml`- og `portraits.xml`-filer med `@xmldom/xmldom`