### PR TITLE
Tilføj flere museer og museumshenvisninger

### DIFF
--- a/data/artwork.xml
+++ b/data/artwork.xml
@@ -3,8 +3,8 @@
     <picture id="cranach-luther" subject="luther">
         Lucas Cranach der Ältere (ca. 1472-1553): <i>Martin Luther</i>, ukendt år.
     </picture>
-    <picture id="rafael-leone-x-1518" wikidata="Q2610729" year="1518 ca.">
-        Rafael: <i>Papa Leone X con i cugini, i cardinali Giulio de' Medici e Luigi de' Rossi.</i>, mellem 1518 og 1519, olie på panel. Uffizierne, Firenze.
+    <picture id="rafael-leone-x-1518" wikidata="Q2610729" year="1518 ca." museum="uffizi" invnr="40">
+        Rafael: <i>Papa Leone X con i cugini, i cardinali Giulio de' Medici e Luigi de' Rossi.</i>, mellem 1518 og 1519, olie på panel.
     </picture>
     <picture id="loeffler-anna-nielsen-1836" wikidata="Q20415264" year="1836" museum="smk" invnr="KMS8660">Carl Løffler: <i>Skuespilleren Anna Nielsen</i>, ca. 1836, olie på lærred, 23,3 × 20,7 cm.</picture>
     <picture id="tizian-amor-sacro-e-amor-profano-1515" wikidata="Q794077">Tizian: <i>L'Amor sacro e Amor profano</i>, ca. 1515, olie på træ, 118×279 cm. Galleria Borghese, Rom.</picture> <!-- https://en.wikipedia.org/wiki/Sacred_and_Profane_Love -->

--- a/data/museums.xml
+++ b/data/museums.xml
@@ -3,63 +3,115 @@
   <museum id="hirschsprungske">
     <name>Den Hirschsprungske Samling</name>
     <sort-name>Hirschsprungske Samling, Den</sort-name>
+    <link>https://hirschsprung.dk/</link>
   </museum>
   <museum id="skagen">
     <name>Skagens Museum</name>
+    <link>https://skagensmuseum.dk/</link>
   </museum>
   <museum id="thorvaldsens">
     <name>Thorvaldsens Museum</name>
+    <link>https://www.thorvaldsensmuseum.dk/</link>
     <deep-link>http://thorvaldsensmuseum.dk/samlingerne/vaerk/${invNr}</deep-link>
   </museum>
   <museum id="nivaagaard">
     <name>Nivaagaards Malerisamling</name>
+    <link>https://nivaagaard.dk/</link>
     <deep-link>http://www.nivaagaard.dk/samling-da/${objId}</deep-link>
   </museum>
   <museum id="kb">
     <name>Det kongelige Bibliotek</name>
     <sort-name>Kongelige Bibliotek</sort-name>
+    <link>https://www.kb.dk/</link>
     <deep-link>https://digitalesamlinger.kb.dk/images/billed/2010/okt/billeder/object${objId}/da/</deep-link>
   </museum>
   <museum id="smk">
     <name>Statens Museum for Kunst</name>
+    <link>https://www.smk.dk/</link>
     <deep-link>http://collection.smk.dk/#/detail/${invNr}</deep-link>
   </museum>
   <museum id="gleimhaus">
     <name>Gleimhaus, Halberstadt</name>
+    <link>https://www.gleimhaus.de/</link>
     <deep-link>https://www.museum-digital.de/nat/index.php?t=objekt&amp;oges=${objId}</deep-link>
   </museum>
   <museum id="ribe">
     <name>Ribe Kunstmuseum</name>
+    <link>https://www.ribekunstmuseum.dk/</link>
     <deep-link>https://ribekunstmuseum.dk/samling/${invNr}</deep-link>
   </museum>
   <museum id="smb">
     <name>Staatliche Museen zu Berlin</name>
+    <link>https://www.smb.museum/home/</link>
     <deep-link>http://www.smb-digital.de/eMuseumPlus?objectId=${objId}</deep-link>
   </museum>
   <museum id="md">
+    <link>https://www.museum-digital.de/</link>
     <deep-link>https://www.museum-digital.de/nat/index.php?t=objekt&amp;oges=${objId}</deep-link>
   </museum>
   <museum id="npg">
     <name>National Portrait Gallery, London</name>
+    <link>https://www.npg.org.uk/</link>
     <deep-link>https://www.npg.org.uk/collections/search/portrait/${objId}</deep-link>
   </museum>
   <museum id="natmus.se">
     <name>Nationalmuseum, Stockholm</name>
+    <link>https://www.nationalmuseum.se/</link>
     <deep-link>http://collection.nationalmuseum.se/eMP/eMuseumPlus?service=ExternalInterface&amp;module=collection&amp;objectId=${objId}&amp;viewType=detailView</deep-link>
   </museum>
   <museum id="digitalmuseum.no">
+    <link>https://digitaltmuseum.no/</link>
     <deep-link>https://digitaltmuseum.no/${objId}/maleri</deep-link>
   </museum>
   <museum id="digitalmuseum.se">
+    <link>https://digitaltmuseum.se/</link>
     <deep-link>https://digitaltmuseum.se/${objId}/maleri</deep-link>
   </museum>
   <museum id="fnm">
     <name>Frederiksborg Nationalhistorisk Museum</name>
+    <link>https://frederiksborg.dk/</link>
     <!-- invNr må være 'a-841' -->
     <deep-link>https://dnm.dk/kunstvaerk/${invNr}/</deep-link>
   </museum>
   <museum id="glyptoteket">
     <name>Ny Carlsberg Glyptotek</name>
+    <link>https://glyptoteket.dk/</link>
   </museum>
-  <!-- TODO: Alte Nationalgallerie, Berlin -->
+  <museum id="louvre">
+    <name>Musée du Louvre</name>
+    <link>https://www.louvre.fr/</link>
+    <deep-link>https://collections.louvre.fr/ark:/53355/${objId}</deep-link>
+  </museum>
+  <museum id="rijksmuseum">
+    <name>Rijksmuseum</name>
+    <link>https://www.rijksmuseum.nl/nl</link>
+    <deep-link>https://www.rijksmuseum.nl/nl/collectie/object/${objId}</deep-link>
+  </museum>
+  <museum id="mauritshuis">
+    <name>Mauritshuis</name>
+    <link>https://www.mauritshuis.nl/</link>
+    <deep-link>https://www.mauritshuis.nl/nl-nl/verdiep/de-collectie/kunstwerken/${objId}/</deep-link>
+  </museum>
+  <museum id="nationalgallery">
+    <name>The National Gallery, London</name>
+    <sort-name>National Gallery, London</sort-name>
+    <link>https://www.nationalgallery.org.uk/</link>
+    <deep-link>https://www.nationalgallery.org.uk/paintings/${invNr}</deep-link>
+  </museum>
+  <museum id="uffizi">
+    <name>Galleria degli Uffizi</name>
+    <link>https://www.uffizi.it/</link>
+    <deep-link>https://fotoinventari.uffizi.it/it/ricerca-opere?isPostBack=1&amp;numero_opera=${invNr}</deep-link>
+  </museum>
+  <museum id="tate">
+    <name>Tate</name>
+    <link>https://www.tate.org.uk/</link>
+    <deep-link>https://www.tate.org.uk/art/artworks/${invNr}</deep-link>
+  </museum>
+  <museum id="wallace">
+    <name>The Wallace Collection</name>
+    <sort-name>Wallace Collection, The</sort-name>
+    <link>https://www.wallacecollection.org/</link>
+    <deep-link>https://wallacelive.wallacecollection.org/eMP/eMuseumPlus?service=ExternalInterface&amp;module=collection&amp;objectId=${objId}</deep-link>
+  </museum>
 </museums>

--- a/fdirs/ahlmann/1907.xml
+++ b/fdirs/ahlmann/1907.xml
@@ -946,7 +946,7 @@ Hellere glemt — end en bitter Dag
     <firstline>Dit Smil er som en Sejersfærd</firstline>
     <source pages="51"/>
     <pictures>
-        <picture src="ahlmann2022051823-p1.jpg" wikidata="Q12418">Leonardo da Vinci: <i>Ritratto di Monna Lisa del Giocondo</i>, 1503-06, olie på panel, 77 × 53 cm. Louvre.</picture>
+        <picture src="ahlmann2022051823-p1.jpg" wikidata="Q12418" museum="louvre" objid="cl010062370" invnr="INV 779">Leonardo da Vinci: <i>Ritratto di Monna Lisa del Giocondo</i>, 1503-06, olie på panel, 77 × 53 cm.</picture>
     </pictures>
     <quality>korrektur1,kilde,side</quality>
 </head>

--- a/fdirs/blake/artwork.xml
+++ b/fdirs/blake/artwork.xml
@@ -5,30 +5,30 @@
       <!-- http://www.blakearchive.org/copy/but812.1?descId=but812.1.wc.01 -->
       <!-- Canto I  -->
   </picture>
-  <picture id="1824-penetrating-the-forrest" year="1824-01-02">
-      <i>Dante and Virgil Penetrating the Forest</i>, 1824-27, blyant, blæk og vandfarve på papir, 371×527 mm. Tate Gallery, London.
+  <picture id="1824-penetrating-the-forrest" year="1824-01-02" museum="tate" invnr="N03351">
+      <i>Dante and Virgil Penetrating the Forest</i>, 1824-27, blyant, blæk og vandfarve på papir, 371×527 mm.
       <!-- http://www.blakearchive.org/copy/but812.1?descId=but812.1.wc.03 -->
       <!-- Canto II 139-141 -->
   </picture>
-  <picture id="1824-inscription" year="1824-1-03">
-      <i>The Inscription over the Gate</i>, 1824-27, blyant, blæk og vandfarve på papir, 527 × 374 mm. Tate Gallery, London.
+  <picture id="1824-inscription" year="1824-1-03" museum="tate" invnr="N03352">
+      <i>The Inscription over the Gate</i>, 1824-27, blyant, blæk og vandfarve på papir, 527 × 374 mm.
   </picture>
   <picture id="1824-francesca-da-rimini" year="1824-1-05">
       <i>The Circle of the Lustful: Francesca da Rimini (‘The Whirlwind of Lovers’)</i>, 1824-27, blyant, blæk og vandfarve på papir, 243 × 335 mm. Tate Gallery, London.
   </picture>
-  <picture id="1824-cerberus" year="1824-1-06">
-      <i>Cerberus</i>, 1824-27, blyant, blæk og vandfarve på papir, 372 × 528 mm. Tate Gallery, London.
+  <picture id="1824-cerberus" year="1824-1-06" museum="tate" invnr="N03354">
+      <i>Cerberus</i>, 1824-27, blyant, blæk og vandfarve på papir, 372 × 528 mm.
   </picture>
-  <picture id="1824-wood-of-the-self-murderers" year="1824-1-12">
-      <i>The Wood of the Self-Murderers: The Harpies and the Suicides</i>, 1824-27, blyant, blæk og vandfarve på papir, 372×527 mm. Tate Gallery, London.
+  <picture id="1824-wood-of-the-self-murderers" wikidata="Q7775719" year="1824-1-12" museum="tate" invnr="N03356">
+      <i>The Wood of the Self-Murderers: The Harpies and the Suicides</i>, 1824-27, blyant, blæk og vandfarve på papir, 372×527 mm.
       <!-- https://en.wikipedia.org/wiki/The_Wood_of_the_Self-Murderers:_The_Harpies_and_the_Suicides -->
       <!-- Illustration til Dantes Inferno, Cirkel VII, Ring II, Canto XIII. -->
   </picture>
-  <picture id="1824-simoniac-pope" year="1824-1-19">
-      <i>The Simoniac Pope</i>, 1824-27, blyant, blæk og vandfarve på papir, 527 × 368 mm. Tate Gallery, London.
+  <picture id="1824-simoniac-pope" year="1824-1-19" museum="tate" invnr="N03357">
+      <i>The Simoniac Pope</i>, 1824-27, blyant, blæk og vandfarve på papir, 527 × 368 mm.
   </picture>
-  <picture id="1824-beatrice-adressing-dante" year="1824-2-29">
-      <i>Beatrice Addressing Dante from the Car</i>, 1824-27, blyant, blæk og vandfarve på papir, 372×527 mm. Tate Gallery, London.
+  <picture id="1824-beatrice-adressing-dante" wikidata="Q3637289" year="1824-2-29" museum="tate" invnr="N03369">
+      <i>Beatrice Addressing Dante from the Car</i>, 1824-27, blyant, blæk og vandfarve på papir, 372×527 mm.
   </picture>
   <picture id="1824-deity-from" year="1824-3-28">
       <i>The Deity, from whom proceed the Nine Spheres</i>, 1824-27, blyant, blæk og vandfarve på papir. Ashmolean Museum, University of Oxford.

--- a/fdirs/browningr/andre.xml
+++ b/fdirs/browningr/andre.xml
@@ -16,7 +16,7 @@
       <note>Det store indtastningsarbejde er foretaget af Brian Bentsen efter Robert Browning, <i>The Poems</i>, eds. John Pettigrew &amp; Thomas J. Collins, 2 vols., Yale University Press 1981, vol. 2, s. 958.</note>
    </notes>
    <pictures>
-       <picture src="browning2002012901-p1.jpg">Peter Paul Rubens (1577 - 1640): <i>The Judgement of Paris</i>, ca. 1597-1599, olie på lærred, 144,8×193,7cm. The National Gallery, London. <!-- NG-6379 --></picture>
+       <picture src="browning2002012901-p1.jpg" wikidata="Q17519113" museum="nationalgallery" invnr="NG6379">Peter Paul Rubens (1577 - 1640): <i>The Judgement of Paris</i>, ca. 1597-1599, olie på lærred, 144,8×193,7cm.</picture>
    </pictures>
    <quality>korrektur1,kilde,side</quality>
 </head>

--- a/fdirs/michaelis/1900.xml
+++ b/fdirs/michaelis/1900.xml
@@ -1979,7 +1979,7 @@ tyst i Natten sine Spor.
     <firstline>Porten gaar op. Under klingende Spil</firstline>
     <source pages="89-90"/>
     <pictures>
-        <picture src="michaelis2017091538-p1.jpg" wikidata="Q219831">Rembrandt: <i>Nattevagten</i>, 1712, olie på lærred, 363×437cm. Rijksmuseum, Amsterdam.</picture>
+        <picture src="michaelis2017091538-p1.jpg" wikidata="Q219831" museum="rijksmuseum" objid="De-Nachtwacht--3137deb45cd7765f9a76084a16c99544" invnr="SK-C-5">Rembrandt: <i>Nattevagten</i>, 1712, olie på lærred, 363×437cm.</picture>
     </pictures>
     <quality>korrektur1,kilde,side</quality>
 </head>
@@ -2028,7 +2028,7 @@ Hjerterne vaagne bag Skærf og bag Panser.
     <firstline>Tæt skal jeg Tonerne slynge</firstline>
     <source pages="91-92"/>
     <pictures>
-        <picture src="michaelis2017091540-p1.jpg" wikidata="Q9074913">Rembrandt: <i>Saul and David</i>, ca. 1651-1654 og ca. 1655-1658, olie på lærred, 130 × 165,5 cm. Mauritshuis, Den Haag.</picture>
+        <picture src="michaelis2017091540-p1.jpg" wikidata="Q9074913" museum="mauritshuis" objid="saul-en-david-621" invnr="621">Rembrandt: <i>Saul and David</i>, ca. 1651-1654 og ca. 1655-1658, olie på lærred, 130 × 165,5 cm.</picture>
     </pictures>
     <quality>korrektur1,kilde,side</quality>
 </head>
@@ -2140,7 +2140,7 @@ jeg læser alt, hvad du har lidt.
     <firstline>Der aander fra dit Ansigt</firstline>
     <source pages="95-96"/>
     <pictures>
-        <picture src="michaelis2017091544-p1.jpg" wikidata="Q21500197">Rembrandt: <i>Portrait of Hendrikje Stoffels</i>, c.1654-6, olie på lærred, 101,9 × 83,7 cm. The National Gallery, London.</picture>
+        <picture src="michaelis2017091544-p1.jpg" wikidata="Q21500197" museum="nationalgallery" invnr="NG6432">Rembrandt: <i>Portrait of Hendrikje Stoffels</i>, c.1654-6, olie på lærred, 101,9 × 83,7 cm.</picture>
     </pictures>
     <quality>korrektur1,kilde,side</quality>
 </head>

--- a/fdirs/rimestad/1908.xml
+++ b/fdirs/rimestad/1908.xml
@@ -976,7 +976,7 @@ En Hjemvé mod svundne Lyster har fyldt hendes Blik!
     <subtitle>Til Otto Rung</subtitle>
     <firstline>Det Smil blev til i en Mesters Drøm</firstline>
     <pictures>
-        <picture src="rimestad2019030614-p1.jpg" wikidata="Q783215">Leonardo da Vinci: <i>Johannes Døberen</i>, 1513-1516, olie på træ, 69 × 57 cm. Louvre.</picture>
+        <picture src="rimestad2019030614-p1.jpg" wikidata="Q783215" museum="louvre" objid="cl010062371" invnr="INV 775">Leonardo da Vinci: <i>Johannes Døberen</i>, 1513-1516, olie på træ, 69 × 57 cm.</picture>
     </pictures>
     <notes>
         <note>Otto Rung (1874-1945), jurist, embedsmands, forfatter og især kendt som produktiv manuskriptforfatter.</note>

--- a/fdirs/staffeldt/andre.xml
+++ b/fdirs/staffeldt/andre.xml
@@ -51,7 +51,7 @@ Gierne jeg for Kiephest og for Dukke
       <note>Trykt i Poulsens <i>Nytaarsgave</i> for 1802.</note>
    </notes>
    <pictures>
-      <picture src="staffeldt1999030406.jpg" wikidata="Q727875">Vecellio Tiziano (1490-1576): »Venere di Urbino« (1538), oliemaleri, 119 × 165 cm, Galleria degli Uffizi, Firenze.</picture>
+      <picture src="staffeldt1999030406.jpg" wikidata="Q727875" museum="uffizi" invnr="1437">Vecellio Tiziano (1490-1576): »Venere di Urbino« (1538), oliemaleri, 119 × 165 cm.</picture>
    </pictures>
    <quality>korrektur1</quality>
    <keywords>sonnet</keywords>

--- a/fdirs/tennyson/1842.xml
+++ b/fdirs/tennyson/1842.xml
@@ -15,7 +15,7 @@
    <firstline>On either side the river lie</firstline>
    <pictures>
       <picture src="tennyson1999041201-p1.jpg">John William Waterhouse (<year>1849</year>-<year>1917</year>): »The Lady of Shalott (looking at Lancelot)« (<year>1894</year>), oliemaleri, 142 × 86 cm, City Art Gallery, Leeds.</picture>
-      <picture src="tennyson1999041201-p2.jpg">John William Waterhouse (<year>1849</year>-<year>1917</year>): »The Lady of Shalott (on boat)« (<year>1888</year>), oliemaleri, 153 × 200 cm, The Tate Gallery, London.</picture>
+      <picture src="tennyson1999041201-p2.jpg" wikidata="Q2445726" museum="tate" invnr="N01543">John William Waterhouse (<year>1849</year>-<year>1917</year>): »The Lady of Shalott (on boat)« (<year>1888</year>), oliemaleri, 153 × 200 cm.</picture>
       <picture src="tennyson1999041201-p3.jpg">John William Waterhouse (<year>1849</year>-<year>1917</year>): »"I am half sick of shadows," said the Lady of Shalott« (<year>1916</year>), oliemaleri, 100 × 74 cm, Art Gallery of Ontario, Toronto.</picture>
    </pictures>
    <quality>korrektur1</quality>

--- a/fdirs/thomson/1730s.xml
+++ b/fdirs/thomson/1730s.xml
@@ -1214,7 +1214,7 @@ To scenes where love and bliss immortal reign.
         <note>The subject proposed. Invocation. Address to Mr. Dodington. An introductory reflection on the motion of the heavenly bodies; whence the succession of the Seasons. As the face of nature in this season is almost uniform, the progress of the poem is a description of a Summer's day. The dawn. Sun-rising. Hymn to the sun. Forenoon. Summer insects described. Hay-making. Sheep-shearing. Noonday. A woodland retreat. Group of herds and flocks. A solemn grove: how it affects a contemplative mind. A cataract, and rude scene. View of Summer in the torrid zone. Storm of thunder and lightning. A tale. The storm over. A serene afternoon. Bathing. Hour of walking. Transition to the prospect of a rich, well-cultivated country; which introduces a panegyric on Great Britain. Sunset. Evening. Night. Summer meteors. A comet. The whole concluding with the praise of philosophy.</note>
     </notes>
    <pictures>
-       <picture src="thomson2017122902-p1.jpg">William Etty: <i>Musidora: The Bather - 'At The Doubtful Breeze Alarmed'</i>, 1846, olie på lærred, 65,1×50,2 cm. Tate Britain, London.</picture>
+       <picture src="thomson2017122902-p1.jpg" wikidata="Q21013226" museum="tate" invnr="N00614">William Etty: <i>Musidora: The Bather - 'At The Doubtful Breeze Alarmed'</i>, 1846, olie på lærred, 65,1×50,2 cm.</picture>
    </pictures>
     <quality>korrektur1</quality>
 </head>


### PR DESCRIPTION
## Ændringer

- Tilføjer nye museums-id’er i data/museums.xml: louvre, rijksmuseum, mauritshuis, nationalgallery, uffizi, tate og wallace.
- Tilføjer officielle museumsforsider som link på alle museumsdefinitioner.
- Fjerner TODO’en om Alte Nationalgallerie, da relevante poster bruger smb.
- Tilføjer strukturerede museum-, invnr-/objid- og wikidata-id’er på nyligt matchede værker.
- Holder ændringen til datafiler; ingen websitevisning af museumshjemmesider i denne PR.

## Validering

- git diff --check
- xmllint --noout på ændrede XML-filer
- npm test -- --runInBand __tests__/kalliopework-relaxng.test.js __tests__/info-xml-relaxng.test.js

Refs #1231