### PR TITLE
Tilføj flere Wikidata-id'er til billeder

### DIFF
--- a/docs/style-guide.md
+++ b/docs/style-guide.md
@@ -12,6 +12,12 @@ Denne guide samler projektets faste konventioner, især dem der er nemme at glem
 
 - Portrætter og kunstgrafik ligger i `public/images/<id>/`.
 - Der må ikke ligge `.jpg`, `.jpeg`, `.png`, `.gif` eller `.webp` under `fdirs/`.
+- Når billedmetadata som `wikidata`, `museum`, `objid` og `invnr` opdateres, skal alle
+  kilder med `<picture>` gennemgås: `data/artwork.xml`, `fdirs/<id>/artwork.xml`,
+  `data/events.xml`, `fdirs/<id>/events.xml`, værkernes XML-filer, `data/keywords/*.xml`,
+  `data/about/*.xml` og `fdirs/<id>/portraits.xml`.
+- Husk at `<picture artwork="...">` og `<picture portrait="...">` er referencer; metadata
+  bør normalt ligge på det refererede billede i `artwork.xml` eller `portraits.xml`.
 - `fdirs/<id>/portraits.xml` refererer lokale filer med filnavn, fx `src="p1.jpg"` og `square-src="p1-square.jpg"`.
 - Den faktiske fil for `fdirs/<id>/portraits.xml` skal derfor være `public/images/<id>/p1.jpg`.
 - Square portraits er normalt manuelt beskårne kvadratiske billeder og skal også ligge i `public/images/<id>/`.

--- a/fdirs/blake/artwork.xml
+++ b/fdirs/blake/artwork.xml
@@ -24,7 +24,7 @@
       <!-- https://en.wikipedia.org/wiki/The_Wood_of_the_Self-Murderers:_The_Harpies_and_the_Suicides -->
       <!-- Illustration til Dantes Inferno, Cirkel VII, Ring II, Canto XIII. -->
   </picture>
-  <picture id="1824-simoniac-pope" year="1824-1-19" museum="tate" invnr="N03357">
+  <picture id="1824-simoniac-pope" wikidata="Q23693055" year="1824-1-19" museum="tate" invnr="N03357">
       <i>The Simoniac Pope</i>, 1824-27, blyant, blæk og vandfarve på papir, 527 × 368 mm.
   </picture>
   <picture id="1824-beatrice-adressing-dante" wikidata="Q3637289" year="1824-2-29" museum="tate" invnr="N03369">

--- a/fdirs/hansenc/artwork.xml
+++ b/fdirs/hansenc/artwork.xml
@@ -24,7 +24,7 @@
     <picture id="rodeg-1" subject="rodeg" museum="fnm" invnr="a-6663">
         <i>Gotfred Rode</i>, olie på lærred, ukendt år.
     </picture>
-    <picture id="den-grundlovgivende-rigsforsamling-1861" year="1861-1865" museum="fnm" invnr="a-15">
+    <picture id="den-grundlovgivende-rigsforsamling-1861" wikidata="Q3202466" year="1861-1865" museum="fnm" invnr="a-15">
         <i>Den Grundlovgivende Rigsforsamling</i>, 1861-65, 338×500cm.
     </picture>
     <picture id="ploug-1863" year="1863" subject="plough">

--- a/fdirs/ingemann/1832.xml
+++ b/fdirs/ingemann/1832.xml
@@ -2643,7 +2643,7 @@ Regner det atter idag? fort da mod Solskin og Vaar!
    <source pages="112"/>
    <pictures>
        <picture src="ingemann2017100436-p2.jpg">H.C. Andersen: <i>Landeveien over de Pontinske Sumpe; man seer Circes Ø; nu Circello</i>, tegning, 22. marts 1834. Odense Bys Museer. <!-- http://www.hcandersen-homepage.dk/?page_id=59773 --></picture>
-       <picture src="ingemann2017100436-p1.jpg" objid="958670" museum="smb">August Kopisch (1799-1853): <i>Die Pontinischen Sümpfe bei Sonnenuntergang</i>, 1848, olie på lærred, 62 × 111 cm. Alte Nationalgalerie, Berlin. <!-- Berlin, Staatliche Museen zu Berlin - Preußischer Kulturbesitz, Nationalgalerie, Inventar-Nr. W.S. 118, Zugang: Zusammenführung, 1991 --></picture>
+       <picture src="ingemann2017100436-p1.jpg" wikidata="Q50119302" objid="958670" museum="smb">August Kopisch (1799-1853): <i>Die Pontinischen Sümpfe bei Sonnenuntergang</i>, 1848, olie på lærred, 62 × 111 cm. Alte Nationalgalerie, Berlin. <!-- Berlin, Staatliche Museen zu Berlin - Preußischer Kulturbesitz, Nationalgalerie, Inventar-Nr. W.S. 118, Zugang: Zusammenführung, 1991 --></picture>
    </pictures>
    <quality>korrektur1,kilde,side</quality>
 </head>

--- a/fdirs/oehlenschlaeger/1860-21.xml
+++ b/fdirs/oehlenschlaeger/1860-21.xml
@@ -5551,7 +5551,7 @@ Den nok forbedrer sig med Tiden.
     <subtitle>Den 27de Januar 1829.</subtitle>
     <firstline>See Graveren i aarle Stund</firstline>
     <pictures>
-        <picture src="oehlenschlaeger2019021677-p1.jpg" year="1894" museum="smk" invnr="KMS1500">Carl Thomsen: <i>Rahbek ved sin hustrus dødsleje</i>, 1894, olie på lærred, 65.5 × 80 cm.</picture>
+        <picture src="oehlenschlaeger2019021677-p1.jpg" wikidata="Q20355613" year="1894" museum="smk" invnr="KMS1500">Carl Thomsen: <i>Rahbek ved sin hustrus dødsleje</i>, 1894, olie på lærred, 65.5 × 80 cm.</picture>
     </pictures>
     <source pages="145-148"/>
     <keywords>rahbekk</keywords>

--- a/fdirs/thorvaldsen/artwork.xml
+++ b/fdirs/thorvaldsen/artwork.xml
@@ -39,7 +39,7 @@
   <picture id="1815-dagen" year="1815" museum="thorvaldsens" invnr="A902" >
       <i>Dagen</i>, 1815, marmor, ⌀ 80 cm.
   </picture>
-  <picture id="1816-venus" year="1816" museum="thorvaldsens" invnr="A853" >
+  <picture id="1816-venus" wikidata="Q75556437" year="1816" museum="thorvaldsens" invnr="A853" >
       <i>Venus med æblet</i>, 1813-16, marmor, 160,8cm.
   </picture>
   <picture id="1816-eckersberg" year="1816" subject="eckersberg" museum="thorvaldsens" invnr="A788" >
@@ -58,5 +58,4 @@
       <i>Friedrich Schiller</i>, 1836, gips, 391 cm.
   </picture>
 </pictures>
-
 


### PR DESCRIPTION
## Ændringer

- dokumenterer at billedmetadata skal gennemgå alle kilder med `<picture>`, herunder værker, events, keywords, about-tekster, artwork og portraits
- tilføjer verificerede Wikidata-id'er til fem billeder i artwork- og værkdata
- placerer metadata på de fælles artwork-poster, hvor billederne genbruges via `artwork="..."`

## Validering

- `npm test -- --runTestsByPath __tests__/kalliopework-relaxng.test.js __tests__/info-xml-relaxng.test.js __tests__/commondata.test.js`
