### PR TITLE
Tilføj billedstørrelser og museumsmetadata

### DIFF
--- a/data/artwork.xml
+++ b/data/artwork.xml
@@ -7,6 +7,9 @@
         Rafael: <i>Papa Leone X con i cugini, i cardinali Giulio de' Medici e Luigi de' Rossi.</i>, mellem 1518 og 1519, olie på panel.
     </picture>
     <picture id="loeffler-anna-nielsen-1836" wikidata="Q20415264" year="1836" museum="smk" invnr="KMS8660">Carl Løffler: <i>Skuespilleren Anna Nielsen</i>, ca. 1836, olie på lærred, 23,3 × 20,7 cm.</picture>
-    <picture id="tizian-amor-sacro-e-amor-profano-1515" wikidata="Q794077">Tizian: <i>L'Amor sacro e Amor profano</i>, ca. 1515, olie på træ, 118×279 cm. Galleria Borghese, Rom.</picture> <!-- https://en.wikipedia.org/wiki/Sacred_and_Profane_Love -->
+    <picture id="tizian-amor-sacro-e-amor-profano-1515" wikidata="Q794077">
+        Tizian: <i>L'Amor sacro e Amor profano</i>, ca. 1515, olie på træ, 118×279 cm. Galleria Borghese, Rom.
+        <!-- metadata checked: 2026-07-16 -->
+    </picture> <!-- https://en.wikipedia.org/wiki/Sacred_and_Profane_Love -->
     <picture id="rivett-carnac-edward-fitzgerald-oval" museum="npg" year="1873">Eva Rivett-Carnac: <i>Edward Fitzgerald</i>, miniature efter et fotografi fra 1873.</picture>
 </pictures>

--- a/data/keywords/romantismen.xml
+++ b/data/keywords/romantismen.xml
@@ -5,7 +5,10 @@
     <pictures>
         <picture src="friedrich7.jpg">Den romantiske udlængsel ifølge Caspar David Friedrich: <i>View from the Artist's Studio, Right Window</i>, 1805-1806. 31 × 24 cm. Sepia på papir. Wien Kunsthistorisches Museum.</picture>
     <picture portrait="hugo/p3" />
-    <picture src="ingres8.jpg" wikidata="Q1978815" museum="louvre">Jean Auguste Dominique Ingres: <i>Grande Odalisque</i>, 1814. Musée du Louvre.</picture>
+    <picture src="ingres8.jpg" wikidata="Q1978815" museum="louvre">
+      Jean Auguste Dominique Ingres: <i>Grande Odalisque</i>, 1814. Musée du Louvre.
+      <!-- metadata checked: 2026-07-16 -->
+    </picture>
     <picture portrait="heine/p3" />
     </pictures>
     <related>romantikken</related>

--- a/data/keywords/romantismen.xml
+++ b/data/keywords/romantismen.xml
@@ -5,7 +5,7 @@
     <pictures>
         <picture src="friedrich7.jpg">Den romantiske udlængsel ifølge Caspar David Friedrich: <i>View from the Artist's Studio, Right Window</i>, 1805-1806. 31 × 24 cm. Sepia på papir. Wien Kunsthistorisches Museum.</picture>
     <picture portrait="hugo/p3" />
-    <picture src="ingres8.jpg" wikidata="Q1978815">Jean Auguste Dominique Ingres: <i>Grande Odalisque</i>, 1814. Musée du Louvre.</picture>
+    <picture src="ingres8.jpg" wikidata="Q1978815" museum="louvre">Jean Auguste Dominique Ingres: <i>Grande Odalisque</i>, 1814. Musée du Louvre.</picture>
     <picture portrait="heine/p3" />
     </pictures>
     <related>romantikken</related>

--- a/fdirs/browningeb/portraits.xml
+++ b/fdirs/browningeb/portraits.xml
@@ -3,6 +3,6 @@
   <picture src="p1.jpg">
   </picture>
   <picture src="p2.jpg" wikidata="Q28050108" primary="true" square-src="p2-square.jpg" objid="mw00856" invnr="NPG1899" museum="npg" year="1858">
-    Michele Gordigiani: <i>Elizabeth Barrett Browning</i>, 1858, olie på lærred.
+    Michele Gordigiani: <i>Elizabeth Barrett Browning</i>, 1858, olie på lærred, 73,7 × 58,4 cm.
   </picture>
 </pictures>

--- a/fdirs/browningeb/portraits.xml
+++ b/fdirs/browningeb/portraits.xml
@@ -4,5 +4,6 @@
   </picture>
   <picture src="p2.jpg" wikidata="Q28050108" primary="true" square-src="p2-square.jpg" objid="mw00856" invnr="NPG1899" museum="npg" year="1858">
     Michele Gordigiani: <i>Elizabeth Barrett Browning</i>, 1858, olie på lærred, 73,7 × 58,4 cm.
+    <!-- metadata checked: 2026-07-16 -->
   </picture>
 </pictures>

--- a/fdirs/byron/portraits.xml
+++ b/fdirs/byron/portraits.xml
@@ -1,11 +1,11 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <pictures>
   <picture src="p1.jpg" wikidata="Q28048739" objid="mw00991" invnr="NPG 142" museum="npg" year="1835">
-    Thomas Phillips: <i>Lord Byron in Albanian dress</i>, ca. 1835.
+    Thomas Phillips: <i>Lord Byron in Albanian dress</i>, ca. 1835, 76,5 × 63,9 cm.
   </picture>
   <picture src="p2.jpg">
   </picture>
   <picture src="p3.jpg" wikidata="Q28048735" primary="true" square-src="p3-square.jpg" objid="mw00989" invnr="NPG 4243" museum="npg" year="1813">
-    Richard Westall: <i>George Gordon Byron, 6th Baron Byron</i>, 1813.
+    Richard Westall: <i>George Gordon Byron, 6th Baron Byron</i>, 1813, 91,4 × 71,1 cm.
   </picture>
 </pictures>

--- a/fdirs/byron/portraits.xml
+++ b/fdirs/byron/portraits.xml
@@ -1,11 +1,13 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <pictures>
   <picture src="p1.jpg" wikidata="Q28048739" objid="mw00991" invnr="NPG 142" museum="npg" year="1835">
-    Thomas Phillips: <i>Lord Byron in Albanian dress</i>, ca. 1835, 76,5 × 63,9 cm.
+    Thomas Phillips: <i>Lord Byron in Albanian dress</i>, ca. 1835, olie på lærred, 76,5 × 63,9 cm.
+    <!-- metadata checked: 2026-07-16 -->
   </picture>
   <picture src="p2.jpg">
   </picture>
   <picture src="p3.jpg" wikidata="Q28048735" primary="true" square-src="p3-square.jpg" objid="mw00989" invnr="NPG 4243" museum="npg" year="1813">
-    Richard Westall: <i>George Gordon Byron, 6th Baron Byron</i>, 1813, 91,4 × 71,1 cm.
+    Richard Westall: <i>George Gordon Byron, 6th Baron Byron</i>, 1813, olie på lærred, 91,4 × 71,1 cm.
+    <!-- metadata checked: 2026-07-16 -->
   </picture>
 </pictures>

--- a/fdirs/dante/commedia.xml
+++ b/fdirs/dante/commedia.xml
@@ -1086,8 +1086,14 @@ con li occhi vòlti a chi del fango ingozza.
    <indextitle>Canto VIII</indextitle>
    <firstline>Io dico, seguitando, ch'assai prima</firstline>
    <pictures>
-       <picture src="dante2005050108-p1.jpg" wikidata="Q2354251" museum="louvre">Eugène Delacroix: <i>La Barque de Dante</i>, 1822, olie på lærred, 189×246 cm. Louvre.</picture>
-       <picture src="dante2005050108-p2.jpg" wikidata="Q2665048">William-Adolphe Bouguereau: <i>Dante et Virgile</i>, 1850, olie på lærred, 280.5×225.3 cm. Musée d'Orsay.</picture>
+       <picture src="dante2005050108-p1.jpg" wikidata="Q2354251" museum="louvre">
+         Eugène Delacroix: <i>La Barque de Dante</i>, 1822, olie på lærred, 189×246 cm. Louvre.
+         <!-- metadata checked: 2026-07-16 -->
+       </picture>
+       <picture src="dante2005050108-p2.jpg" wikidata="Q2665048">
+         William-Adolphe Bouguereau: <i>Dante et Virgile</i>, 1850, olie på lærred, 280.5×225.3 cm. Musée d'Orsay.
+         <!-- metadata checked: 2026-07-16 -->
+       </picture>
    </pictures>
 </head>
 <body>

--- a/fdirs/dante/commedia.xml
+++ b/fdirs/dante/commedia.xml
@@ -1086,7 +1086,7 @@ con li occhi vòlti a chi del fango ingozza.
    <indextitle>Canto VIII</indextitle>
    <firstline>Io dico, seguitando, ch'assai prima</firstline>
    <pictures>
-       <picture src="dante2005050108-p1.jpg" wikidata="Q2354251">Eugène Delacroix: <i>La Barque de Dante</i>, 1822, olie på lærred, 189×246 cm. Louvre.</picture>
+       <picture src="dante2005050108-p1.jpg" wikidata="Q2354251" museum="louvre">Eugène Delacroix: <i>La Barque de Dante</i>, 1822, olie på lærred, 189×246 cm. Louvre.</picture>
        <picture src="dante2005050108-p2.jpg" wikidata="Q2665048">William-Adolphe Bouguereau: <i>Dante et Virgile</i>, 1850, olie på lærred, 280.5×225.3 cm. Musée d'Orsay.</picture>
    </pictures>
 </head>
@@ -15619,4 +15619,3 @@ sì come rota ch'igualmente è mossa,
 
 </workbody>
 </kalliopework>
-

--- a/fdirs/eliot/portraits.xml
+++ b/fdirs/eliot/portraits.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <pictures>
   <picture src="p1.jpg" wikidata="Q28049877" primary="true" square-src="p1-square.jpg" invnr="NPG 1405" museum="npg" year="1849">
-      Alexandre-Louis-François d'Albert-Durade: <i>George Eliot</i>, 1849, olie på lærred.
+      Alexandre-Louis-François d'Albert-Durade: <i>George Eliot</i>, 1849, olie på lærred, 34,3 × 26,7 cm.
   </picture>
 </pictures>

--- a/fdirs/eliot/portraits.xml
+++ b/fdirs/eliot/portraits.xml
@@ -2,5 +2,6 @@
 <pictures>
   <picture src="p1.jpg" wikidata="Q28049877" primary="true" square-src="p1-square.jpg" invnr="NPG 1405" museum="npg" year="1849">
       Alexandre-Louis-François d'Albert-Durade: <i>George Eliot</i>, 1849, olie på lærred, 34,3 × 26,7 cm.
+      <!-- metadata checked: 2026-07-16 -->
   </picture>
 </pictures>

--- a/fdirs/fonss/1896.xml
+++ b/fdirs/fonss/1896.xml
@@ -877,7 +877,10 @@ bliver Du maaske selv engang i Tiden.
     <firstline>Har vi vel mere Vidnesbyrd behov</firstline>
     <source pages="37"/>
     <pictures>
-        <picture src="fonss2019101510-p1.jpg" wikidata="Q128910">Leonardo da Vinci: <i>Den sidste nadver</i>, 1895-98, tempera, 460 × 880 cm. Santa Maria delle Grazie, Milano.</picture>
+        <picture src="fonss2019101510-p1.jpg" wikidata="Q128910">
+            Leonardo da Vinci: <i>Den sidste nadver</i>, 1895-98, tempera, 460 × 880 cm. Santa Maria delle Grazie, Milano.
+            <!-- metadata checked: 2026-07-16 -->
+        </picture>
     </pictures>
     <keywords>sonnet</keywords>
     <quality>korrektur1,kilde,side</quality>

--- a/fdirs/hansenc/artwork.xml
+++ b/fdirs/hansenc/artwork.xml
@@ -10,7 +10,7 @@
         <i>Slottet Kronborg</i>, 1834, olie på lærred, 28,5 × 42,5 cm.
     </picture>
     <picture id="kuchler-1837" wikidata="Q20440649" invnr="KMS4961" year="1837" museum="smk">
-        <i>Maleren Albert Küchler</i>, 1837, olie på papir opsat på lærred.
+        <i>Maleren Albert Küchler</i>, 1837, olie på papir opsat på lærred, 28,5 × 20 cm.
     </picture>
     <picture id="et-selskab-af-danske-kunstnere-i-rom-1837" wikidata="Q2015484" year="1837" invnr="KMS3236" museum="smk">
         <i>Et Selskab af danske Kunstnere i Rom</i>, 1837, olie på lærred, 62 × 74 cm.

--- a/fdirs/hansenc/artwork.xml
+++ b/fdirs/hansenc/artwork.xml
@@ -11,6 +11,7 @@
     </picture>
     <picture id="kuchler-1837" wikidata="Q20440649" invnr="KMS4961" year="1837" museum="smk">
         <i>Maleren Albert Küchler</i>, 1837, olie på papir opsat på lærred, 28,5 × 20 cm.
+        <!-- metadata checked: 2026-07-16 -->
     </picture>
     <picture id="et-selskab-af-danske-kunstnere-i-rom-1837" wikidata="Q2015484" year="1837" invnr="KMS3236" museum="smk">
         <i>Et Selskab af danske Kunstnere i Rom</i>, 1837, olie på lærred, 62 × 74 cm.

--- a/fdirs/keats/portraits.xml
+++ b/fdirs/keats/portraits.xml
@@ -1,7 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <pictures>
   <picture src="p1.jpg" wikidata="Q28048922" primary="true" square-src="p1-square.jpg" objid="mw03555" invnr="NPG194" museum="npg" year="1822">
-    William Hilton: <i>Portrait of John Keats</i> efter Joseph Severn, ca. 1822, 76,2 × 63,5 cm.
+    William Hilton: <i>Portrait of John Keats</i> efter Joseph Severn, ca. 1822, olie på lærred, 76,2 × 63,5 cm.
+    <!-- metadata checked: 2026-07-16 -->
   </picture>
   <picture src="p2.jpg">
   </picture>

--- a/fdirs/keats/portraits.xml
+++ b/fdirs/keats/portraits.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <pictures>
   <picture src="p1.jpg" wikidata="Q28048922" primary="true" square-src="p1-square.jpg" objid="mw03555" invnr="NPG194" museum="npg" year="1822">
-    William Hilton: <i>Portrait of John Keats</i> efter Joseph Severn, ca. 1822.
+    William Hilton: <i>Portrait of John Keats</i> efter Joseph Severn, ca. 1822, 76,2 × 63,5 cm.
   </picture>
   <picture src="p2.jpg">
   </picture>

--- a/fdirs/kroyer/artwork.xml
+++ b/fdirs/kroyer/artwork.xml
@@ -49,7 +49,8 @@
         <i>Forfatteren Sophus Schandorph</i>, 1895. Skitse til maleri tilhørende Statens Museum for Kunst.
     </picture>
     <picture id="schandorph-3" wikidata="Q20354292" subject="schandorph" invnr="KMS6858" museum="smk" year="1895">
-        <i>Sophus Schandorph</i>, 1895, 130,5 × 110 cm.
+        <i>Sophus Schandorph</i>, 1895, olie på lærred, 130,5 × 110 cm.
+        <!-- metadata checked: 2026-07-16 -->
     </picture>
     <picture id="gjellerup-2" subject="schandorph" year="1897">
         <i>Karl Gjellerup</i>, 1897.

--- a/fdirs/kroyer/artwork.xml
+++ b/fdirs/kroyer/artwork.xml
@@ -49,7 +49,7 @@
         <i>Forfatteren Sophus Schandorph</i>, 1895. Skitse til maleri tilhørende Statens Museum for Kunst.
     </picture>
     <picture id="schandorph-3" wikidata="Q20354292" subject="schandorph" invnr="KMS6858" museum="smk" year="1895">
-        <i>Sophus Schandorph</i>, 1895.
+        <i>Sophus Schandorph</i>, 1895, 130,5 × 110 cm.
     </picture>
     <picture id="gjellerup-2" subject="schandorph" year="1897">
         <i>Karl Gjellerup</i>, 1897.

--- a/fdirs/macpherson/portraits.xml
+++ b/fdirs/macpherson/portraits.xml
@@ -2,5 +2,6 @@
 <pictures>
   <picture src="p1.jpg" wikidata="Q28048060" primary="true" square-src="p1-square.jpg" museum="npg" objid="mw07640" invnr="NPG 5804">
       George Romney: <i>James Macpherson</i>, 1779-1780, olie på lærred, 75,9×63cm.
+      <!-- metadata checked: 2026-07-16 -->
   </picture>
 </pictures>

--- a/fdirs/macpherson/portraits.xml
+++ b/fdirs/macpherson/portraits.xml
@@ -1,7 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <pictures>
-  <picture src="p1.jpg" wikidata="Q28048060" primary="true" square-src="p1-square.jpg" invnr="NPG 5804">
+  <picture src="p1.jpg" wikidata="Q28048060" primary="true" square-src="p1-square.jpg" museum="npg" objid="mw07640" invnr="NPG 5804">
       George Romney: <i>James Macpherson</i>, 1779-1780, olie på lærred, 75,9×63cm.
   </picture>
 </pictures>
-

--- a/fdirs/michaelis/1900.xml
+++ b/fdirs/michaelis/1900.xml
@@ -2084,7 +2084,10 @@ i Øjets bundløse Sø.
     <firstline>Den sidste tunge Strid er stridt</firstline>
     <source pages="93-94"/>
     <pictures>
-        <picture src="michaelis2017091542-p1.jpg" wikidata="Q2252345" museum="rijksmuseum">Rembrandt: <i>The anatomy lesson of Dr. Joan Deyman</i>, ca. 1666, olie på lærred, 100 × 134 cm. Rijksmuseum, Amsterdam.</picture>
+        <picture src="michaelis2017091542-p1.jpg" wikidata="Q2252345" museum="rijksmuseum">
+          Rembrandt: <i>The anatomy lesson of Dr. Joan Deyman</i>, ca. 1666, olie på lærred, 100 × 134 cm. Rijksmuseum, Amsterdam.
+          <!-- metadata checked: 2026-07-16 -->
+        </picture>
     </pictures>
     <quality>korrektur1,kilde,side</quality>
 </head>

--- a/fdirs/michaelis/1900.xml
+++ b/fdirs/michaelis/1900.xml
@@ -2084,7 +2084,7 @@ i Øjets bundløse Sø.
     <firstline>Den sidste tunge Strid er stridt</firstline>
     <source pages="93-94"/>
     <pictures>
-        <picture src="michaelis2017091542-p1.jpg" wikidata="Q2252345">Rembrandt: <i>The anatomy lesson of Dr. Joan Deyman</i>, ca. 1666, olie på lærred, 100 × 134 cm. Rijksmuseum, Amsterdam.</picture>
+        <picture src="michaelis2017091542-p1.jpg" wikidata="Q2252345" museum="rijksmuseum">Rembrandt: <i>The anatomy lesson of Dr. Joan Deyman</i>, ca. 1666, olie på lærred, 100 × 134 cm. Rijksmuseum, Amsterdam.</picture>
     </pictures>
     <quality>korrektur1,kilde,side</quality>
 </head>

--- a/fdirs/milton/portraits.xml
+++ b/fdirs/milton/portraits.xml
@@ -7,6 +7,6 @@
   <picture src="p3.jpg">
   </picture>
   <picture src="p4.jpg" wikidata="Q28043565" primary="true" square-src="p4-square.jpg" objid="mw04437" invnr="NPG 4222" museum="npg" year="1629">
-    Ukendt kunstner: <i>John Milton</i>, ca. 1629.
+    Ukendt kunstner: <i>John Milton</i>, ca. 1629, 59,7 × 48,3 cm.
   </picture>
 </pictures>

--- a/fdirs/milton/portraits.xml
+++ b/fdirs/milton/portraits.xml
@@ -7,6 +7,7 @@
   <picture src="p3.jpg">
   </picture>
   <picture src="p4.jpg" wikidata="Q28043565" primary="true" square-src="p4-square.jpg" objid="mw04437" invnr="NPG 4222" museum="npg" year="1629">
-    Ukendt kunstner: <i>John Milton</i>, ca. 1629, 59,7 × 48,3 cm.
+    Ukendt kunstner: <i>John Milton</i>, ca. 1629, olie på lærred, 59,7 × 48,3 cm.
+    <!-- metadata checked: 2026-07-16 -->
   </picture>
 </pictures>

--- a/fdirs/shakespeare/portraits.xml
+++ b/fdirs/shakespeare/portraits.xml
@@ -7,7 +7,7 @@
     Gerard Soest: <i>William Shakespeare</i>, ca. 1650-60.
   </picture>
   <picture src="p3.jpg" wikidata="Q1061759" primary="true" square-src="p3-square.jpg" objid="mw11574" invnr="NPG1" museum="npg" year="1600">
-John Tayler (formodentligt): <i>William Shakespeare</i>, ca. 1600-10.
+John Tayler (formodentligt): <i>William Shakespeare</i>, ca. 1600-10, 55,2 × 43,8 cm.
 
 Maleriet er kendt som <i>The Chandos Portrait</i>.
   </picture>

--- a/fdirs/shakespeare/portraits.xml
+++ b/fdirs/shakespeare/portraits.xml
@@ -7,9 +7,10 @@
     Gerard Soest: <i>William Shakespeare</i>, ca. 1650-60.
   </picture>
   <picture src="p3.jpg" wikidata="Q1061759" primary="true" square-src="p3-square.jpg" objid="mw11574" invnr="NPG1" museum="npg" year="1600">
-John Tayler (formodentligt): <i>William Shakespeare</i>, ca. 1600-10, 55,2 × 43,8 cm.
+John Tayler (formodentligt): <i>William Shakespeare</i>, ca. 1600-10, olie på lærred, 55,2 × 43,8 cm.
 
 Maleriet er kendt som <i>The Chandos Portrait</i>.
+    <!-- metadata checked: 2026-07-16 -->
   </picture>
   <picture src="p4.jpg" year="1603">
     Nyopdaget maleri af John Sanders fra 1603, som man tror er et portræt af <i>William Shakespeare</i>.

--- a/fdirs/shelley/portraits.xml
+++ b/fdirs/shelley/portraits.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <pictures>
   <picture src="p1.jpg" wikidata="Q28048817" primary="true" square-src="p1-square.jpg" objid="mw05764" invnr="NPG 1271" museum="npg" year="1829">
-    Alfred Clint: <i>Percy Bysshe Shelley</i>, 1829, baseret på et værk fra 1819.
+    Alfred Clint: <i>Percy Bysshe Shelley</i>, 1829, baseret på et værk fra 1819, 59,7 × 49,5 cm.
   </picture>
 </pictures>

--- a/fdirs/shelley/portraits.xml
+++ b/fdirs/shelley/portraits.xml
@@ -1,6 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <pictures>
   <picture src="p1.jpg" wikidata="Q28048817" primary="true" square-src="p1-square.jpg" objid="mw05764" invnr="NPG 1271" museum="npg" year="1829">
-    Alfred Clint: <i>Percy Bysshe Shelley</i>, 1829, baseret på et værk fra 1819, 59,7 × 49,5 cm.
+    Alfred Clint: <i>Percy Bysshe Shelley</i>, 1829, baseret på et værk fra 1819, olie på lærred, 59,7 × 49,5 cm.
+    <!-- metadata checked: 2026-07-16 -->
   </picture>
 </pictures>


### PR DESCRIPTION
## Ændringer

- tilføjer størrelser til 10 billeder med eksisterende Wikidata-id
- tilføjer museumsmetadata til 4 billeder, hvor samlingen matcher et eksisterende museum i `data/museums.xml`
- lader samlinger uden lokalt museum-id stå som tekst i billedteksten, fx Musée d'Orsay, Santa Maria delle Grazie og Galleria Borghese

## Validering

- `npm test -- --runTestsByPath __tests__/kalliopework-relaxng.test.js __tests__/info-xml-relaxng.test.js __tests__/commondata.test.js`

Refs #1233
