### PR TITLE
Gennemgå billedmetadata for SMK-batch

### DIFF
--- a/data/artwork.xml
+++ b/data/artwork.xml
@@ -6,7 +6,10 @@
     <picture id="rafael-leone-x-1518" wikidata="Q2610729" year="1518 ca." museum="uffizi" invnr="40">
         Rafael: <i>Papa Leone X con i cugini, i cardinali Giulio de' Medici e Luigi de' Rossi.</i>, mellem 1518 og 1519, olie på panel.
     </picture>
-    <picture id="loeffler-anna-nielsen-1836" wikidata="Q20415264" year="1836" museum="smk" invnr="KMS8660">Carl Løffler: <i>Skuespilleren Anna Nielsen</i>, ca. 1836, olie på lærred, 23,3 × 20,7 cm.</picture>
+    <picture id="loeffler-anna-nielsen-1836" wikidata="Q20415264" year="1836" museum="smk" invnr="KMS8660">
+        Carl Løffler: <i>Skuespilleren Anna Nielsen</i>, ca. 1836, olie på lærred, 23,3 × 20,7 cm.
+        <!-- metadata checked: 2026-07-16 -->
+    </picture>
     <picture id="tizian-amor-sacro-e-amor-profano-1515" wikidata="Q794077">
         Tizian: <i>L'Amor sacro e Amor profano</i>, ca. 1515, olie på træ, 118×279 cm. Galleria Borghese, Rom.
         <!-- metadata checked: 2026-07-16 -->

--- a/fdirs/abildgaard/artwork.xml
+++ b/fdirs/abildgaard/artwork.xml
@@ -2,11 +2,12 @@
 <pictures>
     <picture id="1778-hamlet" wikidata="Q20406826" year="1778" museum="smk" invnr="KMS1019" >
         <i>Hamlet hos sin moder</i>, ca. 1778, olie på lærred, 50,5×64cm.
+        <!-- metadata checked: 2026-07-16 -->
     </picture>
     <picture id="1782-christian4" wikidata="Q20277436" year="1782" museum="smk" invnr="KMS1139d" >
         <i>Christian IV på "Trefoldigheden" i slaget på Kolberger Heide 1644</i>, 1782, olie på lærred, 61×37cm.
 
 Skitse til vægbillede i riddersalen på Christiansborg, der brændte med slottet i 1794.
+        <!-- metadata checked: 2026-07-16 -->
     </picture>
 </pictures>
-

--- a/fdirs/bissen/artwork.xml
+++ b/fdirs/bissen/artwork.xml
@@ -10,18 +10,21 @@
       <i>Den danske landsoldat efter sejren</i>, 1850-51, gips, 220cm.
 
 Gipsmodel til bronzestatuen i Fredericia.      
+      <!-- metadata checked: 2026-07-16 -->
   </picture>
   <picture id="ploug-1857-2" subject="plough" year="1857" museum="nivaagaard" objid="herman-wilhelm-bissen-5">
     <i>Marmorbuste af Carl Ploug</i>, 1857, marmor, 40 cm.
   </picture>
   <picture id="ploug-1857" subject="plough" year="1857" museum="smk" invnr="KMS5418">
     <i>Digteren og politikeren Carl Ploug</i>, 1857. Bronze, støbt 1901.
+    <!-- metadata checked: 2026-07-16 -->
   </picture>
   <picture id="hauch-1858" subject="hauch" year="1858">
     <i>C. Hauch</i>, 1858.
   </picture>
   <picture id="winther-1858" subject="winther" year="1858" museum="smk" invnr="KMS5060">
-    <i>Digteren Christian Winther</i>, 1858, gips, 64,4cm.
+    <i>Digteren Christian Winther</i>, 1858, gips, 64,1 cm.
+    <!-- metadata checked: 2026-07-16 -->
   </picture>
   <picture id="ingemann-1859" subject="ingemann" year="1859">
     <i>B.S. Ingemann</i>, 1859.

--- a/fdirs/hansenc/artwork.xml
+++ b/fdirs/hansenc/artwork.xml
@@ -2,12 +2,15 @@
 <pictures>
     <picture id="selvportraet-1825" wikidata="Q20468253" subject="hansenc" museum="smk" invnr="KMS3982" year="1825">
       <i>Selvportræt</i>, 1825, olie på lærred, 63×50 cm.
+      <!-- metadata checked: 2026-07-16 -->
     </picture>
     <picture id="tre-unge-piger-1827" wikidata="Q20354726" year="1827" invnr="KMS125" museum="smk">
         <i>Tre unge piger. Kunstnerens søstre Alvilde, Ida og Henriette</i>, 1827, olie på lærred, 62,5 × 81 cm.
+        <!-- metadata checked: 2026-07-16 -->
     </picture>
     <picture id="slottet-kronborg-1834" wikidata="Q20354987" year="1834" invnr="KMS6815" museum="smk">
         <i>Slottet Kronborg</i>, 1834, olie på lærred, 28,5 × 42,5 cm.
+        <!-- metadata checked: 2026-07-16 -->
     </picture>
     <picture id="kuchler-1837" wikidata="Q20440649" invnr="KMS4961" year="1837" museum="smk">
         <i>Maleren Albert Küchler</i>, 1837, olie på papir opsat på lærred, 28,5 × 20 cm.
@@ -15,6 +18,7 @@
     </picture>
     <picture id="et-selskab-af-danske-kunstnere-i-rom-1837" wikidata="Q2015484" year="1837" invnr="KMS3236" museum="smk">
         <i>Et Selskab af danske Kunstnere i Rom</i>, 1837, olie på lærred, 62 × 74 cm.
+        <!-- metadata checked: 2026-07-16 -->
     </picture>
     <picture id="monrad-1846" year="1846">
         <i>Ditlev Gothard Monrad</i>, 1846. Folketinget, Christiansborg.
@@ -43,5 +47,6 @@
     </picture>
     <picture id="jessen-1830" wikidata="Q20422143" year="1830" invnr="KMS1788" museum="smk">
         <i>Forfatterinden Juliane Marie Jessen</i>, ca. 1830, olie på lærred, 31 × 25.5 cm.
+        <!-- metadata checked: 2026-07-16 -->
     </picture>
 </pictures>

--- a/fdirs/koebke/artwork.xml
+++ b/fdirs/koebke/artwork.xml
@@ -5,21 +5,26 @@
     </picture>
     <picture id="1832-ida-thiele" wikidata="Q20380158" museum="smk" invnr="KMS3136" year="1832">
         <i>Ida Thiele, senere gift Wilde, som barn</i>, 1832, olie på lærred, 22,5×20cm.
+        <!-- metadata checked: 2026-07-16 -->
     </picture>
     <picture id="1833-christian-petersen" wikidata="Q20354582" year="1833-05-22" museum="smk" invnr="KMS3159">
         <i>Urtekræmmer Christian F. Petersen, kunstnerens fætter og svoger</i>, 22/5 1833, olie på lærred,  31,5 × 27 cm.
+        <!-- metadata checked: 2026-07-16 -->
     </picture>
     <picture id="1833-selvportraet" wikidata="Q20267373" subject="koebke" year="1833" museum="smk" invnr="KMS3150">
         <i>Selvportræt</i>, ca. 1833, olie på lærred,  42 × 35,5 cm.
+        <!-- metadata checked: 2026-07-16 -->
     </picture>
     <picture id="1834-hansenc" subject="hansenc" year="1834" museum="ribe" invnr="RKMm0118">
         <i>Portræt af maleren Constantin Hansen</i>, 1834-35, olie på lærred, 107,5 × 87,5 cm.
     </picture>
     <picture id="1835-grethe-petersen" wikidata="Q20440852" year="1835" museum="smk" invnr="KMS3160">
         <i>Cecilie Margrethe Petersen, født Købke, kunstnerens søster</i>, 1835, olie på lærred,  94 × 74 cm.
+        <!-- metadata checked: 2026-07-16 -->
     </picture>
     <picture id="1836-marstrand" wikidata="Q20268310" subject="marstrand" year="1836" museum="smk" invnr="KMS1348">
         <i>Maleren Wilhelm Marstrand</i>, 1836, olie på lærred, 18,5 × 15 cm.
+        <!-- metadata checked: 2026-07-16 -->
     </picture>
     <picture id="1846-krohn" subject="krohn" year="1846" museum="natmus.se" objid="160037">
         <i>Skolebestyrer J. Krohn som barn, kunstnerens søstersøn</i>, 1846, olie på lærred, 30 × 25 cm.

--- a/fdirs/kuchler/artwork.xml
+++ b/fdirs/kuchler/artwork.xml
@@ -9,12 +9,13 @@
     </picture>
     <picture id="en-romersk-gadescene-1833" wikidata="Q20538366" year="1833" invnr="KMS3317" museum="smk">
         <i>En romersk gadescene</i>, 1833, olie på lærred, 60,5×51 cm.
+        <!-- metadata checked: 2026-07-16 -->
     </picture>
     <picture id="andersen-1834" wikidata="Q119716534" year="1834" museum="fnm" invnr="a-701">
         <i>H.C. Andersen</i>, januar 1834, Rom, olie på lærred.
     </picture>
     <picture id="hansenc-1837" wikidata="Q20267924" year="1837" invnr="KMS4964" museum="smk">
         <i>Maleren Constantin Hansen</i>, 1837, olie på papir opsat på lærred, 28 × 20 cm.
+        <!-- metadata checked: 2026-07-16 -->
     </picture>
 </pictures>
-

--- a/fdirs/marstrand/artwork.xml
+++ b/fdirs/marstrand/artwork.xml
@@ -10,7 +10,8 @@
     <i>Portræt af Just Mathias Thiele</i>, ukendt år, olie på lærred, 87,3×70,5 cm.
   </picture>
   <picture id="koebke-1839" wikidata="Q20354392" subject="koebke" year="1839" museum="smk" invnr="KMS3615" >
-      <i>Maleren Christen Købke</i>, 1839, olie på lærred, 233×20cm.
+      <i>Maleren Christen Købke</i>, 1839, olie på lærred, 23 × 20 cm.
+      <!-- metadata checked: 2026-07-16 -->
   </picture>
   <picture id="christian8-1843" subject="christian8" year="1843">
     <i>Christian VIII - Det Dansk-Tyske Monarkis Konge</i>, 1843, olie på lærred. Rosenborg Slot.
@@ -20,6 +21,7 @@
   </picture>
   <picture id="piazza-barberini-1840erne" wikidata="Q20404534" year="1845" museum="smk" invnr="KMS3770">
       <i>En charlatan sælger blanksværte på Piazza Barberini i Rom</i>, 1840'erne, olie på lærred, 37×47,5cm. <!-- Omkr. dateringen skriver SMK: baseret på et fagligt skøn. Formodentlig malet under kunstnerens andet Rom-ophold 1845-48. -->
+      <!-- metadata checked: 2026-07-16 -->
   </picture>
   <picture id="heibergjohanne-1859" subject="heibergjohanne" year="1859" museum="fnm" invnr="a-251">
     <i>Portræt af Johanne Louise Heiberg</i>, 1859, olie på lærred, 196×102cm.
@@ -50,4 +52,3 @@
       <i>Fru Gyllembourg læser op af sine Hverdags-Historier for J.L. Heiberg og Frue</i>
   </picture>
 </pictures>
-


### PR DESCRIPTION
## Ændringer
- gennemgår 20 sikre SMK-værker og markerer dem med `metadata checked: 2026-07-16`
- retter to sikre mål fra SMK-data: Christen Købke-portrættet og Christian Winther-busten

## Validering
- `git diff --check`
- `npm test -- info-xml-relaxng.test.js`
- `npm test -- kalliopework-relaxng.test.js`
- `npm test`
- `npm run build-static`
- `npm run build`

Refs #1233