### PR TITLE
Opdater metadata for NPG-portrætter

### DIFF
--- a/fdirs/barton/portraits.xml
+++ b/fdirs/barton/portraits.xml
@@ -1,7 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <pictures>
   <picture src="p1.jpg" primary="true" square-src="p1-square.jpg" objid="mw35139" invnr="NPG D1023" museum="npg" year="1850">
-      James Henry Lynch, efter Samuel Laurence: <i>Bernard Barton</i>, midten af 1800-tallet, litografi, 169 × 111 mm.
+      James Henry Lynch, efter Samuel Laurence: <i>Bernard Barton</i>, midten af 1800-tallet, litografi, 16,9 × 11,1 cm.
+      <!-- metadata checked: 2026-07-16 -->
   </picture>
 </pictures>
     

--- a/fdirs/blake/portraits.xml
+++ b/fdirs/blake/portraits.xml
@@ -1,7 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <pictures>
   <picture src="p1.jpg" wikidata="Q28048651" primary="true" square-src="p1-square.jpg" objid="mw00609" invnr="NPG212" museum="npg" year="1807">
-    Thomas Phillips: <i>William Blake</i>, 1807, olie på lærred,  921 mm x 720 mm.
+    Thomas Phillips: <i>William Blake</i>, 1807, olie på lærred, 92,1 × 72,0 cm.
+    <!-- metadata checked: 2026-07-16 -->
   </picture>
   <picture src="p2.jpg">
   </picture>

--- a/fdirs/browningr/portraits.xml
+++ b/fdirs/browningr/portraits.xml
@@ -1,6 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <pictures>
   <picture src="p1.jpg" primary="true" square-src="p1-square.jpg" objid="mw247058" invnr="NPG x193639" museum="npg" year="1880">
-      Bassano Ltd (fotograf): <i>Robert Browning</i>, 1880'erne.
+      Bassano Ltd (fotograf): <i>Robert Browning</i>, 1880'erne, bromsølv-postkortfotografi, 12,3 × 8,3 cm.
+      <!-- metadata checked: 2026-07-16 -->
   </picture>
 </pictures>

--- a/fdirs/campbell/portraits.xml
+++ b/fdirs/campbell/portraits.xml
@@ -1,7 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <pictures>
   <picture src="p1.jpg" wikidata="Q28048827" primary="true" square-src="p1-square.jpg" objid="mw01033" invnr="NPG 198" museum="npg" year="1820">
-      Sir Thomas Lawrence: <i>Thomas Campbell</i>, c. 1820, olie på lærred, 914 × 711 mm.
+      Sir Thomas Lawrence: <i>Thomas Campbell</i>, ca. 1820, olie på lærred, 91,4 × 71,1 cm.
+      <!-- metadata checked: 2026-07-16 -->
   </picture>
 </pictures>
     

--- a/fdirs/donne/portraits.xml
+++ b/fdirs/donne/portraits.xml
@@ -2,8 +2,9 @@
 <pictures>
 <!-- Interessant artiklen om restaureringen på NPG: http://www.npg.org.uk/research/conservation/john-donne-and-his-picture -->
   <picture src="p1.jpg" wikidata="Q28042968" primary="true" square-src="p1-square.jpg" objid="mw111844" invnr="NPG 6790" museum="npg" year="1595">
-    Ukendt kunstner: <i>John Donne</i>, ca. 1595.
+    Ukendt kunstner: <i>John Donne</i>, ca. 1595, olie på panel, 77,1 × 62,5 cm.
 
 Dette portræt havde Donne selv hængende og omtaler det som det "picture of myne w[hi]ch is taken in the shaddowes".
+    <!-- metadata checked: 2026-07-16 -->
   </picture>
 </pictures>

--- a/fdirs/hunt/portraits.xml
+++ b/fdirs/hunt/portraits.xml
@@ -1,10 +1,12 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <pictures>
   <picture src="p1.jpg" wikidata="Q28048706" primary="true" square-src="p1-square.jpg" year="1811" objid="mw03305" invnr="NPG 293" museum="npg">
-      Benjamin Robert Haydon: <i>Leigh Hunt</i>, ca. 1811, olie på lærred, 610 × 502 mm.
+      Benjamin Robert Haydon: <i>Leigh Hunt</i>, ca. 1811, olie på lærred, 61,0 × 50,2 cm.
+      <!-- metadata checked: 2026-07-16 -->
   </picture>
   <picture src="p2.jpg" wikidata="Q28049430" objid="mw03307" invnr="NPG 2508" year="1837" museum="npg">
-      Samuel Laurence: <i>Leigh Hunt</i>, ca. 1837, olie på lærred, 1118 × 905 mm.
+      Samuel Laurence: <i>Leigh Hunt</i>, ca. 1837, olie på lærred, 111,8 × 90,5 cm.
+      <!-- metadata checked: 2026-07-16 -->
   </picture>
 </pictures>
     

--- a/fdirs/kipling/portraits.xml
+++ b/fdirs/kipling/portraits.xml
@@ -1,7 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <pictures>
   <picture src="p2.jpg" wikidata="Q28050799" objid="mw03660" invnr="NPG 1863" museum="npg" year="1899">
-    Sir Philip Burne-Jones, 2nd Bt: <i>Rudyard Kipling</i>, 1899, olie på lærred, 749×622mm.
+    Sir Philip Burne-Jones, 2nd Bt: <i>Rudyard Kipling</i>, 1899, olie på lærred, 74,9 × 62,2 cm.
+    <!-- metadata checked: 2026-07-16 -->
   </picture>
   <picture src="p1.jpg" primary="true" square-src="p1-square.jpg" objid="mw58084" invnr="NPG x11811" museum="npg" year="1920">
     Henri Manuel (fotograf): <i>Rudyard Kipling</i>, tidligt i 1920erne.


### PR DESCRIPTION
## Ændringer
- fører 8 rettelser fra CSV tilbage i portræt-XML
- normaliserer materiale og størrelse i billedteksterne
- markerer de 8 portrætter som gennemgået med `metadata checked: 2026-07-16`

## Validering
- `git diff --check`
- `npm test -- info-xml-relaxng.test.js`
- `npm test`
- `npm run build-static`
- `npm run build`

Refs #1233