### PR TITLE
Normaliser rækkefølge i billedtekster

### DIFF
--- a/fdirs/atterbom/portraits.xml
+++ b/fdirs/atterbom/portraits.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <pictures>
   <picture src="p1.jpg" primary="true" square-src="p1-square.jpg" objid="39069" museum="natmus.se" year="1831">
-      Johann Gustaf Sandberg: <i>Per Daniel Amadeus Atterbom</i>, olie på lærred, 23 × 19 cm, 1831. Gripsholms slott, Sverige.
+      Johann Gustaf Sandberg: <i>Per Daniel Amadeus Atterbom</i>, 1831, olie på lærred, 23 × 19 cm. Gripsholms slott, Sverige.
   </picture>
 </pictures>

--- a/fdirs/blunck/artwork.xml
+++ b/fdirs/blunck/artwork.xml
@@ -7,7 +7,6 @@
     <i>Danske kunstnere på osteriet La Gensola i Trastevere i Rom</i>, 1836-37.
   </picture>
   <picture id="1848-selvportraet" museum="nivaagaard" objid="ditlev-blunck-2"> 
-      <i>Selvportræt som friskarer</i>, olie på lærred, 26 × 20 cm, 1848.<!-- https://commons.wikimedia.org/wiki/File:Ditlev_Blunck,_Selvportræt_som_friskarer,_1848,_0214NMK,_Nivaagaards_Malerisamling.jpg -->
+      <i>Selvportræt som friskarer</i>, 1848, olie på lærred, 26 × 20 cm.<!-- https://commons.wikimedia.org/wiki/File:Ditlev_Blunck,_Selvportræt_som_friskarer,_1848,_0214NMK,_Nivaagaards_Malerisamling.jpg -->
   </picture>
 </pictures>
-

--- a/fdirs/hansenc/artwork.xml
+++ b/fdirs/hansenc/artwork.xml
@@ -23,7 +23,7 @@
         <i>N.F.S. Grundtvig</i>, 1847-1848.
     </picture>
     <picture id="rodeg-1" subject="rodeg" museum="fnm" invnr="a-6663">
-        <i>Gotfred Rode</i>, olie på lærred, ukendt år.
+        <i>Gotfred Rode</i>, ukendt år, olie på lærred.
     </picture>
     <picture id="den-grundlovgivende-rigsforsamling-1861" wikidata="Q3202466" year="1861-1865" museum="fnm" invnr="a-15">
         <i>Den Grundlovgivende Rigsforsamling</i>, 1861-65, 338×500cm.

--- a/fdirs/magnusson/portraits.xml
+++ b/fdirs/magnusson/portraits.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <pictures>
   <picture src="p1.jpg" primary="true" square-src="p1-square.jpg" >
-      Emile Lassalle (litograf): <i>Finn Magnussen</i>, litografi, 40 × 27,0 cm, 1838. [fra <i>Voyage en Islande et au Groënland. Publié par order du Roi sous la direction de M. Paul Gaimard ... Atlas zoologique, médical et géographique.</i>]
+      Emile Lassalle (litograf): <i>Finn Magnussen</i>, 1838, litografi, 40 × 27,0 cm. [fra <i>Voyage en Islande et au Groënland. Publié par order du Roi sous la direction de M. Paul Gaimard ... Atlas zoologique, médical et géographique.</i>]
   <!-- https://jcb.lunaimaging.com/luna/servlet/detail/JCB~1~1~501267~115901884:Finn-Magnussen-# -->
   </picture>
 </pictures>

--- a/fdirs/thorvaldsen/artwork.xml
+++ b/fdirs/thorvaldsen/artwork.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <pictures>
   <picture id="thaarup-oval" subject="thaarup" year="1790 ca.">
-      <i>Thomas Thaarup</i>, blyant og vandfarve, 1790'erne, 10,6×8,9 cm. Teatermuseet i Hofteatret.<!-- https://arkivet.thorvaldsensmuseum.dk/personer/thaarup-thomas -->
+      <i>Thomas Thaarup</i>, 1790'erne, blyant og vandfarve, 10,6×8,9 cm. Teatermuseet i Hofteatret.<!-- https://arkivet.thorvaldsensmuseum.dk/personer/thaarup-thomas -->
   </picture>
   <picture id="1803-jason" wikidata="Q4563532" year="1803" museum="thorvaldsens" invnr="A822" >
       <i>Jason med det gyldne skind</i>, 1803, marmor, 242cm.
@@ -58,4 +58,3 @@
       <i>Friedrich Schiller</i>, 1836, gips, 391 cm.
   </picture>
 </pictures>
-

--- a/fdirs/wyatt/portraits.xml
+++ b/fdirs/wyatt/portraits.xml
@@ -3,6 +3,6 @@
   <picture src="p1.jpg">
   </picture>
   <picture src="p2-oval.jpg" primary="true" square-src="p2-square.jpg" year="1540" museum="npg" objid="mw06951" invnr="NPG 2089">
-    <i>Sir Thomas Wyatt</i>, olie på panel, ⌀ 317mm. 1700-tallet efter et maleri af Hans Holbein the Younger fra ca. 1540.
+    <i>Sir Thomas Wyatt</i>, 1700-tallet, olie på panel, ⌀ 317mm. Efter et maleri af Hans Holbein the Younger fra ca. 1540.
   </picture>
 </pictures>


### PR DESCRIPTION
## Ændringer
- retter seks åbenlyse billedtekster til rækkefølgen titel, år, materiale, størrelse
- ændrer kun tekstens rækkefølge, ikke metadata-attributter eller nye kilder

## Validering
- `git diff --check`
- `npm test -- info-xml-relaxng.test.js`
- `npm test`
- `npm run build-static`
- `npm run build`

Refs #1233