### PR TITLE
Gør søgning på digt-id mere direkte

### DIFF
--- a/__tests__/elasticsearch-client.test.js
+++ b/__tests__/elasticsearch-client.test.js
@@ -36,6 +36,9 @@ describe('Elasticsearch client', () => {
       type: 'text',
       analyzer: 'kalliope_text',
     });
+    expect(body.mappings.properties.text.properties.id).toEqual({
+      type: 'keyword',
+    });
     expect(body.mappings.properties.text.properties.title.analyzer).toBe(
       'kalliope_text'
     );
@@ -133,6 +136,7 @@ describe('Elasticsearch client', () => {
                       multi_match: {
                         query: 'aarestrup',
                         fields: [
+                          'text.id^5',
                           'text.title^3',
                           'text.subtitles^2',
                           'text.content_html',
@@ -191,6 +195,7 @@ describe('Elasticsearch client', () => {
                     multi_match: {
                       query: 'rose',
                       fields: [
+                        'text.id^5',
                         'text.title^3',
                         'text.subtitles^2',
                         'text.content_html',

--- a/__tests__/search.test.js
+++ b/__tests__/search.test.js
@@ -1,7 +1,70 @@
-import { totalHitsValue } from '../pages/search.js';
+import {
+  singleMatchingTextIdResultURL,
+  totalHitsValue,
+} from '../pages/search.js';
 
 describe('search page', () => {
   test('gets total hits from Elasticsearch 7 response format', () => {
     expect(totalHitsValue({ total: { value: 7, relation: 'eq' } })).toBe(7);
+  });
+
+  test('redirects to the text when the only result exactly matches the searched id', () => {
+    expect(
+      singleMatchingTextIdResultURL('da', ' aarestrup1838a18 ', {
+        hits: {
+          total: { value: 1, relation: 'eq' },
+          hits: [
+            {
+              _source: {
+                result_type: 'text',
+                text: { id: 'aarestrup1838a18' },
+              },
+            },
+          ],
+        },
+      })
+    ).toBe('/da/text/aarestrup1838a18');
+  });
+
+  test('does not redirect when the single text result does not match the searched id', () => {
+    expect(
+      singleMatchingTextIdResultURL('da', 'blomst', {
+        hits: {
+          total: { value: 1, relation: 'eq' },
+          hits: [
+            {
+              _source: {
+                result_type: 'text',
+                text: { id: 'aarestrup1838a18' },
+              },
+            },
+          ],
+        },
+      })
+    ).toBeNull();
+  });
+
+  test('does not redirect when there are multiple results', () => {
+    expect(
+      singleMatchingTextIdResultURL('da', 'aarestrup1838a18', {
+        hits: {
+          total: { value: 2, relation: 'eq' },
+          hits: [
+            {
+              _source: {
+                result_type: 'text',
+                text: { id: 'aarestrup1838a18' },
+              },
+            },
+            {
+              _source: {
+                result_type: 'text',
+                text: { id: 'aarestrup1838a19' },
+              },
+            },
+          ],
+        },
+      })
+    ).toBeNull();
   });
 });

--- a/pages/search.js
+++ b/pages/search.js
@@ -1,4 +1,5 @@
 import Link from 'next/link';
+import Router from 'next/router';
 import { useContext, useEffect, useState } from 'react';
 import * as Client from '../common/client.js';
 import CommonData from '../common/commondata.js';
@@ -21,6 +22,36 @@ import WorkName from '../components/workname.js';
 import ErrorPage from './error.js';
 
 export const totalHitsValue = (hits) => hits.total.value;
+
+export const singleMatchingTextIdResultURL = (lang, query, result) => {
+  if (
+    query == null ||
+    result == null ||
+    result.error != null ||
+    result.hits == null
+  ) {
+    return null;
+  }
+
+  const normalizedQuery = query.trim();
+  const hits = result.hits.hits || [];
+  if (totalHitsValue(result.hits) !== 1 || hits.length !== 1) {
+    return null;
+  }
+
+  const hit = hits[0];
+  const text = hit._source && hit._source.text;
+  if (
+    hit._source == null ||
+    hit._source.result_type !== 'text' ||
+    text == null ||
+    text.id !== normalizedQuery
+  ) {
+    return null;
+  }
+
+  return Links.textURL(lang, text.id);
+};
 
 const ResultTypeLabel = ({ children }) => (
   <span className="result-type">
@@ -145,6 +176,7 @@ const SearchPage = (props) => {
   const [isFetchingMore, setFetchingMore] = useState(false);
   const [totalHits, setTotalHits] = useState(0);
   const [resultPage, setResultPage] = useState(0);
+  const [redirectURL, setRedirectURL] = useState(null);
 
   const fetchMoreItems = async () => {
     if (isFetchingMore || hits.length >= totalHits) {
@@ -214,16 +246,26 @@ const SearchPage = (props) => {
       if (result.error != null) {
         setError(result.error);
       } else {
+        const textURL = singleMatchingTextIdResultURL(lang, query, result);
+        if (textURL != null) {
+          setRedirectURL(textURL);
+          Router.replace(textURL);
+          return;
+        }
         setResultPage(0);
         setHits(result.hits.hits);
         setTotalHits(totalHitsValue(result.hits));
       }
     };
     asyncLoad();
-  }, [query, poet]);
+  }, [country, lang, poet, query]);
 
   if (error != null) {
     return <ErrorPage error={error} lang={lang} message="Søgning fejlede" />;
+  }
+
+  if (redirectURL != null) {
+    return null;
   }
 
   let resultaterOrd = null;

--- a/tools/libs/elasticsearch-client.js
+++ b/tools/libs/elasticsearch-client.js
@@ -87,6 +87,9 @@ class ElasticSearchClient {
           properties: {
             text: {
               properties: {
+                id: {
+                  type: 'keyword',
+                },
                 title: {
                   type: 'text',
                   analyzer: 'kalliope_text',
@@ -253,7 +256,12 @@ class ElasticSearchClient {
           {
             multi_match: {
               query,
-              fields: ['text.title^3', 'text.subtitles^2', 'text.content_html'],
+              fields: [
+                'text.id^5',
+                'text.title^3',
+                'text.subtitles^2',
+                'text.content_html',
+              ],
             },
           },
         ],


### PR DESCRIPTION
## Ændringer
- Gør tekst-id'er søgbare i Elasticsearch og vægter dem højt i tekstsøgningen.
- Sender brugeren direkte til digtet, når en søgning på id giver præcis ét matchende tekstresultat.
- Dækker både Elasticsearch-queryen og redirect-betingelsen med tests.

## Validering
- npm test

Fixes #1240