### PR TITLE
Prioritér præcise titelmatch i søgning

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -11,3 +11,4 @@ Disse regler gælder for AI-agenter og automatiserede assistenter, der arbejder 
 - Commit, push eller amend aldrig kodeændringer, før brugeren eksplicit har læst ændringen og bedt om commit/push. Det gælder også opdateringer til eksisterende PR-branches.
 - Læs `docs/style-guide.md` før du opretter issues, PRs eller ændringer i data-/billedstrukturen.
 - Ved `gh issue view ... --comments` kan GitHub CLI i non-TTY give tomt tekstoutput for issues uden kommentarer. Brug enten `--json number,title,state,body,comments` eller kør kommandoen med TTY, når issue-indholdet skal læses.
+- Når du opretter eller opdaterer en PR, behøver du ikke vente på GitHubs CI, medmindre brugeren eksplicit beder om det.

--- a/__tests__/elasticsearch-client.test.js
+++ b/__tests__/elasticsearch-client.test.js
@@ -32,6 +32,10 @@ describe('Elasticsearch client', () => {
       tokenizer: 'standard',
       filter: ['lowercase', 'asciifolding'],
     });
+    expect(body.settings.analysis.normalizer.kalliope_keyword).toEqual({
+      type: 'custom',
+      filter: ['lowercase', 'asciifolding'],
+    });
     expect(body.mappings.properties.text.properties.content_html).toEqual({
       type: 'text',
       analyzer: 'kalliope_text',
@@ -45,9 +49,21 @@ describe('Elasticsearch client', () => {
     expect(body.mappings.properties.text.properties.subtitles.analyzer).toBe(
       'kalliope_text'
     );
+    expect(
+      body.mappings.properties.text.properties.title.fields.exact
+    ).toEqual({
+      type: 'keyword',
+      normalizer: 'kalliope_keyword',
+    });
     expect(body.mappings.properties.work.properties.title).toEqual({
       type: 'text',
       analyzer: 'kalliope_text',
+      fields: {
+        exact: {
+          type: 'keyword',
+          normalizer: 'kalliope_keyword',
+        },
+      },
     });
   });
 
@@ -87,72 +103,110 @@ describe('Elasticsearch client', () => {
     await elasticSearchClient.search('kalliope', 'text', 'dk', '', 'aarestrup');
 
     const body = JSON.parse(global.fetch.mock.calls[0][1].body);
-    const resultTypeFilter = body.query.bool.filter[0].bool;
+    const resultTypeQuery = body.query.bool.filter[0].bool;
+    const workQuery = resultTypeQuery.should[1].bool.must[0].bool;
+    const textQuery = resultTypeQuery.should[2].bool.must[0].bool;
 
     expect(body.query.bool.must).toEqual([]);
-    expect(resultTypeFilter).toEqual({
-      should: [
-        {
-          bool: {
-            filter: [{ term: { result_type: 'poet' } }],
-            must: [
-              {
-                multi_match: {
-                  query: 'aarestrup',
-                  fields: ['poet_search^4'],
-                },
-              },
-            ],
-          },
-        },
-        {
-          bool: {
-            must: [
-              {
-                bool: {
-                  filter: [{ term: { result_type: 'work' } }],
-                  must: [
-                    {
-                      multi_match: {
-                        query: 'aarestrup',
-                        fields: ['work.title^3'],
-                      },
-                    },
-                  ],
-                },
-              },
-            ],
-            filter: [{ term: { 'poet.country': 'dk' } }],
-          },
-        },
-        {
-          bool: {
-            must: [
-              {
-                bool: {
-                  filter: [{ term: { result_type: 'text' } }],
-                  must: [
-                    {
-                      multi_match: {
-                        query: 'aarestrup',
-                        fields: [
-                          'text.id^5',
-                          'text.title^3',
-                          'text.subtitles^2',
-                          'text.content_html',
-                        ],
-                      },
-                    },
-                  ],
-                },
-              },
-            ],
-            filter: [{ term: { 'poet.country': 'dk' } }],
-          },
-        },
-      ],
-      minimum_should_match: 1,
+    expect(body.highlight.fields).toEqual({
+      'work.title': {},
+      'text.title': {},
+      'text.content_html': {},
     });
+    expect(resultTypeQuery.minimum_should_match).toBe(1);
+    expect(resultTypeQuery.should[0]).toEqual({
+      bool: {
+        filter: [{ term: { result_type: 'poet' } }],
+        must: [
+          {
+            multi_match: {
+              query: 'aarestrup',
+              fields: ['poet_search^4'],
+            },
+          },
+        ],
+      },
+    });
+    expect(resultTypeQuery.should[1].bool.filter).toEqual([
+      { term: { 'poet.country': 'dk' } },
+    ]);
+    expect(workQuery.filter).toEqual([{ term: { result_type: 'work' } }]);
+    expect(workQuery.must).toEqual([
+      {
+        multi_match: {
+          query: 'aarestrup',
+          fields: ['work.title^8'],
+        },
+      },
+    ]);
+    expect(workQuery.should).toEqual([
+      {
+        match: {
+          'work.title.exact': {
+            query: 'aarestrup',
+            boost: 24,
+          },
+        },
+      },
+      {
+        match_phrase: {
+          'work.title': {
+            query: 'aarestrup',
+            boost: 12,
+          },
+        },
+      },
+      {
+        match_phrase_prefix: {
+          'work.title': {
+            query: 'aarestrup',
+            boost: 6,
+          },
+        },
+      },
+    ]);
+    expect(resultTypeQuery.should[2].bool.filter).toEqual([
+      { term: { 'poet.country': 'dk' } },
+    ]);
+    expect(textQuery.filter).toEqual([{ term: { result_type: 'text' } }]);
+    expect(textQuery.must).toEqual([
+      {
+        multi_match: {
+          query: 'aarestrup',
+          fields: [
+            'text.title^10',
+            'text.subtitles^2',
+            'text.content_html',
+          ],
+        },
+      },
+    ]);
+    expect(textQuery.should).toEqual([
+      {
+        match: {
+          'text.title.exact': {
+            query: 'aarestrup',
+            boost: 40,
+          },
+        },
+      },
+      {
+        match_phrase: {
+          'text.title': {
+            query: 'aarestrup',
+            boost: 20,
+          },
+        },
+      },
+      {
+        match_phrase_prefix: {
+          'text.title': {
+            query: 'aarestrup',
+            boost: 10,
+          },
+        },
+      },
+    ]);
   });
 
   test('searches only works and texts when scoped to a poet', async () => {
@@ -165,50 +219,37 @@ describe('Elasticsearch client', () => {
     );
 
     const body = JSON.parse(global.fetch.mock.calls[0][1].body);
+    const scopedQuery = body.query.bool.must[0].bool;
+    const workQuery = scopedQuery.should[0].bool;
+    const textQuery = scopedQuery.should[1].bool;
 
     expect(body.query.bool.filter).toEqual([
       { term: { 'poet.id': 'aarestrup' } },
       { term: { 'poet.country': 'dk' } },
     ]);
-    expect(body.query.bool.must).toEqual([
-      {
-        bool: {
-          should: [
-            {
-              bool: {
-                filter: [{ term: { result_type: 'work' } }],
-                must: [
-                  {
-                    multi_match: {
-                      query: 'rose',
-                      fields: ['work.title^3'],
-                    },
-                  },
-                ],
-              },
-            },
-            {
-              bool: {
-                filter: [{ term: { result_type: 'text' } }],
-                must: [
-                  {
-                    multi_match: {
-                      query: 'rose',
-                      fields: [
-                        'text.id^5',
-                        'text.title^3',
-                        'text.subtitles^2',
-                        'text.content_html',
-                      ],
-                    },
-                  },
-                ],
-              },
-            },
-          ],
-          minimum_should_match: 1,
+    expect(scopedQuery.minimum_should_match).toBe(1);
+    expect(scopedQuery.should).toHaveLength(2);
+    expect(workQuery.must[0].multi_match.fields).toEqual(['work.title^8']);
+    expect(workQuery.should[0]).toEqual({
+      match: {
+        'work.title.exact': {
+          query: 'rose',
+          boost: 24,
         },
       },
+    });
+    expect(textQuery.must[0].multi_match.fields).toEqual([
+      'text.title^10',
+      'text.subtitles^2',
+      'text.content_html',
     ]);
+    expect(textQuery.should[0]).toEqual({
+      match: {
+        'text.title.exact': {
+          query: 'rose',
+          boost: 40,
+        },
+      },
+    });
   });
 });

--- a/__tests__/elasticsearch-client.test.js
+++ b/__tests__/elasticsearch-client.test.js
@@ -103,11 +103,11 @@ describe('Elasticsearch client', () => {
     await elasticSearchClient.search('kalliope', 'text', 'dk', '', 'aarestrup');
 
     const body = JSON.parse(global.fetch.mock.calls[0][1].body);
-    const resultTypeQuery = body.query.bool.filter[0].bool;
+    const resultTypeQuery = body.query.bool.must[0].bool;
     const workQuery = resultTypeQuery.should[1].bool.must[0].bool;
     const textQuery = resultTypeQuery.should[2].bool.must[0].bool;
 
-    expect(body.query.bool.must).toEqual([]);
+    expect(body.query.bool.filter).toEqual([]);
     expect(body.highlight.fields).toEqual({
       'work.title': {},
       'text.title': {},

--- a/pages/search.js
+++ b/pages/search.js
@@ -64,6 +64,33 @@ const ResultTypeLabel = ({ children }) => (
   </span>
 );
 
+const renderHighlightFragment = (line, keyPrefix = '') => {
+  return line
+    .replace(/\s+/g, ' ')
+    .replace(/^[\s,.!:;?\d"“„]+/, '')
+    .replace(/[\s,.!:;?\d"“„]+$/, '')
+    .split(/(<\/?em>)/)
+    .reduce(
+      (acc, part) => {
+        if (part === '<em>') {
+          acc.highlight = true;
+        } else if (part === '</em>') {
+          acc.highlight = false;
+        } else if (part.length > 0) {
+          acc.parts.push(
+            acc.highlight ? (
+              <em key={`${keyPrefix}em-${acc.parts.length}`}>{part}</em>
+            ) : (
+              part
+            )
+          );
+        }
+        return acc;
+      },
+      { parts: [], highlight: false }
+    ).parts;
+};
+
 const RenderedHits = ({ hits }) => {
   const lang = useContext(LangContext);
 
@@ -94,11 +121,15 @@ const RenderedHits = ({ hits }) => {
         );
       } else if (hit._source.result_type === 'work') {
         const workURL = Links.workURL(lang, poet.id, work.id);
+        const highlightedWorkTitle =
+          highlight && highlight['work.title']
+            ? renderHighlightFragment(highlight['work.title'][0], hit._id)
+            : null;
         item = (
           <div>
             <div className="title">
               <Link href={workURL}>
-                <WorkName work={work} lang={lang} />
+                {highlightedWorkTitle || <WorkName work={work} lang={lang} />}
               </Link>
             </div>
             <div className="poet-and-work">
@@ -115,25 +146,27 @@ const RenderedHits = ({ hits }) => {
         );
       } else {
         const textURL = Links.textURL(lang, text.id);
+        const highlightedTextTitle =
+          highlight && highlight['text.title']
+            ? renderHighlightFragment(highlight['text.title'][0], hit._id)
+            : null;
         let renderedHighlight = null;
         if (highlight && highlight['text.content_html']) {
           // The query is highlighted in each line using <em> by Elasticsearch
           const lines = highlight['text.content_html'];
           renderedHighlight = lines.map((line, i) => {
-            let parts = line
-              .replace(/\s+/g, ' ')
-              .replace(/^[\s,.!:;?\d"“„]+/, '')
-              .replace(/[\s,.!:;?\d"“„]+$/, '')
-              .split(/<\/?em>/);
-            parts[1] = <em key={i}>{parts[1]}</em>;
-            return <div key={i}>{parts}</div>;
+            return (
+              <div key={i}>
+                {renderHighlightFragment(line, `${hit._id}-${i}`)}
+              </div>
+            );
           });
         }
         item = (
           <div>
             <div className="title">
               <Link href={textURL}>
-                <TextName text={text} />
+                {highlightedTextTitle || <TextName text={text} />}
               </Link>
             </div>
             <div className="hightlights">{renderedHighlight}</div>

--- a/tools/libs/elasticsearch-client.js
+++ b/tools/libs/elasticsearch-client.js
@@ -343,7 +343,7 @@ class ElasticSearchClient {
         term: { 'poet.country': country },
       });
     } else {
-      body.query.bool.filter.push({
+      body.query.bool.must.push({
         bool: {
           should: [
             poetSearchQuery,

--- a/tools/libs/elasticsearch-client.js
+++ b/tools/libs/elasticsearch-client.js
@@ -343,6 +343,10 @@ class ElasticSearchClient {
         term: { 'poet.country': country },
       });
     } else {
+      // Keep the actual search query in must/query context so Elasticsearch
+      // calculates _score. Country/result-type limits belong in filter context;
+      // moving the title/text queries there disables title boosts and exact
+      // title matches stop rising to the top.
       body.query.bool.must.push({
         bool: {
           should: [

--- a/tools/libs/elasticsearch-client.js
+++ b/tools/libs/elasticsearch-client.js
@@ -80,6 +80,12 @@ class ElasticSearchClient {
                 filter: ['lowercase', 'asciifolding'],
               },
             },
+            normalizer: {
+              kalliope_keyword: {
+                type: 'custom',
+                filter: ['lowercase', 'asciifolding'],
+              },
+            },
           },
         },
         mappings: {
@@ -93,6 +99,12 @@ class ElasticSearchClient {
                 title: {
                   type: 'text',
                   analyzer: 'kalliope_text',
+                  fields: {
+                    exact: {
+                      type: 'keyword',
+                      normalizer: 'kalliope_keyword',
+                    },
+                  },
                 },
                 content_html: {
                   type: 'text',
@@ -109,6 +121,12 @@ class ElasticSearchClient {
                 title: {
                   type: 'text',
                   analyzer: 'kalliope_text',
+                  fields: {
+                    exact: {
+                      type: 'keyword',
+                      normalizer: 'kalliope_keyword',
+                    },
+                  },
                 },
               },
             },
@@ -236,6 +254,32 @@ class ElasticSearchClient {
         ],
       },
     };
+    const titleBoostQueries = (field, exactBoost) => [
+      {
+        match: {
+          [`${field}.exact`]: {
+            query,
+            boost: exactBoost,
+          },
+        },
+      },
+      {
+        match_phrase: {
+          [field]: {
+            query,
+            boost: exactBoost / 2,
+          },
+        },
+      },
+      {
+        match_phrase_prefix: {
+          [field]: {
+            query,
+            boost: exactBoost / 4,
+          },
+        },
+      },
+    ];
     const workSearchQuery = {
       bool: {
         filter: [{ term: { result_type: 'work' } }],
@@ -243,10 +287,11 @@ class ElasticSearchClient {
           {
             multi_match: {
               query,
-              fields: ['work.title^3'],
+              fields: ['work.title^8'],
             },
           },
         ],
+        should: titleBoostQueries('work.title', 24),
       },
     };
     const textSearchQuery = {
@@ -257,14 +302,14 @@ class ElasticSearchClient {
             multi_match: {
               query,
               fields: [
-                'text.id^5',
-                'text.title^3',
+                'text.title^10',
                 'text.subtitles^2',
                 'text.content_html',
               ],
             },
           },
         ],
+        should: titleBoostQueries('text.title', 40),
       },
     };
     const body = {
@@ -278,6 +323,8 @@ class ElasticSearchClient {
       },
       highlight: {
         fields: {
+          'work.title': {},
+          'text.title': {},
           'text.content_html': {},
         },
       },


### PR DESCRIPTION
## Ændringer

- Tilføjer normaliserede exact-underfelter for værk- og teksttitler i Elasticsearch-indekset.
- Booster præcise titelmatch, titel-frase-match og titel-prefix-match over almindelige brødtekstforekomster.
- Flytter den overordnede resultattype-query ud af filter-kontekst, så Elasticsearch faktisk beregner score ved almindelig søgning.
- Fremhæver titelmatch i søgeresultater for værker og tekster.
- Opdaterer tests for mapping, titelboosts, highlights og scoring-kontekst.

## Validering

- npm test -- --runTestsByPath __tests__/elasticsearch-client.test.js __tests__/search.test.js
- npm test
- git diff --cached --check
- Lokalt på port 3001: Hyrdernes Tilbedelse ligger som første resultat.
- Lokalt på port 3001: Lys-Englen ligger som første resultat.

Fixes #1242