### PR TITLE
Fjern XML-kommentarer ved tekstindlæsning

### DIFF
--- a/__tests__/helpers.test.js
+++ b/__tests__/helpers.test.js
@@ -1,0 +1,51 @@
+import { htmlToXml } from '../tools/libs/helpers.js';
+
+const collected = {
+  texts: new Map(),
+  keywords: new Map(),
+  dict: new Map(),
+};
+
+const lineTexts = html => htmlToXml(html, collected).map(([line]) => line);
+
+describe('helpers', () => {
+  describe('htmlToXml', () => {
+    it('removes inline XML comments', () => {
+      expect(lineTexts('Foraaret <!-- section title -->')).toEqual([
+        'Foraaret',
+      ]);
+    });
+
+    it('preserves word boundaries around inline XML comments', () => {
+      expect(lineTexts('foo <!-- c --> bar')).toEqual(['foo bar']);
+    });
+
+    it('removes XML comment lines without leaving empty numbered lines', () => {
+      expect(
+        htmlToXml(
+          'Første linje\n   <!-- metadata checked -->\nAnden linje',
+          collected
+        )
+      ).toEqual([
+        ['Første linje', { num: 1 }],
+        ['Anden linje', { num: 2 }],
+      ]);
+    });
+
+    it('removes multi-line XML comments without leaving comment fragments', () => {
+      expect(
+        htmlToXml(
+          'Første linje\n' +
+            '   <!-- metadata\n' +
+            '        checked: 2026-07-16\n' +
+            '        source verified -->\n' +
+            'Anden linje',
+          collected
+        )
+      ).toEqual([
+        ['Første linje', { num: 1 }],
+        ['Anden linje', { num: 2 }],
+      ]);
+    });
+  });
+});

--- a/tools/libs/helpers.js
+++ b/tools/libs/helpers.js
@@ -132,8 +132,14 @@ const htmlToXml = (html, collected, isPoetry) => {
       .replace(/^\[(\d+\.?)\]\s*$/gm, '<versenum>[$1]</versenum>');
   }
   html = html
-    .replace(/\n/g, '::NEWLINE-PLACEHOLDER::') // Regexp nedenunder spænder ikke over flere linjer... underligt.
-    .replace(/<!--.*?-->/g, '')
+    .replace(/\n/g, '::NEWLINE-PLACEHOLDER::')
+    .replace(
+      /(^|::NEWLINE-PLACEHOLDER::)[ \t]*<!--.*?-->[ \t]*(::NEWLINE-PLACEHOLDER::|$)/g,
+      (match, before) => before
+    )
+    .replace(/[ \t]*<!--.*?-->[ \t]*/g, match => {
+      return /^[ \t]+<!--.*?-->[ \t]+$/.test(match) ? ' ' : '';
+    })
     .replace(/::NEWLINE-PLACEHOLDER::/g, '\n');
   let decoded = decodeXmlCharacterReferences(
     replaceDashes(


### PR DESCRIPTION
## Ændringer

- Fjerner XML-kommentarer i htmlToXml, uden at kommentarlinjer bliver til tomme tekstlinjer.
- Bevarer ordmellemrum omkring inline-kommentarer.
- Tilføjer unit-tests for inline-kommentarer, kommentarlinjer og kommentarer over flere linjer.

Fixes #1252.

## Validering

- npm test -- __tests__/helpers.test.js
- npm run build-static