### PR TITLE
Opdater Louvre-billedmetadata

### DIFF
--- a/components/picture.js
+++ b/components/picture.js
@@ -27,7 +27,12 @@ const FigCaption = (props) => {
 
   let remoteLink = null;
   if (picture.remoteUrl != null) {
-    remoteLink = <a href={picture.remoteUrl}>⌘</a>;
+    remoteLink = (
+      <>
+        {' '}
+        <a href={picture.remoteUrl}>⌘</a>
+      </>
+    );
   }
 
   let museumRendered = null;

--- a/fdirs/dante/commedia.xml
+++ b/fdirs/dante/commedia.xml
@@ -1086,8 +1086,8 @@ con li occhi vòlti a chi del fango ingozza.
    <indextitle>Canto VIII</indextitle>
    <firstline>Io dico, seguitando, ch'assai prima</firstline>
    <pictures>
-       <picture src="dante2005050108-p1.jpg" wikidata="Q2354251" museum="louvre">
-         Eugène Delacroix: <i>La Barque de Dante</i>, 1822, olie på lærred, 189×246 cm. Louvre.
+       <picture src="dante2005050108-p1.jpg" wikidata="Q2354251" museum="louvre" objid="cl010065871" invnr="INV 3820">
+         Eugène Delacroix: <i>La Barque de Dante</i>, 1822, olie på lærred, 189×246 cm.
          <!-- metadata checked: 2026-07-16 -->
        </picture>
        <picture src="dante2005050108-p2.jpg" wikidata="Q2665048">

--- a/fdirs/rimestad/1908.xml
+++ b/fdirs/rimestad/1908.xml
@@ -976,7 +976,7 @@ En Hjemvé mod svundne Lyster har fyldt hendes Blik!
     <subtitle>Til Otto Rung</subtitle>
     <firstline>Det Smil blev til i en Mesters Drøm</firstline>
     <pictures>
-        <picture src="rimestad2019030614-p1.jpg" wikidata="Q783215" museum="louvre" objid="cl010062371" invnr="INV 775">Leonardo da Vinci: <i>Johannes Døberen</i>, 1513-1516, olie på træ, 69 × 57 cm.</picture>
+        <picture src="rimestad2019030614-p1.jpg" wikidata="Q783215" museum="louvre" objid="cl010062374" invnr="INV 775">Leonardo da Vinci: <i>Johannes Døberen</i>, 1513-1516, olie på træ, 69 × 57 cm.</picture>
     </pictures>
     <notes>
         <note>Otto Rung (1874-1945), jurist, embedsmands, forfatter og især kendt som produktiv manuskriptforfatter.</note>


### PR DESCRIPTION
## Ændringer

- Tilføjer Louvre-objektdata for Delacroix-billedet i Dantes Commedia.
- Retter Louvre-objekt-id for Leonardo da Vincis Johannes Døberen.
- Bevarer mellemrum før eksternt billedlink i billedtekster.

## Validering

- npm run build-static
- npm run build