### PR TITLE
Tilføj machettekster på næsten alle sider

### DIFF
--- a/common/translations.js
+++ b/common/translations.js
@@ -22,6 +22,7 @@ const translations = {
   'en*Biografi': 'Biography',
   'en*Om': 'About',
   'en*Nyheder': 'News',
+  'en*Seneste nyt': 'Latest news',
   'en*Sidst ændret': 'Last modified',
   'en*digtere': 'poets',
   'en*Efter navn': 'By name',
@@ -63,6 +64,8 @@ const translations = {
     "Kalliope's {adjective} poets ordered by birth year. The overview gives a chronological view of the collection's authors.",
   'en*{Adjective} digtere er kun medtaget i begrænset omfang for at belyse den danske digtning.':
     '{Adjective} poets are included only to a limited extent to illuminate Danish poetry.',
+  'en*Kalliope er et digitalt bibliotek for poesi og klassisk litteratur. Her finder du digte, oversættelser, forfatterbiografier og litterære noter, frit tilgængeligt og forbundet gennem personer, værker, steder og historiske perioder.':
+    'Kalliope is a digital library for poetry and classic literature. Here you will find poems, translations, author biographies, and literary notes, freely available and connected through people, works, places, and historical periods.',
   'en*Kalliope er gennem årene blevet til med hjælp fra mange læsere og bidragydere. Her takker vi dem, der har sendt digte, billeder, oplysninger og rettelser eller på anden måde har hjulpet samlingen.':
     'Over the years, Kalliope has been built with help from many readers and contributors. Here we thank those who have sent poems, pictures, information, and corrections, or otherwise helped the collection.',
   'en*Her finder du Kalliopes artikler om litterære perioder, genrer, versformer, begreber og andre emner med tilknytning til digtningen.':
@@ -71,6 +74,14 @@ const translations = {
     'An overview of museums and collections that own artworks and portraits reproduced on Kalliope. Select a museum to see the associated images.',
   'en*En kronologisk oversigt over værker af {poetName} på Kalliope. Vælg et værk for at se dets indhold og læse de tekster, der findes i samlingen.':
     'A chronological overview of works by {poetName} on Kalliope. Select a work to see its contents and read the texts included in the collection.',
+  'en*En oversigt over Bibelens bøger på Kalliope. Vælg en bog for at se dens indhold og læse de tekster, der findes i samlingen.':
+    'An overview of the books of the Bible on Kalliope. Select a book to see its contents and read the texts included in the collection.',
+  'en*En oversigt over folkeviser på Kalliope. Vælg et værk for at se dets indhold og læse de tekster, der findes i samlingen.':
+    'An overview of folk ballads on Kalliope. Select a work to see its contents and read the texts included in the collection.',
+  'en*En oversigt over værker på Kalliope af ukendte forfattere fra {period}. Vælg et værk for at se dets indhold og læse de tekster, der findes i samlingen.':
+    'An overview of works on Kalliope by unknown authors from the {period}. Select a work to see its contents and read the texts included in the collection.',
+  'en*En oversigt over værker i denne samling på Kalliope. Vælg et værk for at se dets indhold og læse de tekster, der findes i samlingen.':
+    'An overview of works in this collection on Kalliope. Select a work to see its contents and read the texts included in the collection.',
   'en*Alle digte af {poetName} på Kalliope ordnet alfabetisk efter titel.':
     'All poems by {poetName} on Kalliope, ordered alphabetically by title.',
   'en*Alle digte af {poetName} på Kalliope ordnet alfabetisk efter tekstens første linje. Listen kan bruges til at finde et digt, når titlen er ukendt.':
@@ -113,6 +124,7 @@ const translations = {
   'de*biografi': 'Biografie',
   'de*Om': 'Über',
   'de*Nyheder': 'Aktuelles',
+  'de*Seneste nyt': 'Neuigkeiten',
   'de*Sidst ændret': 'Zuletzt geändert',
   'de*digtere': 'Dichter',
   'de*digte': 'Gedichte',
@@ -132,6 +144,8 @@ const translations = {
     'Kalliopes {adjective} Dichter nach Geburtsjahr geordnet. Die Übersicht gibt einen chronologischen Einblick in die Autoren der Sammlung.',
   'de*{Adjective} digtere er kun medtaget i begrænset omfang for at belyse den danske digtning.':
     '{Adjective} Dichter sind nur in begrenztem Umfang aufgenommen, um die dänische Dichtung zu beleuchten.',
+  'de*Kalliope er et digitalt bibliotek for poesi og klassisk litteratur. Her finder du digte, oversættelser, forfatterbiografier og litterære noter, frit tilgængeligt og forbundet gennem personer, værker, steder og historiske perioder.':
+    'Kalliope ist eine digitale Bibliothek für Poesie und klassische Literatur. Hier finden Sie Gedichte, Übersetzungen, Autorenbiografien und literarische Notizen, frei zugänglich und verknüpft durch Personen, Werke, Orte und historische Epochen.',
   'de*Kalliope er gennem årene blevet til med hjælp fra mange læsere og bidragydere. Her takker vi dem, der har sendt digte, billeder, oplysninger og rettelser eller på anden måde har hjulpet samlingen.':
     'Kalliope ist im Laufe der Jahre mit Hilfe vieler Leser und Beiträger entstanden. Hier danken wir allen, die Gedichte, Bilder, Informationen und Korrekturen eingesandt oder die Sammlung auf andere Weise unterstützt haben.',
   'de*Her finder du Kalliopes artikler om litterære perioder, genrer, versformer, begreber og andre emner med tilknytning til digtningen.':
@@ -140,6 +154,14 @@ const translations = {
     'Eine Übersicht über Museen und Sammlungen, die auf Kalliope wiedergegebene Kunstwerke und Porträts besitzen. Wählen Sie ein Museum, um die zugehörigen Bilder zu sehen.',
   'de*En kronologisk oversigt over værker af {poetName} på Kalliope. Vælg et værk for at se dets indhold og læse de tekster, der findes i samlingen.':
     'Eine chronologische Übersicht über Werke von {poetName} auf Kalliope. Wählen Sie ein Werk, um dessen Inhalt zu sehen und die in der Sammlung vorhandenen Texte zu lesen.',
+  'de*En oversigt over Bibelens bøger på Kalliope. Vælg en bog for at se dens indhold og læse de tekster, der findes i samlingen.':
+    'Eine Übersicht über die Bücher der Bibel auf Kalliope. Wählen Sie ein Buch, um dessen Inhalt zu sehen und die in der Sammlung vorhandenen Texte zu lesen.',
+  'de*En oversigt over folkeviser på Kalliope. Vælg et værk for at se dets indhold og læse de tekster, der findes i samlingen.':
+    'Eine Übersicht über Volksballaden auf Kalliope. Wählen Sie ein Werk, um dessen Inhalt zu sehen und die in der Sammlung vorhandenen Texte zu lesen.',
+  'de*En oversigt over værker på Kalliope af ukendte forfattere fra {period}. Vælg et værk for at se dets indhold og læse de tekster, der findes i samlingen.':
+    'Eine Übersicht über Werke unbekannter Autoren aus dem {period} auf Kalliope. Wählen Sie ein Werk, um dessen Inhalt zu sehen und die in der Sammlung vorhandenen Texte zu lesen.',
+  'de*En oversigt over værker i denne samling på Kalliope. Vælg et værk for at se dets indhold og læse de tekster, der findes i samlingen.':
+    'Eine Übersicht über Werke in dieser Sammlung auf Kalliope. Wählen Sie ein Werk, um dessen Inhalt zu sehen und die in der Sammlung vorhandenen Texte zu lesen.',
   'de*Alle digte af {poetName} på Kalliope ordnet alfabetisk efter titel.':
     'Alle Gedichte von {poetName} auf Kalliope, alphabetisch nach Titel geordnet.',
   'de*Alle digte af {poetName} på Kalliope ordnet alfabetisk efter tekstens første linje. Listen kan bruges til at finde et digt, når titlen er ukendt.':
@@ -213,6 +235,7 @@ const translations = {
   'fr*biografi': 'biographie',
   'fr*Om': 'À propos',
   'fr*Nyheder': 'Actualités',
+  'fr*Seneste nyt': 'Dernières nouvelles',
   'fr*Sidst ændret': 'Dernière modification',
   'fr*digtere': 'poètes',
   'fr*digte': 'poèmes',
@@ -232,6 +255,8 @@ const translations = {
     'Les poètes {adjective} de Kalliope classés par année de naissance. Cet aperçu donne une vue chronologique des auteurs de la collection.',
   'fr*{Adjective} digtere er kun medtaget i begrænset omfang for at belyse den danske digtning.':
     'Les poètes {adjective} ne sont inclus que dans une mesure limitée afin d’éclairer la poésie danoise.',
+  'fr*Kalliope er et digitalt bibliotek for poesi og klassisk litteratur. Her finder du digte, oversættelser, forfatterbiografier og litterære noter, frit tilgængeligt og forbundet gennem personer, værker, steder og historiske perioder.':
+    'Kalliope est une bibliothèque numérique de poésie et de littérature classique. Vous y trouverez des poèmes, des traductions, des biographies d’auteurs et des notes littéraires, librement accessibles et reliés par des personnes, des œuvres, des lieux et des périodes historiques.',
   'fr*Kalliope er gennem årene blevet til med hjælp fra mange læsere og bidragydere. Her takker vi dem, der har sendt digte, billeder, oplysninger og rettelser eller på anden måde har hjulpet samlingen.':
     'Au fil des années, Kalliope a été constitué avec l’aide de nombreux lecteurs et contributeurs. Nous remercions ici celles et ceux qui ont envoyé des poèmes, des images, des informations et des corrections, ou qui ont aidé la collection d’une autre manière.',
   'fr*Her finder du Kalliopes artikler om litterære perioder, genrer, versformer, begreber og andre emner med tilknytning til digtningen.':
@@ -240,6 +265,14 @@ const translations = {
     'Un aperçu des musées et collections qui possèdent les œuvres d’art et portraits reproduits sur Kalliope. Choisissez un musée pour voir les images associées.',
   'fr*En kronologisk oversigt over værker af {poetName} på Kalliope. Vælg et værk for at se dets indhold og læse de tekster, der findes i samlingen.':
     'Un aperçu chronologique des œuvres de {poetName} sur Kalliope. Choisissez une œuvre pour voir son contenu et lire les textes présents dans la collection.',
+  'fr*En oversigt over Bibelens bøger på Kalliope. Vælg en bog for at se dens indhold og læse de tekster, der findes i samlingen.':
+    'Un aperçu des livres de la Bible sur Kalliope. Choisissez un livre pour voir son contenu et lire les textes présents dans la collection.',
+  'fr*En oversigt over folkeviser på Kalliope. Vælg et værk for at se dets indhold og læse de tekster, der findes i samlingen.':
+    'Un aperçu des ballades populaires sur Kalliope. Choisissez une œuvre pour voir son contenu et lire les textes présents dans la collection.',
+  'fr*En oversigt over værker på Kalliope af ukendte forfattere fra {period}. Vælg et værk for at se dets indhold og læse de tekster, der findes i samlingen.':
+    'Un aperçu des œuvres d’auteurs inconnus du {period} sur Kalliope. Choisissez une œuvre pour voir son contenu et lire les textes présents dans la collection.',
+  'fr*En oversigt over værker i denne samling på Kalliope. Vælg et værk for at se dets indhold og læse de tekster, der findes i samlingen.':
+    'Un aperçu des œuvres de cette collection sur Kalliope. Choisissez une œuvre pour voir son contenu et lire les textes présents dans la collection.',
   'fr*Alle digte af {poetName} på Kalliope ordnet alfabetisk efter titel.':
     'Tous les poèmes de {poetName} sur Kalliope, classés par ordre alphabétique de titre.',
   'fr*Alle digte af {poetName} på Kalliope ordnet alfabetisk efter tekstens første linje. Listen kan bruges til at finde et digt, når titlen er ukendt.':

--- a/common/translations.js
+++ b/common/translations.js
@@ -57,6 +57,30 @@ const translations = {
     '{poetName}: “{poemTitle}” from {workTitle}',
   'en*Søg i Kalliopes {adjective} samling':
     "Search Kalliope's {adjective} collection",
+  'en*En alfabetisk oversigt over de {adjective} digtere på Kalliope. Vælg et navn for at se digterens værker, tekster og biografiske oplysninger.':
+    "An alphabetical overview of Kalliope's {adjective} poets. Select a name to see the poet's works, texts, and biographical information.",
+  'en*De {adjective} digtere på Kalliope ordnet efter fødselsår. Oversigten giver et kronologisk indblik i samlingens forfattere.':
+    "Kalliope's {adjective} poets ordered by birth year. The overview gives a chronological view of the collection's authors.",
+  'en*{Adjective} digtere er kun medtaget i begrænset omfang for at belyse den danske digtning.':
+    '{Adjective} poets are included only to a limited extent to illuminate Danish poetry.',
+  'en*Kalliope er gennem årene blevet til med hjælp fra mange læsere og bidragydere. Her takker vi dem, der har sendt digte, billeder, oplysninger og rettelser eller på anden måde har hjulpet samlingen.':
+    'Over the years, Kalliope has been built with help from many readers and contributors. Here we thank those who have sent poems, pictures, information, and corrections, or otherwise helped the collection.',
+  'en*Her finder du Kalliopes artikler om litterære perioder, genrer, versformer, begreber og andre emner med tilknytning til digtningen.':
+    "Here you will find Kalliope's articles on literary periods, genres, verse forms, concepts, and other topics related to poetry.",
+  'en*En oversigt over museer og samlinger, som ejer kunstværker og portrætter gengivet på Kalliope. Vælg et museum for at se de tilknyttede billeder.':
+    'An overview of museums and collections that own artworks and portraits reproduced on Kalliope. Select a museum to see the associated images.',
+  'en*En kronologisk oversigt over værker af {poetName} på Kalliope. Vælg et værk for at se dets indhold og læse de tekster, der findes i samlingen.':
+    'A chronological overview of works by {poetName} on Kalliope. Select a work to see its contents and read the texts included in the collection.',
+  'en*Alle digte af {poetName} på Kalliope ordnet alfabetisk efter titel.':
+    'All poems by {poetName} on Kalliope, ordered alphabetically by title.',
+  'en*Alle digte af {poetName} på Kalliope ordnet alfabetisk efter tekstens første linje. Listen kan bruges til at finde et digt, når titlen er ukendt.':
+    'All poems by {poetName} on Kalliope, ordered alphabetically by the first line of the text. The list can be used to find a poem when the title is unknown.',
+  'en*Her finder du tekster af andre forfattere, som omtaler eller henvender sig til {poetName}, samt oversættelser af digterens tekster til andre sprog.':
+    "Here you will find texts by other authors that mention or address {poetName}, as well as translations of the poet's texts into other languages.",
+  'en*Her finder du oversættelser af tekster af {poetName} til andre sprog.':
+    'Here you will find translations of texts by {poetName} into other languages.',
+  'en*Her finder du tekster af andre forfattere, som omtaler eller henvender sig til {poetName}.':
+    'Here you will find texts by other authors that mention or address {poetName}.',
   'en*Variant': 'Variation',
   'en*Varianter': 'Variations',
   'en*{varianter} af denne tekst:': '{varianter} of this text:',
@@ -102,6 +126,30 @@ const translations = {
   'de*Søg i Kalliope': 'Kalliope durchsuchen',
   'de*Søg i Kalliopes {adjective} samling':
     'Kalliopes {adjective} Sammlung durchsuchen',
+  'de*En alfabetisk oversigt over de {adjective} digtere på Kalliope. Vælg et navn for at se digterens værker, tekster og biografiske oplysninger.':
+    'Eine alphabetische Übersicht über Kalliopes {adjective} Dichter. Wählen Sie einen Namen, um Werke, Texte und biografische Informationen des Dichters zu sehen.',
+  'de*De {adjective} digtere på Kalliope ordnet efter fødselsår. Oversigten giver et kronologisk indblik i samlingens forfattere.':
+    'Kalliopes {adjective} Dichter nach Geburtsjahr geordnet. Die Übersicht gibt einen chronologischen Einblick in die Autoren der Sammlung.',
+  'de*{Adjective} digtere er kun medtaget i begrænset omfang for at belyse den danske digtning.':
+    '{Adjective} Dichter sind nur in begrenztem Umfang aufgenommen, um die dänische Dichtung zu beleuchten.',
+  'de*Kalliope er gennem årene blevet til med hjælp fra mange læsere og bidragydere. Her takker vi dem, der har sendt digte, billeder, oplysninger og rettelser eller på anden måde har hjulpet samlingen.':
+    'Kalliope ist im Laufe der Jahre mit Hilfe vieler Leser und Beiträger entstanden. Hier danken wir allen, die Gedichte, Bilder, Informationen und Korrekturen eingesandt oder die Sammlung auf andere Weise unterstützt haben.',
+  'de*Her finder du Kalliopes artikler om litterære perioder, genrer, versformer, begreber og andre emner med tilknytning til digtningen.':
+    'Hier finden Sie Kalliopes Artikel über literarische Epochen, Gattungen, Versformen, Begriffe und andere Themen mit Bezug zur Dichtung.',
+  'de*En oversigt over museer og samlinger, som ejer kunstværker og portrætter gengivet på Kalliope. Vælg et museum for at se de tilknyttede billeder.':
+    'Eine Übersicht über Museen und Sammlungen, die auf Kalliope wiedergegebene Kunstwerke und Porträts besitzen. Wählen Sie ein Museum, um die zugehörigen Bilder zu sehen.',
+  'de*En kronologisk oversigt over værker af {poetName} på Kalliope. Vælg et værk for at se dets indhold og læse de tekster, der findes i samlingen.':
+    'Eine chronologische Übersicht über Werke von {poetName} auf Kalliope. Wählen Sie ein Werk, um dessen Inhalt zu sehen und die in der Sammlung vorhandenen Texte zu lesen.',
+  'de*Alle digte af {poetName} på Kalliope ordnet alfabetisk efter titel.':
+    'Alle Gedichte von {poetName} auf Kalliope, alphabetisch nach Titel geordnet.',
+  'de*Alle digte af {poetName} på Kalliope ordnet alfabetisk efter tekstens første linje. Listen kan bruges til at finde et digt, når titlen er ukendt.':
+    'Alle Gedichte von {poetName} auf Kalliope, alphabetisch nach der ersten Zeile des Textes geordnet. Die Liste kann verwendet werden, um ein Gedicht zu finden, wenn der Titel unbekannt ist.',
+  'de*Her finder du tekster af andre forfattere, som omtaler eller henvender sig til {poetName}, samt oversættelser af digterens tekster til andre sprog.':
+    'Hier finden Sie Texte anderer Autoren, die {poetName} erwähnen oder sich an {poetName} richten, sowie Übersetzungen der Texte des Dichters in andere Sprachen.',
+  'de*Her finder du oversættelser af tekster af {poetName} til andre sprog.':
+    'Hier finden Sie Übersetzungen von Texten von {poetName} in andere Sprachen.',
+  'de*Her finder du tekster af andre forfattere, som omtaler eller henvender sig til {poetName}.':
+    'Hier finden Sie Texte anderer Autoren, die {poetName} erwähnen oder sich an {poetName} richten.',
   'de*er oversat af': 'wurde übersetzt von',
   'de*har oversat': 'hat übersetzt',
   'de* et ukendt digt ': ' ein unbekanntes Gedicht ',
@@ -178,6 +226,30 @@ const translations = {
   'fr*Søg i Kalliope': 'Rechercher dans Kalliope',
   'fr*Søg i Kalliopes {adjective} samling':
     'Rechercher dans la collection {adjective} de Kalliope',
+  'fr*En alfabetisk oversigt over de {adjective} digtere på Kalliope. Vælg et navn for at se digterens værker, tekster og biografiske oplysninger.':
+    'Un aperçu alphabétique des poètes {adjective} de Kalliope. Choisissez un nom pour voir les œuvres, les textes et les informations biographiques du poète.',
+  'fr*De {adjective} digtere på Kalliope ordnet efter fødselsår. Oversigten giver et kronologisk indblik i samlingens forfattere.':
+    'Les poètes {adjective} de Kalliope classés par année de naissance. Cet aperçu donne une vue chronologique des auteurs de la collection.',
+  'fr*{Adjective} digtere er kun medtaget i begrænset omfang for at belyse den danske digtning.':
+    'Les poètes {adjective} ne sont inclus que dans une mesure limitée afin d’éclairer la poésie danoise.',
+  'fr*Kalliope er gennem årene blevet til med hjælp fra mange læsere og bidragydere. Her takker vi dem, der har sendt digte, billeder, oplysninger og rettelser eller på anden måde har hjulpet samlingen.':
+    'Au fil des années, Kalliope a été constitué avec l’aide de nombreux lecteurs et contributeurs. Nous remercions ici celles et ceux qui ont envoyé des poèmes, des images, des informations et des corrections, ou qui ont aidé la collection d’une autre manière.',
+  'fr*Her finder du Kalliopes artikler om litterære perioder, genrer, versformer, begreber og andre emner med tilknytning til digtningen.':
+    'Vous trouverez ici les articles de Kalliope sur les périodes littéraires, les genres, les formes versifiées, les notions et d’autres sujets liés à la poésie.',
+  'fr*En oversigt over museer og samlinger, som ejer kunstværker og portrætter gengivet på Kalliope. Vælg et museum for at se de tilknyttede billeder.':
+    'Un aperçu des musées et collections qui possèdent les œuvres d’art et portraits reproduits sur Kalliope. Choisissez un musée pour voir les images associées.',
+  'fr*En kronologisk oversigt over værker af {poetName} på Kalliope. Vælg et værk for at se dets indhold og læse de tekster, der findes i samlingen.':
+    'Un aperçu chronologique des œuvres de {poetName} sur Kalliope. Choisissez une œuvre pour voir son contenu et lire les textes présents dans la collection.',
+  'fr*Alle digte af {poetName} på Kalliope ordnet alfabetisk efter titel.':
+    'Tous les poèmes de {poetName} sur Kalliope, classés par ordre alphabétique de titre.',
+  'fr*Alle digte af {poetName} på Kalliope ordnet alfabetisk efter tekstens første linje. Listen kan bruges til at finde et digt, når titlen er ukendt.':
+    'Tous les poèmes de {poetName} sur Kalliope, classés par ordre alphabétique du premier vers. La liste peut servir à trouver un poème lorsque le titre est inconnu.',
+  'fr*Her finder du tekster af andre forfattere, som omtaler eller henvender sig til {poetName}, samt oversættelser af digterens tekster til andre sprog.':
+    'Vous trouverez ici des textes d’autres auteurs qui mentionnent {poetName} ou s’adressent à {poetName}, ainsi que des traductions des textes du poète dans d’autres langues.',
+  'fr*Her finder du oversættelser af tekster af {poetName} til andre sprog.':
+    'Vous trouverez ici des traductions de textes de {poetName} dans d’autres langues.',
+  'fr*Her finder du tekster af andre forfattere, som omtaler eller henvender sig til {poetName}.':
+    'Vous trouverez ici des textes d’autres auteurs qui mentionnent {poetName} ou s’adressent à {poetName}.',
   'fr*er oversat af': 'a ètè traduit par',
   'fr*har oversat': 'a traduit',
   'fr* et ukendt digt ': ' un poème inconnu ',

--- a/components/pagelead.js
+++ b/components/pagelead.js
@@ -1,0 +1,25 @@
+const PageLead = (props) => {
+  const { children } = props;
+  return (
+    <div className="page-lead">
+      {children}
+      <style jsx>{`
+        .page-lead {
+          max-width: 760px;
+          margin: -10px 0 30px 0;
+          color: #555;
+          font-size: 20px;
+          line-height: 1.45;
+        }
+
+        @media (max-width: 480px) {
+          .page-lead {
+            font-size: 18px;
+          }
+        }
+      `}</style>
+    </div>
+  );
+};
+
+export default PageLead;

--- a/components/pagelead.js
+++ b/components/pagelead.js
@@ -6,7 +6,7 @@ const PageLead = (props) => {
       <style jsx>{`
         .page-lead {
           max-width: 760px;
-          margin: -10px 0 30px 0;
+          margin: -10px 0 60px 0;
           color: #555;
           font-size: 20px;
           line-height: 1.45;

--- a/pages/about.js
+++ b/pages/about.js
@@ -7,6 +7,7 @@ import * as Links from '../components/links.js';
 import { kalliopeMenu } from '../components/menu.js';
 import Note from '../components/note.js';
 import Page from '../components/page.js';
+import PageLead from '../components/pagelead.js';
 import SidebarPictures from '../components/sidebarpictures.js';
 import SidebarSplit from '../components/sidebarsplit.js';
 import SubHeading from '../components/subheading.js';
@@ -79,6 +80,12 @@ const About = (props) => {
     pageBody = (
       <div className="thanks-list">
         <SubHeading>{keyword.title}</SubHeading>
+        <PageLead>
+          {_(
+            'Kalliope er gennem årene blevet til med hjælp fra mange læsere og bidragydere. Her takker vi dem, der har sendt digte, billeder, oplysninger og rettelser eller på anden måde har hjulpet samlingen.',
+            lang
+          )}
+        </PageLead>
         <TwoColumns>{body}</TwoColumns>
         <style jsx>{`
           .thanks-list {

--- a/pages/index.js
+++ b/pages/index.js
@@ -6,6 +6,7 @@ import { kalliopeCrumbs } from '../components/breadcrumbs.js';
 import { formattedDate } from '../components/formatteddate.js';
 import { kalliopeMenu } from '../components/menu.js';
 import Page from '../components/page.js';
+import PageLead from '../components/pagelead.js';
 import Picture from '../components/picture.js';
 import SidebarSplit from '../components/sidebarsplit.js';
 import SplitWhenSmall from '../components/split-when-small.js';
@@ -97,14 +98,9 @@ const News = ({ news }) => {
   const items = news
     .filter((_, i) => i < 5)
     .map((item, i) => {
-      const { date, content_html, content_lang, title } = item;
-      let renderedTitle = null;
-      if (i === 0 && title != null) {
-        renderedTitle = <h3>{title}</h3>;
-      }
+      const { date, content_html, content_lang } = item;
       return (
         <div className="news-item" key={date + i}>
-          {renderedTitle}
           <div className="news-body">
             <TextContent
               contentHtml={content_html}
@@ -116,18 +112,6 @@ const News = ({ news }) => {
           <style jsx>{`
             div.news-item {
               margin-bottom: 20px;
-            }
-            div.news-item:first-child {
-              padding-bottom: 40px;
-              border-bottom: 1px solid #757575;
-              margin-bottom: 50px;
-            }
-
-            :global(div.news-item h3) {
-              font-weight: 100;
-              font-size: 26px;
-              margin: 0 0 20px 0;
-              padding: 0;
             }
             div.news-body {
               line-height: 1.6;
@@ -143,7 +127,12 @@ const News = ({ news }) => {
       );
     });
 
-  return <div>{items}</div>;
+  return (
+    <div>
+      <SubHeading>{_('Seneste nyt', lang)}</SubHeading>
+      {items}
+    </div>
+  );
 };
 
 const zeroPad = (n) => {
@@ -181,6 +170,12 @@ let Index = (props) => {
       menuItems={kalliopeMenu()}
       selectedMenuItem="index"
       paging={paging}>
+      <PageLead>
+        {_(
+          'Kalliope er et digitalt bibliotek for poesi og klassisk litteratur. Her finder du digte, oversættelser, forfatterbiografier og litterære noter, frit tilgængeligt og forbundet gennem personer, værker, steder og historiske perioder.',
+          lang
+        )}
+      </PageLead>
       <SidebarSplit sidebar={sidebar}>
         <div>
           <News news={news} lang={lang} />

--- a/pages/keywords.js
+++ b/pages/keywords.js
@@ -8,6 +8,7 @@ import LangSelect from '../components/langselect.js';
 import * as Links from '../components/links.js';
 import { kalliopeMenu } from '../components/menu.js';
 import Page from '../components/page.js';
+import PageLead from '../components/pagelead.js';
 import SectionedList from '../components/sectionedlist.js';
 
 const groupsByLetter = (keywords) => {
@@ -63,6 +64,12 @@ const Keywords = (props) => {
       pageTitle={_('Nøgleord', lang)}
       menuItems={kalliopeMenu()}
       selectedMenuItem="keywords">
+      <PageLead>
+        {_(
+          'Her finder du Kalliopes artikler om litterære perioder, genrer, versformer, begreber og andre emner med tilknytning til digtningen.',
+          lang
+        )}
+      </PageLead>
       {renderedGroups}
       <LangSelect path={requestPath} />
     </Page>

--- a/pages/mentions.js
+++ b/pages/mentions.js
@@ -8,6 +8,7 @@ import { poetCrumbsWithTitle } from '../components/breadcrumbs.js';
 import * as Links from '../components/links.js';
 import { poetMenu } from '../components/menu.js';
 import Page from '../components/page.js';
+import PageLead from '../components/pagelead.js';
 import { poetNameString } from '../components/poetname-helpers.js';
 import PoetName from '../components/poetname.js';
 import { TextInline } from '../components/textcontent.js';
@@ -237,6 +238,42 @@ const TranslationsSection = (props) => {
   return <Section title={title} items={items} />;
 };
 
+const MentionsLead = (props) => {
+  const { hasReferences, hasTranslations, lang, poet } = props;
+  const poetName = poetNameString(poet, false, false, lang);
+  if (hasReferences && hasTranslations) {
+    return (
+      <PageLead>
+        {_(
+          'Her finder du tekster af andre forfattere, som omtaler eller henvender sig til {poetName}, samt oversættelser af digterens tekster til andre sprog.',
+          lang,
+          { poetName }
+        )}
+      </PageLead>
+    );
+  }
+  if (hasTranslations) {
+    return (
+      <PageLead>
+        {_(
+          'Her finder du oversættelser af tekster af {poetName} til andre sprog.',
+          lang,
+          { poetName }
+        )}
+      </PageLead>
+    );
+  }
+  return (
+    <PageLead>
+      {_(
+        'Her finder du tekster af andre forfattere, som omtaler eller henvender sig til {poetName}.',
+        lang,
+        { poetName }
+      )}
+    </PageLead>
+  );
+};
+
 const MentionsPage = (props) => {
   const { lang, poet, mentions, translations, primary, secondary, error } =
     props;
@@ -272,6 +309,9 @@ const MentionsPage = (props) => {
       />
     );
   }
+  const hasReferences =
+    mentions.length > 0 || primary.length > 0 || secondary.length > 0;
+  const hasTranslations = translations.length > 0;
 
   return (
     <Page
@@ -287,6 +327,12 @@ const MentionsPage = (props) => {
       menuItems={poetMenu(poet)}
       poet={poet}
       selectedMenuItem="mentions">
+      <MentionsLead
+        hasReferences={hasReferences}
+        hasTranslations={hasTranslations}
+        lang={lang}
+        poet={poet}
+      />
       <div style={{ paddingTop: '3px' }}>{sections}</div>
     </Page>
   );

--- a/pages/museums.js
+++ b/pages/museums.js
@@ -5,6 +5,7 @@ import { kalliopeCrumbs } from '../components/breadcrumbs.js';
 import * as Links from '../components/links.js';
 import { kalliopeMenu } from '../components/menu.js';
 import Page from '../components/page.js';
+import PageLead from '../components/pagelead.js';
 import ErrorPage from './error.js';
 
 const MuseumsPage = (props) => {
@@ -39,6 +40,12 @@ const MuseumsPage = (props) => {
       pageTitle={_('Museer', lang)}
       menuItems={kalliopeMenu()}
       selectedMenuItem="keywords">
+      <PageLead>
+        {_(
+          'En oversigt over museer og samlinger, som ejer kunstværker og portrætter gengivet på Kalliope. Vælg et museum for at se de tilknyttede billeder.',
+          lang
+        )}
+      </PageLead>
       <div className="two-columns" style={{ lineHeight: 1.7 }}>
         {items}
       </div>

--- a/pages/poets.js
+++ b/pages/poets.js
@@ -10,6 +10,7 @@ import CountryPicker from '../components/countrypicker.js';
 import { formatYearInterval, parseDate } from '../components/formatteddate.js';
 import * as Links from '../components/links.js';
 import Page from '../components/page.js';
+import PageLead from '../components/pagelead.js';
 import PoetName from '../components/poetname.js';
 import SectionedList from '../components/sectionedlist.js';
 import ErrorPage from './error.js';
@@ -74,6 +75,13 @@ const poetYearIntervalTitle = (year) => {
   const intervalStart = Math.floor(year / 25) * 25;
   const intervalEnd = intervalStart + 24;
   return formatYearInterval(intervalStart, intervalEnd);
+};
+
+const countryAdjective = (country, lang) => {
+  const cn = CommonData.countries.filter((c) => {
+    return c.code === country;
+  })[0];
+  return cn.adjective[lang];
 };
 
 const groupsByYear = (poets, lang, country) => {
@@ -162,6 +170,35 @@ const Poets = (props) => {
   const countryCodeToURL = (code) => {
     return Links.poetsURL(lang, groupBy, code);
   };
+  const adjective = countryAdjective(country, lang);
+  const nonDanishNote =
+    country === 'dk'
+      ? null
+      : _(
+          '{Adjective} digtere er kun medtaget i begrænset omfang for at belyse den danske digtning.',
+          lang,
+          { adjective, Adjective: Strings.toTitleCase(adjective) }
+        );
+  const lead =
+    groupBy === 'name' ? (
+      <PageLead>
+        {_(
+          'En alfabetisk oversigt over de {adjective} digtere på Kalliope. Vælg et navn for at se digterens værker, tekster og biografiske oplysninger.',
+          lang,
+          { adjective }
+        )}{' '}
+        {nonDanishNote}
+      </PageLead>
+    ) : (
+      <PageLead>
+        {_(
+          'De {adjective} digtere på Kalliope ordnet efter fødselsår. Oversigten giver et kronologisk indblik i samlingens forfattere.',
+          lang,
+          { adjective }
+        )}{' '}
+        {nonDanishNote}
+      </PageLead>
+    );
   return (
     <Page
       headTitle={_('Digtere', lang) + ' - Kalliope'}
@@ -171,6 +208,7 @@ const Poets = (props) => {
       selectedMenuItem={groupBy}
       country={country}
       pageTitle={pageTitle}>
+      {lead}
       <CountryPicker
         style={{ marginBottom: '60px' }}
         lang={lang}

--- a/pages/texts.js
+++ b/pages/texts.js
@@ -7,6 +7,7 @@ import { poetCrumbsWithTitle } from '../components/breadcrumbs.js';
 import * as Links from '../components/links.js';
 import { poetMenu } from '../components/menu.js';
 import Page from '../components/page.js';
+import PageLead from '../components/pagelead.js';
 import { poetNameString } from '../components/poetname-helpers.js';
 import PoetName from '../components/poetname.js';
 import SectionedList from '../components/sectionedlist.js';
@@ -104,6 +105,24 @@ const TextsPage = (props) => {
 
   const lastCrumbTitle =
     type === 'titles' ? _('Titler', lang) : _('Førstelinjer', lang);
+  const lead =
+    type === 'titles' ? (
+      <PageLead>
+        {_(
+          'Alle digte af {poetName} på Kalliope ordnet alfabetisk efter titel.',
+          lang,
+          { poetName: poetNameString(poet, false, false, lang) }
+        )}
+      </PageLead>
+    ) : (
+      <PageLead>
+        {_(
+          'Alle digte af {poetName} på Kalliope ordnet alfabetisk efter tekstens første linje. Listen kan bruges til at finde et digt, når titlen er ukendt.',
+          lang,
+          { poetName: poetNameString(poet, false, false, lang) }
+        )}
+      </PageLead>
+    );
 
   return (
     <Page
@@ -116,6 +135,7 @@ const TextsPage = (props) => {
       menuItems={poetMenu(poet)}
       poet={poet}
       selectedMenuItem={type}>
+      {lead}
       {renderedGroups}
     </Page>
   );

--- a/pages/works.js
+++ b/pages/works.js
@@ -7,6 +7,7 @@ import { worksCrumbs } from '../components/breadcrumbs.js';
 import * as Links from '../components/links.js';
 import { poetMenu } from '../components/menu.js';
 import Page from '../components/page.js';
+import PageLead from '../components/pagelead.js';
 import PicturesGrid from '../components/picturesgrid.js';
 import { poetNameString } from '../components/poetname-helpers.js';
 import PoetName from '../components/poetname.js';
@@ -78,6 +79,13 @@ const WorksPage = (props) => {
       menuItems={poetMenu(poet)}
       poet={poet}
       selectedMenuItem="works">
+      <PageLead>
+        {_(
+          'En kronologisk oversigt over værker af {poetName} på Kalliope. Vælg et værk for at se dets indhold og læse de tekster, der findes i samlingen.',
+          lang,
+          { poetName: poetNameString(poet, false, false, lang) }
+        )}
+      </PageLead>
       <div className="two-columns">
         {stack}
         <style jsx>{`

--- a/pages/works.js
+++ b/pages/works.js
@@ -15,6 +15,81 @@ import Stack from '../components/stack.js';
 import WorksList from '../components/workslist.js';
 import ErrorPage from './error.js';
 
+const romanNumerals = {
+  16: 'XVI',
+  17: 'XVII',
+  18: 'XVIII',
+  19: 'XIX',
+};
+
+const ordinalNumber = (number) => {
+  const remainder10 = number % 10;
+  const remainder100 = number % 100;
+  if (remainder10 === 1 && remainder100 !== 11) {
+    return `${number}st`;
+  }
+  if (remainder10 === 2 && remainder100 !== 12) {
+    return `${number}nd`;
+  }
+  if (remainder10 === 3 && remainder100 !== 13) {
+    return `${number}rd`;
+  }
+  return `${number}th`;
+};
+
+const periodFromAnonymousId = (poet, lang) => {
+  const match = poet.id.match(/^anonym(\d{4})/);
+  if (match == null) {
+    return null;
+  }
+  const year = parseInt(match[1]);
+  const century = year / 100 + 1;
+  if (lang === 'en') {
+    return `${ordinalNumber(century)} century`;
+  }
+  if (lang === 'de') {
+    return `${century}. Jahrhundert`;
+  }
+  if (lang === 'fr') {
+    return `${romanNumerals[century] || century}e siècle`;
+  }
+  return `${year}-tallet`;
+};
+
+const worksLead = (poet, lang) => {
+  if (poet.id === 'bibel') {
+    return _(
+      'En oversigt over Bibelens bøger på Kalliope. Vælg en bog for at se dens indhold og læse de tekster, der findes i samlingen.',
+      lang
+    );
+  }
+  if (poet.id.indexOf('folkeviser') === 0) {
+    return _(
+      'En oversigt over folkeviser på Kalliope. Vælg et værk for at se dets indhold og læse de tekster, der findes i samlingen.',
+      lang
+    );
+  }
+  const anonymousPeriod = periodFromAnonymousId(poet, lang);
+  if (anonymousPeriod != null) {
+    return _(
+      'En oversigt over værker på Kalliope af ukendte forfattere fra {period}. Vælg et værk for at se dets indhold og læse de tekster, der findes i samlingen.',
+      lang,
+      { period: anonymousPeriod }
+    );
+  }
+  if (poet.type === 'collection') {
+    return _(
+      'En oversigt over værker i denne samling på Kalliope. Vælg et værk for at se dets indhold og læse de tekster, der findes i samlingen.',
+      lang
+    );
+  }
+  return _(
+    'En kronologisk oversigt over værker af {poetName} på Kalliope. Vælg et værk for at se dets indhold og læse de tekster, der findes i samlingen.',
+    lang,
+    { poetName: poetNameString(poet, false, false, lang) }
+  );
+};
+
 const WorksPage = (props) => {
   const { lang, poet, works, artwork, error } = props;
 
@@ -79,13 +154,7 @@ const WorksPage = (props) => {
       menuItems={poetMenu(poet)}
       poet={poet}
       selectedMenuItem="works">
-      <PageLead>
-        {_(
-          'En kronologisk oversigt over værker af {poetName} på Kalliope. Vælg et værk for at se dets indhold og læse de tekster, der findes i samlingen.',
-          lang,
-          { poetName: poetNameString(poet, false, false, lang) }
-        )}
-      </PageLead>
+      <PageLead>{worksLead(poet, lang)}</PageLead>
       <div className="two-columns">
         {stack}
         <style jsx>{`


### PR DESCRIPTION
## Resumé

- Tilføjer en genbrugelig PageLead-komponent til sidemanchetter.
- Tilføjer lokaliserede manchette-tekster på oversigter for om/tak, nøgleord, museer, digtere, tekster, omtaler og værker.
- Tilføjer en kort kommentar på ikke-danske digteroversigter om, at de er medtaget for at belyse dansk digtning.

## Validering

- `node --check common/translations.js`
- `npm test -- --runInBand`
- `npm run build`
