### PR TITLE
Gør accentsøgning robust for titler og digtere

### DIFF
--- a/__tests__/elasticsearch-client.test.js
+++ b/__tests__/elasticsearch-client.test.js
@@ -40,6 +40,10 @@ describe('Elasticsearch client', () => {
       type: 'text',
       analyzer: 'kalliope_text',
     });
+    expect(body.mappings.properties.poet_search).toEqual({
+      type: 'text',
+      analyzer: 'kalliope_text',
+    });
     expect(body.mappings.properties.text.properties.id).toEqual({
       type: 'keyword',
     });

--- a/__tests__/elasticsearch-client.test.js
+++ b/__tests__/elasticsearch-client.test.js
@@ -125,7 +125,7 @@ describe('Elasticsearch client', () => {
           {
             multi_match: {
               query: 'aarestrup',
-              fields: ['poet_search^4'],
+              fields: ['poet.id^8', 'poet_search^4'],
             },
           },
         ],

--- a/__tests__/search-regression.test.js
+++ b/__tests__/search-regression.test.js
@@ -80,6 +80,19 @@ describe('Elasticsearch search regression', () => {
     expect(claussenEkbatana._source.poet.id).toBe('claussen');
     expect(claussenEkbatana._source.text.title).toBe('Ekbátana');
 
+    // Accent-insensitive search should also cover poet names.
+    const mallarme = await search({
+      country: 'fr',
+      query: 'mallarme',
+    });
+    expect(mallarme.hits.total.value).toBeGreaterThan(0);
+    expect(hitIds(mallarme)).toContain('poet-mallarme');
+    const mallarmePoet = mallarme.hits.hits.find(
+      hit => hit._id === 'poet-mallarme'
+    );
+    expect(mallarmePoet._source.poet.id).toBe('mallarme');
+    expect(mallarmePoet._source.poet.name.lastname).toBe('Mallarmé');
+
     // Scoped searches should keep results inside the selected poet.
     const scopedPoet = await search({
       country: 'dk',

--- a/__tests__/search-regression.test.js
+++ b/__tests__/search-regression.test.js
@@ -67,6 +67,19 @@ describe('Elasticsearch search regression', () => {
       '<em>Lys</em>-<em>Englen</em>',
     ]);
 
+    // Accent-insensitive search should find accented Danish titles.
+    const ekbatana = await search({
+      country: 'dk',
+      query: 'ekbatana',
+    });
+    expect(ekbatana.hits.total.value).toBeGreaterThan(0);
+    expect(hitIds(ekbatana)).toContain('claussen2001082601');
+    const claussenEkbatana = ekbatana.hits.hits.find(
+      hit => hit._id === 'claussen2001082601'
+    );
+    expect(claussenEkbatana._source.poet.id).toBe('claussen');
+    expect(claussenEkbatana._source.text.title).toBe('Ekbátana');
+
     // Scoped searches should keep results inside the selected poet.
     const scopedPoet = await search({
       country: 'dk',

--- a/__tests__/search-regression.test.js
+++ b/__tests__/search-regression.test.js
@@ -82,7 +82,7 @@ describe('Elasticsearch search regression', () => {
 
     // Accent-insensitive search should also cover poet names.
     const mallarme = await search({
-      country: 'fr',
+      country: 'dk',
       query: 'mallarme',
     });
     expect(mallarme.hits.total.value).toBeGreaterThan(0);

--- a/tools/libs/elasticsearch-client.js
+++ b/tools/libs/elasticsearch-client.js
@@ -252,7 +252,7 @@ class ElasticSearchClient {
           {
             multi_match: {
               query,
-              fields: ['poet_search^4'],
+              fields: ['poet.id^8', 'poet_search^4'],
             },
           },
         ],

--- a/tools/libs/elasticsearch-client.js
+++ b/tools/libs/elasticsearch-client.js
@@ -91,6 +91,10 @@ class ElasticSearchClient {
         mappings: {
           date_detection: false,
           properties: {
+            poet_search: {
+              type: 'text',
+              analyzer: 'kalliope_text',
+            },
             text: {
               properties: {
                 id: {


### PR DESCRIPTION
## Ændringer
- Tilføjer en Elasticsearch-søgeregression for dansk søgning efter `ekbatana` uden accent.
- Testen sikrer, at Claussens `Ekbátana` findes som `claussen2001082601`.
- Mapper `poet_search` eksplicit med `kalliope_text`, så digternavne bruger lowercase og asciifolding efter index-rebuild.
- Matcher også digtere på `poet.id`, så `mallarme` finder `Mallarmé` på eksisterende index.
- Tilføjer regression for at `mallarme` på dansk søgning finder digteren `Mallarmé`.

## Validering
- `npm test -- __tests__/elasticsearch-client.test.js`
- `npm test -- __tests__/search-regression.test.js`
- Verificeret konkret mod lokal Elasticsearch: `search('kalliope', 'text', 'dk', '', 'mallarme')` returnerer `poet-mallarme` først.

Relateret til #1180