### PR TITLE
Ret værktøjer til digterimport

### DIFF
--- a/tools/add-poet.rb
+++ b/tools/add-poet.rb
@@ -31,8 +31,8 @@ end
 @fieldvalues = {}
 @fieldvalidations = {
     'Digter-id' => lambda do |id|
-        if File.directory?("fdirs/#{id}")
-            abort "Mappen fdirs/#{id} findes allerede."
+        if File.exist?("fdirs/#{id}/info.xml")
+            abort "fdirs/#{id}/info.xml findes allerede."
         end
     end
 }
@@ -57,7 +57,7 @@ end
 @birthplace = wrapInTag(@fieldvalues['Fødested'], 'place', '      ')
 @deathplace = wrapInTag(@fieldvalues['Dødssted'], 'place', '      ')
 
-Dir.mkdir(@poetFolder)
+Dir.mkdir(@poetFolder) unless File.directory?(@poetFolder)
 
 def writeXML(filename, xml)
     File.open("#{@poetFolder}/#{filename}", 'w') do |file|

--- a/tools/old2kalliope.rb
+++ b/tools/old2kalliope.rb
@@ -121,6 +121,10 @@ def printFooter()
     puts "</kalliopework>"
 end
 
+def normalizePages(pages)
+  pages.sub(/\A(\d+)-\1\z/, '\1')
+end
+
 def printPoem()
   printHeader()
   if @facsimile and (not @page or @page.strip.length == 0)
@@ -182,12 +186,13 @@ def printPoem()
     puts "    </notes>"
   end
   if @source and @page
+      pages = normalizePages(@page)
       if @facsimile_page
-        puts "    <source pages=\"#{@page}\" facsimile-pages=\"#{@facsimile_page}\" />"
+        puts "    <source pages=\"#{pages}\" facsimile-pages=\"#{@facsimile_page}\" />"
       elsif @page =~ /[ivx]+/i
-        puts "    <source pages=\"#{@page}\" facsimile-pages=\"10\" />"
+        puts "    <source pages=\"#{pages}\" facsimile-pages=\"10\" />"
       else
-        puts "    <source pages=\"#{@page}\"/>"
+        puts "    <source pages=\"#{pages}\"/>"
       end
   end
   if @written or @performed or @event


### PR DESCRIPTION
## Ændringer

- Lader `tools/add-poet.rb` genbruge en eksisterende digtermappe, hvis der endnu ikke findes `info.xml`.
- Normaliserer `SIDE:N-N` til `pages="N"` i `tools/old2kalliope.rb`.

## Validering

- `ruby -c tools/add-poet.rb`
- `ruby -c tools/old2kalliope.rb`
- `npm test -- --runInBand`
