### PR TITLE
Tilføj rapport over OCR-kandidater

### DIFF
--- a/__tests__/report-ocr-candidates.test.js
+++ b/__tests__/report-ocr-candidates.test.js
@@ -1,0 +1,423 @@
+import {
+  findOcrCandidatesInFile,
+  formatCandidate,
+  removeIgnoredXml,
+  removeXmlMarkup,
+  repeatedWordsInContext,
+  stripXml,
+  suggestedWordform,
+  textBlocks,
+  wordHasAaCircumflexMix,
+  wordHasAaRingMix,
+  wordHasInternalUppercase,
+  wordHasInternalUppercaseCircumflex,
+} from '../tools/report-ocr-candidates.js';
+
+describe('OCR candidate report helpers', () => {
+  it('strips XML markup from report context', () => {
+    expect(stripXml('Sig <i>min</i> Tid &amp; vent.')).toBe(
+      'Sig min Tid vent.'
+    );
+  });
+
+  it('removes ignored editorial XML while preserving line numbers', () => {
+    const lines = removeIgnoredXml(
+      'Tekst\n<note>på moderne dansk</note>\nMere'
+    ).split('\n');
+
+    expect(lines.length).toBe(3);
+    expect(lines[1].trim()).toBe('');
+  });
+
+  it('removes XML markup but preserves metadata text and line numbers', () => {
+    const lines = removeXmlMarkup(
+      '<notes>\n<note>opfÃ¸rte skuespil</note>\n</notes>'
+    ).split('\n');
+
+    expect(lines).toHaveLength(3);
+    expect(lines[1].trim()).toBe('opfÃ¸rte skuespil');
+  });
+
+  it('finds text blocks with id, language override and line number', () => {
+    const blocks = textBlocks(
+      [
+        '<kalliopework id="test" author="test">',
+        '<text id="one">',
+        'Linje',
+        '</text>',
+        '<text id="two" lang="fr">',
+        'Ligne',
+        '</text>',
+        '</kalliopework>',
+      ].join('\n')
+    );
+
+    expect(blocks.map(block => [block.id, block.lang, block.startLine])).toEqual(
+      [
+        ['one', null, 2],
+        ['two', 'fr', 5],
+      ]
+    );
+  });
+
+  it('recognizes mixed and internal uppercase character patterns', () => {
+    expect(wordHasAaRingMix('saå')).toBe(true);
+    expect(wordHasAaRingMix('påa')).toBe(true);
+    expect(wordHasAaRingMix('stråalende')).toBe(true);
+    expect(wordHasAaRingMix('rååbte')).toBe(true);
+    expect(wordHasAaRingMix('på')).toBe(false);
+
+    expect(wordHasAaCircumflexMix('Straâler')).toBe(true);
+    expect(wordHasAaCircumflexMix('naâr')).toBe(true);
+    expect(wordHasAaCircumflexMix('hâr')).toBe(false);
+
+    expect(wordHasInternalUppercaseCircumflex('bÔer')).toBe(true);
+    expect(wordHasInternalUppercaseCircumflex('Ô')).toBe(false);
+
+    expect(wordHasInternalUppercase('tidJig')).toBe(true);
+    expect(wordHasInternalUppercase('liUe')).toBe(true);
+    expect(wordHasInternalUppercase('detNat')).toBe(true);
+    expect(wordHasInternalUppercase('Nympher')).toBe(false);
+    expect(wordHasInternalUppercase('DgF')).toBe(false);
+  });
+
+  it('recognizes suspicious wordforms and repeated adjacent words', () => {
+    expect(suggestedWordform('håndled')).toBe('handled');
+    expect(suggestedWordform('Måned')).toBe('Maned');
+    expect(suggestedWordform('måned')).toBe('maned');
+    expect(suggestedWordform('måne')).toBeNull();
+
+    expect(repeatedWordsInContext('Du trilled som som Perler')).toEqual([
+      'som som',
+    ]);
+    expect(repeatedWordsInContext('Det er som klare Perler')).toEqual([]);
+    expect(repeatedWordsInContext('Ha ha! Ja ja.')).toEqual([]);
+    expect(repeatedWordsInContext("Naar Læremo'er er ude")).toEqual([]);
+  });
+
+  it('reports local suspicious character deviations in Danish text blocks', () => {
+    const candidates = findOcrCandidatesInFile({
+      filename: 'fdirs/test/aa.xml',
+      lang: 'da',
+      text: [
+        '<kalliopework id="aa" author="test">',
+        '<text id="one">',
+        'saå han bort',
+        'se paå den Fisker',
+        'et aåbent Barneøje',
+        'i stråalende Lue',
+        'de rååbte alle',
+        'tætte Straâler',
+        'Som bÔer i Naboe-Laget.',
+        '</text>',
+        '</kalliopework>',
+      ].join('\n'),
+    });
+
+    expect(candidates.map(candidate => [candidate.word, candidate.rule])).toEqual(
+      [
+        ['saå', 'mixed-aa-ring'],
+        ['paå', 'mixed-aa-ring'],
+        ['aåbent', 'mixed-aa-ring'],
+        ['stråalende', 'mixed-aa-ring'],
+        ['rååbte', 'mixed-aa-ring'],
+        ['Straâler', 'mixed-aa-circumflex'],
+        ['bÔer', 'internal-uppercase-circumflex'],
+      ]
+    );
+    expect(candidates.every(candidate => candidate.priority === 'høj')).toBe(
+      true
+    );
+  });
+
+  it('reports a single å or â occurrence in a Danish text block', () => {
+    const candidates = findOcrCandidatesInFile({
+      filename: 'fdirs/test/single.xml',
+      lang: 'da',
+      text: [
+        '<kalliopework id="single" author="test">',
+        '<text id="ring">',
+        'Let på min Fod,',
+        '</text>',
+        '<text id="circumflex">',
+        'Nu tâlte Magtens Stemmer,',
+        '</text>',
+        '</kalliopework>',
+      ].join('\n'),
+    });
+
+    expect(candidates.map(candidate => [candidate.word, candidate.rule])).toEqual(
+      [
+        ['på', 'single-a-ring-in-text'],
+        ['tâlte', 'suspicious-wordform'],
+      ]
+    );
+  });
+
+  it('reports known suspicious wordforms with suggested corrections', () => {
+    const candidates = findOcrCandidatesInFile({
+      filename: 'fdirs/test/wordforms.xml',
+      lang: 'da',
+      text: [
+        '<kalliopework id="wordforms" author="test">',
+        '<text id="handled">',
+        'Saaledes håndled Kongen i sin Vrede,',
+        '</text>',
+        '<text id="maned">',
+        'Som måned han et Gjenfærd bort,',
+        '</text>',
+        '<text id="mattet">',
+        'Din Tro var måttet af Skuffelser,',
+        '</text>',
+        '<text id="talte">',
+        'Nu tâlte Magtens Stemmer,',
+        '</text>',
+        '</kalliopework>',
+      ].join('\n'),
+    });
+
+    expect(
+      candidates.map(candidate => [
+        candidate.word,
+        candidate.rule,
+        candidate.reason,
+      ])
+    ).toEqual([
+      [
+        'håndled',
+        'suspicious-wordform',
+        'mistænkelig ordform; mulig rettelse: handled',
+      ],
+      [
+        'måned',
+        'suspicious-wordform',
+        'mistænkelig ordform; mulig rettelse: maned',
+      ],
+      [
+        'måttet',
+        'suspicious-wordform',
+        'mistænkelig ordform; mulig rettelse: mattet',
+      ],
+      [
+        'tâlte',
+        'suspicious-wordform',
+        'mistænkelig ordform; mulig rettelse: talte',
+      ],
+    ]);
+  });
+
+  it('reports internal uppercase letters in every language', () => {
+    const candidates = findOcrCandidatesInFile({
+      filename: 'fdirs/test/fr.xml',
+      lang: 'fr',
+      text: [
+        '<kalliopework id="fr" author="test">',
+        '<text id="fr">',
+        'dans leurs plaintes nouveIIes',
+        '</text>',
+        '</kalliopework>',
+      ].join('\n'),
+    });
+
+    expect(candidates.map(candidate => [candidate.word, candidate.rule])).toEqual(
+      [['nouveIIes', 'internal-uppercase']]
+    );
+  });
+
+  it('reports probable missing spaces before uppercase letters', () => {
+    const candidates = findOcrCandidatesInFile({
+      filename: 'fdirs/test/spacing.xml',
+      lang: 'da',
+      text: '<text id="spacing">dog er detNat endnu</text>',
+    });
+
+    expect(candidates.map(candidate => [candidate.word, candidate.rule])).toEqual(
+      [['detNat', 'internal-uppercase']]
+    );
+  });
+
+  it('reports mojibake in metadata and text regardless of language', () => {
+    const candidates = findOcrCandidatesInFile({
+      filename: 'fdirs/test/mojibake.xml',
+      lang: 'en',
+      text: [
+        '<kalliopework id="mojibake" author="test">',
+        '<workhead>',
+        '<notes><note>Et opfÃ¸rte skuespil.</note></notes>',
+        '</workhead>',
+        '<workbody>',
+        '<text id="english">an aâ€°rial ship</text>',
+        '<text id="swedish" lang="sv">Âskan går.</text>',
+        '</workbody>',
+        '</kalliopework>',
+      ].join('\n'),
+    });
+
+    expect(
+      candidates.map(candidate => [
+        candidate.line,
+        candidate.textId,
+        candidate.word,
+        candidate.rule,
+      ])
+    ).toEqual([
+      [3, '', 'opfÃ¸rte', 'mojibake'],
+      [6, 'english', 'aâ€°rial', 'mojibake'],
+      [7, 'swedish', 'Âskan', 'mojibake'],
+    ]);
+  });
+
+  it('reports repeated adjacent words in Danish text with low priority', () => {
+    const candidates = findOcrCandidatesInFile({
+      filename: 'fdirs/test/repeated.xml',
+      lang: 'da',
+      text: '<text id="repeated">Du trilled som som Perler</text>',
+    });
+
+    expect(
+      candidates.map(candidate => [
+        candidate.word,
+        candidate.rule,
+        candidate.priority,
+      ])
+    ).toEqual([['som som', 'repeated-adjacent-word', 'lav']]);
+  });
+
+  it('does not report repeated adjacent words in non-Danish text', () => {
+    const candidates = findOcrCandidatesInFile({
+      filename: 'fdirs/test/en.xml',
+      lang: 'en',
+      text: '<text id="en">one last last kiss</text>',
+    });
+
+    expect(candidates).toEqual([]);
+  });
+
+  it('does not report modern Danish text blocks with many å words', () => {
+    const candidates = findOcrCandidatesInFile({
+      filename: 'fdirs/test/modern.xml',
+      lang: 'da',
+      text: [
+        '<kalliopework id="modern" author="test">',
+        '<text id="modern">',
+        'Når solen slår hvirvler på ruden',
+        'og står så grå i morgenlys',
+        '</text>',
+        '</kalliopework>',
+      ].join('\n'),
+    });
+
+    expect(candidates).toEqual([]);
+  });
+
+  it('does not report deferred wordform candidates', () => {
+    const candidates = findOcrCandidatesInFile({
+      filename: 'fdirs/test/wordforms.xml',
+      lang: 'da',
+      text: [
+        '<kalliopework id="wordforms" author="test">',
+        '<text id="wordforms">',
+        'naar de taler, som de tænkar?',
+        'han fåtted Rytmens Styrke',
+        '</text>',
+        '</kalliopework>',
+      ].join('\n'),
+    });
+
+    expect(candidates).toEqual([]);
+  });
+
+  it('skips non-Danish files and text blocks with non-Danish language overrides', () => {
+    expect(
+      findOcrCandidatesInFile({
+        filename: 'fdirs/test/fr.xml',
+        lang: 'fr',
+        text: '<text id="fr">se paå votre âme</text>',
+      })
+    ).toEqual([]);
+
+    expect(
+      findOcrCandidatesInFile({
+        filename: 'fdirs/test/da.xml',
+        lang: 'da',
+        text: [
+          '<kalliopework id="da" author="test">',
+          '<text id="fr" lang="fr">se paå votre âme</text>',
+          '<text id="da">se paå den Fisker</text>',
+          '</kalliopework>',
+        ].join('\n'),
+      }).map(candidate => candidate.textId)
+    ).toEqual(['da']);
+  });
+
+  it('ignores notes, pictures and skip-index texts', () => {
+    const candidates = findOcrCandidatesInFile({
+      filename: 'fdirs/test/ignored.xml',
+      lang: 'da',
+      text: [
+        '<kalliopework id="ignored" author="test">',
+        '<text id="skip" skip-index="true">se paå den Fisker opfÃ¸rte</text>',
+        '<text id="body">',
+        '<!-- se paå den Fisker -->',
+        '<note>se paå den Fisker</note>',
+        '<picture src="x.jpg">Som bÔer i Naboe-Laget.</picture>',
+        'Mange Aar uden mistænkelige tegn',
+        '</text>',
+        '</kalliopework>',
+      ].join('\n'),
+    });
+
+    expect(candidates).toEqual([]);
+  });
+
+  it('allows individual OCR rules to be ignored per text block', () => {
+    const candidates = findOcrCandidatesInFile({
+      filename: 'fdirs/test/ignore-rule.xml',
+      lang: 'da',
+      text: [
+        '<kalliopework id="ignore-rule" author="test">',
+        '<text id="body" ignore-tests="single-a-ring-in-text">',
+        'Let på min Fod,',
+        'Som bÔer i Naboe-Laget.',
+        '</text>',
+        '</kalliopework>',
+      ].join('\n'),
+    });
+
+    expect(candidates.map(candidate => [candidate.word, candidate.rule])).toEqual(
+      [['bÔer', 'internal-uppercase-circumflex']]
+    );
+  });
+
+  it('allows all new OCR rules to be ignored per text block', () => {
+    const candidates = findOcrCandidatesInFile({
+      filename: 'fdirs/test/ignore-new-rules.xml',
+      lang: 'da',
+      text: [
+        '<text id="body" ignore-tests="internal-uppercase,mojibake,repeated-adjacent-word">',
+        'detNat som som opfÃ¸rte',
+        '</text>',
+      ].join('\n'),
+    });
+
+    expect(candidates).toEqual([]);
+  });
+
+  it('formats candidates with text id and rule', () => {
+    const candidate = findOcrCandidatesInFile({
+      filename: 'fdirs/test/format.xml',
+      lang: 'da',
+      text: [
+        '<kalliopework id="format" author="test">',
+        '<text id="format">',
+        'Som bÔer i Naboe-Laget.',
+        '</text>',
+        '</kalliopework>',
+      ].join('\n'),
+    })[0];
+
+    expect(formatCandidate(candidate)).toBe(
+      'høj\tfdirs/test/format.xml:3\tformat\tbÔer\tinternal-uppercase-circumflex\tstort circumflex-tegn midt i ord\tSom bÔer i Naboe-Laget.'
+    );
+  });
+});

--- a/package.json
+++ b/package.json
@@ -22,6 +22,7 @@
     "test-watch": "jest --watch",
     "test-ci": "jest",
     "test2": "next test",
+    "report-ocr-candidates": "node tools/report-ocr-candidates.js",
     "build-static": "node tools/build-static.js",
     "build-graph": "node tools/build-graph.js",
     "build-static-force-reload": "node tools/build-static.js --force-reload",

--- a/tools/report-ocr-candidates.js
+++ b/tools/report-ocr-candidates.js
@@ -1,0 +1,492 @@
+import fs from 'fs';
+import path from 'path';
+import { execFileSync } from 'child_process';
+import { fileURLToPath } from 'url';
+
+const wordChars = 'A-Za-zÆØÅæøåÀ-ÖØ-öø-ÿ';
+const wordRegexp = new RegExp(
+  `(?<![${wordChars}])([${wordChars}]+)(?![${wordChars}])`,
+  'gu'
+);
+const defaultPatterns = ['fdirs/*/*.xml', 'data/*.xml'];
+const deferredWordformWords = new Set(['fåtted']);
+const allowedInternalUppercaseWords = new Set(['DgF']);
+const allowedRepeatedWords = new Set([
+  'av',
+  'duidu',
+  'ej',
+  'ei',
+  'etc',
+  'faar',
+  'ha',
+  'haa',
+  'halli',
+  'hej',
+  'hi',
+  'ho',
+  'hu',
+  'hurra',
+  'hys',
+  'ja',
+  'jo',
+  'kuk',
+  'naa',
+  'nej',
+  'ney',
+  'nø',
+  'sa',
+  'saa',
+  'se',
+  'tys',
+  'vov',
+]);
+const suspiciousWordformSuggestions = new Map([
+  ['fåst', 'fast'],
+  ['grâl', 'gral'],
+  ['håndled', 'handled'],
+  ['måned', 'maned'],
+  ['måttet', 'mattet'],
+  ['skål', 'skal'],
+  ['tâlte', 'talte'],
+  ['tåled', 'taaled'],
+]);
+const repeatedWordRegexp = new RegExp(
+  `(?<![${wordChars}'’-])([${wordChars}]{2,})\\s+\\1(?![${wordChars}'’-])`,
+  'giu'
+);
+const mojibakeTokenRegexp = new RegExp(
+  `[${wordChars}’']*(?:Ã[\\u0080-\\u00BF]|â€.|Â(?:ngst|skan))[${wordChars}’']*`,
+  'gu'
+);
+
+const priorityOrder = new Map([
+  ['høj', 0],
+  ['middel', 1],
+  ['lav', 2],
+]);
+
+const preserveLineBreaks = text =>
+  text.replace(/[^\n]/g, match => (match === '\r' ? '\r' : ' '));
+
+const removeIgnoredXml = text =>
+  text
+    .replace(/<!--[\s\S]*?-->/g, preserveLineBreaks)
+    .replace(
+      /<text\b(?=[^>]*\bskip-index="true")[\s\S]*?<\/text>/g,
+      preserveLineBreaks
+    )
+    .replace(/<note\b[\s\S]*?<\/note>/g, preserveLineBreaks)
+    .replace(/<picture\b[\s\S]*?<\/picture>/g, preserveLineBreaks);
+
+const removeXmlMarkup = text =>
+  text
+    .replace(/<!--[\s\S]*?-->/g, preserveLineBreaks)
+    .replace(/<[^>]+>/g, preserveLineBreaks);
+
+const stripXml = text =>
+  text
+    .replace(/<!--[\s\S]*?-->/g, ' ')
+    .replace(/<note\b[\s\S]*?<\/note>/g, ' ')
+    .replace(/<picture\b[\s\S]*?<\/picture>/g, ' ')
+    .replace(/<[^>]+>/g, ' ')
+    .replace(/&(?:amp|apos|gt|lt|quot);/g, ' ')
+    .replace(/\s+/g, ' ')
+    .trim();
+
+const getAttr = (tag, attrName) =>
+  tag.match(new RegExp(`\\s${attrName}="([^"]*)"`))?.[1] ?? null;
+
+const ignoredTests = tag =>
+  (getAttr(tag, 'ignore-tests') ?? '')
+    .split(',')
+    .map(testName => testName.trim())
+    .filter(testName => testName.length > 0);
+
+const lineNumberAt = (text, index) => text.slice(0, index).split('\n').length;
+
+const textBlocks = text =>
+  Array.from(text.matchAll(/<text\b[^>]*>[\s\S]*?<\/text>/g), match => {
+    const block = match[0];
+    const openingTag = block.match(/<text\b[^>]*>/)?.[0] ?? '';
+    const startLine = lineNumberAt(text, match.index);
+    return {
+      id: getAttr(openingTag, 'id') ?? '',
+      lang: getAttr(openingTag, 'lang'),
+      ignoredTests: ignoredTests(openingTag),
+      skipIndex: getAttr(openingTag, 'skip-index') === 'true',
+      startLine,
+      endLine: startLine + block.split('\n').length - 1,
+      text: block,
+    };
+  });
+
+const wordsInContext = context =>
+  Array.from(context.matchAll(wordRegexp), match => match[1]);
+
+const wordHasAaRingMix = word => /(?:[aA][åÅ]|[åÅ][aAåÅ])/.test(word);
+
+const wordHasAaCircumflexMix = word => /(?:[aA][âÂ]|[âÂ][aA]|aa[âÂ])/u.test(word);
+
+const wordHasInternalUppercaseCircumflex = word =>
+  new RegExp(`[${wordChars}][ÂÊÎÔÛ][${wordChars}]`, 'u').test(word);
+
+const wordHasInternalUppercase = word =>
+  !allowedInternalUppercaseWords.has(word) && /\p{Ll}\p{Lu}/u.test(word);
+
+const wordHasAaRing = word => /[åÅ]/u.test(word);
+
+const wordHasCircumflexA = word => /[âÂ]/u.test(word);
+
+const shouldDeferWordformAnalysis = word =>
+  deferredWordformWords.has(word.toLowerCase());
+
+const suggestedWordform = word => {
+  const suggestion = suspiciousWordformSuggestions.get(word.toLowerCase());
+  if (suggestion == null) {
+    return null;
+  }
+  if (word[0] === word[0].toUpperCase()) {
+    return suggestion[0].toUpperCase() + suggestion.slice(1);
+  }
+  return suggestion;
+};
+
+const repeatedWordsInContext = context =>
+  Array.from(context.matchAll(repeatedWordRegexp))
+    .filter(match => !allowedRepeatedWords.has(match[1].toLowerCase()))
+    .map(match => match[0]);
+
+const compareCandidates = (a, b) => {
+  return (
+    (priorityOrder.get(a.priority) ?? 99) -
+      (priorityOrder.get(b.priority) ?? 99) ||
+    a.file.localeCompare(b.file) ||
+    a.line - b.line ||
+    a.word.localeCompare(b.word)
+  );
+};
+
+const loadPoetLangs = rootDir => {
+  const langs = new Map();
+  const fdirs = path.join(rootDir, 'fdirs');
+  if (!fs.existsSync(fdirs)) {
+    return langs;
+  }
+
+  for (const poetId of fs.readdirSync(fdirs)) {
+    const infoFilename = path.join(fdirs, poetId, 'info.xml');
+    if (!fs.existsSync(infoFilename)) {
+      continue;
+    }
+    const infoText = fs.readFileSync(infoFilename, 'utf8');
+    const lang = infoText.match(/<person\b[^>]*\slang="([^"]+)"/)?.[1];
+    if (lang != null) {
+      langs.set(poetId, lang);
+    }
+  }
+
+  return langs;
+};
+
+const trackedFiles = (rootDir, patterns = defaultPatterns) =>
+  execFileSync('git', ['ls-files', ...patterns], {
+    cwd: rootDir,
+    encoding: 'utf8',
+  })
+    .split('\n')
+    .filter(Boolean)
+    .filter(filename => fs.existsSync(path.join(rootDir, filename)));
+
+const langForFile = (filename, poetLangs) => {
+  const parts = filename.split('/');
+  if (parts[0] !== 'fdirs' || parts.length < 3) {
+    return null;
+  }
+  return poetLangs.get(parts[1]) ?? null;
+};
+
+const candidateKey = candidate =>
+  [candidate.file, candidate.line, candidate.textId, candidate.word].join('\t');
+
+const addCandidate = (candidates, seenCandidates, candidate) => {
+  if (candidate.ignoredTests.includes(candidate.rule)) {
+    return;
+  }
+
+  const key = candidateKey(candidate);
+  const existingIndex = seenCandidates.get(key);
+
+  if (existingIndex == null) {
+    seenCandidates.set(key, candidates.length);
+    candidates.push(candidate);
+    return;
+  }
+
+  const existing = candidates[existingIndex];
+  if (
+    (priorityOrder.get(candidate.priority) ?? 99) <
+    (priorityOrder.get(existing.priority) ?? 99)
+  ) {
+    candidates[existingIndex] = candidate;
+  }
+};
+
+const findTextBlockCandidates = ({ filename, block, lang = 'da' }) => {
+  const candidates = [];
+  const seenCandidates = new Map();
+  const searchableText = removeIgnoredXml(block.text);
+  const lines = searchableText.split('\n');
+  const aaRingHits = [];
+  const circumflexAHits = [];
+  const suspiciousWordformHits = [];
+
+  lines.forEach((lineText, index) => {
+    const context = stripXml(lineText);
+    if (context === '') {
+      return;
+    }
+
+    for (const word of wordsInContext(context)) {
+      const hit = {
+        file: filename,
+        line: block.startLine + index,
+        textId: block.id,
+        word,
+        context,
+      };
+
+      if (wordHasInternalUppercaseCircumflex(word)) {
+        addCandidate(candidates, seenCandidates, {
+          ...hit,
+          ignoredTests: block.ignoredTests,
+          priority: 'høj',
+          rule: 'internal-uppercase-circumflex',
+          reason: 'stort circumflex-tegn midt i ord',
+        });
+      } else if (wordHasInternalUppercase(word)) {
+        addCandidate(candidates, seenCandidates, {
+          ...hit,
+          ignoredTests: block.ignoredTests,
+          priority: 'høj',
+          rule: 'internal-uppercase',
+          reason: 'stort bogstav eller manglende mellemrum midt i ord',
+        });
+      }
+
+      if (lang !== 'da' || shouldDeferWordformAnalysis(word)) {
+        continue;
+      }
+
+      if (wordHasAaRing(word)) {
+        aaRingHits.push(hit);
+      }
+      if (wordHasCircumflexA(word)) {
+        circumflexAHits.push(hit);
+      }
+
+      const suggestion = suggestedWordform(word);
+      if (suggestion != null) {
+        suspiciousWordformHits.push({ ...hit, suggestion });
+      }
+
+      if (wordHasAaRingMix(word)) {
+        addCandidate(candidates, seenCandidates, {
+          ...hit,
+          ignoredTests: block.ignoredTests,
+          priority: 'høj',
+          rule: 'mixed-aa-ring',
+          reason: 'blandet a/å-form i samme ord',
+        });
+      } else if (wordHasAaCircumflexMix(word)) {
+        addCandidate(candidates, seenCandidates, {
+          ...hit,
+          ignoredTests: block.ignoredTests,
+          priority: 'høj',
+          rule: 'mixed-aa-circumflex',
+          reason: 'blandet a/â-form i samme ord',
+        });
+      }
+    }
+
+    if (lang === 'da') {
+      for (const repetition of repeatedWordsInContext(context)) {
+        addCandidate(candidates, seenCandidates, {
+          file: filename,
+          line: block.startLine + index,
+          textId: block.id,
+          word: repetition,
+          context,
+          ignoredTests: block.ignoredTests,
+          priority: 'lav',
+          rule: 'repeated-adjacent-word',
+          reason: 'samme ord står to gange i træk',
+        });
+      }
+    }
+  });
+
+  for (const hit of suspiciousWordformHits) {
+    const localDeviationCount = wordHasAaRing(hit.word)
+      ? aaRingHits.length
+      : circumflexAHits.length;
+    if (localDeviationCount !== 1) {
+      continue;
+    }
+    addCandidate(candidates, seenCandidates, {
+      ...hit,
+      ignoredTests: block.ignoredTests,
+      priority: 'middel',
+      rule: 'suspicious-wordform',
+      reason: `mistænkelig ordform; mulig rettelse: ${hit.suggestion}`,
+    });
+  }
+
+  if (aaRingHits.length === 1) {
+    addCandidate(candidates, seenCandidates, {
+      ...aaRingHits[0],
+      ignoredTests: block.ignoredTests,
+      priority: 'middel',
+      rule: 'single-a-ring-in-text',
+      reason: 'eneste å/Å-forekomst i dansk tekst',
+    });
+  }
+
+  if (circumflexAHits.length === 1) {
+    addCandidate(candidates, seenCandidates, {
+      ...circumflexAHits[0],
+      ignoredTests: block.ignoredTests,
+      priority: 'middel',
+      rule: 'single-circumflex-a-in-text',
+      reason: 'eneste â/Â-forekomst i dansk tekst',
+    });
+  }
+
+  return candidates;
+};
+
+const findMojibakeCandidatesInFile = ({ filename, text }) => {
+  const candidates = [];
+  const seenCandidates = new Map();
+  const blocks = textBlocks(text);
+  const lines = removeXmlMarkup(text).split('\n');
+
+  lines.forEach((lineText, index) => {
+    const line = index + 1;
+    const block = blocks.find(
+      candidateBlock =>
+        line >= candidateBlock.startLine && line <= candidateBlock.endLine
+    );
+    if (block?.skipIndex) {
+      return;
+    }
+
+    const context = lineText.replace(/\s+/g, ' ').trim();
+    if (context === '') {
+      return;
+    }
+
+    for (const match of context.matchAll(mojibakeTokenRegexp)) {
+      addCandidate(candidates, seenCandidates, {
+        file: filename,
+        line,
+        textId: block?.id ?? '',
+        word: match[0],
+        context,
+        ignoredTests: block?.ignoredTests ?? [],
+        priority: 'høj',
+        rule: 'mojibake',
+        reason: 'tegnfølge tyder på forkert tegnkodning',
+      });
+    }
+  });
+
+  return candidates;
+};
+
+const findOcrCandidatesInFile = ({ filename, text, lang }) => {
+  const mojibakeCandidates = findMojibakeCandidatesInFile({ filename, text });
+  const blockCandidates = textBlocks(text).flatMap(block => {
+    const activeLang = block.lang ?? lang;
+    if (block.skipIndex) {
+      return [];
+    }
+
+    return findTextBlockCandidates({ filename, block, lang: activeLang });
+  });
+
+  return [...mojibakeCandidates, ...blockCandidates];
+};
+
+const findOcrCandidates = ({ rootDir = process.cwd(), files = null } = {}) => {
+  const poetLangs = loadPoetLangs(rootDir);
+  const filenames = files ?? trackedFiles(rootDir);
+  const candidates = filenames.flatMap(filename => {
+    const fullFilename = path.join(rootDir, filename);
+    return findOcrCandidatesInFile({
+      filename,
+      text: fs.readFileSync(fullFilename, 'utf8'),
+      lang: langForFile(filename, poetLangs),
+    });
+  });
+
+  return candidates.sort(compareCandidates);
+};
+
+const formatCandidate = candidate =>
+  [
+    candidate.priority,
+    `${candidate.file}:${candidate.line}`,
+    candidate.textId,
+    candidate.word,
+    candidate.rule,
+    candidate.reason,
+    candidate.context,
+  ].join('\t');
+
+const usage = () => {
+  console.error('Brug: node tools/report-ocr-candidates.js [fil ...]');
+};
+
+const printFooter = candidateCount => {
+  console.error(`${candidateCount} kandidat(er) fundet.`);
+  console.error(
+    'Legitime forekomster kan undtages pr. regel med fx ignore-tests="regelnavn" på det relevante <text>-element.'
+  );
+};
+
+const main = () => {
+  const args = process.argv.slice(2);
+  if (args.includes('--help') || args.includes('-h')) {
+    usage();
+    return;
+  }
+
+  const files = args.length > 0 ? args : null;
+  const candidates = findOcrCandidates({ files });
+  candidates.forEach(candidate => {
+    console.log(formatCandidate(candidate));
+  });
+  printFooter(candidates.length);
+};
+
+if (fileURLToPath(import.meta.url) === process.argv[1]) {
+  main();
+}
+
+export {
+  findOcrCandidates,
+  findOcrCandidatesInFile,
+  findMojibakeCandidatesInFile,
+  findTextBlockCandidates,
+  formatCandidate,
+  removeIgnoredXml,
+  removeXmlMarkup,
+  repeatedWordsInContext,
+  stripXml,
+  suggestedWordform,
+  textBlocks,
+  wordHasAaCircumflexMix,
+  wordHasAaRingMix,
+  wordHasInternalUppercase,
+  wordHasInternalUppercaseCircumflex,
+};


### PR DESCRIPTION
## Ændringer

- Tilføjer `tools/report-ocr-candidates.js`, som rapporterer konservative OCR-kandidater med prioritet, fil, linje, tekst-id, ord, regel og kontekst.
- Finder bl.a. blandede `a`/`å`- og `a`/`â`-former, store bogstaver midt i ord, mojibake og gentagne naboord.
- Tilføjer npm-scriptet `report-ocr-candidates`.
- Dækker rapportlogikken med Jest-tests.

## Validering

- `npm test -- report-ocr-candidates --runInBand`
- `npm test -- --runInBand`
- `npm run report-ocr-candidates -- fdirs/nielsenlc/1905.xml`

Fixes #1241
