### PR TITLE
Tilføj facsimilevisning til VS Code-extensionen

### DIFF
--- a/__tests__/vscode-facsimile.test.js
+++ b/__tests__/vscode-facsimile.test.js
@@ -1,0 +1,134 @@
+import { createRequire } from 'module';
+
+const require = createRequire(import.meta.url);
+const {
+  normalizeFacsimileId,
+  resolveFacsimileForPosition,
+} = require('../tools/vscode-kalliope-syntax/facsimile.cjs');
+
+const filename = '/repo/fdirs/testpoet/1900.xml';
+
+const resolveAt = (xml, marker) => {
+  const offset = xml.indexOf(marker);
+  expect(offset).toBeGreaterThanOrEqual(0);
+  return resolveFacsimileForPosition(xml, filename, offset);
+};
+
+describe('VS Code Kalliope facsimile resolver', () => {
+  it('deduces facsimile pages from printed pages and offset', () => {
+    const xml = `<?xml version="1.0" encoding="UTF-8"?>
+<kalliopework>
+  <workhead>
+    <source facsimile="book.pdf" facsimile-pages-num="40" facsimile-pages-offset="8">Book</source>
+  </workhead>
+  <workbody>
+    <text id="poem1">
+      <head>
+        <title>Poem One</title>
+        <source pages="11-12"/>
+      </head>
+      <body><poetry>marker</poetry></body>
+    </text>
+  </workbody>
+</kalliopework>`;
+
+    expect(resolveAt(xml, 'marker')).toMatchObject({
+      ok: true,
+      facsimile: 'book',
+      facsimilePages: [19, 20],
+      pages: [
+        { page: 19, filename: '018.jpg' },
+        { page: 20, filename: '019.jpg' },
+      ],
+    });
+  });
+
+  it('lets explicit facsimile-pages override computed pages', () => {
+    const xml = `<?xml version="1.0" encoding="UTF-8"?>
+<kalliopework>
+  <workhead>
+    <source facsimile="book" facsimile-pages-num="40" facsimile-pages-offset="8">Book</source>
+  </workhead>
+  <workbody>
+    <text id="poem1">
+      <head>
+        <title>Poem One</title>
+        <source pages="11-12" facsimile-pages="9-11"/>
+      </head>
+      <body><poetry>marker</poetry></body>
+    </text>
+  </workbody>
+</kalliopework>`;
+
+    expect(resolveAt(xml, 'marker')).toMatchObject({
+      ok: true,
+      facsimilePages: [9, 11],
+      pages: [
+        { page: 9, filename: '008.jpg' },
+        { page: 10, filename: '009.jpg' },
+        { page: 11, filename: '010.jpg' },
+      ],
+    });
+  });
+
+  it('removes pdf suffixes from facsimile ids', () => {
+    expect(normalizeFacsimileId('115308068587.pdf')).toBe('115308068587');
+    expect(normalizeFacsimileId('115308068587.PDF')).toBe('115308068587');
+  });
+
+  it('uses named work sources from source in attributes', () => {
+    const xml = `<?xml version="1.0" encoding="UTF-8"?>
+<kalliopework>
+  <workhead>
+    <source id="bd1" facsimile="first" facsimile-pages-num="40" facsimile-pages-offset="1">First</source>
+    <source id="bd2" facsimile="second.pdf" facsimile-pages-num="80" facsimile-pages-offset="20">Second</source>
+  </workhead>
+  <workbody>
+    <text id="poem2">
+      <head>
+        <title>Poem Two</title>
+        <source in="bd2" pages="3"/>
+      </head>
+      <body><poetry>marker</poetry></body>
+    </text>
+  </workbody>
+</kalliopework>`;
+
+    expect(resolveAt(xml, 'marker')).toMatchObject({
+      ok: true,
+      sourceId: 'bd2',
+      facsimile: 'second',
+      facsimilePages: [23, 23],
+      pages: [{ page: 23, filename: '022.jpg' }],
+    });
+  });
+
+  it('uses the enclosing text source when the cursor is inside prose', () => {
+    const xml = `<?xml version="1.0" encoding="UTF-8"?>
+<kalliopework>
+  <workhead>
+    <source facsimile="book.pdf" facsimile-pages-num="61" facsimile-pages-offset="6">Book</source>
+  </workhead>
+  <workbody>
+    <text id="prose1">
+      <head>
+        <title>Den Første Psalme</title>
+        <source pages="2-10"/>
+      </head>
+      <body>
+        <prose font-size="small">Indledning</prose>
+        <prose>marker</prose>
+      </body>
+    </text>
+  </workbody>
+</kalliopework>`;
+
+    expect(resolveAt(xml, 'marker')).toMatchObject({
+      ok: true,
+      textId: 'prose1',
+      title: 'Den Første Psalme',
+      facsimile: 'book',
+      facsimilePages: [8, 16],
+    });
+  });
+});

--- a/tools/vscode-kalliope-syntax/README.md
+++ b/tools/vscode-kalliope-syntax/README.md
@@ -1,20 +1,96 @@
-# Kalliope Syntax for VS Code
+# Kalliope-extension til VS Code
 
-Syntax highlighting for Kalliope `old2kalliope` input files.
+Extensionen giver syntaksfremhævning til Kalliopes `old2kalliope`-filer og kan
+vise facsimilesider ved siden af et værk-XML, mens teksten redigeres.
 
-The language is selected automatically for `.txt` files whose first line starts
-with `KILDE:`.
+Syntaksen vælges automatisk for `.txt`-filer, hvis første linje begynder med
+`KILDE:`. Facsimilevisningen bruges i værkfiler under
+`fdirs/<digter>/<værk>.xml`.
 
-## Install
+## Installation
 
-Install the workspace copy as a symlink in VS Code's extension directory:
+Kør installationsscriptet fra roden af Kalliope-repositoriet:
 
 ```sh
 tools/install-vscode-kalliope-syntax.sh
 ```
 
-Restart VS Code after installing.
+Scriptet opretter et symbolsk link fra VS Codes extension-mappe til
+workspace-versionen:
 
-The Kalliope workspace also contains `.vscode/settings.json` with token colors for this grammar. In that setup, text-header commands such as `T:`, `F:`, and text-level `DIGTER:` use the green `keyword.other.header.text.kalliope` scope, while work-header commands use `keyword.other.header.work.kalliope`.
+```text
+~/.vscode/extensions/thabz.kalliope-syntax
+  -> tools/vscode-kalliope-syntax
+```
 
-VS Code does not load arbitrary extensions directly from a workspace folder. The install script is therefore needed once per machine; after that, starting VS Code in this source tree will use the workspace settings automatically.
+Genstart derefter VS Code. Man kan også vælge `Developer: Reload Window` i
+kommandopaletten. Åbn hele Kalliope-repositoriet som workspace, så extensionen
+kan finde den lokale `facsimiles`-mappe og bruge indstillingerne i
+`.vscode/settings.json`.
+
+Installationsscriptet skal normalt kun køres én gang pr. maskine. Fordi
+installationen er et symbolsk link, bliver ændringer i extensionens kildekode
+tilgængelige efter `Developer: Reload Window`; den skal ikke geninstalleres.
+
+## Vis en facsimile
+
+1. Åbn en værkfil under `fdirs/<digter>/<værk>.xml`.
+2. Placér cursoren inde i det ønskede `<text>`- eller `<prose>`-element.
+3. Åbn kommandopaletten med `⇧⌘P` på macOS eller `Ctrl+Shift+P` på Linux og
+   Windows.
+4. Vælg `Kalliope: Vis facsimile for aktuelt digt`.
+
+Facsimilen åbnes i et panel ved siden af XML-editoren. Når panelet er åbent,
+opdateres det automatisk, når cursoren flyttes til en anden tekst. Panelet kan
+lukkes som en almindelig editorfane.
+
+Extensionen finder siderne ud fra tekstens `<head><source>` og værkets
+`<workhead><source>`. Normalt beregnes facsimilesiden fra `pages` og
+`facsimile-pages-offset`. En eksplicit `facsimile-pages`-attribut bruges, når
+tryksidens nummer ikke kan beregnes direkte, eksempelvis ved romertal.
+
+## Lokale og eksterne billeder
+
+Extensionen leder først efter lokale billeder i denne struktur:
+
+```text
+facsimiles/<digter>/<facsimile-id>/000.jpg
+facsimiles/<digter>/<facsimile-id>/001.jpg
+...
+```
+
+Hvis en lokal side ikke findes, forsøger extensionen som standard at hente den
+fra `https://kalliope.org/static/facsimiles`.
+
+Følgende indstillinger kan ændres i VS Codes settings:
+
+- `kalliope.facsimiles.localRoot`: Lokal rodmappe; standard er `facsimiles` i
+  workspace-roden.
+- `kalliope.facsimiles.remoteBaseUrl`: Basis-URL til eksterne facsimiler.
+- `kalliope.facsimiles.autoUpdate`: Om panelet automatisk følger cursoren;
+  standard er `true`.
+
+## Fejlfinding
+
+Hvis kommandoen ikke findes, så kontrollér, at installationsscriptet er kørt,
+og genindlæs VS Code med `Developer: Reload Window`.
+
+Hvis panelet viser en forklaring i stedet for et billede, så kontrollér:
+
+- at filen ligger under `fdirs/<digter>/`;
+- at cursoren står i et `<text>`- eller `<prose>`-element;
+- at teksten har et `<head><source>`;
+- at værkets source har `facsimile` og om nødvendigt
+  `facsimile-pages-offset`;
+- at `pages` eller `facsimile-pages` indeholder et gyldigt numerisk sidetal.
+
+## Syntaksfarver
+
+Kalliope-workspacet indeholder `.vscode/settings.json` med tokenfarver til
+`old2kalliope`-grammatikken. Teksthovedkommandoer som `T:`, `F:` og
+tekstniveauets `DIGTER:` bruger scopet `keyword.other.header.text.kalliope`,
+mens værkhovedkommandoer bruger `keyword.other.header.work.kalliope`.
+
+VS Code indlæser ikke vilkårlige extensions direkte fra en workspace-mappe.
+Derfor er installationsscriptet nødvendigt, selv om extensionens kildekode
+ligger i repositoriet.

--- a/tools/vscode-kalliope-syntax/extension.js
+++ b/tools/vscode-kalliope-syntax/extension.js
@@ -1,7 +1,10 @@
 const path = require('path');
+const fs = require('fs');
 const vscode = require('vscode');
+const { resolveFacsimileForPosition } = require('./facsimile.cjs');
 
 const languageId = 'kalliope-old';
+let facsimilePanel = null;
 
 const isKalliopeOldText = document => {
   if (document.uri.scheme !== 'file') {
@@ -22,12 +25,185 @@ const updateLanguage = async document => {
   }
 };
 
+const escapeHtml = value => {
+  return String(value)
+    .replace(/&/g, '&amp;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;')
+    .replace(/"/g, '&quot;');
+};
+
+const getWorkspaceFolder = document => {
+  const folder = vscode.workspace.getWorkspaceFolder(document.uri);
+  if (folder != null) {
+    return folder;
+  }
+  return vscode.workspace.workspaceFolders
+    ? vscode.workspace.workspaceFolders[0]
+    : null;
+};
+
+const configValue = (key, fallback) => {
+  return vscode.workspace
+    .getConfiguration('kalliope.facsimiles')
+    .get(key, fallback);
+};
+
+const resolveLocalRoot = document => {
+  const configuredRoot = configValue('localRoot', 'facsimiles');
+  if (path.isAbsolute(configuredRoot)) {
+    return configuredRoot;
+  }
+  const workspaceFolder = getWorkspaceFolder(document);
+  const workspaceRoot = workspaceFolder
+    ? workspaceFolder.uri.fsPath
+    : path.dirname(document.fileName);
+  return path.resolve(workspaceRoot, configuredRoot);
+};
+
+const pageImageUri = (webview, document, result, page) => {
+  const localRoot = resolveLocalRoot(document);
+  const localPath = path.join(
+    localRoot,
+    result.poetId,
+    result.facsimile,
+    page.filename
+  );
+  if (fs.existsSync(localPath)) {
+    return webview.asWebviewUri(vscode.Uri.file(localPath)).toString();
+  }
+  const remoteBaseUrl = configValue(
+    'remoteBaseUrl',
+    'https://kalliope.org/static/facsimiles'
+  ).replace(/\/+$/, '');
+  return [
+    remoteBaseUrl,
+    encodeURIComponent(result.poetId),
+    encodeURIComponent(result.facsimile),
+    encodeURIComponent(page.filename),
+  ].join('/');
+};
+
+const facsimileHtml = (webview, document, result) => {
+  const cspSource = webview.cspSource;
+  if (!result.ok) {
+    return `<!doctype html>
+<html lang="da">
+<head>
+  <meta charset="UTF-8">
+  <meta http-equiv="Content-Security-Policy" content="default-src 'none'; style-src ${cspSource} 'unsafe-inline';">
+  <style>
+    body { margin: 0; padding: 24px; font-family: var(--vscode-font-family); color: var(--vscode-foreground); background: var(--vscode-editor-background); }
+    h1 { margin: 0 0 12px; font-size: 18px; font-weight: 600; }
+    p { margin: 0; line-height: 1.5; color: var(--vscode-descriptionForeground); }
+  </style>
+</head>
+<body>
+  <h1>Kalliope facsimile</h1>
+  <p>${escapeHtml(result.reason)}</p>
+</body>
+</html>`;
+  }
+
+  const images = result.pages
+    .map(page => {
+      const src = pageImageUri(webview, document, result, page);
+      return `<figure>
+  <figcaption>Facsimile-side ${page.page}</figcaption>
+  <img src="${escapeHtml(src)}" alt="Facsimile-side ${page.page}">
+</figure>`;
+    })
+    .join('\n');
+
+  return `<!doctype html>
+<html lang="da">
+<head>
+  <meta charset="UTF-8">
+  <meta http-equiv="Content-Security-Policy" content="default-src 'none'; img-src ${cspSource} https:; style-src ${cspSource} 'unsafe-inline';">
+  <style>
+    body { margin: 0; font-family: var(--vscode-font-family); color: var(--vscode-foreground); background: var(--vscode-editor-background); }
+    header { position: sticky; top: 0; z-index: 1; padding: 12px 16px; border-bottom: 1px solid var(--vscode-panel-border); background: var(--vscode-editor-background); }
+    h1 { margin: 0; font-size: 15px; line-height: 1.35; font-weight: 600; }
+    .meta { margin-top: 4px; font-size: 12px; color: var(--vscode-descriptionForeground); }
+    main { padding: 16px; }
+    figure { margin: 0 0 18px; }
+    figcaption { margin-bottom: 8px; font-size: 12px; color: var(--vscode-descriptionForeground); }
+    img { display: block; width: 100%; height: auto; background: var(--vscode-editorWidget-background); }
+  </style>
+</head>
+<body>
+  <header>
+    <h1>${escapeHtml(result.title || result.textId || 'Kalliope facsimile')}</h1>
+    <div class="meta">${escapeHtml(result.poetId)}/${escapeHtml(result.facsimile)} · side ${escapeHtml(result.facsimilePages.join('-'))}</div>
+  </header>
+  <main>${images}</main>
+</body>
+</html>`;
+};
+
+const updateFacsimilePanel = editor => {
+  if (editor == null || editor.document.uri.scheme !== 'file') {
+    return;
+  }
+  const document = editor.document;
+  const result = resolveFacsimileForPosition(
+    document.getText(),
+    document.fileName,
+    document.offsetAt(editor.selection.active)
+  );
+
+  if (facsimilePanel == null) {
+    facsimilePanel = vscode.window.createWebviewPanel(
+      'kalliopeFacsimile',
+      'Kalliope facsimile',
+      vscode.ViewColumn.Beside,
+      {
+        enableScripts: false,
+        localResourceRoots: [vscode.Uri.file(resolveLocalRoot(document))],
+      }
+    );
+    facsimilePanel.onDidDispose(() => {
+      facsimilePanel = null;
+    });
+  } else {
+    facsimilePanel.webview.options = {
+      enableScripts: false,
+      localResourceRoots: [vscode.Uri.file(resolveLocalRoot(document))],
+    };
+  }
+
+  facsimilePanel.title =
+    result.ok && result.title
+      ? `Facsimile: ${result.title}`
+      : 'Kalliope facsimile';
+  facsimilePanel.webview.html = facsimileHtml(
+    facsimilePanel.webview,
+    document,
+    result
+  );
+};
+
+const showFacsimileForCurrentText = () => {
+  updateFacsimilePanel(vscode.window.activeTextEditor);
+};
+
+const shouldAutoUpdateFacsimile = () => {
+  return (
+    facsimilePanel != null &&
+    configValue('autoUpdate', true)
+  );
+};
+
 const activate = context => {
   vscode.workspace.textDocuments.forEach(document => {
     updateLanguage(document);
   });
 
   context.subscriptions.push(
+    vscode.commands.registerCommand(
+      'kalliope.showFacsimileForCurrentText',
+      showFacsimileForCurrentText
+    ),
     vscode.workspace.onDidOpenTextDocument(document => {
       updateLanguage(document);
     }),
@@ -38,6 +214,18 @@ const activate = context => {
         })
       ) {
         updateLanguage(event.document);
+      }
+      if (
+        shouldAutoUpdateFacsimile() &&
+        vscode.window.activeTextEditor &&
+        event.document === vscode.window.activeTextEditor.document
+      ) {
+        updateFacsimilePanel(vscode.window.activeTextEditor);
+      }
+    }),
+    vscode.window.onDidChangeTextEditorSelection(event => {
+      if (shouldAutoUpdateFacsimile()) {
+        updateFacsimilePanel(event.textEditor);
       }
     })
   );

--- a/tools/vscode-kalliope-syntax/facsimile.cjs
+++ b/tools/vscode-kalliope-syntax/facsimile.cjs
@@ -1,0 +1,330 @@
+const path = require('path');
+
+const parseAttributes = text => {
+  const attrs = {};
+  const attrRe = /([A-Za-z_:][\w:.-]*)\s*=\s*(?:"([^"]*)"|'([^']*)')/g;
+  let match;
+  while ((match = attrRe.exec(text)) != null) {
+    attrs[match[1]] = match[2] != null ? match[2] : match[3];
+  }
+  return attrs;
+};
+
+const parseXmlNodes = xml => {
+  const root = {
+    name: '#document',
+    attrs: {},
+    start: 0,
+    openEnd: 0,
+    end: xml.length,
+    children: [],
+    parent: null,
+  };
+  const stack = [root];
+  const tagRe =
+    /<!--[\s\S]*?-->|<!\[CDATA\[[\s\S]*?\]\]>|<\?[\s\S]*?\?>|<![^>]*>|<\/?([A-Za-z_:][\w:.-]*)([^<>]*?)\/?>/g;
+  let match;
+
+  while ((match = tagRe.exec(xml)) != null) {
+    const raw = match[0];
+    const name = match[1];
+    if (name == null || raw.startsWith('<?') || raw.startsWith('<!--')) {
+      continue;
+    }
+
+    if (raw.startsWith('</')) {
+      for (let i = stack.length - 1; i > 0; i--) {
+        const node = stack[i];
+        if (node.name === name) {
+          node.end = match.index + raw.length;
+          stack.length = i;
+          break;
+        }
+      }
+      continue;
+    }
+
+    const parent = stack[stack.length - 1];
+    const selfClosing = /\/\s*>$/.test(raw);
+    const node = {
+      name,
+      attrs: parseAttributes(match[2] || ''),
+      start: match.index,
+      openEnd: match.index + raw.length,
+      end: selfClosing ? match.index + raw.length : xml.length,
+      children: [],
+      parent,
+    };
+    parent.children.push(node);
+    if (!selfClosing) {
+      stack.push(node);
+    }
+  }
+
+  return root;
+};
+
+const childByName = (node, name) => {
+  return node.children.find(child => child.name === name) || null;
+};
+
+const childrenByName = (node, name) => {
+  return node.children.filter(child => child.name === name);
+};
+
+const findDescendantsByName = (node, names, result = []) => {
+  for (const child of node.children) {
+    if (names.has(child.name)) {
+      result.push(child);
+    }
+    findDescendantsByName(child, names, result);
+  }
+  return result;
+};
+
+const findSmallestNodeAtOffset = (nodes, offset) => {
+  let best = null;
+  for (const node of nodes) {
+    if (node.start <= offset && offset <= node.end) {
+      if (best == null || node.start >= best.start) {
+        best = node;
+      }
+    }
+  }
+  return best;
+};
+
+const innerXml = (xml, node) => {
+  return xml.slice(node.openEnd, node.end).replace(new RegExp(`</${node.name}>\\s*$`), '');
+};
+
+const stripTags = text => {
+  return text
+    .replace(/<[^>]*>/g, '')
+    .replace(/\s+/g, ' ')
+    .trim();
+};
+
+const parseKalliopeWorkPath = fileName => {
+  const parts = path.normalize(fileName).split(path.sep);
+  const fdirsIndex = parts.lastIndexOf('fdirs');
+  if (fdirsIndex === -1 || parts.length < fdirsIndex + 3) {
+    return null;
+  }
+  const poetId = parts[fdirsIndex + 1];
+  const basename = parts[fdirsIndex + 2];
+  if (!basename.toLowerCase().endsWith('.xml')) {
+    return null;
+  }
+  return {
+    poetId,
+    workId: basename.replace(/\.xml$/i, ''),
+  };
+};
+
+const parseNumericRange = value => {
+  if (value == null || value.trim() === '') {
+    return null;
+  }
+  const parts = value.split(/\s*-\s*/);
+  const from = parseInt(parts[0], 10);
+  const to = parts[1] != null ? parseInt(parts[1], 10) : from;
+  if (!Number.isInteger(from) || !Number.isInteger(to)) {
+    return null;
+  }
+  return [from, to];
+};
+
+const normalizeFacsimileId = facsimile => {
+  return facsimile == null ? null : facsimile.replace(/\.pdf$/i, '');
+};
+
+const padPageFilename = page => {
+  return `${page - 1}`.padStart(3, '0') + '.jpg';
+};
+
+const getTitle = (xml, textNode) => {
+  const head = childByName(textNode, 'head');
+  const title = head ? childByName(head, 'title') : null;
+  const firstline = head ? childByName(head, 'firstline') : null;
+  if (title != null) {
+    return stripTags(innerXml(xml, title));
+  }
+  if (firstline != null) {
+    return stripTags(innerXml(xml, firstline));
+  }
+  return textNode.attrs.id || textNode.name;
+};
+
+const getWorkSources = (workNode, xml) => {
+  const workhead = childByName(workNode, 'workhead');
+  const sources = {};
+  if (workhead == null) {
+    return sources;
+  }
+
+  for (const sourceNode of childrenByName(workhead, 'source')) {
+    const id = sourceNode.attrs.id || 'default';
+    const facsimile = normalizeFacsimileId(sourceNode.attrs.facsimile);
+    const offset = sourceNode.attrs['facsimile-pages-offset'];
+    const pageCount = sourceNode.attrs['facsimile-pages-num'];
+    sources[id] = {
+      id,
+      sourceText: stripTags(innerXml(xml, sourceNode)),
+      facsimile,
+      facsimilePagesOffset:
+        offset == null || offset === '' ? null : parseInt(offset, 10),
+      facsimilePageCount:
+        pageCount == null || pageCount === '' ? null : parseInt(pageCount, 10),
+    };
+  }
+  return sources;
+};
+
+const resolveFacsimileForPosition = (xml, fileName, offset) => {
+  const pathInfo = parseKalliopeWorkPath(fileName);
+  if (pathInfo == null) {
+    return {
+      ok: false,
+      reason: 'Denne fil ligger ikke under fdirs/<digter>/<værk>.xml.',
+    };
+  }
+
+  const tree = parseXmlNodes(xml);
+  const workNode = findDescendantsByName(tree, new Set(['kalliopework']))[0];
+  if (workNode == null) {
+    return {
+      ok: false,
+      reason: 'Filen ligner ikke en Kalliope-værkfil.',
+    };
+  }
+
+  const textNode = findSmallestNodeAtOffset(
+    findDescendantsByName(workNode, new Set(['text'])),
+    offset
+  );
+  if (textNode == null) {
+    return {
+      ok: false,
+      reason: 'Cursoren står ikke i en <text> med facsimile.',
+    };
+  }
+
+  const head = childByName(textNode, 'head');
+  const sourceNode = head ? childByName(head, 'source') : null;
+  if (sourceNode == null) {
+    return {
+      ok: false,
+      title: getTitle(xml, textNode),
+      textId: textNode.attrs.id || null,
+      reason: 'Den aktuelle tekst har ingen <head><source>.',
+    };
+  }
+
+  const sources = getWorkSources(workNode, xml);
+  const sourceId = sourceNode.attrs.in || 'default';
+  const workSource = sources[sourceId];
+  if (workSource == null) {
+    return {
+      ok: false,
+      title: getTitle(xml, textNode),
+      textId: textNode.attrs.id || null,
+      reason: `Teksten refererer til en ukendt work source: ${sourceId}.`,
+    };
+  }
+
+  const facsimile =
+    normalizeFacsimileId(sourceNode.attrs.facsimile) || workSource.facsimile;
+  if (facsimile == null) {
+    return {
+      ok: false,
+      title: getTitle(xml, textNode),
+      textId: textNode.attrs.id || null,
+      reason: 'Kilden har ingen facsimile-attribut.',
+    };
+  }
+
+  let facsimilePages = parseNumericRange(sourceNode.attrs['facsimile-pages']);
+  if (facsimilePages == null && sourceNode.attrs['facsimile-pages'] != null) {
+    return {
+      ok: false,
+      title: getTitle(xml, textNode),
+      textId: textNode.attrs.id || null,
+      reason: `facsimile-pages er ikke numerisk: ${sourceNode.attrs['facsimile-pages']}.`,
+    };
+  }
+
+  if (facsimilePages == null) {
+    const pages = parseNumericRange(sourceNode.attrs.pages);
+    if (pages == null) {
+      return {
+        ok: false,
+        title: getTitle(xml, textNode),
+        textId: textNode.attrs.id || null,
+        reason:
+          'Tekstens pages kan ikke beregnes numerisk. Brug facsimile-pages for romertal eller specialpaginer.',
+      };
+    }
+    if (!Number.isInteger(workSource.facsimilePagesOffset)) {
+      return {
+        ok: false,
+        title: getTitle(xml, textNode),
+        textId: textNode.attrs.id || null,
+        reason: 'Work source mangler facsimile-pages-offset.',
+      };
+    }
+    facsimilePages = [
+      pages[0] + workSource.facsimilePagesOffset,
+      pages[1] + workSource.facsimilePagesOffset,
+    ];
+  }
+
+  if (facsimilePages[0] > facsimilePages[1]) {
+    return {
+      ok: false,
+      title: getTitle(xml, textNode),
+      textId: textNode.attrs.id || null,
+      reason: 'Facsimile-sideintervallet har fra-side efter til-side.',
+    };
+  }
+
+  if (
+    Number.isInteger(workSource.facsimilePageCount) &&
+    facsimilePages[1] > workSource.facsimilePageCount
+  ) {
+    return {
+      ok: false,
+      title: getTitle(xml, textNode),
+      textId: textNode.attrs.id || null,
+      reason: `Facsimile-side ${facsimilePages[1]} er større end kildens ${workSource.facsimilePageCount} sider.`,
+    };
+  }
+
+  const pages = [];
+  for (let page = facsimilePages[0]; page <= facsimilePages[1]; page++) {
+    pages.push({
+      page,
+      filename: padPageFilename(page),
+    });
+  }
+
+  return {
+    ok: true,
+    ...pathInfo,
+    textId: textNode.attrs.id || null,
+    title: getTitle(xml, textNode),
+    sourceId,
+    facsimile,
+    facsimilePages,
+    pages,
+  };
+};
+
+module.exports = {
+  normalizeFacsimileId,
+  padPageFilename,
+  parseKalliopeWorkPath,
+  parseNumericRange,
+  parseXmlNodes,
+  resolveFacsimileForPosition,
+};

--- a/tools/vscode-kalliope-syntax/package.json
+++ b/tools/vscode-kalliope-syntax/package.json
@@ -11,7 +11,9 @@
   "activationEvents": [
     "onStartupFinished",
     "onLanguage:plaintext",
-    "onLanguage:kalliope-old"
+    "onLanguage:kalliope-old",
+    "onLanguage:xml",
+    "onCommand:kalliope.showFacsimileForCurrentText"
   ],
   "categories": [
     "Programming Languages"
@@ -33,6 +35,32 @@
         "scopeName": "source.kalliope.old",
         "path": "./syntaxes/kalliope-old.tmLanguage.json"
       }
-    ]
+    ],
+    "commands": [
+      {
+        "command": "kalliope.showFacsimileForCurrentText",
+        "title": "Kalliope: Vis facsimile for aktuelt digt"
+      }
+    ],
+    "configuration": {
+      "title": "Kalliope",
+      "properties": {
+        "kalliope.facsimiles.localRoot": {
+          "type": "string",
+          "default": "facsimiles",
+          "description": "Lokal rodmappe for facsimile-billeder. Relative stier fortolkes fra workspace-roden."
+        },
+        "kalliope.facsimiles.remoteBaseUrl": {
+          "type": "string",
+          "default": "https://kalliope.org/static/facsimiles",
+          "description": "Fallback-URL for facsimile-billeder, når en lokal billedfil ikke findes."
+        },
+        "kalliope.facsimiles.autoUpdate": {
+          "type": "boolean",
+          "default": true,
+          "description": "Opdater det åbne facsimile-split automatisk, når cursoren flyttes."
+        }
+      }
+    }
   }
 }


### PR DESCRIPTION
## Hvad ændrer PR'en?

- tilføjer en VS Code-kommando, der viser facsimilesider for teksten ved cursoren
- følger automatisk cursoren, mens facsimilepanelet er åbent
- bruger lokale facsimilebilleder med fallback til Kalliopes eksterne billedserver
- understøtter beregnede sideintervaller, eksplicitte `facsimile-pages` og navngivne værkkilder
- tilføjer konfigurationsmuligheder og dansk dokumentation til extensionen
- tilføjer tests af facsimile-resolveren

## Validering

- `npm test -- --runInBand` — 38 testsuiter og 2.259 tests består
- `node --check tools/vscode-kalliope-syntax/extension.js`
- `node --check tools/vscode-kalliope-syntax/facsimile.cjs`
- `git diff --check`
