### PR TITLE
Forbedr PDF-generering med CropBox

### DIFF
--- a/__tests__/build-facsimiles.test.js
+++ b/__tests__/build-facsimiles.test.js
@@ -109,8 +109,8 @@ page   num  type   width height color comp bpc  enc interp  object ID x-ppi y-pp
     expect(
       calls.filter(call => call.cmd === 'pdftoppm').map(call => call.args)
     ).toEqual([
-      expect.arrayContaining(['-f', '1', '-l', '1']),
-      expect.arrayContaining(['-f', '3', '-l', '3']),
+      expect.arrayContaining(['-cropbox', '-f', '1', '-l', '1']),
+      expect.arrayContaining(['-cropbox', '-f', '3', '-l', '3']),
     ]);
   });
 

--- a/tools/build-facsimiles.js
+++ b/tools/build-facsimiles.js
@@ -138,6 +138,7 @@ const renderPageWithPdftoppm = async (
   try {
     await command('pdftoppm', [
       '-jpeg',
+      '-cropbox',
       '-f',
       String(page),
       '-l',


### PR DESCRIPTION
## Ændringer

- brug PDF'ens CropBox ved rendering af faksimilesider med `pdftoppm`
- opdater testen, så CropBox-flaget kontrolleres for hver renderet side

## Validering

- `npm test -- --runInBand __tests__/build-facsimiles.test.js`
