### PR TITLE
Understøt digter på sektioner i gammelt format

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -33,6 +33,21 @@ jobs:
         env:
           CI: true
 
+  old2kalliope:
+    name: Run old2kalliope tests
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Use Ruby 3.3
+        uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: '3.3'
+
+      - name: Run old2kalliope tests
+        run: ruby test/old2kalliope_test.rb
+
   build-static:
     name: Run build-static smoke
     runs-on: ubuntu-latest

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -14,6 +14,12 @@
         }
       },
       {
+        "scope": "keyword.other.header.section.kalliope, keyword.other.section.kalliope",
+        "settings": {
+          "foreground": "#569CD6"
+        }
+      },
+      {
         "scope": "keyword.other.header.todo.kalliope",
         "settings": {
           "foreground": "#D7BA7D",

--- a/__tests__/anthologies.test.js
+++ b/__tests__/anthologies.test.js
@@ -1,8 +1,10 @@
+import { DOMParser } from '@xmldom/xmldom';
 import {
   ANTHOLOGY_WORK_ID,
   buildVirtualAnthologyWorks,
   isAnthologyText,
   publicationTextId,
+  resolveAuthorId,
   sourceWorkFilename,
   worksForPoet,
 } from '../tools/build-static/anthologies.js';
@@ -16,6 +18,61 @@ import {
 } from '../tools/build-static/xml.js';
 
 describe('antologiplaceringer', () => {
+  it('arver forfatter fra den nærmeste sektion', () => {
+    const doc = new DOMParser().parseFromString(
+      `<kalliopework author="antologierdk">
+        <workbody>
+          <section author="sektionsdigter">
+            <content>
+              <text id="arvet" />
+              <section author="indre-digter">
+                <content>
+                  <text id="indre" />
+                  <text id="overskrevet" author="tekst-digter" />
+                </content>
+              </section>
+            </content>
+          </section>
+          <text id="vaerkets" />
+        </workbody>
+      </kalliopework>`,
+      'text/xml'
+    );
+    const texts = Array.from(doc.getElementsByTagName('text'));
+    const author = id => {
+      const text = Array.from(doc.getElementsByTagName('text')).find(
+        node => node.getAttribute('id') === id
+      );
+      return resolveAuthorId(text, 'fallback');
+    };
+
+    expect(texts).toHaveLength(4);
+    expect(author('arvet')).toBe('sektionsdigter');
+    expect(author('indre')).toBe('indre-digter');
+    expect(author('overskrevet')).toBe('tekst-digter');
+    expect(author('vaerkets')).toBe('antologierdk');
+  });
+
+  it('bruger udgivelses-id for tekster i en forfattersektion', () => {
+    const doc = new DOMParser().parseFromString(
+      `<workbody>
+        <section author="hansenfj">
+          <head><title>F. J. Hansen</title></head>
+          <content>
+            <text id="solnedgang">
+              <head><title>Solnedgang</title></head>
+            </text>
+          </content>
+        </section>
+      </workbody>`,
+      'text/xml'
+    );
+
+    const toc = build_section_toc(doc.documentElement, 'antologierdk');
+
+    expect(toc[0].content[0].id).toBe('solnedganga');
+  });
+
   it('genkender en anden tekstforfatter og danner udgivelses-id', () => {
     expect(isAnthologyText('arnesen-kall', 'antologierdk')).toBe(true);
     expect(isAnthologyText('antologierdk', 'antologierdk')).toBe(false);

--- a/__tests__/vscode-syntax.test.js
+++ b/__tests__/vscode-syntax.test.js
@@ -1,0 +1,22 @@
+import fs from 'fs';
+
+describe('VS Code old2kalliope syntax', () => {
+  const grammar = JSON.parse(
+    fs.readFileSync(
+      'tools/vscode-kalliope-syntax/syntaxes/kalliope-old.tmLanguage.json',
+      'utf8',
+    ),
+  );
+
+  it('treats DIGTER below SEKTION as section metadata', () => {
+    const sectionHead = grammar.repository['section-head'];
+    const authorPattern = sectionHead.patterns.find(pattern =>
+      pattern.match?.includes('DIGTER:'),
+    );
+
+    expect(sectionHead.begin).toContain('SEKTION');
+    expect(authorPattern.captures['1'].name).toBe(
+      'keyword.other.header.section.kalliope',
+    );
+  });
+});

--- a/data/kalliopework.rng
+++ b/data/kalliopework.rng
@@ -118,6 +118,7 @@
   <define name="section">
     <element name="section">
       <optional><attribute name="id"><text/></attribute></optional>
+      <optional><attribute name="author"><text/></attribute></optional>
       <optional><attribute name="level"><text/></attribute></optional>
       <optional><attribute name="variant"><text/></attribute></optional>
       <optional><attribute name="aliases"><text/></attribute></optional>

--- a/docs/xml-work-format.md
+++ b/docs/xml-work-format.md
@@ -293,7 +293,7 @@ Særlige linjeformer:
 Sektioner grupperer tekster og kan nestes:
 
 ```xml
-<section id="del-1" level="2">
+<section id="del-1" author="hansenfj" level="2">
   <head>
     <title>Foerste del</title>
   </head>
@@ -306,6 +306,9 @@ Sektioner grupperer tekster og kan nestes:
 Attributter paa `<section>`:
 
 - `id`: gor sektionen linkbar og giver den egen tekstside med intern TOC.
+- `author`: valgfrit forfatter-id, som arves af alle tekster og undersektioner.
+  Et `author` direkte paa en indlejret `<section>` eller `<text>` overskriver den
+  arvede forfatter i den paagaeldende gren.
 - `level`: overskriftsniveau i indholdsfortegnelsen.
 - `variant`: variant-id, ligesom paa `<text>`.
 - `aliases`: gamle id'er, ligesom paa `<text>`.

--- a/test/old2kalliope_test.rb
+++ b/test/old2kalliope_test.rb
@@ -1,0 +1,405 @@
+require 'minitest/autorun'
+require 'open3'
+require 'rbconfig'
+require 'rexml/document'
+require 'rexml/xpath'
+require 'tempfile'
+
+class Old2KalliopeTest < Minitest::Test
+  ROOT = File.expand_path('..', __dir__)
+  CONVERTER = File.join(ROOT, 'tools', 'old2kalliope.rb')
+
+  def test_prints_a_template_without_an_input_file
+    output, error, status = Open3.capture3(RbConfig.ruby, CONVERTER)
+
+    assert status.success?, error
+    assert_includes output, "KILDE:\nDIGTER:"
+    assert_includes output, "SEKTION:\nDIGTER:"
+    assert_includes output, 'SLUTSEKTION'
+  end
+
+  def test_converts_work_and_text_metadata
+    document = convert_and_parse(<<~TEXT)
+      KILDE:Red.: <i>Digte</i>, København, 1852.
+      DIGTER:vaerkejer
+      FACSIMILE:scan.pdf
+      FACSIMILE-SIDER:20
+      FACSIMILE-OFFSET:2
+      TITELBLAD:Digte / 1852
+      ID:vaerk
+      NOTE:Værknote
+      TODO:Tjek værket
+
+      T:Solnedgang
+      TOCTITEL:Solnedgang i TOC
+      INDEXTITEL:Solnedgang i indeks
+      LINKTITEL:Solnedgang som link
+      U:Første undertitel
+      U:Anden undertitel
+      F:Det spredes meer og meer
+      ID:solnedgang
+      DIGTER:hansenfj
+      N:natur,aften
+      NOTE:Tekstnote
+      SIDE:3-3
+      FACSIMILE-SIDE:5
+      SKREVET:1851
+      FREMFØRT:1852-01-01
+      BEGIVENHED:1852
+      SPROG:da
+      VARIANT:anden-variant
+      CREDITS:Indtastet af NN
+      TODO:Tjek teksten
+
+      Det _spredes_ =meer= og *meer*
+      SLUT
+    TEXT
+
+    work = document.root
+    workhead = REXML::XPath.first(document, '/kalliopework/workhead')
+    text = REXML::XPath.first(document, '//text')
+    head = REXML::XPath.first(text, 'head')
+
+    assert_equal 'vaerk', work.attributes['id']
+    assert_equal 'vaerkejer', work.attributes['author']
+    assert_equal 'Digte', element_text(workhead, 'title')
+    assert_equal '1852', element_text(workhead, 'year')
+    assert_equal 'scan.pdf', REXML::XPath.first(workhead, 'source').attributes['facsimile']
+    assert_equal '20', REXML::XPath.first(workhead, 'source').attributes['facsimile-pages-num']
+    assert_equal '2', REXML::XPath.first(workhead, 'source').attributes['facsimile-pages-offset']
+
+    assert_equal 'solnedgang', text.attributes['id']
+    assert_equal 'hansenfj', text.attributes['author']
+    assert_equal 'anden-variant', text.attributes['variant']
+    assert_equal 'da', text.attributes['lang']
+    assert_equal 'Solnedgang', element_text(head, 'title')
+    assert_equal 'Solnedgang i TOC', element_text(head, 'toctitle')
+    assert_equal 'Solnedgang i indeks', element_text(head, 'indextitle')
+    assert_equal 'Solnedgang som link', element_text(head, 'linktitle')
+    assert_equal %w[Første\ undertitel Anden\ undertitel],
+                 REXML::XPath.match(head, 'subtitle/line').map(&:text)
+    assert_equal 'Det spredes meer og meer', element_text(head, 'firstline')
+    assert_equal 'natur,aften', element_text(head, 'keywords')
+    assert_equal '1851', element_text(head, 'dates/written')
+    assert_equal '1852-01-01', element_text(head, 'dates/performed')
+    assert_equal '1852', element_text(head, 'dates/event')
+
+    source = REXML::XPath.first(head, 'source')
+    assert_equal '3', source.attributes['pages']
+    assert_equal '5', source.attributes['facsimile-pages']
+    assert_equal %w[Tekstnote Indtastet\ af\ NN],
+                 REXML::XPath.match(head, 'notes/note').map(&:text)
+    assert_equal 'credits', REXML::XPath.match(head, 'notes/note')[1].attributes['type']
+    assert_equal %w[i w b], REXML::XPath.match(text, 'body/poetry/*').map(&:name)
+  end
+
+  def test_section_author_is_emitted_without_repeating_it_on_texts
+    document = convert_and_parse(<<~TEXT)
+      KILDE:<i>Antologi</i> 1872
+      DIGTER:antologierdk
+      ID:1872
+
+      SEKTION:F. J. Hansen
+
+      DIGTER:hansenfj
+
+      T:Solnedgang
+      F:Det spredes meer og meer
+      ID:solnedgang
+
+      Det spredes meer og meer
+
+      T:Et andet digt
+      F:En anden førstelinje
+      ID:andet
+
+      En anden førstelinje
+      SLUTSEKTION
+
+      T:Uden for sektionen
+      F:Værkets egen forfatter
+      ID:udenfor
+
+      Værkets egen forfatter
+      SLUT
+    TEXT
+
+    section = REXML::XPath.first(document, '//section')
+    texts = texts_by_id(document)
+
+    assert_equal 'hansenfj', section.attributes['author']
+    assert_nil texts['solnedgang'].attributes['author']
+    assert_nil texts['andet'].attributes['author']
+    assert_nil texts['udenfor'].attributes['author']
+    assert_equal section, containing_section(texts['solnedgang'])
+    assert_equal section, containing_section(texts['andet'])
+    assert_nil containing_section(texts['udenfor'])
+  end
+
+  def test_nested_sections_override_and_restore_authors
+    document = convert_and_parse(<<~TEXT)
+      KILDE:<i>Antologi</i> 1872
+      DIGTER:antologierdk
+      ID:1872
+
+      SEKTION:Ydre
+      DIGTER:ydre-digter
+
+      T:Ydre digt
+      F:Ydre førstelinje
+      ID:ydre
+
+      Ydre førstelinje
+
+      SEKTION2:Indre
+      DIGTER:indre-digter
+
+      T:Indre digt
+      F:Indre førstelinje
+      ID:indre
+
+      Indre førstelinje
+      SEKTIONSLUT
+
+      T:Ydre igen
+      F:Ydre igen førstelinje
+      ID:ydre-igen
+
+      Ydre igen førstelinje
+      SLUTSEKTION
+
+      T:Udenfor
+      F:Udenfor førstelinje
+      ID:udenfor
+
+      Udenfor førstelinje
+      SLUT
+    TEXT
+
+    sections = REXML::XPath.match(document, '//section')
+    texts = texts_by_id(document)
+
+    assert_equal 'ydre-digter', sections[0].attributes['author']
+    assert_nil sections[0].attributes['level']
+    assert_equal 'indre-digter', sections[1].attributes['author']
+    assert_equal '2', sections[1].attributes['level']
+    assert_equal sections[0], containing_section(texts['ydre'])
+    assert_equal sections[1], containing_section(texts['indre'])
+    assert_equal sections[0], containing_section(texts['ydre-igen'])
+    assert_nil containing_section(texts['udenfor'])
+  end
+
+  def test_a_text_author_overrides_a_section_and_is_reset_for_the_next_text
+    document = convert_and_parse(<<~TEXT)
+      KILDE:<i>Antologi</i> 1872
+      DIGTER:antologierdk
+
+      SEKTION:En digter
+      DIGTER:sektionsdigter
+
+      T:Gæstedigt
+      DIGTER:gaestedigter
+      F:Gæstens førstelinje
+      ID:gaest
+
+      Gæstens førstelinje
+
+      T:Sektionens digt
+      F:Sektionens førstelinje
+      ID:sektion
+
+      Sektionens førstelinje
+      SLUTSEKTION
+      SLUT
+    TEXT
+
+    texts = texts_by_id(document)
+
+    assert_equal 'gaestedigter', texts['gaest'].attributes['author']
+    assert_nil texts['sektion'].attributes['author']
+  end
+
+  def test_a_numbered_section_without_digter_has_no_author
+    document = convert_and_parse(<<~TEXT)
+      KILDE:<i>Antologi</i> 1872
+      DIGTER:antologierdk
+
+      SEKTION12:Tillæg
+
+      T:Et digt
+      F:En førstelinje
+      ID:digt
+
+      En førstelinje
+      SLUTSEKTION
+      SLUT
+    TEXT
+
+    section = REXML::XPath.first(document, '//section')
+
+    assert_nil section.attributes['author']
+    assert_equal '12', section.attributes['level']
+  end
+
+  def test_converts_prose_and_body_type_changes
+    document = convert_and_parse(<<~TEXT)
+      KILDE:<i>Prosa</i> 1900
+      DIGTER:digter
+      DATO:20260721
+
+      T:Prosatekst
+      TYPE:prose
+
+      Første afsnit
+      TYPE:quote
+      Et citat
+
+      T:Digt
+      F:Første vers
+
+      Første vers
+      SLUT
+    TEXT
+
+    texts = REXML::XPath.match(document, '//text')
+
+    assert_equal %w[digter2026072101 digter2026072102],
+                 texts.map { |text| text.attributes['id'] }
+    assert_equal %w[prose quote],
+                 REXML::XPath.match(texts[0], 'body/*').map(&:name)
+    assert_equal ['poetry'], REXML::XPath.match(texts[1], 'body/*').map(&:name)
+  end
+
+  def test_rejects_blank_facsimile_page_count
+    assert_conversion_fails(<<~TEXT, 'FEJL: FACSIMILE-SIDER er blank')
+      KILDE:<i>Digte</i> 1900
+      DIGTER:digter
+      FACSIMILE-SIDER:
+    TEXT
+  end
+
+  def test_requires_page_numbers_when_a_facsimile_is_configured
+    assert_conversion_fails(<<~TEXT, 'mangler sideangivelse')
+      KILDE:<i>Digte</i> 1900
+      DIGTER:digter
+      FACSIMILE:scan.pdf
+
+      T:Digt
+      F:Første vers
+
+      Første vers
+      SLUT
+    TEXT
+  end
+
+  def test_rejects_incomplete_page_ranges
+    assert_conversion_fails(<<~TEXT, 'har kun halv sideangivelse: 7-')
+      KILDE:<i>Digte</i> 1900
+      DIGTER:digter
+      FACSIMILE:scan.pdf
+
+      T:Digt
+      F:Første vers
+      SIDE:7-
+
+      Første vers
+      SLUT
+    TEXT
+  end
+
+  def test_requires_a_firstline_for_poetry
+    assert_conversion_fails(<<~TEXT, 'mangler førstelinje')
+      KILDE:<i>Digte</i> 1900
+      DIGTER:digter
+
+      T:Digt
+
+      Et vers
+      SLUT
+    TEXT
+  end
+
+  def test_rejects_duplicate_firstlines
+    assert_conversion_fails(<<~TEXT, 'har mere end én F:')
+      KILDE:<i>Digte</i> 1900
+      DIGTER:digter
+
+      T:Digt
+      F:Første vers
+      F:Andet første vers
+
+      Første vers
+      SLUT
+    TEXT
+  end
+
+  def test_rejects_spaces_in_keywords
+    assert_conversion_fails(<<~TEXT, 'har mellemrum i sine nøgleord')
+      KILDE:<i>Digte</i> 1900
+      DIGTER:digter
+
+      T:Digt
+      F:Første vers
+      N:to ord
+
+      Første vers
+      SLUT
+    TEXT
+  end
+
+  def test_rejects_unknown_text_headers
+    assert_conversion_fails(<<~TEXT, 'Unknown header-line: UKENDT:værdi')
+      KILDE:<i>Digte</i> 1900
+      DIGTER:digter
+
+      T:Digt
+      F:Første vers
+      UKENDT:værdi
+
+      Første vers
+      SLUT
+    TEXT
+  end
+
+  private
+
+  def convert(input)
+    Tempfile.create(['old2kalliope', '.txt']) do |file|
+      file.write(input)
+      file.flush
+      return Open3.capture3(RbConfig.ruby, CONVERTER, file.path)
+    end
+  end
+
+  def convert_and_parse(input)
+    output, error, status = convert(input)
+    assert status.success?, error
+    REXML::Document.new(output)
+  end
+
+  def assert_conversion_fails(input, message)
+    _output, error, status = convert(input)
+    refute status.success?
+    assert_includes error, message
+  end
+
+  def texts_by_id(document)
+    REXML::XPath.match(document, '//text').to_h do |text|
+      [text.attributes['id'], text]
+    end
+  end
+
+  def containing_section(element)
+    current = element.parent
+    until current.nil? || current.is_a?(REXML::Document)
+      return current if current.name == 'section'
+
+      current = current.parent
+    end
+    nil
+  end
+
+  def element_text(element, path)
+    REXML::XPath.first(element, path)&.text
+  end
+end

--- a/tools/build-static.js
+++ b/tools/build-static.js
@@ -106,6 +106,7 @@ import {
   buildVirtualAnthologyWorks,
   isAnthologyText,
   publicationTextId,
+  resolveAuthorId,
   sourceFilesForText,
   worksForPoet,
 } from './build-static/anthologies.js';
@@ -574,7 +575,7 @@ const handle_work = async (work) => {
       const partName = tagName(part);
         if (partName === 'text') {
           const textId = safeGetAttr(part, 'id');
-          const textAuthorId = safeGetAttr(part, 'author');
+          const textAuthorId = resolveAuthorId(part, poetId);
           const anthologyText = isAnthologyText(textAuthorId, poetId);
           const renderedTextId =
             anthologyText ? publicationTextId(textId) : textId;
@@ -760,7 +761,7 @@ const handle_work = async (work) => {
       .filter((part) => safeGetAttr(part, 'id') != null)
       .map((part) => {
         const sourceTextId = safeGetAttr(part, 'id');
-        const textAuthorId = safeGetAttr(part, 'author');
+        const textAuthorId = resolveAuthorId(part, poetId);
         const textId =
           isAnthologyText(textAuthorId, poetId) ?
             publicationTextId(sourceTextId)
@@ -1022,7 +1023,7 @@ const works_first_pass = (collected) => {
         const indextitle = extractTitle(head, 'indextitle');
         const aliases = parseAliases(safeGetAttr(part, 'aliases'));
         const textDates = extractDates(head);
-        const textAuthorId = safeGetAttr(part, 'author');
+        const textAuthorId = resolveAuthorId(part, poetId);
         const anthologyText = isAnthologyText(textAuthorId, poetId);
 
         if (anthologyText && collected.poets.get(textAuthorId) == null) {

--- a/tools/build-static/anthologies.js
+++ b/tools/build-static/anthologies.js
@@ -1,3 +1,5 @@
+import { safeGetAttr } from './xml.js';
+
 const ANTHOLOGY_WORK_ID = 'antologier';
 const ANTHOLOGY_WORK_TITLE = 'Tekster i andre udgivelser';
 
@@ -5,6 +7,18 @@ const publicationTextId = textId => `${textId}a`;
 
 const isAnthologyText = (textAuthorId, publicationPoetId) =>
   textAuthorId != null && textAuthorId !== publicationPoetId;
+
+const resolveAuthorId = (node, fallbackAuthorId) => {
+  let current = node;
+  while (current != null) {
+    const authorId = safeGetAttr(current, 'author');
+    if (authorId != null && authorId.length > 0) {
+      return authorId;
+    }
+    current = current.parentNode;
+  }
+  return fallbackAuthorId;
+};
 
 const sourceWorkKey = text =>
   `${text.sourcePoetId || text.poetId}/${text.sourceWorkId || text.workId}`;
@@ -112,6 +126,7 @@ export {
   buildVirtualAnthologyWorks,
   isAnthologyText,
   publicationTextId,
+  resolveAuthorId,
   sourceFilesForText,
   sourceWorkFilename,
   sourceWorkKey,

--- a/tools/build-static/toc.js
+++ b/tools/build-static/toc.js
@@ -23,6 +23,7 @@ import {
 import {
   isAnthologyText,
   publicationTextId,
+  resolveAuthorId,
   worksForPoet,
 } from './anthologies.js';
 
@@ -37,7 +38,7 @@ const build_section_toc = (section, publicationPoetId = null) => {
     const partName = tagName(part);
     if (partName === 'text') {
       const sourceTextId = safeGetAttr(part, 'id');
-      const textAuthorId = safeGetAttr(part, 'author');
+      const textAuthorId = resolveAuthorId(part, publicationPoetId);
       const textId =
         isAnthologyText(textAuthorId, publicationPoetId) ?
           publicationTextId(sourceTextId)

--- a/tools/old2kalliope.rb
+++ b/tools/old2kalliope.rb
@@ -10,6 +10,7 @@ def printTemplate()
     puts "TITELBLAD:"
     puts ""
     puts "SEKTION:"
+    puts "DIGTER:"
     puts ""
     puts "T:"
     puts "F:"
@@ -27,6 +28,7 @@ end
 @poemcount = 1;
 @header_printed = false
 @section_title_stack = []
+@pending_section = nil
 
 # Work data
 @poetid = 'POETID'
@@ -251,18 +253,32 @@ def printPoem()
   @poemcount += 1
 end
 
-def printStartSektion(title, level)
+def printStartSektion(title, level, author)
   levelAttr = ''
   if not level.nil? and level.length > 0
       levelAttr = " level=\"#{level}\""
   end
+  authorAttr = ''
+  if not author.nil? and author.length > 0
+      authorAttr = " author=\"#{author}\""
+  end
   printHeader()
-  puts "<section#{levelAttr}>"
+  puts "<section#{authorAttr}#{levelAttr}>"
   puts "<head>"
   puts "    <title>#{title}</title>"
   puts "</head>"
   puts "<content>"
   puts ""
+end
+
+def printPendingSection(author = nil)
+  return if @pending_section.nil?
+
+  title = @pending_section[:title]
+  level = @pending_section[:level]
+  @section_title_stack.push(title)
+  printStartSektion(title, level, author)
+  @pending_section = nil
 end
 
 def printEndSection(sectionTitle)
@@ -282,6 +298,16 @@ end
 
 File.readlines(ARGV[0]).each do |line|
   next if @done;
+  if @pending_section
+    if line.start_with?('DIGTER:')
+      printPendingSection(line[7..-1].strip)
+      next
+    elsif line.strip.length == 0
+      next
+    else
+      printPendingSection()
+    end
+  end
   if line.start_with?('SLUT') and not line.start_with?('SLUTSEKTION')
     @done = true
     if @state != 'NONE'
@@ -386,10 +412,10 @@ File.readlines(ARGV[0]).each do |line|
       if (@state == 'INBODY')
           printPoem();
       end
-      sectionTitle = line.gsub(/^SEKTION\d?:/,'').strip
-      @section_title_stack.push(sectionTitle)
-      print printStartSektion(sectionTitle, level)
+      sectionTitle = line.gsub(/^SEKTION\d*:/,'').strip
+      @pending_section = { title: sectionTitle, level: level }
       @state = 'NONE'
+      next
   end
   if line.start_with?('SLUTSEKTION') or line.start_with?('SEKTIONSLUT')
       if @state != 'NONE'
@@ -438,7 +464,7 @@ File.readlines(ARGV[0]).each do |line|
     elsif line.start_with?("SKREVET:")
       @written = line[8..-1].strip
     elsif line.start_with?("FREMFØRT:")
-      @written = line[9..-1].strip
+      @performed = line[9..-1].strip
     elsif line.start_with?("BEGIVENHED:")
       @event = line.gsub(/^BEGIVENHED:/,'').strip
     elsif line.start_with?("SPROG:")
@@ -475,6 +501,7 @@ File.readlines(ARGV[0]).each do |line|
   end
 end
 
+printPendingSection()
 if @state != 'NONE'
     printPoem()
 end

--- a/tools/vscode-kalliope-syntax/README.md
+++ b/tools/vscode-kalliope-syntax/README.md
@@ -90,6 +90,8 @@ Kalliope-workspacet indeholder `.vscode/settings.json` med tokenfarver til
 `old2kalliope`-grammatikken. Teksthovedkommandoer som `T:`, `F:` og
 tekstniveauets `DIGTER:` bruger scopet `keyword.other.header.text.kalliope`,
 mens værkhovedkommandoer bruger `keyword.other.header.work.kalliope`.
+`DIGTER:` umiddelbart under `SEKTION:` bruger det særskilte scope
+`keyword.other.header.section.kalliope`.
 
 VS Code indlæser ikke vilkårlige extensions direkte fra en workspace-mappe.
 Derfor er installationsscriptet nødvendigt, selv om extensionens kildekode

--- a/tools/vscode-kalliope-syntax/syntaxes/kalliope-old.tmLanguage.json
+++ b/tools/vscode-kalliope-syntax/syntaxes/kalliope-old.tmLanguage.json
@@ -7,7 +7,10 @@
       "include": "#work-head"
     },
     {
-      "include": "#section-line"
+      "include": "#section-head"
+    },
+    {
+      "include": "#section-end"
     },
     {
       "include": "#text-head-line"
@@ -67,9 +70,40 @@
         }
       ]
     },
-    "section-line": {
+    "section-head": {
       "name": "meta.section.kalliope",
-      "match": "^(SEKTION\\d*:|SLUTSEKTION|SEKTIONSLUT|SLUT)(.*)$",
+      "begin": "^(SEKTION\\d*:)(.*)$",
+      "beginCaptures": {
+        "1": {
+          "name": "keyword.other.section.kalliope"
+        }
+      },
+      "end": "^(?!(?:DIGTER:|\\s*$))",
+      "patterns": [
+        {
+          "name": "meta.header.section.kalliope",
+          "match": "^(DIGTER:)(.*)$",
+          "captures": {
+            "1": {
+              "name": "keyword.other.header.section.kalliope"
+            },
+            "2": {
+              "patterns": [
+                {
+                  "include": "#inline-markup"
+                }
+              ]
+            }
+          }
+        },
+        {
+          "include": "#inline-markup"
+        }
+      ]
+    },
+    "section-end": {
+      "name": "meta.section.kalliope",
+      "match": "^(SLUTSEKTION|SEKTIONSLUT|SLUT)(.*)$",
       "captures": {
         "1": {
           "name": "keyword.other.section.kalliope"


### PR DESCRIPTION
## Sammenfatning

- tillad `DIGTER:` under `SEKTION:` i det gamle tekstformat og skriv forfatteren på XML-sektionen
- lad sektionsforfatteren gå i arv til digtenes metadata og TOC-links med tekstniveauet som overskrivning
- tilføj syntaksfarvning og dokumentation for sektionsforfattere
- flyt regressionstesten af `old2kalliope` til en selvstændig Ruby/Minitest-suite og kør den i et separat CI-job
- ret `FREMFØRT:`, så værdien skrives som fremførelsesdato og ikke som tilblivelsesdato

## Test

- `npm test -- --runInBand` — 45 suites og 2.294 tests bestået
- `ruby test/old2kalliope_test.rb` — 14 tests og 82 assertions bestået
- `KALLIOPE_SKIP_ELASTICSEARCH=1 KALLIOPE_SKIP_IMAGE_THUMBNAILS=1 npm run build-static-force-reload`
- `git diff --check`
