### PR TITLE
Valider sektionsmarkører i txt2xml

### DIFF
--- a/test/txt2xml_test.rb
+++ b/test/txt2xml_test.rb
@@ -241,6 +241,31 @@ class Txt2XmlTest < Minitest::Test
     assert_equal '12', section.attributes['level']
   end
 
+  def test_rejects_a_section_without_an_end_marker
+    assert_conversion_fails(<<~TEXT, 'FEJL: SEKTION »Uafsluttet« mangler SLUTSEKTION')
+      KILDE:<i>Antologi</i> 1872
+      DIGTER:antologierdk
+
+      SEKTION:Uafsluttet
+
+      T:Et digt
+      F:En førstelinje
+
+      En førstelinje
+      SLUT
+    TEXT
+  end
+
+  def test_rejects_an_end_marker_without_a_section
+    assert_conversion_fails(<<~TEXT, 'FEJL: SLUTSEKTION uden tilhørende SEKTION')
+      KILDE:<i>Antologi</i> 1872
+      DIGTER:antologierdk
+
+      SLUTSEKTION
+      SLUT
+    TEXT
+  end
+
   def test_converts_prose_and_body_type_changes
     document = convert_and_parse(<<~TEXT)
       KILDE:<i>Prosa</i> 1900

--- a/tools/txt2xml.rb
+++ b/tools/txt2xml.rb
@@ -287,6 +287,12 @@ def printEndSection(sectionTitle)
   puts ""
 end
 
+def ensureSectionsClosed()
+  return if @section_title_stack.empty?
+
+  abort "FEJL: SEKTION »#{@section_title_stack.last}« mangler SLUTSEKTION"
+end
+
 File.readlines(ARGV[0]).each do |line|
   if line =~ /<note>.*\] .*<\/note>/
     @found_corrections = true
@@ -309,6 +315,7 @@ File.readlines(ARGV[0]).each do |line|
     end
   end
   if line.start_with?('SLUT') and not line.start_with?('SLUTSEKTION')
+    ensureSectionsClosed()
     @done = true
     if @state != 'NONE'
         printPoem();
@@ -418,6 +425,9 @@ File.readlines(ARGV[0]).each do |line|
       next
   end
   if line.start_with?('SLUTSEKTION') or line.start_with?('SEKTIONSLUT')
+      if @section_title_stack.empty?
+          abort "FEJL: SLUTSEKTION uden tilhørende SEKTION"
+      end
       if @state != 'NONE'
           printPoem();
       end
@@ -502,6 +512,7 @@ File.readlines(ARGV[0]).each do |line|
 end
 
 printPendingSection()
+ensureSectionsClosed()
 if @state != 'NONE'
     printPoem()
 end


### PR DESCRIPTION
## Ændringer

- afvis en `SEKTION`, der ikke afsluttes med `SLUTSEKTION`
- afvis en `SLUTSEKTION` uden en tilhørende åben sektion
- tilføj regressionstests for begge fejltilfælde

## Test

- `ruby test/txt2xml_test.rb`
