### PR TITLE
Gør fejl om manglende billeder tydeligere

### DIFF
--- a/__tests__/sharp-images.test.js
+++ b/__tests__/sharp-images.test.js
@@ -72,6 +72,15 @@ describe('sharp image helpers', () => {
     });
   });
 
+  it('explains how to fix a missing image file', async () => {
+    const input = path.join(tmpdir, 'missing.jpg');
+
+    await expect(imageSizeSync(input)).rejects.toThrow(
+      `Billedfilen findes ikke: ${input}\n` +
+        'Tilføj filen, eller ret billedreferencen i XML-kilden.'
+    );
+  });
+
   it('keeps existing thumbnails when the source mtime changes without content changes', async () => {
     process.chdir(tmpdir);
     fs.mkdirSync('public/images/poet', { recursive: true });

--- a/tools/build-static.js
+++ b/tools/build-static.js
@@ -1440,4 +1440,7 @@ const main = async () => {
   print_benchmarking_results();
 };
 
-main();
+main().catch(error => {
+  console.error(`\nFEJL: ${error.message || error}`);
+  process.exitCode = 1;
+});

--- a/tools/build-static/image.js
+++ b/tools/build-static/image.js
@@ -13,7 +13,10 @@ let collected_imagesizes = new Map(
 
 const readImageSize = async filename => {
   if (!fileExists(filename)) {
-    throw `image size failed for missing file: ${filename}`;
+    throw new Error(
+      `Billedfilen findes ikke: ${filename}\n` +
+        'Tilføj filen, eller ret billedreferencen i XML-kilden.'
+    );
   }
   const cached = collected_imagesizes.get(filename);
   if (cached != null && !isFileModified(filename)) {
@@ -28,7 +31,7 @@ const readImageSize = async filename => {
     collected_imagesizes.set(filename, size);
     return size;
   } catch (e) {
-    throw `${filename}: ${e}`;
+    throw new Error(`${filename}: ${e.message || e}`);
   }
 };
 


### PR DESCRIPTION
## Ændringer

- vis en kort og handlingsanvisende fejl, når en refereret billedfil mangler
- undgå Node.js' `UnhandledPromiseRejection`-staktrace ved buildfejl
- tilføj en regressionstest for beskeden om manglende billeder

## Test

- `npm test -- --runInBand __tests__/sharp-images.test.js`
- verificeret med `npm run build-static` mod en manglende titelbladfil
