### PR TITLE
Forbedr output og validering i build-static

### DIFF
--- a/__tests__/build-static-progress.test.js
+++ b/__tests__/build-static-progress.test.js
@@ -1,0 +1,23 @@
+import { createProgressReporter } from '../tools/build-static/progress.js';
+
+describe('build-static progress reporting', () => {
+  it('reports periodically and once when finished', () => {
+    const messages = [];
+    const progress = createProgressReporter(
+      'Skrev tekstfiler',
+      2,
+      message => messages.push(message)
+    );
+
+    for (let i = 0; i < 5; i += 1) {
+      progress.increment();
+    }
+    progress.finish();
+
+    expect(messages).toEqual([
+      'Skrev tekstfiler: 2',
+      'Skrev tekstfiler: 4',
+      'Skrev tekstfiler: 5 (færdig)',
+    ]);
+  });
+});

--- a/__tests__/build-static-validation.test.js
+++ b/__tests__/build-static-validation.test.js
@@ -1,0 +1,26 @@
+import { validateFirstlineMarkup } from '../tools/build-static/validation.js';
+
+describe('build-static validation', () => {
+  it('explains how to remove markup from a firstline', () => {
+    expect(() =>
+      validateFirstlineMarkup(
+        { title: 'Til unge Herr’ <w>Rosenstok</w>' },
+        'antologierdk2026072110',
+        'fdirs/antologierdk/1868.xml'
+      )
+    ).toThrow(
+      'Teksten "antologierdk2026072110" i fdirs/antologierdk/1868.xml har markup i <firstline>.\n' +
+        'Fjern markup fra F:-linjen i txt2xml-kilden eller fra <firstline> i XML-filen.'
+    );
+  });
+
+  it('accepts a plain firstline', () => {
+    expect(() =>
+      validateFirstlineMarkup(
+        { title: 'Til unge Herr’ Rosenstok' },
+        'antologierdk2026072110',
+        'fdirs/antologierdk/1868.xml'
+      )
+    ).not.toThrow();
+  });
+});

--- a/tools/build-static.js
+++ b/tools/build-static.js
@@ -89,6 +89,8 @@ import {
   print_benchmarking_results,
 } from './build-static/benchmarking.js';
 import { mapLimit } from './build-static/concurrency.js';
+import { createProgressReporter } from './build-static/progress.js';
+import { validateFirstlineMarkup } from './build-static/validation.js';
 import { build_works_toc, build_section_toc } from './build-static/toc.js';
 import { update_elasticsearch } from './build-static/elastic.js';
 import { loadExternalIdentifiers } from './build-static/external-identifiers.js';
@@ -133,6 +135,7 @@ let collected = {
 
 // Ready after second pass
 let collected_works = new Map();
+let textBuildProgress = null;
 
 const parseAliases = (value) => {
   if (value == null) {
@@ -171,6 +174,7 @@ const buildTextAliasRedirects = (redirects, texts) => {
 };
 
 const build_bio_json = async (collected) => {
+  const progress = createProgressReporter('Skrev bio.json-filer', 100);
   const codeModified = isFileModified(
     'tools/build-static.js',
     'tools/build-static/artwork.js',
@@ -187,7 +191,7 @@ const build_bio_json = async (collected) => {
       (poetId) => `fdirs/${poetId}/artwork.xml`,
     ),
   );
-  return mapLimit(
+  const results = await mapLimit(
     Array.from(collected.poets.entries()),
     async (entry) => {
       const [poetId, poet] = entry;
@@ -230,10 +234,12 @@ const build_bio_json = async (collected) => {
       data.timeline = await build_poet_timeline_json(poet, collected);
       data.portraits = await build_portraits_json(poet, collected);
       const destFilename = `public/api/${poet.id}/bio.json`;
-      console.log(destFilename);
       writeJSON(destFilename, data);
+      progress.increment();
     },
   );
+  progress.finish();
+  return results;
 };
 
 const build_poet_workids = () => {
@@ -531,8 +537,8 @@ const handle_text = async (
       indexable: placement.indexable !== false,
     },
   };
-  console.log(Paths.textPath(textId));
   writeJSON(Paths.textPath(textId), text_data);
+  textBuildProgress?.increment();
 };
 
 const handle_work = async (work) => {
@@ -587,9 +593,11 @@ const handle_work = async (work) => {
           if (indextitle == null) {
             throw `${textId} mangler førstelinje, indextitle og title i ${poetId}/${workId}.xml`;
           }
-          if (firstline != null && firstline.title.indexOf('<') > -1) {
-            throw `${textId} har markup i førstelinjen i ${poetId}/${workId}.xml`;
-          }
+          validateFirstlineMarkup(
+            firstline,
+            textId,
+            `fdirs/${poetId}/${workId}.xml`
+          );
           if (firstline != null && firstline.title.trim().length === 0) {
             throw `${textId} har blank førstelinje i ${poetId}/${workId}.xml`;
           }
@@ -923,6 +931,7 @@ const works_first_pass = (collected) => {
     works.size === 0 ||
     dates.size === 0 ||
     anthologyCodeModified;
+  const progress = createProgressReporter('Indlæste værkfiler', 100);
 
   let parentIdsToFillIn = new Map(); // Bruges til nedenstående second-pass som klistrer parent-data på
 
@@ -1118,8 +1127,10 @@ const works_first_pass = (collected) => {
           addTextDates(dates, text, textDates);
         }
       });
+      progress.increment();
     });
   });
+  progress.finish();
 
   buildVirtualAnthologyWorks({ ...collected, works, texts });
 
@@ -1164,42 +1175,44 @@ const works_second_pass = async (collected) => {
     });
   });
 
-  return mapLimit(jobs, async ({ poetId, workId }) => {
-    const filename = `fdirs/${poetId}/${workId}.xml`;
-    if (!fileExists(filename)) {
-      return;
-    }
-    const sourceFiles = new Set([
-      'tools/build-static.js',
-      'tools/build-static/anthologies.js',
-      `fdirs/${poetId}/info.xml`,
-      filename,
-    ]);
-    collected.texts.forEach(text => {
-      if (
-        (text.sourcePoetId || text.poetId) === poetId &&
-        (text.sourceWorkId || text.workId) === workId
-      ) {
-        sourceFilesForText(text).forEach(sourceFile =>
-          sourceFiles.add(sourceFile)
-        );
+  textBuildProgress = createProgressReporter('Skrev tekstfiler');
+  try {
+    await mapLimit(jobs, async ({ poetId, workId }) => {
+      const filename = `fdirs/${poetId}/${workId}.xml`;
+      if (!fileExists(filename)) {
+        return;
       }
-    });
-    const poetMetadataModified = Array.from(collected.texts.values()).some(
-      text =>
-        (text.sourcePoetId || text.poetId) === poetId &&
-        (text.sourceWorkId || text.workId) === workId &&
-        collected.poetMetadataDirty?.has(text.poetId)
-    );
-    if (!poetMetadataModified && !isFileModified(...sourceFiles)) {
-      return;
-    }
-    let doc = loadXMLDoc(filename);
-    const work = getChildByTagName(doc, 'kalliopework');
-    const head = getChildByTagName(work, 'workhead');
-    const data = collected.works.get(`${poetId}/${workId}`);
-    let sources = {};
-    getChildrenByTagName(head, 'source').forEach((sourceNode) => {
+      const sourceFiles = new Set([
+        'tools/build-static.js',
+        'tools/build-static/anthologies.js',
+        `fdirs/${poetId}/info.xml`,
+        filename,
+      ]);
+      collected.texts.forEach(text => {
+        if (
+          (text.sourcePoetId || text.poetId) === poetId &&
+          (text.sourceWorkId || text.workId) === workId
+        ) {
+          sourceFilesForText(text).forEach(sourceFile =>
+            sourceFiles.add(sourceFile)
+          );
+        }
+      });
+      const poetMetadataModified = Array.from(collected.texts.values()).some(
+        text =>
+          (text.sourcePoetId || text.poetId) === poetId &&
+          (text.sourceWorkId || text.workId) === workId &&
+          collected.poetMetadataDirty?.has(text.poetId)
+      );
+      if (!poetMetadataModified && !isFileModified(...sourceFiles)) {
+        return;
+      }
+      let doc = loadXMLDoc(filename);
+      const work = getChildByTagName(doc, 'kalliopework');
+      const head = getChildByTagName(work, 'workhead');
+      const data = collected.works.get(`${poetId}/${workId}`);
+      let sources = {};
+      getChildrenByTagName(head, 'source').forEach((sourceNode) => {
       let source = null;
       const sourceInner = safeGetInnerXML(sourceNode);
       if (sourceInner != null && sourceInner.length > 0) {
@@ -1239,18 +1252,23 @@ const works_second_pass = async (collected) => {
         };
       }
       sources[sourceId] = source;
-    });
-    data.sources = sources;
-    collected_works.set(poetId + '-' + workId, data);
+      });
+      data.sources = sources;
+      collected_works.set(poetId + '-' + workId, data);
 
-    // TODO: Make handle_work non-recursive by using a simple XPath
-    // to select all the poems and prose texts.
-    await handle_work(work); // Creates texts
-    doc = null;
-  });
+      // TODO: Make handle_work non-recursive by using a simple XPath
+      // to select all the poems and prose texts.
+      await handle_work(work); // Creates texts
+      doc = null;
+    });
+    textBuildProgress.finish();
+  } finally {
+    textBuildProgress = null;
+  }
 };
 
 const build_poet_works_json = (collected) => {
+  const progress = createProgressReporter('Skrev works.json-filer', 100);
   collected.poets.forEach((poet, poetId) => {
     safeMkdir(`public/api/${poetId}`);
 
@@ -1303,9 +1321,10 @@ const build_poet_works_json = (collected) => {
       artwork,
     };
     const worksOutFilename = `public/api/${poetId}/works.json`;
-    console.log(worksOutFilename);
     writeJSON(worksOutFilename, objectToWrite);
+    progress.increment();
   });
+  progress.finish();
 };
 
 const build_news = (collected) => {
@@ -1333,7 +1352,6 @@ const build_news = (collected) => {
     });
     const outfile = `public/api/news_${lang}.json`;
     writeJSON(outfile, list);
-    console.log(outfile);
   });
 };
 

--- a/tools/build-static/about.js
+++ b/tools/build-static/about.js
@@ -77,7 +77,6 @@ const build_about_pages = async (collected) => {
       content_lang: lang,
       content_html: htmlToXml(safeGetInnerXML(body), collected),
     };
-    console.log(paths.json);
     writeJSON(paths.json, data);
   });
 };

--- a/tools/build-static/elastic.js
+++ b/tools/build-static/elastic.js
@@ -387,7 +387,6 @@ const update_elasticsearch = async collected => {
       console.log(
         'Elasticsearch server not available; skipping search index update.'
       );
-      console.log(error.message);
       return;
     }
     console.log('Elasticsearch update failed.');

--- a/tools/build-static/keywords.js
+++ b/tools/build-static/keywords.js
@@ -80,7 +80,6 @@ const build_keywords = async collected => {
         });
         const outFilename = `${outputFolder}/${id}.json`;
         outputFilenames.add(`${id}.json`);
-        console.log(outFilename);
         writeJSON(outFilename, data);
         collected_keywords.set(id, { id, title });
       }
@@ -88,13 +87,11 @@ const build_keywords = async collected => {
     for (const filename of fs.readdirSync(outputFolder)) {
       if (filename.endsWith('.json') && !outputFilenames.has(filename)) {
         const staleFilename = `${outputFolder}/${filename}`;
-        console.log(`Removing ${staleFilename}`);
         fs.unlinkSync(staleFilename);
       }
     }
     writeCachedJSON('collected.keywords', Array.from(collected_keywords));
     const outFilename = `public/api/keywords.json`;
-    console.log(outFilename);
     writeJSON(outFilename, keywords_toc);
   }
   return collected_keywords;

--- a/tools/build-static/lines.js
+++ b/tools/build-static/lines.js
@@ -7,6 +7,7 @@ import {
 import { primaryTextVariantId } from './variants.js';
 import { poetName, workName } from './formatting.js';
 import { sourceFilesForText } from './anthologies.js';
+import { createProgressReporter } from './progress.js';
 
 function stripDiacriticsGreek(str) {
   return (
@@ -167,6 +168,7 @@ const build_global_lines_json = (collected) => {
 };
 
 const build_poet_lines_json = (collected) => {
+  const progress = createProgressReporter('Skrev texts.json-filer', 100);
   collected.poets.forEach((poet, poetId) => {
     const poetTexts = Array.from(collected.texts.values()).filter(
       text => text.poetId === poetId && text.indexable !== false
@@ -224,9 +226,10 @@ const build_poet_lines_json = (collected) => {
       lines: collectedLines,
     };
     const linesOutFilename = `public/api/${poetId}/texts.json`;
-    console.log(linesOutFilename);
     writeJSON(linesOutFilename, data);
+    progress.increment();
   });
+  progress.finish();
 };
 
 export {

--- a/tools/build-static/mentions.js
+++ b/tools/build-static/mentions.js
@@ -25,6 +25,7 @@ import {
 import { poetName, workLinkName } from './formatting.js';
 import { primaryTextVariantId } from './variants.js';
 import { loadExternalIdentifiers } from './external-identifiers.js';
+import { createProgressReporter } from './progress.js';
 
 const person_mentions_dirty = new Set();
 
@@ -311,6 +312,7 @@ const build_mentions_data = (
 };
 
 const build_mentions_json = (collected) => {
+  const progress = createProgressReporter('Skrev mentions.json-filer', 100);
   const build_html = (poemId) => {
     const meta = collected.texts.get(poemId);
     if (meta == null) {
@@ -370,9 +372,10 @@ const build_mentions_json = (collected) => {
       loadExternalIdentifiers(poetId),
     );
 
-    console.log(outFilename);
     writeJSON(outFilename, data);
+    progress.increment();
   });
+  progress.finish();
 };
 
 export {

--- a/tools/build-static/museums.js
+++ b/tools/build-static/museums.js
@@ -115,7 +115,6 @@ const build_museum_pages = collected => {
       artwork,
     };
     const path = `public/api/museums/${museumId}.json`;
-    console.log(path);
     writeJSON(path, json);
   });
 };

--- a/tools/build-static/progress.js
+++ b/tools/build-static/progress.js
@@ -1,0 +1,25 @@
+const createProgressReporter = (
+  label,
+  interval = 1000,
+  logger = console.log
+) => {
+  let count = 0;
+
+  return {
+    increment() {
+      count += 1;
+      if (count % interval === 0) {
+        logger(`${label}: ${count}`);
+      }
+    },
+    finish() {
+      if (count % interval !== 0 || count === 0) {
+        logger(`${label}: ${count} (færdig)`);
+      }
+    },
+  };
+};
+
+export {
+  createProgressReporter,
+};

--- a/tools/build-static/toc.js
+++ b/tools/build-static/toc.js
@@ -8,6 +8,7 @@ import {
 } from '../libs/helpers.js';
 import { collect_git_modified_dates } from './git.js';
 import { mapLimit } from './concurrency.js';
+import { createProgressReporter } from './progress.js';
 import { extractTitle, get_notes, get_pictures } from './parsing.js';
 import { workName } from './formatting.js';
 import { sortWorks } from '../../common/worksort.js';
@@ -89,6 +90,7 @@ const extract_subworks = (poetId, workbody, collected) => {
 
 const build_works_toc = async (collected) => {
   const modifiedDates = collect_git_modified_dates();
+  const progress = createProgressReporter('Skrev toc.json-filer', 100);
 
   const workFilesForPoet = (poetId) => {
     return Array.from(
@@ -166,7 +168,7 @@ const build_works_toc = async (collected) => {
     });
   });
 
-  return mapLimit(jobs, async ({ poetId, workId, work: workMeta }) => {
+  const results = await mapLimit(jobs, async ({ poetId, workId, work: workMeta }) => {
     const { pageWorks, poet, poetWorksModified } = poetData.get(poetId);
     if (workMeta.virtualType === 'anthology') {
       if (
@@ -198,7 +200,6 @@ const build_works_toc = async (collected) => {
         .sort()
         .pop();
       const tocFilename = `public/api/${poetId}/${workId}-toc.json`;
-      console.log(tocFilename);
       writeJSON(tocFilename, {
         poet,
         toc,
@@ -210,6 +211,7 @@ const build_works_toc = async (collected) => {
         prev,
         next,
       });
+      progress.increment();
       return;
     }
     const filename = `fdirs/${poetId}/${workId}.xml`;
@@ -237,11 +239,13 @@ const build_works_toc = async (collected) => {
         next,
       };
       const tocFilename = `public/api/${poetId}/${workId}-toc.json`;
-      console.log(tocFilename);
       writeJSON(tocFilename, toc_file_data);
+      progress.increment();
     }
     doc = null;
   });
+  progress.finish();
+  return results;
 };
 
 export {

--- a/tools/build-static/validation.js
+++ b/tools/build-static/validation.js
@@ -1,0 +1,12 @@
+const validateFirstlineMarkup = (firstline, textId, filename) => {
+  if (firstline != null && firstline.title.includes('<')) {
+    throw new Error(
+      `Teksten "${textId}" i ${filename} har markup i <firstline>.\n` +
+        'Fjern markup fra F:-linjen i txt2xml-kilden eller fra <firstline> i XML-filen.'
+    );
+  }
+};
+
+export {
+  validateFirstlineMarkup,
+};

--- a/tools/libs/helpers.js
+++ b/tools/libs/helpers.js
@@ -6,6 +6,7 @@ import plimit from 'p-limit';
 import sharp from 'sharp';
 import * as CommonData from '../../common/commondata.js';
 import * as ImagePaths from '../../common/imagepaths.js';
+import { createProgressReporter } from '../build-static/progress.js';
 
 const envInt = (name, fallback) => {
   const value = parseInt(process.env[name], 10);
@@ -313,7 +314,6 @@ const resizeImage = async (inputfile, outputfile, maxWidth) => {
     await sharp(inputfile)
       .resize({ width: maxWidth, withoutEnlargement: true })
       .toFile(outputfile);
-    console.log(outputfile);
     return outputfile;
   } catch (err) {
     console.log(err);
@@ -342,6 +342,10 @@ const buildThumbnails = async (
   options = {}
 ) => {
   const tasks = [];
+  const progress = createProgressReporter(
+    `Genererede thumbnails i ${topFolder}`,
+    100
+  );
   const thumbnailOutputPath =
     options.thumbnailOutputPath || defaultThumbnailOutputPath;
   const pipeJoinedExts = CommonData.availableImageFormats.join('|');
@@ -384,8 +388,14 @@ const buildThumbnails = async (
                 : sourceMtime > outputMtime)
             ) {
               tasks.push(
-                limit(() => {
-                  return resizeImage(fullFilename, outputfile, width);
+                limit(async () => {
+                  const result = await resizeImage(
+                    fullFilename,
+                    outputfile,
+                    width
+                  );
+                  progress.increment();
+                  return result;
                 })
               );
             }
@@ -398,6 +408,7 @@ const buildThumbnails = async (
   handleDirRecursive(topFolder);
 
   await Promise.all(tasks);
+  progress.finish();
 };
 
 export {


### PR DESCRIPTION
## Resumé

- erstatter fil-for-fil-output med periodiske statuslinjer for de store build-trin
- fjerner overflødigt output fra mindre build-trin og skjuler den rå `fetch failed`-besked, når Elasticsearch ikke kører
- giver en mere handlingsanvisende fejl ved markup i `<firstline>`
- tilføjer tests af progress-rapportering og valideringsbeskeden

## Test

- `npm test -- --runInBand` (47 test suites, 2.298 tests)
