### PR TITLE
Escape ampersander i txt2xml-output

### DIFF
--- a/test/txt2xml_test.rb
+++ b/test/txt2xml_test.rb
@@ -93,6 +93,29 @@ class Txt2XmlTest < Minitest::Test
     assert_equal %w[i w b], REXML::XPath.match(text, 'body/poetry/*').map(&:name)
   end
 
+  def test_escapes_bare_ampersands_without_double_escaping_entities
+    document = convert_and_parse(<<~TEXT)
+      KILDE:Red.: <i>Digte &amp; Sange</i>, Forlag & Søn, 1900.
+      DIGTER:digter
+      TITELBLAD:Magt & Ære
+      NOTE:Liv & Død
+
+      T:Sol & Måne
+      F:Sol & Måne
+
+      Sol & Måne
+      SLUT
+    TEXT
+
+    workhead = REXML::XPath.first(document, '/kalliopework/workhead')
+    text = REXML::XPath.first(document, '//text')
+
+    assert_equal 'Digte & Sange', element_text(workhead, 'title')
+    assert_equal 'Liv & Død', element_text(workhead, 'notes/note')
+    assert_equal 'Sol & Måne', element_text(text, 'head/title')
+    assert_equal 'Sol & Måne', REXML::XPath.first(text, 'body/poetry').text.strip
+  end
+
   def test_section_author_is_emitted_without_repeating_it_on_texts
     document = convert_and_parse(<<~TEXT)
       KILDE:<i>Antologi</i> 1872

--- a/tools/txt2xml.rb
+++ b/tools/txt2xml.rb
@@ -127,6 +127,10 @@ def normalizePages(pages)
   pages.sub(/\A(\d+)-\1\z/, '\1')
 end
 
+def escapeBareAmpersands(line)
+  line.gsub(/&(?!(?:amp|apos|gt|lt|quot|#\d+|#x[0-9a-fA-F]+);)/, '&amp;')
+end
+
 def printPoem()
   printHeader()
   if @facsimile and (not @page or @page.strip.length == 0)
@@ -324,6 +328,7 @@ File.readlines(ARGV[0]).each do |line|
     next
   end
   line_before = line
+  line = escapeBareAmpersands(line)
   while line =~ /\t/
       line = line.gsub(/\t/,'    ')
   end


### PR DESCRIPTION
## Resumé

- escaper bare ampersander til `&amp;` i `txt2xml`-input
- bevarer allerede gyldige XML-entiteter uden dobbelt escaping
- tilføjer regressionstest for metadata og brødtekst

## Test

- `ruby test/txt2xml_test.rb` (17 tests, 93 assertions)
- `npm test -- --runInBand` (45 test suites, 2.295 tests)
