### PR TITLE
Optimer build-static uden ændringer

### DIFF
--- a/__tests__/build-static-progress.test.js
+++ b/__tests__/build-static-progress.test.js
@@ -20,4 +20,17 @@ describe('build-static progress reporting', () => {
       'Skrev tekstfiler: 5 (færdig)',
     ]);
   });
+
+  it('does not report anything when no work was done', () => {
+    const messages = [];
+    const progress = createProgressReporter(
+      'Skrev tekstfiler',
+      2,
+      message => messages.push(message)
+    );
+
+    progress.finish();
+
+    expect(messages).toEqual([]);
+  });
 });

--- a/tools/build-static.js
+++ b/tools/build-static.js
@@ -124,6 +124,7 @@ const skipElasticsearch = envFlag('KALLIOPE_SKIP_ELASTICSEARCH');
 
 let collected = {
   texts: new Map(),
+  textsByPoet: new Map(),
   works: new Map(),
   workids: new Map(),
   keywords: new Map(),
@@ -1134,10 +1135,17 @@ const works_first_pass = (collected) => {
 
   buildVirtualAnthologyWorks({ ...collected, works, texts });
 
+  const textsByPoet = new Map();
+  texts.forEach(text => {
+    if (text.indexable === false) {
+      return;
+    }
+    const poetTexts = textsByPoet.get(text.poetId) || [];
+    poetTexts.push(text);
+    textsByPoet.set(text.poetId, poetTexts);
+  });
   collected.poets.forEach((poet, poetId) => {
-    const poetTexts = Array.from(texts.values()).filter(
-      text => text.poetId === poetId && text.indexable !== false
-    );
+    const poetTexts = textsByPoet.get(poetId) || [];
     poet.has_works =
       (collected.workids.get(poetId) || []).length > 0 ||
       works.has(`${poetId}/${ANTHOLOGY_WORK_ID}`);
@@ -1163,11 +1171,21 @@ const works_first_pass = (collected) => {
     writeCachedJSON('collected.dates', Array.from(sortCollectedDates(dates)));
     writeCachedJSON('collected.poets', Array.from(collected.poets));
   }
-  return { works, texts, dates };
+  return { works, texts, textsByPoet, dates };
 };
 
 const works_second_pass = async (collected) => {
   const jobs = [];
+  const textsBySourceWork = new Map();
+  collected.texts.forEach(text => {
+    const sourcePoetId = text.sourcePoetId || text.poetId;
+    const sourceWorkId = text.sourceWorkId || text.workId;
+    const key = `${sourcePoetId}/${sourceWorkId}`;
+    const texts = textsBySourceWork.get(key) || [];
+    texts.push(text);
+    textsBySourceWork.set(key, texts);
+  });
+
   collected.poets.forEach((poet, poetId) => {
     safeMkdir(`public/api/${poetId}`);
     collected.workids.get(poetId).forEach((workId) => {
@@ -1188,21 +1206,14 @@ const works_second_pass = async (collected) => {
         `fdirs/${poetId}/info.xml`,
         filename,
       ]);
-      collected.texts.forEach(text => {
-        if (
-          (text.sourcePoetId || text.poetId) === poetId &&
-          (text.sourceWorkId || text.workId) === workId
-        ) {
-          sourceFilesForText(text).forEach(sourceFile =>
-            sourceFiles.add(sourceFile)
-          );
-        }
+      const sourceTexts = textsBySourceWork.get(`${poetId}/${workId}`) || [];
+      sourceTexts.forEach(text => {
+        sourceFilesForText(text).forEach(sourceFile =>
+          sourceFiles.add(sourceFile)
+        );
       });
-      const poetMetadataModified = Array.from(collected.texts.values()).some(
-        text =>
-          (text.sourcePoetId || text.poetId) === poetId &&
-          (text.sourceWorkId || text.workId) === workId &&
-          collected.poetMetadataDirty?.has(text.poetId)
+      const poetMetadataModified = sourceTexts.some(text =>
+        collected.poetMetadataDirty?.has(text.poetId)
       );
       if (!poetMetadataModified && !isFileModified(...sourceFiles)) {
         return;
@@ -1384,13 +1395,14 @@ const main = async () => {
     build_poets_first_pass,
     collected,
   );
-  const { works, texts, dates } = await b(
+  const { works, texts, textsByPoet, dates } = await b(
     'works_first_pass',
     works_first_pass,
     collected,
   );
   collected.works = works;
   collected.texts = texts;
+  collected.textsByPoet = textsByPoet;
   collected.dates = dates;
   collected.artwork = await b('build_artwork', build_artwork, collected);
   await b(

--- a/tools/build-static/git.js
+++ b/tools/build-static/git.js
@@ -1,4 +1,7 @@
 import { execFileSync } from 'child_process';
+import { loadJSON, safeMkdir, writeJSON } from '../libs/helpers.js';
+
+const GIT_MODIFIED_DATES_CACHE = 'caches/git-modified-dates.json';
 
 const GIT_MODIFIED_DATE_PATHS = [
   'fdirs/**/*.xml',
@@ -31,8 +34,16 @@ const parseGitModifiedDatesLog = (log) => {
 };
 
 const collect_git_modified_dates = () => {
+  let head;
   let log;
   try {
+    head = execFileSync('git', ['rev-parse', 'HEAD'], {
+      encoding: 'utf8',
+    }).trim();
+    const cached = loadJSON(GIT_MODIFIED_DATES_CACHE);
+    if (cached?.head === head) {
+      return new Map(cached.dates);
+    }
     log = execFileSync(
       'git',
       [
@@ -55,7 +66,13 @@ const collect_git_modified_dates = () => {
     throw error;
   }
 
-  return parseGitModifiedDatesLog(log);
+  const modifiedDates = parseGitModifiedDatesLog(log);
+  safeMkdir('caches');
+  writeJSON(GIT_MODIFIED_DATES_CACHE, {
+    head,
+    dates: Array.from(modifiedDates),
+  });
+  return modifiedDates;
 };
 
 export {

--- a/tools/build-static/lines.js
+++ b/tools/build-static/lines.js
@@ -170,9 +170,7 @@ const build_global_lines_json = (collected) => {
 const build_poet_lines_json = (collected) => {
   const progress = createProgressReporter('Skrev texts.json-filer', 100);
   collected.poets.forEach((poet, poetId) => {
-    const poetTexts = Array.from(collected.texts.values()).filter(
-      text => text.poetId === poetId && text.indexable !== false
-    );
+    const poetTexts = collected.textsByPoet.get(poetId) || [];
     const filenames = Array.from(
       new Set(poetTexts.flatMap(sourceFilesForText))
     );

--- a/tools/build-static/progress.js
+++ b/tools/build-static/progress.js
@@ -13,7 +13,7 @@ const createProgressReporter = (
       }
     },
     finish() {
-      if (count % interval !== 0 || count === 0) {
+      if (count > 0 && count % interval !== 0) {
         logger(`${label}: ${count} (færdig)`);
       }
     },

--- a/tools/build-static/toc.js
+++ b/tools/build-static/toc.js
@@ -89,7 +89,13 @@ const extract_subworks = (poetId, workbody, collected) => {
 };
 
 const build_works_toc = async (collected) => {
-  const modifiedDates = collect_git_modified_dates();
+  let modifiedDates = null;
+  const getModifiedDates = () => {
+    if (modifiedDates == null) {
+      modifiedDates = collect_git_modified_dates();
+    }
+    return modifiedDates;
+  };
   const progress = createProgressReporter('Skrev toc.json-filer', 100);
 
   const workFilesForPoet = (poetId) => {
@@ -195,7 +201,7 @@ const build_works_toc = async (collected) => {
       }));
       const { prev, next } = resolvePrevNextWork(pageWorks, workId);
       const modified = workMeta.sourceFiles
-        .map(filename => modifiedDates.get(filename))
+        .map(filename => getModifiedDates().get(filename))
         .filter(date => date != null)
         .sort()
         .pop();
@@ -234,7 +240,7 @@ const build_works_toc = async (collected) => {
         work: collected.works.get(`${poetId}/${workId}`),
         notes: work_data.notes || [],
         pictures: work_data.pictures || [],
-        modified: modifiedDates.get(filename),
+        modified: getModifiedDates().get(filename),
         prev,
         next,
       };


### PR DESCRIPTION
## Resumé

- indekserer tekster pr. digter og kildeværk i stedet for gentagne fulde gennemløb
- genbruger `textsByPoet` mellem første pass og genereringen af `texts.json`
- indsamler kun Git-datoer til TOC, når en fil faktisk skal skrives
- cacher Git-modificeringsdatoer pr. commit til sitemap og TOC
- skjuler progress-beskeder, når et build-trin ikke har udført noget arbejde

## Ydelse

No-op-build med thumbnails og Elasticsearch slået fra:

- samlet tid: 3.436 ms → 710 ms
- `works_first_pass`: 626 ms → 133 ms
- `build_poet_lines_json`: 516 ms → 11 ms
- `works_second_pass`: 20 ms → 18 ms
- `build_works_toc`: 994 ms → 141 ms
- `build_sitemap_xml`: 910 ms → 73 ms

## Test

- `npm test -- --runInBand` (47 test suites, 2.299 tests)
- gentagne no-op-kørsler af `npm run build-static` med timing aktiveret
