### PR TITLE
Tilføj Makefile til Docker Compose-arbejdsgange

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,49 @@
+.DEFAULT_GOAL := help
+
+COMPOSE ?= docker compose
+POETS ?=
+
+.PHONY: help elasticsearch build-static build-static-force-reload \
+	build-facsimiles extract-facsimiles reextract-facsimiles \
+	sync-wikidata app status
+
+help:
+	@printf '%s\n' \
+		'make elasticsearch              Start Elasticsearch' \
+		'make build-static              Byg statiske data' \
+		'make build-static-force-reload Byg statiske data uden cachede build-data' \
+		'make build-facsimiles          Udtræk facsimiler og byg thumbnails' \
+		'make extract-facsimiles        Udtræk sider fra nye facsimile-PDF’er' \
+		'make reextract-facsimiles      Erstat tidligere udtrukne facsimile-sider' \
+		'make sync-wikidata             Synkroniser metadata fra Wikidata' \
+		'make app                       Byg og start appen' \
+		'make status                    Vis status for Docker Compose-services'
+
+elasticsearch:
+	$(COMPOSE) up -d elasticsearch
+
+build-static: elasticsearch
+	$(COMPOSE) --profile build build static-builder
+	$(COMPOSE) --profile build run --rm static-builder
+
+build-static-force-reload: elasticsearch
+	$(COMPOSE) --profile build build static-builder
+	$(COMPOSE) --profile build run --rm static-builder npm run build-static-force-reload
+
+build-facsimiles:
+	$(COMPOSE) --profile facsimiles run --rm --build facsimile-builder npm run build-facsimiles -- all
+
+extract-facsimiles:
+	$(COMPOSE) --profile facsimiles run --rm --build facsimile-builder npm run build-facsimiles -- extract
+
+reextract-facsimiles:
+	$(COMPOSE) --profile facsimiles run --rm --build facsimile-builder npm run build-facsimiles -- reextract
+
+sync-wikidata:
+	$(COMPOSE) --profile tools run --rm --build wikidata-sync $(POETS)
+
+app:
+	$(COMPOSE) up --build -d app
+
+status:
+	$(COMPOSE) ps

--- a/README.md
+++ b/README.md
@@ -11,6 +11,7 @@ Krav:
 
 - Node.js 20 eller nyere
 - Docker, hvis Elasticsearch skal køres lokalt via Compose
+- Make til genvejene omkring Docker Compose
 
 Installer afhængigheder:
 
@@ -21,7 +22,7 @@ npm install
 Start Elasticsearch på `localhost:9200`:
 
 ```shell
-docker compose up -d elasticsearch
+make elasticsearch
 ```
 
 Byg de statiske data og start appen:
@@ -62,19 +63,19 @@ Sync køres fra hosten, så containeren ikke får adgang til lokale SSH-nøgler.
 Udtræk sider fra nye PDF'er:
 
 ```shell
-docker compose --profile facsimiles run --rm --build facsimile-builder npm run build-facsimiles -- extract
+make extract-facsimiles
 ```
 
 Overskriv eksisterende output for fundne PDF'er:
 
 ```shell
-docker compose --profile facsimiles run --rm --build facsimile-builder npm run build-facsimiles -- reextract
+make reextract-facsimiles
 ```
 
 Kør hele kæden med udtrækning og thumbnails:
 
 ```shell
-docker compose --profile facsimiles run --rm --build facsimile-builder npm run build-facsimiles -- all
+make build-facsimiles
 ```
 
 PDF-udtræk bruger som standard `KALLIOPE_FACSIMILE_EXTRACTOR=auto`, som
@@ -105,25 +106,23 @@ git pull --ff-only
 Byg og kør static-builderen:
 
 ```shell
-docker compose up -d elasticsearch
-docker compose --profile build build static-builder
-docker compose --profile build run --rm static-builder
+make build-static
 ```
 
 Byg og genstart appen:
 
 ```shell
-docker compose up --build -d app
+make app
 ```
 
 Tjek at containerne kører:
 
 ```shell
-docker compose ps
+make status
 ```
 
 Ved større dataændringer kan static-buildet køres med fuld reload:
 
 ```shell
-docker compose --profile build run --rm static-builder npm run build-static-force-reload
+make build-static-force-reload
 ```

--- a/docs/xml-info-format.md
+++ b/docs/xml-info-format.md
@@ -226,13 +226,13 @@ de øvrige eksterne id'er af `tools/sync-wikidata.rb`. Kør synkroniseringen i
 dens kortlivede værktøjscontainer:
 
 ```sh
-docker-compose run --rm wikidata-sync
+make sync-wikidata
 ```
 
 Angiv eventuelt en eller flere digter-id'er for kun at synkronisere dem:
 
 ```sh
-docker-compose run --rm wikidata-sync pope andersen
+make sync-wikidata POETS="pope andersen"
 ```
 
 Der kan findes andre sjældne id-felter i data; de bør dokumenteres her, når de får aktiv brug.

--- a/tools/README.md
+++ b/tools/README.md
@@ -27,11 +27,11 @@ anbefalede arbejdsgang bruger Docker Compose, så Poppler-afhængighederne finde
 i et ensartet miljø:
 
 ```sh
-docker compose --profile facsimiles run --rm --build facsimile-builder \
-  npm run build-facsimiles -- all
+make build-facsimiles
 ```
 
-Kommandoen accepterer `extract`, `reextract`, `thumbnails` eller `all`. Se
+Selve værktøjet accepterer `extract`, `reextract`, `thumbnails` eller `all`.
+Make-targets findes også til `extract` og `reextract`. Se
 [facsimileafsnittet i projektets README](../README.md#facsimile-generering) for
 den fulde arbejdsgang.
 
@@ -98,8 +98,8 @@ som kildetekst.
 Kør det anbefalet i værktøjscontaineren:
 
 ```sh
-docker compose run --rm wikidata-sync
-docker compose run --rm wikidata-sync DIGTER-ID [DIGTER-ID ...]
+make sync-wikidata
+make sync-wikidata POETS="DIGTER-ID [DIGTER-ID ...]"
 ```
 
 Uden digter-id'er behandles alle mapper i `fdirs/`. Lokal kørsel med Ruby


### PR DESCRIPTION
## Ændringer

- tilføjer Make-targets til de almindelige Docker Compose-arbejdsgange
- understøtter afgrænset Wikidata-synkronisering via `POETS`
- opdaterer dokumentationen til at bruge de nye genveje

## Validering

- `make --dry-run` for alle targets
- `make status`
- `docker compose config --quiet`
- `npm test -- --runInBand`

Fixes #1280
