### PR TITLE
Tilføj W.H. Abbott og utituleret sonet

### DIFF
--- a/fdirs/abbott/1914.xml
+++ b/fdirs/abbott/1914.xml
@@ -1,0 +1,39 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<kalliopework id="1914" author="abbott" status="incomplete" type="poetry">
+<workhead>
+   <title>Vision: A Book of Lyrics</title>
+   <year>1914</year>
+   <source>W. H. Abbott: <i>Vision: A Book of Lyrics</i>, Elkin Mathews, London, 1914.</source>
+</workhead>
+<workbody>
+
+<text id="abbott2026072201">
+<head>
+   <title>To live Christ-lorn, to feel no Hand in mine</title>
+   <firstline>To live Christ-lorn, to feel no Hand in mine</firstline>
+   <source pages="15"/>
+   <quality>korrektur1,kilde,side</quality>
+</head>
+<body>
+<poetry>
+To live Christ-lorn, to feel no Hand in mine
+Thro’ the long way: to wander on, with night
+About my eyes, and never find the light.
+To hear the inconstant wind in oak and pine,
+The pitiless, rhythmic roar of the salt sea,
+Ebbing and flowing! To read, thro’ a thousand springs,
+The ceaseless drive and swirl of sundering things,
+Nature’s vain birth-pangs, and the death to be!
+
+To measure out Time’s day: to mark its morn,
+And noon, and eve, wasted in sterile strife
+For that it hungers after! And to know
+Myself no other than the smiling scorn
+Of some brute law, which mocks, in death and life,
+My heart’s deep cry:—Ah, God; if it were so!
+</poetry>
+</body>
+</text>
+
+</workbody>
+</kalliopework>

--- a/fdirs/abbott/info.xml
+++ b/fdirs/abbott/info.xml
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<person id="abbott" country="gb" lang="en" type="poet">
+  <name>
+    <firstname>W.H.</firstname>
+    <lastname>Abbott</lastname>
+  </name>
+  <period>
+    <born>
+      <date>?</date>
+    </born>
+    <dead>
+      <date>?</date>
+    </dead>
+  </period>
+  <works>1914</works>
+</person>


### PR DESCRIPTION
## Resumé

- tilføjer W.H. Abbott som engelsk digter
- registrerer *Vision: A Book of Lyrics* fra 1914
- tilføjer den utitulerede sonet »To live Christ-lorn, to feel no Hand in mine« med kildehenvisning til side 15

## Validering

- XML-filerne validerer mod repoets RELAX NG-skemaer
- de relevante Jest-tests består (2.087 tests)
