### PR TITLE
Tilføj Rossettis Ave

### DIFF
--- a/fdirs/rossettid/1870.xml
+++ b/fdirs/rossettid/1870.xml
@@ -1,0 +1,143 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<kalliopework id="1870" author="rossettid" status="incomplete" type="poetry">
+<workhead>
+   <title>Poems</title>
+   <year>1870</year>
+   <source>Dante Gabriel Rossetti: <i>Poems</i>, F. S. Ellis, London, 1870. Digitaliseret i <a href="https://rossettiarchive.iath.virginia.edu/docs/1-1870.1stedn.rad.html">The Rossetti Archive</a>.</source>
+</workhead>
+<workbody>
+
+<text id="rossettid2026072201">
+<head>
+   <title>Ave</title>
+   <firstline>Mother of the Fair Delight</firstline>
+   <source pages="41-46"/>
+   <quality>korrektur1,kilde,side</quality>
+</head>
+<body>
+<poetry>
+Mother of the Fair Delight,
+Thou handmaid perfect in God’s sight,
+Now sitting fourth beside the Three,
+Thyself a woman-Trinity,—
+Being a daughter borne to God,
+Mother of Christ from stall to rood,
+And wife unto the Holy Ghost:—
+Oh when our need is uttermost,
+Think that to such as death may strike
+Thou once wert sister sisterlike!
+Thou headstone of humanity,
+Groundstone of the great Mystery,
+Fashioned like us, yet more than we!
+
+Mind’st thou not (when June’s heavy breath
+Warmed the long days in Nazareth,)
+That eve thou didst go forth to give
+Thy flowers some drink that they might live
+One faint night more amid the sands?
+Far off the trees were as pale wands
+Against the fervid sky: the sea
+Sighed further off eternally
+As human sorrow sighs in sleep.
+Then suddenly the awe grew deep,
+As of a day to which all days
+Were footsteps in God’s secret ways:
+Until a folding sense, like prayer,
+Which is, as God is, everywhere,
+Gathered about thee; and a voice
+Spake to thee without any noise,
+Being of the silence:—‘Hail,’ it said,
+‘Thou that art highly favourèd;
+The Lord is with thee here and now;
+Blessed among all women thou.’
+
+Ah! knew’st thou of the end, when first
+That Babe was on thy bosom nurs’d?—
+Or when He tottered round thy knee
+Did thy great sorrow dawn on thee?—
+And through His boyhood, year by year
+Eating with Him the Passover,
+Didst thou discern confusedly
+That holier sacrament, when He,
+The bitter cup about to quaff,
+Should break the bread and eat thereof?—
+Or came not yet the knowledge, even
+Till on some day forecast in Heaven
+His feet passed through thy door to press
+Upon His Father’s business?—
+Or still was God’s high secret kept?
+
+Nay, but I think the whisper crept
+Like growth through childhood. Work and play,
+Things common to the course of day,
+Awed thee with meanings unfulfill’d;
+And all through girlhood, something still’d
+Thy senses like the birth of light,
+When thou hast trimmed thy lamp at night
+Or washed thy garments in the stream;
+To whose white bed had come the dream
+That He was thine and thou wast His
+Who feeds among the field-lilies.
+O solemn shadow of the end
+In that wise spirit long contain’d!
+O awful end! and those unsaid
+Long years when It was Finishèd!
+
+Mind’st thou not (when the twilight gone
+Left darkness in the house of John,)
+Between the naked window-bars
+That spacious vigil of the stars?—
+For thou, a watcher even as they,
+Wouldst rise from where throughout the day
+Thou wroughtest raiment for His poor;
+And, finding the fixed terms endure
+Of day and night which never brought
+Sounds of His coming chariot,
+Wouldst lift through cloud-waste unexplor’d
+Those eyes which said, ‘How long, O Lord?’
+Then that disciple whom He loved,
+Well heeding, haply would be moved
+To ask thy blessing in His name;
+And that one thought in both, the same
+Though silent, then would clasp ye round
+To weep together,—tears long bound,
+Sick tears of patience, dumb and slow.
+Yet, ‘Surely I come quickly,’—so
+He said, from life and death gone home.
+Amen: even so, Lord Jesus, come!
+
+But oh! what human tongue can speak
+That day when death was sent to break
+From the tir’d spirit, like a veil,
+Its covenant with Gabriel
+Endured at length unto the end?
+What human thought can apprehend
+That mystery of motherhood
+When thy Beloved at length renew’d
+The sweet communion severèd,—
+His left hand underneath thine head
+And His right hand embracing thee?—
+Lo! He was thine, and this is He!
+
+Soul, is it Faith, or Love, or Hope,
+That lets me see her standing up
+Where the light of the Throne is bright?
+Unto the left, unto the right,
+The cherubim, arrayed, conjoint,
+Float inward to a golden point,
+And from between the seraphim
+The glory issues for a hymn.
+
+O Mary Mother, be not loth
+To listen,—thou whom the stars clothe,
+Who seëst and mayst not be seen!
+Hear us at last, O Mary Queen!
+Into our shadow bend thy face,
+Bowing thee from the secret place,
+O Mary Virgin, full of grace!
+</poetry>
+</body>
+</text>
+
+</workbody>
+</kalliopework>

--- a/fdirs/rossettid/info.xml
+++ b/fdirs/rossettid/info.xml
@@ -15,7 +15,7 @@
     </dead>
   </period>
   <literary-periods>symbolisme-og-fin-de-siecle</literary-periods>
-  <works>1861,1881,andre</works>
+  <works>1861,1870,1881,andre</works>
   <identifiers>
     <wikidata>Q186748</wikidata>
     <wikipedia-da>Dante Gabriel Rossetti</wikipedia-da>


### PR DESCRIPTION
## Resumé

- tilføjer Dante Gabriel Rossettis digt »Ave« fra *Poems* (1870)
- registrerer 1870-udgaven i forfatterens værkliste
- angiver førsteudgaven i The Rossetti Archive samt sidetal 41–46 som kilde

## Test

- XML-filerne valideret med `xmllint` mod repoets Relax NG-schemaer
- 9 relevante Jest-tests kørt: 20 tests bestået
