### PR TITLE
Ret filrettigheder ved facsimilesynkronisering

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -5,7 +5,7 @@ POETS ?=
 
 .PHONY: help elasticsearch build-static build-static-force-reload \
 	build-facsimiles extract-facsimiles reextract-facsimiles \
-	sync-wikidata app status
+	sync-facsimiles sync-wikidata app status
 
 help:
 	@printf '%s\n' \
@@ -15,6 +15,7 @@ help:
 		'make build-facsimiles          Udtræk facsimiler og byg thumbnails' \
 		'make extract-facsimiles        Udtræk sider fra nye facsimile-PDF’er' \
 		'make reextract-facsimiles      Erstat tidligere udtrukne facsimile-sider' \
+		'make sync-facsimiles           Synkroniser facsimiler til webserveren' \
 		'make sync-wikidata             Synkroniser metadata fra Wikidata' \
 		'make app                       Byg og start appen' \
 		'make status                    Vis status for Docker Compose-services'
@@ -38,6 +39,9 @@ extract-facsimiles:
 
 reextract-facsimiles:
 	$(COMPOSE) --profile facsimiles run --rm --build facsimile-builder npm run build-facsimiles -- reextract
+
+sync-facsimiles:
+	./tools/sync-facsimiler.sh
 
 sync-wikidata:
 	$(COMPOSE) --profile tools run --rm --build wikidata-sync $(POETS)

--- a/__tests__/sync-facsimiler.test.js
+++ b/__tests__/sync-facsimiler.test.js
@@ -1,0 +1,55 @@
+import { spawnSync } from 'child_process';
+import fs from 'fs';
+import os from 'os';
+import path from 'path';
+
+describe('sync-facsimiler', () => {
+  let tmpdir;
+
+  beforeEach(() => {
+    tmpdir = fs.mkdtempSync(path.join(os.tmpdir(), 'kalliope-sync-test-'));
+  });
+
+  afterEach(() => {
+    fs.rmSync(tmpdir, { recursive: true, force: true });
+  });
+
+  it('gør mapper og filer læsbare for webserveren', () => {
+    const sourceDir = path.join(tmpdir, 'source');
+    const pagesDir = path.join(sourceDir, 'work');
+    const destinationDir = path.join(tmpdir, 'destination');
+    const pdfFilename = path.join(sourceDir, 'work.pdf');
+    const pageFilename = path.join(pagesDir, '000.jpg');
+    fs.mkdirSync(pagesDir, { recursive: true });
+    fs.mkdirSync(destinationDir);
+    fs.writeFileSync(pdfFilename, 'pdf');
+    fs.writeFileSync(pageFilename, 'jpg');
+    fs.chmodSync(pagesDir, 0o700);
+    fs.chmodSync(pdfFilename, 0o600);
+    fs.chmodSync(pageFilename, 0o600);
+
+    const result = spawnSync('sh', ['tools/sync-facsimiler.sh'], {
+      cwd: process.cwd(),
+      encoding: 'utf8',
+      env: {
+        ...process.env,
+        KALLIOPE_FACSIMILE_SOURCE_DIR: sourceDir,
+        KALLIOPE_FACSIMILE_RSYNC_TARGET: destinationDir,
+      },
+    });
+
+    expect(result.status).toBe(0);
+    expect(fs.statSync(pagesDir).mode & 0o777).toBe(0o755);
+    expect(fs.statSync(pdfFilename).mode & 0o777).toBe(0o644);
+    expect(fs.statSync(pageFilename).mode & 0o777).toBe(0o644);
+    expect(fs.statSync(path.join(destinationDir, 'work')).mode & 0o777).toBe(
+      0o755
+    );
+    expect(fs.statSync(path.join(destinationDir, 'work.pdf')).mode & 0o777).toBe(
+      0o644
+    );
+    expect(
+      fs.statSync(path.join(destinationDir, 'work', '000.jpg')).mode & 0o777
+    ).toBe(0o644);
+  });
+});

--- a/tools/README.md
+++ b/tools/README.md
@@ -116,7 +116,9 @@ konfigurerede Kalliope-server:
 ```
 
 Scriptet bruger SSH og rsync fra værtsmaskinen og forudsætter adgang til den
-server, der er angivet i scriptet.
+server, der er angivet i scriptet. Inden synkronisering sættes lokale mapper til
+`755` og filer til `644`. `rsync` overfører derefter rettighederne, så
+webserveren også kan læse nye facsimiler oprettet af Docker.
 
 ## Editorintegrationer
 

--- a/tools/sync-facsimiler.sh
+++ b/tools/sync-facsimiler.sh
@@ -2,6 +2,9 @@
 
 set -eu
 
-target="jec@10.0.0.5:/Volumes/Alma/Faksimiler"
+source_dir="${KALLIOPE_FACSIMILE_SOURCE_DIR:-facsimiles}"
+target="${KALLIOPE_FACSIMILE_RSYNC_TARGET:-jec@10.0.0.5:/Volumes/Alma/Faksimiler}"
 
-rsync -rva --no-perms facsimiles/ "$target"
+find "$source_dir" -type d -exec chmod 755 {} +
+find "$source_dir" -type f -exec chmod 644 {} +
+rsync -rva "$source_dir/" "$target"


### PR DESCRIPTION
## Resumé

- normaliserer lokale facsimilemapper til `755` og filer til `644` før synkronisering
- lader `rsync -a` overføre rettighederne, så Docker-genererede facsimiler kan læses af webserveren
- gør kilde og destination konfigurerbare med miljøvariable til sikker test
- tilføjer `make sync-facsimiles` og dokumenterer permissionsadfærden

## Validering

- regressionstesten kører en rigtig lokal rsync og kontrollerer rettighederne i både kilde og destination
- alle 48 Jest-testpakker består: 2.303 tests
- `make help` og `make -n sync-facsimiles` kontrolleret
