### PR TITLE
Skjul tom noteoverskrift ved faksimiler

### DIFF
--- a/pages/text.js
+++ b/pages/text.js
@@ -96,18 +96,11 @@ const Refs = ({ refs, contentLang }) => {
   );
 };
 
-const SidebarSection = ({
-  title,
-  children,
-  printHidden = false,
-  printOnly = false,
-}) => {
+const SidebarSection = ({ title, children, printHidden = false }) => {
   if (children == null) {
     return null;
   }
-  const className = `sidebar-section${printHidden ? ' print-hidden' : ''}${
-    printOnly ? ' print-only' : ''
-  }`;
+  const className = `sidebar-section${printHidden ? ' print-hidden' : ''}`;
   return (
     <section className={className}>
       <h3>{title}</h3>
@@ -121,13 +114,7 @@ const SidebarSection = ({
           font-weight: normal;
           margin: 0 0 10px;
         }
-        .sidebar-section.print-only {
-          display: none;
-        }
         @media print {
-          .sidebar-section.print-only {
-            display: block;
-          }
           .sidebar-section.print-hidden {
             display: none;
           }
@@ -460,13 +447,17 @@ const TextPage = (props) => {
     ),
     lang
   );
-  const renderedNoteSection =
-    notes.length > 0 || text.has_footnotes ? (
-      <SidebarSection title={noteHeading} printOnly={!hasScreenNotes}>
+  let renderedNoteSection = null;
+  if (hasScreenNotes) {
+    renderedNoteSection = (
+      <SidebarSection title={noteHeading}>
         {notes}
         <FootnoteList />
       </SidebarSection>
-    ) : null;
+    );
+  } else if (notes.length > 0) {
+    renderedNoteSection = notes;
+  }
   const renderedRefs = text.refs.length > 0 ? (
     <SidebarSection title={refsHeading} printHidden>
       <Refs refs={text.refs} contentLang={text.content_lang} />

--- a/pages/text.js
+++ b/pages/text.js
@@ -327,9 +327,8 @@ const TextPage = (props) => {
       notes.push(element);
     });
 
-  const hasScreenNotes = notes.length > 0 || text.has_footnotes;
-
   let sourceText = '';
+  let renderedPrintSource = null;
   if (text.source != null) {
     const source = text.source;
     sourceText = 'Teksten følger ';
@@ -341,19 +340,22 @@ const TextPage = (props) => {
     }
     sourceText += source.pages + '.';
 
-    let className = null;
-    if (text.source.facsimilePages != null) {
-      // Vi har en facsimile, hvorunder vi viser sourceText, så denne note skal kun vises på print.
-      className = 'print-only';
-    }
-    notes.push(
-      <Note className={className} key="source" type="source">
-        <TextContent
-          contentHtml={[[sourceText, { html: true }]]}
-          contentLang="da"
-        />
-      </Note>
+    const sourceContent = (
+      <TextContent
+        contentHtml={[[sourceText, { html: true }]]}
+        contentLang="da"
+      />
     );
+    if (text.source.facsimilePages != null) {
+      // Billedteksten skjules ved udskrift, så kildehenvisningen vises separat dér.
+      renderedPrintSource = <div className="print-only">{sourceContent}</div>;
+    } else {
+      notes.push(
+        <Note key="source" type="source">
+          {sourceContent}
+        </Note>
+      );
+    }
   }
 
   let textPictures = [...text.pictures];
@@ -447,17 +449,13 @@ const TextPage = (props) => {
     ),
     lang
   );
-  let renderedNoteSection = null;
-  if (hasScreenNotes) {
-    renderedNoteSection = (
+  const renderedNoteSection =
+    notes.length > 0 || text.has_footnotes ? (
       <SidebarSection title={noteHeading}>
         {notes}
         <FootnoteList />
       </SidebarSection>
-    );
-  } else if (notes.length > 0) {
-    renderedNoteSection = notes;
-  }
+    ) : null;
   const renderedRefs = text.refs.length > 0 ? (
     <SidebarSection title={refsHeading} printHidden>
       <Refs refs={text.refs} contentLang={text.content_lang} />
@@ -485,12 +483,23 @@ const TextPage = (props) => {
     sidebar = (
       <div>
         {renderedNoteSection}
+        {renderedPrintSource}
         <RelatedDateTexts texts={text.related_date_texts || []} lang={lang} />
         {renderedRefs}
         {renderedTranslations}
         {renderedVariants}
         {renderedKeywords}
         {renderedPictures}
+        <style jsx>{`
+          .print-only {
+            display: none;
+          }
+          @media print {
+            .print-only {
+              display: block;
+            }
+          }
+        `}</style>
       </div>
     );
   }

--- a/pages/text.js
+++ b/pages/text.js
@@ -96,11 +96,18 @@ const Refs = ({ refs, contentLang }) => {
   );
 };
 
-const SidebarSection = ({ title, children, printHidden = false }) => {
+const SidebarSection = ({
+  title,
+  children,
+  printHidden = false,
+  printOnly = false,
+}) => {
   if (children == null) {
     return null;
   }
-  const className = `sidebar-section${printHidden ? ' print-hidden' : ''}`;
+  const className = `sidebar-section${printHidden ? ' print-hidden' : ''}${
+    printOnly ? ' print-only' : ''
+  }`;
   return (
     <section className={className}>
       <h3>{title}</h3>
@@ -114,7 +121,13 @@ const SidebarSection = ({ title, children, printHidden = false }) => {
           font-weight: normal;
           margin: 0 0 10px;
         }
+        .sidebar-section.print-only {
+          display: none;
+        }
         @media print {
+          .sidebar-section.print-only {
+            display: block;
+          }
           .sidebar-section.print-hidden {
             display: none;
           }
@@ -327,6 +340,8 @@ const TextPage = (props) => {
       notes.push(element);
     });
 
+  const hasScreenNotes = notes.length > 0 || text.has_footnotes;
+
   let sourceText = '';
   if (text.source != null) {
     const source = text.source;
@@ -447,7 +462,7 @@ const TextPage = (props) => {
   );
   const renderedNoteSection =
     notes.length > 0 || text.has_footnotes ? (
-      <SidebarSection title={noteHeading}>
+      <SidebarSection title={noteHeading} printOnly={!hasScreenNotes}>
         {notes}
         <FootnoteList />
       </SidebarSection>


### PR DESCRIPTION
## Problem

Tekster med en faksimile viste overskriften "Note", selv om den eneste note var en kildehenvisning, der er skjult på skærmen og kun vises ved udskrift.

Fixes #1283.

## Løsning

- viser kun notesektionen med overskrift, når teksten har noter eller fodnoter
- holder faksimilens kildehenvisning helt adskilt fra notesektionen
- bevarer kildehenvisningen separat ved udskrift, hvor selve faksimilen skjules

## Validering

- `npm test -- --runInBand` — 2.302 tests består
- `npm run build` — produktionsbuildet består
