### PR TITLE
Ilia Fibiger: Digtninger (1867)

### DIFF
--- a/1867.txt
+++ b/1867.txt
@@ -1,0 +1,2500 @@
+KILDE:Ilia Fibiger: <i>Digtninger</i>, den Gyldendalske Boghandel (F. Hegel), Kjøbenhavn, 1867.
+DIGTER:fibiger-ilia
+FACSIMILE:11520802671C.pdf
+FACSIMILE-SIDER:125
+TITELBLAD:DIGTNINGER / AF / ILIA FIBIGER. // Med Forfatterindens Biographi og Portrait. // Kjøbenhavn. / Forlagt af den Gyldendalske Boghandel (F. Hegel). / Trykt hos J. H. Schultz. / 1867.
+
+T:Speilet
+F:Der var engang et Ægtepar, som sad sammen paa
+SIDE:1-9
+
+D er var engang et Ægtepar, som sad sammen paa
+deres Sølvbryllupsdag og saae tilbage paa de henrundne
+Aar.
+De var gaaet i Fred og Kjærlighed; Lykken
+havde fulgt dem i alle Foretagender.
+Dog sukkede
+Konen.
+Et Haab var uopfyldt: Vuggen, som hendes
+forsynlige Moder havde givet med i Udstyr, stod endnu
+ubrugt i en Krog, skamfuld skjult under det over
+bredte Lagen.
+„Hvad er alt Andet?“
+sagde hun.
+„Fattigfolk har Børn i Flokkevis. Havde vi et Barn,
+selv det fattigste af Alle , det var Mere end al vor
+Velstand. “ Manden vilde trøste hende, men hun drog
+Lagenet tilside, puslede og glattede Vuggepuderne, og
+hendes Taarer faldt paa dem som Perler, de langsomt
+indsugede.
+Uger gik og Maaneder, og Konen blev stille og
+tankefuld.
+Hun blev glad og bedrøvet; hun kunde
+ikke fatte sin Lykke. Men da Tiden var omme, fødte
+
+hun et Pigebarn, friskt og fint som en Blomsterknup.
+Da var Forældrenes Glæde uden Grændser.
+De begyndte snart at lave til Barselgilde, men
+intet Menneske syntes dem værdigt til at bære Barnet.
+Rundt om boede fem Feer; de fire vare hoit elskede
+af Menneskene, den femte var frygtet, thi kun sjeldent
+feiede hun deres Ønsker.
+Ægtefolkene overveiede,
+hvem af de Fire de vel skulde vælge til Fadder. De
+havde gjerne hidkaldt dem Alle, men frygtede for at
+forterne den Femte.
+Da traf det sig saa heldigt, at
+denne just gjorde en Reise.
+Hurtig beredte de Alt,
+og Manden gik i Kisteklæder at bede de fire Feer til
+Fadder.
+De kom og lagde deres Gaver paa Vuggen:
+Glæde, Skjønhed, Haab og Kjærlighed. Dagen svandt
+i Fryd, og Feerne havde just taget Afsked, da Døren
+atter gik op, og den Bortreiste traad ind. Forældrene
+sprang forskrækket op.
+Konen rev Dugen af Bordet
+og bredte en ny paa, Manden nærmede sig med
+ydmyge Beklagelser over ikke at have truffet hende.
+Men Feen smilede venligt og nærmede sig Vuggen.
+„Ei hvilke glimrende Gaver!“ sagde hun, „det Barn
+vil voxe op i stor Fristelse.
+En Lykke er det, at I
+leve og kunne vogte paa hende. “ — Ak, sukkede
+Faderen, vi ere gamle og kunne vel ikke gjøre Reg
+ning paa at følge hende ret langt paa Veien. — Feen
+saae atter paa Barnet og sagde:
+„Meget Godt have
+mine Søstre givet hende, men Beskyttelsen mangler.
+
+Hvad er Haab, hvad er Kjærlighed, naar de vende
+sig imod den Urette? Hvad er den blinde Lykke i
+det uvidende Barns Haand? En Skat,
+som hver
+Daare kan gribe og vende til hendes egen Fordær
+velse. “ Da græd Moderen bitterlig, men Feen sagde:
+„Jeg vil give hende en Talisman, som skal staae
+hende bi, om Naturens Gang kalder Eder tidligt fra
+hende. See dette lille Speil! Naar Beileren trænger
+sig frem med sin Kj ærlighed, lad hende da holde det
+for hans Øie.
+Da vil det vise sig , om han er den
+Rette. “
+Hun hængte Speilet om Barnets Hals og
+gik, fulgt af Forældrenes Velsignelser.
+Barnet voxede til, og aldrig fordunklede nogen
+laare dets Øie.
+Hun kom kun lidt blandt andre
+Børn , thi Ingen syntes Forældrene gode nok , men
+hjemme havde hun fuldt op af Morskab, og de faa
+udvalgte Legekammerater undredes over hendes Mun
+terhed og Frihed.
+Jomfrualderen nærmede sig ; da
+tog Forældrene hende en Dag imellem dem og under
+rettede hende om det lille * Speils Egenskab, hun
+endnu bar som et Legetoi om Halsen.
+Tankefuld
+stirrede Pigen i det; kun utydeligt saae hun sit
+Billed: Blomster og blinkende Stjerneskud gled gjeg-
+lende hen over det.
+Fra den Dag saae hun oftere
+i Speilet og undrede sig over de drømmeagtige Sy
+ner, som gik hen over dets Flade.
+En Dag vandrede hun i Skoven, som stødte til
+hendes Forældres Have-, da traadte en ung Mand
+
+hende imøde.
+Pigen veg forskrækket tilbage, men
+ved det andet Blik forekom han hende saa bekjendt,
+at hun atter forvirret standsede.
+Han rodmede som
+hun, stammede og greb hendes Haand. Men hun rev
+sig løs og ilede hjem.
+Saaledes gik en lille Tid.
+Naar de Unge van
+drede sammen i Haven, saae de Gamle smilende efter
+dem og beraadsloge, om det vel snart kunde være
+paa Tide at raadspørge Speilet. — En Aftenstund
+sad de To i Skoven, tæt udenfor Havelaagen; han
+havde tilstaaet sin Kjærlighed, og det første Kys
+havde beseglet Pagten.
+Men som hun boiede sig for
+hans B lik, gled det blinkende Speil frem, som hun
+bar paa Brystet. Hvad er det? spurgte han og greb
+det spøgende.
+En Fee har givet mig det, svarede
+Pigen; det vil prøve min Beilers Troskab.
+Hun
+klemte sin Haand sammen om Speilet, men han kys
+sede Fingrene op og saae i det.
+Det blændede for hans Øie.
+Ikke sit, men Pi
+gens Billede saae han.« Dog kunde han ikke fast
+holde det: det var som tusinde Ildgnister gik over
+det, sittrende og forvirrende; tilsidst syntes det ham,
+som det Hele splintredes og henflød i Taage. Mat og
+kold om Hjertet vilde han med Magt vende sit Øie
+mod Pigen; da lød et Veraab fra Haven, og hun
+sprang forfærdet op. Husets Folk søgte hende; hendes
+Moder laae døende i Stuen.
+
+Hun ilede ind. Han hørte ikke, hvad der taltes;
+sløv og forvirret fjernede han sig, da hun var borte.
+Den gamle Kone var rammet af et Slag og formaaede
+ikke at tale, men døende greb hun endnu efter Speilet
+om Datterens Hals. Faa Dage gik, saa fulgte Faderen
+hende, og den friske Grav gjemte Forældrenes trætte
+Lemmer. Pigen græd, men Feernes Gaver blomstrede
+i hendes Bryst; med Haab og tilsløret Glæde ventede
+hun, at han skulde komme.
+Da gik Dag for Dag, og Skoven gulnedes, Levet
+hvirvledes hen, og Sneen tyngede Grenene; Vinteren
+var der, men han kom ikke.
+Pigen saae i sit Speil
+og hensank i sælsomme Drømme; hun ventede og
+ventede, men han kom ikke. Da græd hun bittrere
+Taarer; de faldt paa Glasset og kaldte hans Billed
+frem.
+Det blev som en Leg.
+Taarerne mildnedes,
+og Billedet blev svagere; Stjerneskud og drømmeagtige
+Syner gled hen over det.
+Tiden gik, og Skoven grønnedes; nær og fjernt
+sang Fuglene under dens Kroner. Da længtes Pigen
+inderligt, og hun gik daglig under den grønne Hvæl
+ving, men Ingen mødte hende paa den kjendte Sti.
+Saa drog hun langveis bort at søge den Elskede.
+Men den svale Vind omstrøg hendes Kind, og tusind
+nye Blomster spirede frem for hendes Fod.
+Menne
+skene modtoge hende med Glæde og Kjærlighed og
+kappedes om at berede hende et Hjem. Da blev hun
+
+let om Hjertet, som hun kunde omfatte den hele Ver
+den og drage den til sig i freidig Velvillie.
+Saaledes gik vel en god Tid; da begyndte Noget
+at længes i hendes Hjerte.
+Hun horte ikke. som
+for, ligegyldig paa Beilernes Ord; hun tænkte, hvor
+sødt det havde været at elske. Da saae hun mangen
+gang paa den Bedende og tænkte:
+Vidste jeg, han
+var den Rette, da kunde jeg vel elske ham. Og hun
+trak Speilet frem og bad ham see ret fast deri. Men
+Speilet drev sit Gjogløspil og forvirrede hans Sands;
+for eller senere trak han sig forlegen tilbage.
+hedrovedes efterhaanden Pigens Hjerte, og hun læng
+tes bort fra de troløse Mennesker.
+Men i Ensom
+hed opblomstrede atter Feernes Gaver, og hun fre
+dede om de altid spædere Spirer, der smykkede hen
+des Vei.
+Saaledes gik hun gjennem Livet, søgt og søgende,
+altid skuffet.
+Da hvilede hun sig i Ensomhed og
+saae hen over de mange, de lange Aar, som Intet havde
+efterladt hende. — Som hun saaledes sad, nærmede
+en Mand sig, alvorlig og god af Aasyn.
+Han un
+dredes over at finde hende i denne O rk, han satte
+sig hos hende og talede venligt til hende.
+Da vir
+kede Feernes Faddergave; han saae ikke Alderens
+Spor i hendes A nsigt, men han ynkedes over hendes
+Skrøbelighed, og hans Hjerte var fanget.
+Han op
+slog sin Bo i hendes Nærhed, og snart talede hans
+Ord, som hans Øine, om Kjærlighed.
+
+Og Pigen skjulte Speilet i sin Klædnings Folder
+og trykkede sin Haand fast imod det.
+Men snart
+tænkte hun:
+Hvor turde jeg kalde ham Min, naar
+jeg vandt ham ved at undgaae Prøven ? Jeg vil vove
+det Sidste.
+Hun drog Speilet frem og holdt det
+skjælvende, med et bonligt Blik, hen for ham. Han
+greb hendes Haand og saae længe deri; da kyssede
+han Haanden, reiste sig langsomt, og gik.
+Og hun
+vidste, at han vilde ikke vende tilbage.
+Da stod medet den femte Fee for hende og be
+tragtede hende med et triumpherende Smil.
+Pigen
+loste Speilet af sin Hals, rakte hende det og sagde:
+lag Din Gave, som har bedraget mig for mit Liv.
+„Skrøbeligt var hvad Du tabte,“ svarede Feen.
+„Bag Havet ligger Din Lykkes Land. “ Og hun for
+lod hende smilende.
+Men Pigen sad for den synkende Sol, i den
+stille Nat; hun sad der endnu, da Dagen atter hæl
+dede.
+Hun prøvede ikke at reise sig; det var, som
+Alderen pludselig var falden paa hende med sin Bly
+vægt. Hun saae ud over den ode Slette og tænkte:
+Kunde jeg græde, saa mine Taarer svulmede op til
+et stort Hav; da seilede jeg over det og kom til min
+Lykkes Land. — Hendes Hjerte blev tungere; Sorgens
+Væld steg høiere, saa Draaberne langsomt fyldte
+Diet.
+Da nærmede et Barn sig med Skjørtet fuldt
+al Blomster
+„Kjender Du mig?" spurgte den Lille.
+
+„Jeg er Din glade Barndom, som kommer for at græde
+med Dig.“
+Og det rystede sine Blomster ud for hendes Fod,
+satte sig og græd.
+Da strømmede Taarerne fra den
+gamle Piges D ine, saa et lille Vand samlede sig
+foran hende.
+Men en rosenkrandset Ungmo nærmede
+sig, trykkede sig mod hendes Bryst og hviskede:
+„Kjender Du mig? Jeg er den første Kjærligheds
+lyksalige Tid.
+Jeg kommer for at græde med Dig. “
+Og Begges Taarer strømmede, saa Vandet bredte sig
+som en stor Sø foran de Grædende.
+Da kom nær
+og fjernt, fra en hel Række af Aar, en hel Hærskare
+af Savn og sørgeklædte Timer.
+De bredte sig til
+begge Sider langs Søens Rand og græd stille i det
+stille Vand; dog steg det kun langsomt.
+Da rørtes
+der sagte ved Kvindens Skulder, og hun vendte sit
+Hoved.
+Der stod en tilsløret Skikkelse og rakte taus
+og bedende sin Haand imod hende. Men hun kjendte
+sit sidste Haab og drog den til sig.
+Den kastede
+sig ned med Hovedet paa hendes Knæ og græd, saa
+Søen svulmede uoverskuelig vidt, og hvert Savn og
+Sorg gled ned i dens Bølger.
+Erindringerne var slumret ind, men Kvinden
+sad i den dæmrende Nat og stirrede ud over Taa-
+rernes stille Hav.
+Da rørtes Vandet sagte, og midt
+ude hævede en Skikkelse sig. kjendt, som den alt
+engang drømte Drøm.
+Den vinkede hende med en
+stor Aakandeblomst, den holdt i Haanden. Hun reiste
+
+sig møisomt, men stod tvivlraadig ved Bredden. Da
+rev den Ventende Bladene af Blomsten og slyngede
+dem langt hen imod hende. De spredtes i en Stribe,
+som smaa hvide Stentoppe til Overgang over Bækken.
+Og Kvinden satte sin Pod paa det forste gyngende
+Blad; da gik hun lettere, og hendes Hoved hævede
+sig.
+Por hvert Skridt faldt en Vægt af Aarenes
+Byrde af, og ung og deilig som i sin forste Tid
+stod hun ude paa Vandet.
+Da saae hun under Fla
+den hans udrakte Haand, og tabende ethvert Fodfæste
+greb hun efter den. Men han omslyngede hende fast
+og drog hende med sig til den dybe Bund.
+Solen steg, og Vandet sank. Alt mere og mere
+svandt det, og med vidunderlig Fylde fremspirede
+Græs og Blomster i Dalen.
+Kun midt blev en Brond
+tilbage, saa dyb, saa dyb, at intet Oreatur kunde
+naae at drikke af dens Vand. Men stirrede Vandreren
+længe ned i den klare Grund, da paakom ham en
+inderlig Længsel, saa han med Magt maatte rive
+sig los for at vandre videre.
+
+T:Stemninger
+U:_1851—59._
+F:Hjælpeløse Hjerte
+SIDE:10-16
+
+Hjælpeløse Hjerte,
+holcl Dig rolig kun;
+bær ilen Din Smerte
+til Din sidste Stund.
+Herreløse Kvinde,
+Jordens Fryd forglem.
+Lær ihast at finde
+Veien til Dit Hjem.
+Trang den Vei mon falde,
+og min Fod er træt.
+Herre!
+Mild Du kalde
+den, som standser let.
+Herre!
+Mild Du række
+mig Din Haand saa god.
+Selv Du til Dig trække
+den, som staaer imod.
+Thi skjøndt stærkt jeg længes,
+skjøndt jeg Fred ei har,
+skjøndt mit Hjerte trænges
+af en Sorrig svar —
+
+Dog sig Øiet vender
+efter Jordens Tant,
+og de matte Hænder
+gribe, hvad det fandt.
+Og skjøndt Blomstens Smykke
+falder af ihast,
+de begj ærlig trykke
+sig om Tornen fast.
+Herre ! Les min Kvide!
+Tag Du mig ved Haand.
+Selv jeg kan ei slide
+mig af Yerdens Baand.
+Tag mig mod min Yillie!
+Lad mig græde ud
+og saa hvile stille
+hos min Herre og Gud.
+
+Min Fryd den er saa lille, min Sorg den er saa stor;
+mit Hjerte er som tynget af tre Skuffer Jord.
+Mit Hjerte saa betynget dog finder ingen Bo,
+thi Graven er ei gravet end, hvor det saa trygt skal boe.
+Hvor er den Glædens lyse, den underfulde Tid,
+da Livets Sol sig hæver, saa straalende og blid,
+da første Nyheds Morgendug i Glands indhyller Alt,
+og Livet er et Eventyr, nu førstegang fortalt?
+Hvor er, o svale Dæmring, Din Aftens sidste Stund,
+da Døden selv saa stille mig dysse skal i Blund
+og lægge mig i Fredens Arm og ved dens hulde Bryst,
+mens Haabet hvisker sagtelig om Salighedens Lyst.
+Nu staaer jeg midt imellem og er saa mat og svag;
+dog veed jeg, den vil ende, den lummerhede Dag.
+Og naar jeg tjener trofast kun, hvor ensom jeg er sat,
+saa venter mig en Hvile sød i Gravens dybe Nat.
+Saa venter mig den bedste, den evige Trøst,
+naar jeg engang skal høre min Herres milde Bøst:
+„Du stakkels syndige Skabning, kom, thi dog Du var
+mig kjær;
+blev Du paa Jord en Fremmed kun, saa vær da
+hjemme her.“
+
+Midtveis paa Livets lange Bane staaer
+idag jeg jo; de femogtredive Aar
+tilbagelagt — hvor kan det muligt være?
+Dog har jeg vandret langt med Sorrig stor
+den tomme Vei hen over kolde Jord,
+der luktes over dem, som var mig kjære.
+Vel var de Tre.
+For En jeg serged kun;
+kun engang brod den frem fra Hjertets Grund,
+den dybe Sorg, opdæmmet der saa længe.
+Den meste svundne Tid den skylled bort,
+og derfor har jeg levet nu saa kort,
+thi nyt sig maatte Alt igjen fremtrænge.
+Og jeg er glad idag; jeg frygter ei
+meer for at gaae min underlige Vei;
+jeg troer, jeg tor vel være, som jeg skabtes.
+Kjærligheds Rigdom blev nu ei min Deel,
+men kan jeg, fattig, kun mig samle heel,
+saa vandt jeg dog, hvor Meget end der tabtes.
+Paa mit eget Hjertes Hoivande jeg svommer,
+og Verden mig synes saa skjon og saa rig;
+om Fred og om Lykke jeg sværme’nde drammer
+— men sank jeg, var snart jeg et Lig.
+
+Ei meer jeg hjemløs er paa Jord,
+jeg har mig en Hvileplads fundet.
+Paa den jeg hygger, paa den jeg boer,
+da har jeg Freden vundet.
+Den spirer op som spæde Straa
+i den Krog, hvor jeg trak mig tilbage.
+Jeg bygger en lille Hytte derpaa;
+der bliver jeg alle Dage.
+Jeg hygger Hytte, boer deri,
+mens udenfor Fuglene synge.
+Jeg gaaer ad Skovens halvtraadte Sti,
+hvor Blomster staae tæt i Klynge.
+Da binder jeg mig Krandse smaa
+og hænger dem trindt i min Hytte.
+Jeg sætter mig hen og seer derpaa:
+herfra jeg aldrig vil flytte.
+Engang en silde Aftenstund
+saa kommer vel Den, jeg venter.
+Han kysser mit Die, han kysser min Mund
+og hort til «in Himmel mig henter.
+
+Men hvor vel mon den Hytte staae,
+hvor blev den Byggegrund funden?
+Det var i Hjertets inderste Vraa,
+da Verdens Sorg var forvunden.
+Yndige Land,
+hvor i min Ungdom jeg boede og bygged!
+Bolgebeskyllet af kjolige Strand
+og af lovkronede Træer overskygget!
+Kan jeg ei komme derhen?
+Kan jeg dog aldrig, dog aldrig didkomme igjen?
+Skygge der var,
+skraanende Dale, omhvælvet af høieste Himmel.
+Aftnen var liflig, og Natten saa klar;
+stille nedblinkede Stjernernes Vrimmel.
+Enkelt et Stjerneskud gik
+lovende hen for det ønskende, drømmende Blik.
+Kommer jeg did,
+naar min henvaklende Vandring i Livet er omme?
+Naar jeg har levet den tilmaalte Tid,
+naar jeg gjør Opbrud ved Dødens velsignede Komme?
+Fører vel den mig derhen?
+Finder jeg der, hvad jeg drømmende eied, igjen?
+
+Jeg gaaer ei bort i Livets Vaar,
+end ikke i dets Sommer.
+Ak nei! jeg stormforreven staaer,
+naar Efteraaret kommer.
+Vel hvirvløs ned det sidste Blad,
+for jeg i Graven blunder.
+O, hvor vil jeg dog være glad,
+naar det mod Døden stunder.
+Da skal jeg gjemmes trygt og godt
+og sove sødt og længe.
+I Muld da staaer mit faste Slot,
+hvor Sorg ei kan indtrænge.
+Ei Sorg, ei Savn, ei Længselsve
+kan trænge ind i Borgen ;
+og hvad der end paa Jord kan skee:
+mig rammer ikke Sorgen.
+Den har jo hele Verdens Rund,
+dens Rige gaaer saa vide.
+Men i den kjole Gjemmegrund
+der boer kun Søvnen blide.
+
+Jeg længes efter Søvnen sød
+alt med de milde Drømme.
+Thi kom kun snart, trofaste Død,
+Gud vil vist naadig dømme.
+Af Almuelivet.
+(
+
+T:Fra Jylland
+F:Aftnen var liflig, og Natten saa klar
+SIDE:17-18
+
+)
+orden for Limfjorden findes et Sted,
+hvor sig en Lyngbanke blidt skraaner ned
+men imod østen den sandmagre Grund
+sænker sig brat mod smaastenede Bund.
+Med deres Hænder et Ægtepar der
+danned en Tilflugt for Yind og for Veir,
+grov sig i Bakken møisommeligt ind,
+til der blev stort nok for nøisomme Sind.
+Reiste en Mur af selvsamlede Sten,
+Forsiden blev det, saa fast og saa pæn.
+Tætted og luned og pynted tilsidst;
+Trivselen kom der ved Aarenes Frist,
+
+Der, hvor de bygged, de boede med Fred;
+Eiendomsretten dem Ingen bestred.
+Vidt om i Landet dog ofte de drog,
+Fedlen han streg, Tamburinen hun slog.
+Selvlavet var den, en underlig Ting.
+Men i hvor vidt end de droge omkring,
+kjendte dog Alle de dygtige To,
+der, ret som Fuglene, selv bygged Bo.
+Engang jeg traf dem. Vi talede lidt,
+som det nu faldt sig, om Dat og om Dit.
+Og iblandt Andet jeg spor, om de bar
+ei noget Barn, da gier Manden det Svar:
+„Nei, i den Ting var vor Lykke jo svær:
+Fem vel vi havde, dog dede Enhver. “
+Sagtens jeg studsed, thi Konen faldt ind,
+slettende efter med varsomme Sind:
+„Jo, for den Fattige er det et Held;
+Jomfruen selv maa betænke det vel.
+Bredet til To er tidt knapt nok endda:
+Hvis vi var Flere — kvor kom det da fra?“
+Videre drog de med Kling og med Klang;
+jeg havde hørt kun en Fattigmandssang.
+Moderen glemmer sit Haab og sin Nød:
+Jordgjemte Barn er — Besparen af Brød.
+
+T:En Vaagekone
+F:Med stille Sind
+SIDE:19-20
+
+M ed stille Sind
+hun tripper ud, hun tripper ind,
+den gamle Vaagemoer.
+Hun tripper om den Nat saa lang;
+er Pinen haard, er Tiden trang,
+hun trippende ved Sengen staaer
+og hjælper, mens hun Utak faaer.
+Hun nikker tidt,
+og Hov’det vakler for hvert Skridt,
+som om det halv sad løst.
+Hun ryster paa den runkne Haand,
+og hendes slidnedtrykte Aand
+omtaaget synes, dog hun veed,
+naar det kun gjælder, god Besked.
+Hun henter Vand
+om Morgnen, og ved fulde Spand
+hun faaer en god Passiar.
+Selvfemte hun ved Posten staaer,
+mens alle Munde tappert gaaer,
+og det, næst Caffen, er den Trøst,
+der bode maa paa Livets Brøst.
+Hun reder Seng,
+hun feier Gulv, er Alløs Dreng;
+hun sendes her og hist.
+
+Naar endelig det Slid er endt,
+har næsten hver en Patient
+et Ærind end at give med.
+Er det besørget, faaer hun Fred.
+Saa gaaer i Slid
+hver Nat og Dagens halve Tid;
+hun maa vel slides op.
+Hun falder af, hun blinker tidt,
+hun selv om Natten blunder lidt.
+Men stadig hun i Aaget gaaer,
+som vented hundred slige Aar.
+Hvad boer der vel
+paa Bunden af den gamle Sjæl,
+saa trælløslidt og sløv?
+I Hverdagslivets støvgraa Dragt
+en stadig Sorg der holder Vagt.
+Den sank tilbunds, som Skatten rød
+i Muddergravens dunkle Skjød.
+Hun grubler paa,
+hvordan det skal den Datter gaae,
+hun fik i Ungdoms Tid.
+Det gik tilbage Aar for Aar,
+og nu selv Datt’ren „skreven staaer“.
+I Gaffen faldt en Taare tidt
+ved Tanken, at det kom saa vidt.
+
+I Ned og Savn
+hun tyer dog ind til Moders Favn.
+Hun tyer til Moders Pung.
+Hun plyndrer hende for hver Hvid
+og skjælder tidt til samme Tid.
+Men Mod’ren sukker i sin Nod;
+„Hvor skal det gaae, naar jeg er ded?“
+I
+
+T:En Episode
+F:I Nød og Savn
+SIDE:21-22
+
+)
+Paa Hospitalet hares ind
+en Kvinde, ung og fin.
+Hun syntes alt at hore til
+i Dødens snævre Skrin.
+Fra Stiftelsen hun kom.
+Sit Barn
+hun der tilbage lod.
+Det døde, før det Lyset saae,
+mens Slaget endnu stod.
+Paa 17—18 lagdes hun,
+det stakkels unge Blod
+Og hvad hun led, det veed kun Gud;
+hun taug med taaligt Mod.
+Hun fremmed var.
+End ikke En
+for hendes Skyld kom did.
+Den „svenske Pige“ eied ei
+en Ven, og ei en Hvid.
+
+Men Stuelægen saae tilsidst
+dog hendes stille Nød.
+Han hende et Far Skilling gav
+til The og til lidt Brød.
+Dag sneg sig hen for Dag; det blev
+af Maaneder et Tal.
+Saa var hun rask.
+Hun skrives ud.
+„Den Svenske" bort nu skal.
+Paa Lægens Der det pikker let,
+og med beskeden Færd
+indtræder hun at takke ham,
+hun mest maa takke her.
+Den unge Læge samler sig
+til et Formaningsord.
+Hun svarer blidt: „Vær uden Frygt:
+Min Lidelse var stor".
+Hvad gjor Du nu? — „Jeg tjene vil
+som før."
+Og har et Sted? —
+,,Nei Kors! Den svenske Kjælder kun.
+for mig jeg aaben veed.
+For otte Skilling der et Degn
+man være kan, og da
+jeg finder mig et Herskab vel." -
+Hvor faaer Du Penge fra?
+
+Hun seer ned paa sin hvide Haand
+med den Udtemtes Ro.
+„Jeg har endnu den'Ring, hvormed
+Han fæstede min Tro.“
+Og hermed gik hun.
+Dødens Svælg
+var hun gaaet tæt forbi.
+Hver jordisk Fryd og Frydens Frugt
+var sunket ned deri.
+(
+
+T:Sypigens Beretning
+F:Hun seer ned paa sin hvide Haand
+SIDE:23-25
+
+)
+Nei, Frøkenen maa troe mig, det er saa surt et Liv
+at boe imellem simple Folk med deres Smuds og Kiv.
+Og jeg er fra min Barndom til ganske Andet vant:
+Min Faer var Constabel, og vort Hus var galant.
+Min Moer var Degnedatter.
+Den Tid er nu forhi.
+Hun hviler længst i Jorden, for alle Sorger fri.
+Min lille Signe aldrig hun hørte Noget om,
+og det var ganske godt, maaskee, da hun ukaldet kom.
+Jeg har dog kun den Ene, mens mangen En har Tre;
+det gjør den største Forskjel, som vel Enhver kan see!
+Nei, Himlen mig bevare, thi Ære og Dyd
+det er paa Jord den hedste Trøst, det er den største
+Fryd.
+
+Saa lærer jeg min Signe. Men, hvad jeg sige vil:
+Det er dog ganske grueligt, som ofte det gaaer til.
+Der boer nu Dør om Dør med os et Par, som bringer tidt
+mit Blod ikog. Jeg heftig er; mit Sind er ikke blidt.
+Før gik jeg ind at stifte Fred og skammed hende ud.
+Da blev hun lynegal engang og sagde —fri mig Gud! —
+jeg nævner ei de Ord, som hun tog i sin Mund.
+Hun skulde nødig sige Sligt, en saadan En, som hun!
+Nu henter jeg vor Vært.
+Han staaer som en Blok
+med Næverne i Siden kun og gloer, saa har hun nok.
+Hun vover ei at mukke. Men bag Værtens brede Byg
+staaer Manden saa og skjælder; der føler han sig tryg.
+Om hun er yngre? Jo, hun er i Alder just med mig.
+Vi gik i Skole sammen.
+Nu hilses vi ei.
+At trænge mig paa er ei min Character;
+og somme Ting kun nødig man hører og seer.
+Men tidt dog jeg sidder, naar hun tager paa Vei,
+og maa lytte derefter, om jeg vil eller ei.
+Min lille Signe trykker dybt sit Hoved i mit Skjød,
+og Beggeto vi græde ved at tænke paa hans Nød.
+Han var en gammel Skræddersvend, af dem, der passe Sit;
+en retskaffen Sjæl, men lidt sær i sit Snit.
+Han havde Alt i Orden; han i Ligkassen var,
+og mangen Daler hen han i Bikuben bar.
+
+Ja, Himlen raader underligt. Hvordan han fik den Ven,
+det kan jeg aldrig fatte.
+Det var en Dreiersvend.
+Han boede hos den Gamle. Det var hans Et og Alt;
+men han for al hans Godhed har ham skammelig betalt.
+Han prelled ham bestandig, lo ham ud paa hans Bag;
+han havde tusind Planer for, var med i vildest Lag.
+Han smidsked for hver Pige, han holdt dem for Nar,
+men allermest dog hende, som Skræddersvenden har.
+Hun tænkte nu saa sikkert, at han „vilde hende No’e t;“
+men Ingenting han vilde, som jeg har altid troet.
+To Børn ved ham hun fik kun. Og paaengang hun spor,
+at han gifter en Enke, han har tjent som Markor.
+Hun gjorde da Spektakler, som Hver vel tænke kan.
+Han tyssed paa og lovede at skafle snart en Mand.
+Han taled nu for Skrædderen, det stakkels gamle Skrog,
+og viste ham, hvor rart det var, om han en Kone tog.
+Han friede selv for Vennen, og han Forlover var,
+Skjondt Skræddersvenden vred sig, saa blev de dog et Par.
+Den Gamle alt begyndte at åee til Sagen mildt;
+dafik han Prygl den tredie Dag, og al hans Fryd var spildt.
+d Nu hanker hun ham daglig, saa jeg tor sværge paa,
+n at mangengang det stakkels Skind er baade brun og blaa.
+d Nei, Himlen mig bevare for sligt Ægteskabs Lyst;
+H jeg og min lille Signe vi er hinandens Trost.
+
+T:Nattearbeid
+F:Hun er jo dog igrunden et faderløst Barn
+SIDE:26-27
+
+Hun er jo dog igrunden et faderløst Barn.
+Hvad hjælper vel en Fader, naar han kun er et Skarn?
+Jeg vilde ikke „søge ham ;“ jeg holdt mig for god.
+Før syer jeg og træller, til min Haand staaer i Blod.
+Gud unde mig kun Helsen, saa skaffer jeg vel Brød,
+men faldt jeg fra, da seer jeg kun for hende Sorg og Ned
+Nei, skal jeg bort, jeg heder Gud, at han vil kalde da
+mig og min lille Signe paaengang herfra.
+(Nattfearbeid.)
+Det lysner over Baggaardstag,
+og Huset sover trygt.
+Nu kan jeg til mit Arbeid gaae
+i Mag og uden Frygt.
+En stakkels Pige trælle maa
+for Andre Nat og Dag-,
+hvordan hun faaer sit Eget gjort,
+det bliver hendes Sag.
+Men Gud skee Lov for Jens! Han er
+saa ærekjær og tro.
+Paa Søndag lyses trediegang,
+saa skal vi fæste Bo.
+
+Gud signe ham! Og den, som her
+jeg stopper Puden til!
+Lidt mere Fyld! Det fattig Lam
+saa sodt da sove vil.
+Paa Sopha hviler Fruen sig
+og stonner for hvert Skridt.
+Men jeg maa bære Vand endnu
+og vadske Trappen tidt.
+Dog Gud seer ned og gier nok mig
+en Glut saa sund og trind,
+mens hun, som sidst, en Skrælling faaer,
+der skjælver for hver Vind.
+Til Nytaar hk jeg fire Mark
+for Aarets sure Slid. —
+Naa da, hvor Dynen slunker ind!
+Den vidner om min Flid.
+Jeg faaer sye til. Dog, lidt endnu,
+skjendt Vuggen færdig er.
+Til Jens kan jeg vel bjerge end
+en lille Pakke Fjer. —
+Nu Kosten fat og feiet op,
+og Sengen redt saa pænt.
+Jo, Stine hun er fix og net,
+og hendes Kammer rent.
+
+Den Seng vil blive mig lidt haard
+den Tid, der er igjen.
+Dog gjør man Meer vel- for sit Barn
+og for sin Hjertensven. —
+(
+
+T:Et uægte Barn
+F:Den Seng vil blive mig lidt haard
+SIDE:28-32
+
+)
+Hun var langt over Ungdoms Aar,
+og hvast var hendes Sind.
+Det var som Hyhenrosens Hæk
+i Yintrens skarpe Yind.
+Men aldrig havde og hun staaet
+i Sommerdragt, som den-,
+for hende hver en Livets Blomst
+som Knup var visnet hen.
+Hun voxed op som Pleiebarn,
+og der blev godt betalt.
+Hun i saa pæn en Skole gik
+og nemmed hurtig Alt.
+Hun mærked sig saa mangt et Vink,
+da svulmed Haabets Elv.
+Da hun blev confirmeert, det hed:
+Sørg nu Du for Dig selv.
+
+Saa tjente hun.
+Skjøndt hun var flink,
+hun skiftede dog tidt.
+Hun passed ei blandt Folk.
+Der var
+for Meget og for Lidt.
+Hun vidste, hendes Faders Plads
+var tidt ved Kongens Bord.
+Hun vidste, hendes Moder sov
+i Sognets Fattigjord.
+Hun gik engang om Condition,
+hun stod for Fruen snild.
+Da var det hendes Søster, som
+ei aned, hun var til.
+1 ilsidst hun til et Herskab kom,
+det var nær Rungstedgaard.
+En Frue med to Døttre kun,
+der tjente hun et Aar.
+Hun blev der et, hun blev der to,
+hun blev der vel en Snes.
+Hun tjente tro, behersked snart
+saa strengt den lille Kreds.
+Hun tjente, som det sjeldent sees.
+Hun fandt jo der et Hjem.
+De taalte Alt. De vidste, hun
+i Døden gik for dem.
+
+Dog var hun dem et Huskors svært.
+Men imod En hun kun
+var god og næsten altfor om:
+Den Ene var en Hund.
+For lang Tid siden kom iblandt
+en Slagter der med Kjød.
+Han hviskede til Pigen tidt,
+da blussed Kinden rod.
+Hun klapped Hesten for hans Vogn,
+hun fored Hunden mild.
+Hun satte Manden selv tilbord
+ved lune Kjekkenild.
+Medet han borte blev.
+Men hun
+beholdt den lodne Hund.
+Forgjæves søgte Husets Folk
+at gjætte Sagens Grund.
+Hun tav.
+Og Dag og Aar gik hen;
+en Række.
+Hunden nu
+blev gammel, syg og styg og fæl;
+den var Enhver en Gru.
+Hun saae, hvad nænsom halv og halv
+forknyt man mildt fortav.
+Hun trykked Hunden til sit Bryst:
+„Snart aabner sig Din Grav.“
+
+En Morgen, kort for Solen steg,
+hun med sin gamle Hund
+med uvant Haand roer ene ud
+paa blanke Øresund.
+Hun tager Aaren ind, og nu
+hun sysler med sit Værk.
+Et Fiskernet hun knyttet har
+af Traaden, tyk og stærk.
+Hun vikler det om Hunden fast;
+den knurrer kun saa smaat.
+I Hjørnet hinder hun en Sten,
+som ret kan tynge godt.
+Sin Psalmebog med Gyldensnit
+hun tager stille frem.
+„Du fulgte mig i Kirken tidt,
+følg Du min Ven nu hjem.
+Du fulgte mig i Ungdoms Aar,
+Du siden gjemtes hen.
+Naar I tilbunds nu Begge gaaer,
+vi sees ei meer igjen.“
+Hun tager frem en Perløsnor,
+et Hjerte hænger ved.
+„Du fandt ei Fred paa vide Jord;
+find nu i Havet Fred.“
+
+ISMPMtMR
+Og af sit Øre tager hun
+en Slangering saa glat.
+„Jeg fik den i saa glad en Stund;
+det var min Barndoms Skat."
+Snart er det Hele pakket til,
+og sorrigknuget hun
+nu trykker Hunden til sit Bryst
+og sin fortrukne Mund.
+Den blinker dorsk og snøfter qvalt
+med tyktomtaaget Aand,
+mens gjennem Maskerne den dog
+vil slikke hendes Haand.
+Da vælter hun den med et Skrig
+ud over Baadens Band
+og synker ned paa Bunden, mens
+den sank i dybe Vand.
+Men da hun atter reiste sig,
+ei mindste Spor hun saae;
+kun Morgensolens HimmelGlands,
+som over Vandet laae.
+Hun styrer Baaden taus til Land,
+og taus hun vandrer hjem.
+Der speider Hver, men Ingen spor,
+hvor Hunden er igjen.
+
+Men dobbelt stiv og dobbelt hvas
+hun nu iblandt dem gaaer.
+For deres Skyld fik Hjertet jo
+det sidste, dybe Saar.
+
+T:Christian Fibiger
+U:_1859._
+F:Nu hviler fra Dit lange Dagværk Du
+SIDE:32-34
+
+Nu hviler fra Dit lange Dagværk Du,
+velsignet gjennem Taarer af saa Mange.
+Din Sjæl var træt, til Hvile stod dens Hu,
+Livsbaandet holdt Dig, som det holdt en Fange.
+Det brast. Ei Bortgang var Dig Dødens Stund,
+den var Din Ankomst kun til Lysets Rige.
+Din Aand faldt her alt i et stakket Blund
+for klar og samlet til sin Gud at stige.
+Fred felge Dig.
+Du var en virksom Mand,
+til Livets Aftentaage dækked Aanden.
+Din Kraft var kløgtig, og Din Gudsfrygt sand,
+Hjertet var ømt og hjælperig var Haanden.
+
+Din Ungdoms Brud nu ved Din Kiste staaer;
+som trofast Hustru sad hun ved Dit Leie.
+Og Øine Børn med Sorg i Hjertet gaaer
+halvspredte om paa Livets nye Veie.
+Og de, hvem Du en anden Fader var,
+de Brøderhorn, de vil Dig aldrig glemme.
+Blandt Minder fra en Fortid, lys og klar,
+vil Onke l C h r i s t i a n s Navn de helligt gjemme.
+
+T:Jacob Scavenius Fibiger
+F:Simpel af Hjerte og trofast af Aand
+SIDE:34-35
+
+Simpel af Hjerte og trofast af Aand,
+knyttet til Øine ved ommeste Baand
+var Du, en Støtte for Børn og for Viv,
+selv dog et Barn i det daglige Liv.
+Landet paaskjonned sin dygtige Søn,
+sparede ikke Beundringens Løn;
+hjemme han gik dog, som Ingenting var:
+aldrig sin Hæder tilskue han bar.
+
+Hjemme han sad som et Barn ved sin Bog,
+grandskede ivrig de fremmede Sprog;
+glæded sig over hvert Ord, som han vandt,
+over de Tanker, som derved oprandt.
+Hjemme! Hvem var vel i Hjemmet som han?
+Halvt som et Barn og saa helt dog en Mand;
+glad som en Brudgom ved Kvinden, hvem alt
+liregang ti Aar han Sin havde kaldt.
+Altid det Billed vil staae for min Sjæl,
+som Du sad hos os en Julenatsqveld:
+Isgraat var Haaret, men Ansigtet dog
+talte til Øiet med Englenes Sprog.
+Kun hos de Børn, som — saa spæde og smaa
+bæres paa Armen, det Udtryk jeg saae.
+O hvem der kunde saa hel og saa ren
+naae til sin Grav, til dens dækkende Sten!
+
+T:Dronning Ingeborgs Klage
+F:Hvor det lysner
+SIDE:36-42
+
+H vor det lysner!
+Lysner gjennem dunkelgrenne Lovtag,
+hvor jeg gjexnte mig for Dagens Klarhed,
+hvor jeg skjulte mine matte, slove,
+halvudslukte Øine for dens Straaler.
+Se, det spiller!
+Spiller med et Lysglimt der paa Grunden.
+Sol, hvad vil Du? Kjender ei Du Skaansel?
+Spotter med Din Glands Du Danmarks Dronning,
+hun, den usløste blandt usle Kvinder?
+Engang! Engang!
+Ja, da var jeg ung og rig og haabfuld.
+Solen skinned, Folket jubled, Kongen,
+Danmarks Konge rakte glad mig Haanden,
+mens to Rigers Klokker klang til Bryllup.
+*) Datter af Kong Magnus Ladulås i Sverrig, trolovet med Erik
+Menved 1288, gift med ham i Helsingborg 1296. Hun fødte sin
+* Ægtefælle 14 Sønner, der dels vare dødfødte dels døde smaa.
+Den sidste Søn skal, 1 Maaneder gammel, være bleven dræbt
+ved at falde ud af Vognen, da Dronningen 1318 kjørte fra
+Abrahamstrup (nu Jægerspris) til Holbek.
+Af Sorg derover
+gik hun i St. Clara Kloster i Roeskilde, hvor hun døde 15de
+August 1319, tre Maaneder før Kongen.
+
+Han var Brudgom.
+O, saa straaløskjon som selve Solen
+stod han ved min Side, Glandsomgivet,
+saa jeg voved knap at hæve Hiet,
+for at mode hans henrykte Blik.
+Dage svandt da.
+Saligt svandt de, hver en himmelsk Drøm kun.
+Og jeg sad der som en Fugl i Reden,
+mens min Mage kj ærlig den omkredste,
+sad og vented Kvindens hedste Skat.
+Hjerteskatten!
+Skat med Øine som den dybe Himmel,
+Skat med Læber smaa, med bitte Hænder,
+som op efter Moderharmen række,
+som selv Hjertet let af Brystet rev.
+Sode Spæde!
+Ligger atter her Du i mit Skjod?
+Favner jeg Dig med de matte Hænder,
+pusler jeg Dig let og leger med Dig,
+stiller hver Din Længsel og Begjær ?
+Knuppen visned,
+den henvisned alt i fagrest Udspring.
+Tom stod Vuggen — Taarer væded Skjodet,
+og min Ægtemages Oie vendtes
+mørkt mod Jorden, hvor hans Yndling laae.
+
+Flere fulgte.
+Flere stod som Stjerner smaa paa Himlen
+i den maaneløse Nat og fyldte
+Huset med en Glands, som mig gjenfødte,
+som gjengav min Herre Liv og Lyst.
+Mange Taarer,
+tidlig fældede og silde rundne,
+fylde som en Vandflod Rummet mellem
+hine milde, fredopfyldte Dage
+og det Dødens Liv, jeg lever nu.
+Dog jeg seer dem,
+seer dem gjennem Taareflodens Bølger.
+Øine straale, lyse Lokker vifte,
+Rosenkinder smile, Læber aabnes,
+som de vilde nævne Modernavnet.
+Død, som barnløs,
+barnløs altid over Jorden vandrer,
+o, Du spotted med en Moders Smerte:
+En og En og En Du rev dem fra mig —
+En og En og En Du tog dem Alle.
+Tog dem Alle.
+Du tog Meer — Du tog min Husbonds Hjerte,
+saa han i sin Sorg sig mørk forhærded,
+saa han vendte bort sig fra sin Hustru —
+hun, som ham saa svage Børn kun fødte.
+
+Alle laae de
+i de smaa, de sortbetrukne Kister.
+Atter fyldte Haabet dog mit Hjerte,
+skjøndt jeg, angstbetagen, neppe voved
+det at troe, ja, voved knap at haabe.
+Eriks Øie
+hviled tvivlsomglad igjen dog paa mig,
+og som Solen bryder gjennem Skyen
+svandt hans Harm, da, lig den Første, atter
+Kongesønnen smilte i mit Skjød.
+Første! Sidste!
+Hjertets Vuggesang og Morgenlovsang!
+Ord, soin med en hellig Glands omstraale
+Den, der først os aabned Lykkens Solland,
+Den, der Afskedshvile gav deri.
+Første! Sidste!
+Atter var jeg Eriks elskte Kvinde,
+Atter sad jeg, mens, som Straaet bølger
+sagte hen for Vinden, Mindet hvisked,
+sad jeg der med Lykken i min Favn.
+Sad jeg stille,
+sad jeg der med Lykken i min Favn. —
+Svandt Du, Solglimt, eller er det Diet,
+som, af Taarers Sørgeflor omhyllet,
+ikke skimter meer Dit svage Spil?
+
+Jlf ;•
+Solen skinned
+paa hin Dag, ei Sky fordunkled Himlen:
+Svaler svang sig høit igjennem Luften
+sikkert tumlende paa lette Vinger.
+Alting taled kun om Fryd og Tryghed.
+Spænd for Karmen!
+bed min Herre; Luften styrker Drengen,
+og Danfolket glædes, uaar det skuer
+Den, til hvem det alt sit Haab har knyttet,
+Den, det vil med Fryd til Konge kaare.
+Og jeg klædte
+glad min Skat i liden Silkekjortel,
+kyssed spæde Fod og gjemte vel den,
+vikled varlig ham i guldbaldyrte
+Svøb, at ingen Vind ham skulde skade.
+Høit han lo da.
+Høit han lo, da jeg fra Karmen viste
+ham til Folket, som trindtfra tilstremmed
+jublende, mens frydefuldt mit Hjerte
+hæved sig med Tak til Himlens Herre.
+Ve! Hvad var det?
+Dødens Slaphed sank i mine Haandled,
+Rædsels Lyn mit Oie blænded — Hjertet,
+isomskabt, dog i sin Isnen vidste
+hvad der skete, selv før det var skeet.
+
+Knust!
+Der laae han
+blodig — knust mod Hjulet, knust mod Jorden.
+Alting standsed — Folkets Skrig sig reiste
+som en Mur imod mig — indelukket
+sad jeg, som i Vanvids Fangebur.
+I mit Skjød dog
+lagdes han, og end engang han sukked,
+engang end — og Alting var forbi.
+Karmen vendtes — hjemad gik det — hjemad —
+hjem med Eriks knuste Yndlings Lig.
+Laae jeg nede!
+Laae jeg tusind Favne dybt i Jorden!
+Kom med Lindring Orme der og gnaved
+Sorgens Gled ud af mit pinte Hjerte,
+Sorgens Spire af fortærte Bryst!
+Men jeg sidder
+her, hvor Levet, mæt af Sol og Regnskyl,
+skygger over mig, mens Jorden, suget
+fuld af Nattens Taarer. som end glindse
+paa fjorfaldent Lev, for mig er lukt.
+Kun to Græsstraa,
+Græsstraa smaa, som midt i Gangen opskjød,
+vifte stille.
+Jer betroer min Sorg jeg.
+O saa mildt, saa mildt, saa ukjendt med den
+bittre Smerte, staae I for mit Blik.
+
+T:Sværmeri
+F:De hørte fortælle om Kongens Søn
+SIDE:42-43
+
+I il! i
+Hils dernede!
+Bed om Plads for en usalig Kvinde!
+Hils med Eders Rodder smaa og bed kun
+om en fattig Plads for Danmarks Dronning,
+om en Plet, hvor hun kan finde Ro.
+Jeg i Drømme
+seer igjen da vel hver Hjertets Yndling.
+Jeg, naar Livets Traad er bristet, atter,
+atter hist et venligt Blik vel vinder
+af den Elskte, som mig hader nu.
+Jeg vil bie.
+Jeg vil bede, naar mit Hjerte tystnes,
+naar min Tanke samler sig, saa klart jeg
+kjender selv, hvad det saa haardt omknuger,
+bede for hans Held og for min Dud.
+
+Da bygged et Slot de blandt Roser ilon,
+der sidder nu Bruden hos Kongens Søn.
+Mens Fuglene synge, og Sol skinner klar,
+de To sidde der, det lyksaligste Par.
+
+T:Familieliv
+F:Jeg ligger i min Moders Skjød
+SIDE:43
+
+Jeg ligger i min Moders Skjød
+og .seer i min Faders Die.
+Jeg hører min Søsters Stemme sød —
+maa det mig ei fornøie?
+Min Moder er en Frue prud,
+saa rig som ingen Anden;
+hun smykker sig i grønne Skrud
+#med Blomsterstads om Randen.
+Min Fader er en Ridder stor
+— mod ham er hun en Terne —
+han spreder SolGlands over Jord,
+hans Seng er redt med Stjerne.
+Min Søster er hver lille Fugl,
+hvis Sang mig maa fornøie,
+hver Blomst, der bryder Jordens Skjul,
+saa liflig for mit Die.
+
+En Brøder har jeg sagtens med,
+han tidt besværlig falder.
+Han eder min Familiefred:
+man Menneske ham kalder.
+
+T:I Maaneskin
+F:De sad en silde Aftenstund
+SIDE:44-45
+
+De sad en silde Aftenstund
+paa Trappens kolde Sten,
+mens Skyggen dækked Engens Bund,
+og Maanen skinned ren.
+Og Skyer kom, og Skyer gik,
+de drev ad Himlen hen,
+og Maanen, dækt et Oieblik,
+fremstraaled klar igjen.
+De skulde hjem, men gik ei hjem,
+det var en sælsom Lyst,
+det var, som Maanen vinkte dem
+til fremmed Land og Kyst.
+Da skred en modig Vandrer dem
+med tunge Trin forbi.
+Han ved sin Stav gik ensom frem
+ad Nattens vilde Sti.
+
+Men med et Kuldegys de To
+hinanden tog i Favn,
+og sugte saa til sødest Ro
+i Faderhusets Havn.
+
+T:Niels Ebbesen
+F:Grev Geert han drager i Jylland op
+SIDE:45-48
+
+Grev Geert han drager i Jylland op
+med rige Riddere og Svende.
+Hvor findes i Danmark den Heltetrop,
+som Faren kan afvende?
+Hvor findes i Danmark en samlet Magt?
+Landet er halvt lagt øde.
+Til Undergang er det næsten bragt,
+skjøndt Skylden er mest hos de Døde.
+Nu deres Børn det undgjælde maa
+og de, som ei det forskylder.
+Tydsken tager, hvad han kan faae.
+Hver Rytter sin Pose fylder.
+Bondens Tag gaaer op i Røg,
+Oldinger husvilde vanke.
+Mord og Brand er kun en Spøg
+i en Landseknægts blodige Tanke.
+
+Ridderne see det med bitter Harm.
+Hvad skal de mod Fjenden gjøre?
+Hvor de kan bringe en eneste Arm,
+han tyve mod dem kan føre.
+.Norden for Randers mødtes en Dag
+Grev Geert med en Mand af de Danske.
+Men som de taltes ved om den Sag,
+den Ridder kasted sin Handske.
+„Spar Øine Trudsler.
+Jeg er ikke Den,
+der tvungen Ed Dig skal sværge.
+Du mindes det vel: Jeg kommer igjen !
+Se til Dig at værne og værge!“
+Greven sover i Randersby,
+midt i sin talrige Skare.
+Ridderen kommer foruden Sky,
+faa Svende kun med ham fare.
+Ridderen trænger i Gaarden ind;
+ved Bulderet vækkes den Herre.
+Han stirrer og blegner om solbrændt Kind:
+Mon det kan Ebbesen være?
+Ebbesen snart i hans Kammer staaer:
+Hvad hjælpe de talrige Skarer?
+Grev Geert faaer hurtigt sit Banesaar,
+og Ebbesen frelst bortfarer.
+
+Da bredte sig atter et Morgenskjær
+hen over Danmarks Rige.
+Vei baned Ebbesens brede Sværd
+for en Konge, der søger sin Lige.
+Men førend Atterdags Sol oprandt,
+laae Ebbesen under Tue.
+Han Heltedøden i Kampen fandt,
+thi Tydsken var svær at kue. —
+Og siig, hvad Frelserløn han ned
+for Seiren, han os mon vinde?
+Den Fattigste bod barn sin sidste Bid Brød,
+og Folket ham reiser et Minde.
+Aarhundreder byggedes alt derpaa,
+mens Slægter kommer og svinde;
+det bygges i Slot og i laveste Vraa,
+det bygges af Mand og af Kvinde.
+Den Mindestotte ei styrtes kan;
+det er en uslukkelig Kjerte.
+H v e r D a n sk , der e lsk e r sit F ø d e l a n d ,
+b æ r N ie ls Ebbesens Navn i s it Hjerte.
+
+T:Epigram
+F:Ingen Kvindesorg er saa stor
+SIDE:48
+
+den svinder jo bort for Beilerord;
+ingen Kvindesorg er saa ringe,
+den kan jo Taarer i Diet bringe.
+
+T:Stjernen
+F:Og dersom nu en Stjerne sank
+SIDE:48-49
+
+Og dersom nu en Stjerne sank
+til os fra Himlen ned,
+hvor faldt den vel, saa klar og blank,
+hvor valgte den sit Sted?
+Mon den igjennem klare Luft
+skjod ned i mørken Muld
+og spired op med liflig Duft
+en Blomst, saa underfuld?
+Mon den i Fuglens Rede fandt
+et stakket Ly og svang
+sig vinget op, naar Sol oprandt,
+med aldrig horte Sang ?
+
+Mon den sank ned i selvblaa Hav
+og blev en Perle ren,
+saa kostelig, at Kongen gav
+for den hver Ædelsten?
+O nei! Den kom, useet og tyst,
+til Stevets faldne Son
+og gjemte sig i sorgfuldt Bryst
+og blev en ydmyg Bon.
+Og blev en Længsel, stærk og stor,
+der sprængte Syndens Baand,
+et Forsæt, der opsvang fra Jord
+den dybtnedtrykte Aand.
+Og hvilte der med stille Magt,
+imens han Kampen stred,
+og dulgte der sin Straalepragt,
+mens han mod Maalet skred.
+Men med hans sidste Suk den foer
+— et saligt Stjerneskud —
+mod Himlen op fra dunkle Jord
+og bar hans Sjæl til Gud.
+
+T:Præstens Søn
+F:Tre Piger stode og hviltes ved
+SIDE:50-57
+
+Tre Piger stode og hviltes ved
+det Landsbyled,
+det Landsbyled efter Qveld.
+De skulde hjem, men gik ikke hjem;
+det var, som Stedet fængslede dem
+— og Grunden kjendte de selv.
+De dæmrende Stjerner faae større Glands,
+mens som til Dands,
+til Dands beredte de staae.
+Da gaaer med lokkende Flagerflugt
+et Stjerneskud over Himlen smukt,
+og Pigernes ønsker det naae.
+Men inderligt ønske de Hver især,
+skjøndt En og Hver,
+ja, Hver bar kun samme Bøn:
+„Før Aar og Dag han som Beiler staae;
+om Alt han bede, og Alt han faae,
+den Eneste, Præstens Søn!“
+Med Blussen og bankende Hjerte de
+det Varsel see,
+det Varsel om Fremtids Lyst.
+
+Med lenlig Fryd vil nu Hver gaae hjem;
+da drager der Noget ad Veien frem,
+hvor den dreier mod tangklædt Kyst.
+Det skrider tyst og tungt og sort
+ad Veien fort,
+ad Veien mod Landsbyen ned.
+Den dæmpede Mumlen, de tunge Trin
+fremhæres af Nattens sukkende Vind,
+mens Toget drager afsted.
+Du rige Christ! En Baare! Se!
+O Ye! O Ve!
+O Ve! Her Klager og Ben!
+En Druknet! en stakkels Fiskers Lig!
+De arme Folk! Hvem er det? Sig:
+— „Præstens eneste Sen.
+Imorges han heiste sit Seil med Sang,
+som vidt henklang,
+henklang over skinnende Vig.
+Saa styred han bort, da Sol oprandt.
+Mod Aften hans kæntrede Baad vi fandt
+og fandt ham selv som et Lig.“
+Da synker en Taage for Pigernes Blik.
+De stille gik,
+gik stille Hver til sit Hjem.
+
+Med skjælvende Hjerte, paa vaklende Fod
+de suge til Sengen, saa taus og god,
+og der styrte Taarerne frem. —
+Tungtskridende Tid har i sit Fjed
+tidt Trosten med,
+tidt Trosten saa tæt i sit Spor.
+For Nodderne modne af Haslerne faldt,
+har Smedens Datter en Beiler alt,
+og Jubel i Hjertet boer.
+En Fremmed var han kommen did.
+Hver Aften blid,
+hver Aften i Lunden de gaae.
+Dog se! Engang, efter sedest Lyst,
+laae hun ded med en blodig Plet paa sit Bryst.
+Men ham ei mere man saae. —
+Det lider stærkt mod Juletid;
+den Fest saa blid,
+den Fest saa blid rykker nær.
+Og Alle har travlt,-men Degnens mest;
+der redes med Fryd til dobbelt Fest,
+til Bryllup for Datteren kjær.
+Der kom en Gjæst fra den store Stad,
+og Pigen glad,
+saa glad til den Fremmede saae.
+
+Nu bindes der paa hendes Brudekrands,
+Fiolerne stemmes alt til Dands:
+imorgen skal Bryllupet staae.
+Den Morgen kommer.
+„Vor unge Brud
+vil sove ud,
+vil sove, men ei hun faaer Fred.”
+De Piger i Kamret finde et Lig,
+og Alle hidile ved deres Skrig.
+Kun Brudgommen kommer ei med. —
+Fra Himlen nedstraaler den blanke Sol,
+og bly Viol,
+Viol staaer i Græsset dulgt.
+End Mollerens Datter saa kummerfuld gaaer.
+Den Svend, hendes Fader fæsted iaar,
+har lonligt dog efter fulgt.
+Forst hores neppe hans stille Bon.
+Hos Præstens Son,
+hos ham hendes Sjæl kun er.
+Men snart bortglider hans Billed svagt;
+for Somren end staaer i fuldest Pragt,
+har alt hun den Anden kjær.
+Og Bryllupet feires med Sang og Klang.
+Den Dag saa lang,
+
+De sidde ved Aften om Brudebord;
+da føler Bruden en Længsel stor,
+som dreves bun ud i det Frie.
+Da Tumlen voxer, hun lister sig ud.
+Han følger sin Brud,
+han følger af festsmykte Hus.
+Men inde med Latter og Skjæmteord
+de Gjæster dem savne og ønske i Chor
+Godnat ved de klinkende Krus.
+Saa solklar oprinder den næste Dag.
+Med lunt Behag,
+Behag alt den Moder staaer
+for Kammerets Dør.
+Den er lukket fast.
+Hun banker saa skjælmsk, hun banker med Hast,
+men intet Svar hun dog faaer.
+Da gribes hun af en isnende Skræk.
+Hun iler væk,
+Hun ilsomt faaer Manden derhen.
+Han sprænger ihast den lukte Dør:
+Kamret er tomt, og opredt som før
+Staaer Sengen, som vented den end.
+Der ledes i Have, i Hus, paa Loft,
+i Mark og Toft,
+i Mark og Toft og ved Kjær.
+
+Den hele Landsby gaaer søgende med;
+Unge og Gamle fare afsted
+i vildforstyrrede Færd.
+De gaae forbi den Kirkegaard,
+og Skaren staaer,
+staaer stille med gruende Sind.
+Hvad skinner saa hvidt paa Graven hist?
+Hvad skinner bag Bosenbuskens Qvist,
+som vugges i Sommervind?
+Med halvlukket Øie, med halvaaben Mund
+hun fin og rund,
+rund ligger i dybeste Blund.
+Krandsen hænger i Haaret lost;
+en Blodplet sees paa letblottede Bryst
+men et Smil om farvelos Mund.
+Moderen kaster sig med et Skrig
+over elskte Lig,
+trykker Liget fast til sit Bryst.
+„Mit Barn! hvad vil Du hos Præstens Søn?
+Har ei Du længe nok grædt iløn,
+og fandt Du tilsidt ikke Trøst?“
+Men Skaren udstøder et skingert Skrig.
+Den styrter sig,
+sig vildt mod omfredede Høi.
+
+Med Spader, med Skuffer, med Hænder man grov,
+Op heises Kisten i hidbragt Tov.
+Da stilløs den summende Støi.
+Den aabnes
+Med Rædsel Enhver nu seer
+jordfæstede Leer,
+jordfæstet alt for et Aar.
+Men i den gulnede Skjortes Flig
+halvfrisk en Urtekost dølger sig:
+den smykkede Bruden igaar.
+Tre Guldringe glimre paa Fingerled.
+Dem fik han ei med,
+ei med i sin tidlige Grav.
+Saa Mange kjende de Ringe smaa.
+Paa Jomfruhænder man før dem saae:
+Hver sin til en Beiler gav.
+„Ham er det! Præstens Søn! Han brød
+sin Grav, og død,
+død søgte han Livets Lyst.
+En Pæl i hans Hjerte!
+Vi give ham Fred!
+En Pæl! Vi ham mane i Jorden ned,
+hvor Ormene blive hans Trost.“
+„Holdt!“ lyder det.
+Præsten iblandt dem staaer.
+Hans hvide Haar,
+hans Haar er som reist af en Vind.
+
+Med brændende Oie, med udstrakt Haand
+han staaer der, en bydende Gravens Aand,
+med dødningblegeste Kind.
+Han træder op paa klumpede Muld,
+som dækkede huld,
+saa huldt hans aarsavnede Fryd.
+Han stirrer paa Kisten til sidste Farvel
+og læser en brændende Bon for hans Sjæl,
+Men trindtom hores ei Lyd.
+„I lægge nu Bruden i Brudgoms Favn,
+i Jesu Navn,
+i Jesu Navn sænk dem ned.
+Men dybt I grave!
+Om Dage faa
+skal min trygtgjemmende Kiste staae
+paa deres, saa faae de vel Fred.“
+Graven er kastet, og med et Blik,
+der til Hjerte gik,
+til Hjerte gik Alle, sin Arm
+han rækker skjærmende over den.
+Saa synker han selv saa stille hen,
+bortsovet fra Livets Harm.
+Om Dage faa hans Kiste stod,
+en Vogter god,
+en Vogter god hos de To.
+
+Snart vandt sig om Graven et Blomsterflor
+men dybt under Tuen kun Søvnen boer
+og j ordforglemmende Bo.
+
+T:Den Første
+F:Snart vandt sig om Graven et Blomsterflor
+SIDE:58-59
+
+U ød og borte,
+gjemt i Jordens Skjød, det dybe sorte,
+gjemt for evig er mit Hjertes Skat.
+Yel jeg kjender
+Livets Lov; hun ei tilbagevender.
+Dog jeg lønlig leder Dag og Nat
+Fra det Fjerne
+som en lille, halvtilsløret Stjerne
+lokker mig Dit Blik, i Døden slukt.
+Og jeg stirrer,
+til min Tanke sælsomt sig forvirrer:
+Nei, det Die kan ei være lukt.
+Jeg maa lede.
+End paa Jorden findes vel min Glæde;
+gjemt den græder i en ussel Vraa.
+Børn der findes.
+
+Aldrig dog min Skat tilbagevindes —
+aldrig Dig jeg blandt de Mange saae.
+Huset fyldes.
+Alt, hvad Hjertet eier, bort alt skylløs,
+mens Du smuldrer i Din lille Grav.
+Bryd Dit Gjemme!
+See, Du ventes der, hvor Du var hjemme!
+Alt er Dit, om Alt end bort jeg gav.
+Kom saa lille,
+kom saa spæd en Aften mørk og stille,
+gjem Dig i en Kurv alt for min Dør.
+Naar Du vender
+Diet mod mig, strax mit Barn jeg kjender,
+og jeg bliver glad, som aldrig før.
+Slutte? Glemme?
+Nøies? — Nei, jeg vil min Tanke gjemme,
+men saa trygt jeg venter Dig endnu.
+Glad ved alle
+dem, som sødt mig monne Moder kalde,
+higer dog mod Dig min Længselshu.
+
+T:Spændt og Slapt
+F:Gamle Kvinde, Du, som sidder bøiet dybt mod Jord
+SIDE:60-61
+
+Oamle Kvinde, Du, som sidder bøiet dybt mod Jord!
+Seger Du i Muldets Furer tabte Tiders Spor?
+Staaer, usynlig for mit Die, Fædrenes Bedrift
+der indristet, og Du tyder tro den gamle Skrift?
+„Vel jeg grubler, vel jeg seger, men end ei jeg fandt.
+Seger efter Spor af Blodet, som i Jord nedrandt.
+Strækker efter Kampens Frugter ud min tomme Haand,
+seer og favner dog kun Savnets blodløslede Aand.Ci
+Kampen, Kjære? Ak, for Sløsvig! — Det en Hæder var,
+og Forsonlighedens milde Frugter den jo bar.
+Ja, ved Isted faldt min Brøder. Krandset paa min Væg
+hænger han hos Preusens Fredrik, han med Storheds
+Præg.
+„Og ved Isted faldt min yngste, faldt min sidste Sen,
+mens den anden nær ved Sløsvig slumred alt i Len.
+Levedækt og grensværgjemt kan Begge slumre sedt,
+men jeg seer ei Frugt af Blodet, varmt og ungt og redt.„
+Freden, Kjære! Næringsfrihed, Sjælens sunde Bo,
+saa i Hus med fordums Fjender vi velvilligt boe.
+Tillid til den Magt, som styrer, Haab for Danmarks
+Held,
+rolig Nyden af det Givne, sit og Andres Vel.
+
+..Andres Vel? Er Danmark trygt end — gid det være
+saa! —
+andetsteds dog Frihedskampens røde Bølger gaae.
+Lidt vi vistnok kunde gjøre! Om end Blodets Guld
+spares maa, vi Sølvets Bistand række dem saa huld.“
+Sværme Kvinder nu for Polen? Ak, Du gammel er!
+Danmarks fagre Døttre har kun Nordens Ungdom kjær.
+Polen! Ja, var selv jeg falden — som let kunde skeet —
+i Begeistring! Men at nødes — nei, der blev Du Beet.
+„Fremmed er mig hver Din Yttring, fremmed hvert
+Dit Ord.
+Svandt da, hvad med Savn jeg søger, sporløst hort
+fra Jord?
+Sluktes Flammen? Løstes Aanden op i Veir og Yind?
+Blev Livskilden til et Springvand for barnagtigt Sind?“
+Yil man see! Du drev nok gjerne mig til storslaaet
+Daad?
+Smile maa jeg, nægter dog ei Bistand Dig og Baad.
+Kjøb for dette Tremarkstykke Caffe og Tobak.
+Vil Du ikke, nu, saa kast det hen til Din Polak. —
+Kvinden seer paa Tremarkstykket; Lidt hun eier kun.
+Paa sit Bryst dog end en Mynt hun bærer, stor og rund.
+Prismedaillen! Hendes Søn, som under Løven sov,
+vandt som Kunstner jo saa tidligt første Løn og Lov.
+
+JWSiRMIrøfMi
+Begge Mynter hun indsvøber, bærer saa dem hen,
+krammer end saa fast med Haanden Hjertets gamle Ven.
+I Brevkassen ned de synke, klinge dump mod Bund,
+og hun M er det til Afsked dybt i Hjertets Grund.
+Men da Maanen klar og rund hun seer ved Aftentid,
+fyldes hendes gamle Øie af en Taare blid.
+„Snart med begge mine Sønner skal jeg sammen boe.
+Jeg har gjort det Lidt, jeg kunde. Himlen give Bo. ‘-
+
+T:Prøven
+F:Jeg under Tøflen
+SIDE:62-70
+
+D er skjænkes Yin, der skjænkes Mjød,
+og Borgens Herre staaer
+med Smil om Mund, med Krus i Haand
+ved Skaalen for den Lilievaand,
+der blev hans Hustru sød.
+Der skjænkes Mjød, der skjænkes Vin —
+fra Bord det driver ned —
+og Borgens Herre, vild i Hu,
+mod Kongegjæst sig vender nu,
+fremtrædende et Trin.
+
+„Jeg under Tøflen?
+Yel saa hør,
+— og Ed er hvert mit Ord — :
+Forlang hvad Prøve selv I vil,
+og kan I vinde dette Spil,
+min Hustru Jer tilhør. “
+„Hans Æresord!
+I Vidner er!“
+udraaber Kongen brat.
+„Jeg bryder af min Krones Guld
+den bedste Sten, af Straaler fuld.
+Den er min Indsats her.
+Stort er det, hvad her spilløs om,
+og Spillet være stort.
+Et Aar med hver en Hjerteqval
+Din Hustru Du hjemsøge skal,
+da fældes hendes Dom.
+Og hvis da hendes Haand saa fin
+end holder fast, hvis hun
+til Modstand aldrig ægges op,
+da staaer Du stolt paa Seirens Top.
+Hvis ikke — er hun Min.“
+En Gysen gjennem Kidderen gaaer.
+Det drukne Mod forsvandt.
+Men hvert et Blik han stirre seer,
+mens Kongen staaer og lialvveis leer
+og han hans Haandslag faaer.
+
+„Nu mine Mænd!
+Op og afsted,
+at Intet robes her.
+Og Du, min Ven: En rolig Nat.
+Din Ære har i Pant Du sat,
+Dit Ord jeg tager med “
+Den unge Yiv saa huld og om
+sin Husbond træder nær.
+Den Haand, hun let paa hans har lagt,
+han kaster vredent bort med Magt.
+Mon det vel er en Drøm?
+Hvert Ord, hun siger, er nu galt,
+og hendes Taushed Trods.
+I hvor hun staaer, i hvor hun gaaer,
+hun Utak kun for Alting faaer;
+dog bærer mild hun Alt.
+Forst sogte hun med kjærlig Bøn,
+med sode Elskovsord
+at hoie hans forvendte Sind.
+Da blev han som en Hvirvelvind.
+Nu græder hun ilon.
+
+Men Kongen sender Bud og Brev:
+„Har Du Din Ed forglemt?
+Du staaer jo som en Bidder prud,
+har kun een Hustru og een Gud.
+For veegt Du Sagen drev."
+Da vender han med opbragt Hu
+sit Blik mod Terners Flok.
+En kjen, en næsvis lille Ting
+han giver Spanger, giver Bing,
+hun er hans Guddom nu.
+Han tager Sioret af sin Yiv
+og hendes Hovedguld.
+„Den Skjenneste det hører til.
+Du skjæmmer, hvad Dig pryde vil;
+her blomstrer Lyst og Liv."
+Men Kongen sender atter Bud:
+„Hvor er Din svorne Tro?
+Biv hendes Barn fra hende bort,
+saa kommer hendes Taal tilkort."
+Han seer ad Yindvet ud.
+Da Kongen sidst var der som Gjæst,
+stod Som’ren i sin Pragt.
+Nu drysser Sneens hvide Dun
+og dækker Jorden til saa luu.
+Nu kommer Julens Fest.
+
+„Pak Drengen til.“ — Hvad skal min Dreng?
+— „Han er kun til Besvær.
+Han fjernes skal.“
+Lad ei det skee!
+Jeg døer, skal jeg om Natten see
+hans tomme lille Seng.
+„Den flyttes kan.“ — Saa sæt det ud!
+Se Sneens kolde Fnug!
+„Yæk skal han.“ — Lad mig følge med!
+Kun med!
+Og Eders Kjærlighed
+jeg prise skal for Gud!
+For førstegang han fuldt nu seer
+den blege, svundne Kind.
+En Gysen gjennem ham vel gaaer,
+men ubønhørlig Æren staaer:
+Han vender sig og leer.
+De Græsstraa smaa med spædest Magt
+beseire mørke Muld.
+Da faaer han Brev: „Lyv Drengen død:
+Paa Reisen blegned Kinden rød!
+Besind Dig paa vor Pagt.“
+Han krammer Brevet i sin Haand
+og stirrer vildt til Jord.
+De Græsstraa bringe ham en Trøst:
+„Snart kommer Som’ren med sin Høst;
+da brister Pagtens Baand.“
+
+Men ved hans Budskab Kvinden staaer
+som Marmorstotte stiv.
+Hun vakled, og til Jorden ned
+hun sank i Dødens laante Fred.
+Dog vaagned hun til Liv.
+Hun tæt laae trykket til hans Bryst;
+hans Die skinned vaadt.
+Han satte Drengens Liv paa Spil:
+Det mindes hun, og troste vil
+med Blik og brudte Bost.
+Men som af Vanvid slagen nu
+han stoder hende hort.
+Med knyttet Haand han styrter ud
+og truer selv ad Himlens Gud,
+der taaler slig en Gru.
+Men end et Brev fra Kongen kom:
+„Har Du Din Ære glemt?
+Hun lever høit som Bidderviv:
+Forstødt hun bjerge selv sit Liv.
+Saa kan der fældes Dom.“
+Han seer sig om med uvist Blik.
+Men Helveds Fyrste staaer
+Bi paa hans Vei.
+Og Æren fræk
+betvinger den alt vakte Skræk.
+— Den sidste Offer fik.
+
+Forstødt hun gaaer fra Borgen ned.
+Paa Vindelbroen end
+hun vender sig med udstrakt Haand
+og beder Fredens milde Aand
+omsvæve dette Sted.
+Hun standser først i dunkle Skov;
+Hun sank til grønklædt Grund.
+Med slappet Haand og henstrakt Fod
+hun hviler tæt ved Egens Bod.
+Der laae hun, som hun sov.
+Og Kongen snart for hende staaer:
+„Jeg elsked længst iløn.
+Se, Kronen vinker!
+Følg mig nu.“
+Hun støder bort hans Haand med Grif,
+og intet Svar han faaer.
+De Nonner kom med Trøstensord
+vil føre hende med.
+Hun følger ei.
+Hun bygger sig
+af Qvas en Hytte skrøbelig.
+I Skoven nu hun boer. —
+
+Men Prøvens Tid udrunden er,
+og Kongen, gram i Hu,
+har brudt af Kronens rode Guld
+den blanke Sten, af Straaler fuld,
+et Hertugdom vel værd.
+Hun sidder mat ved Egerod,
+de Nonner troste vil.
+Men tabt i Drømme stirrer hun
+kun ind i Skovens dunkle Grund,
+som hun dem ei forstod.
+Da glimter det bag Skovens Træer;
+hun blinker mat derved.
+En smykket Skare nærmer sig,
+men forrest gaaer, bleg som et Lig,
+Den, hun ei dromte nær.
+Han træder saa tvivlraadig frem.
+Med Magt han fatter Mod.
+Han knæler ned, med boiet Aand,
+og kysser hendes tynde Haand
+og hendes nogne Fod.
+Han fatter sig.
+Han tager frem
+en Sten saa straalefuld.
+
+Han lægger den i hendes Skjød
+og blusser atter, stolt og rud:
+„Min Brud! Følg nu mig hjem.
+Jeg elsker Dig.
+Jeg elsked steds;
+Din Dreng er ikke død.
+En Prøve var det.
+Snart Du staaer
+med Kongesten i dunkle Haar,
+den Første i Din Kreds. “
+Hun, mens han taled, langsomt sig
+har reist saa rank og stiv.
+Hun aabner Læhen, tier dog,
+mens Diet taler sælsomt Sprog,
+som leved op et Lig.
+Han fører hastigt Drengen hen,
+men ei til ham hun seer.
+Hun slaaer med begge Hænder bort
+sit lange Haar og stirrer fort.
+Da blegner han igjen.
+„Det sorte Skrud! Det hvide Lin!“
+udbryder hun med Magt.
+„Skjær Haaret af! Og bring mig hid
+en Pandeskal, saa ren og hvid!
+O Død! Nu er jeg Din.“
+
+De Nonner Kreds om hende slaae;
+hun synker dem i Favn.
+saa gaadefuldt blev hendes Blik,
+mens svagt et Suk fra Læben gik,
+og som et Lig hun laae. —
+Han vidt til fremmed Land drog hort,
+og Drengen arved Alt.
+Men heit ved Træets hule Gren
+i Beden Kongens Ædelsten
+blev gjemt af Bavnen sort.
+
+T:Glæde i Sorgen
+F:De glade Venner kalde Dig
+SIDE:71-72
+
+(Efter G o e th e .)
+Hvorfor er Du bedrevet dog,
+mens Alt er lyst og let?
+Paa Øine Øine seer jeg det:
+Du har jo nylig grædt.
+Og har i Enrum og jeg grædt,
+saa lad kun mig derom.
+Mens Taaren randt, til Hjertet der
+dog sedt en Lindring kom.
+
+De glade Venner kalde Dig.:
+O, kom dog til vort Bryst!
+Og hvad Du end kan have tabt,
+hos os Du finde Trost.
+I larmer om og aner ei,
+hvad Kval jeg lønlig bær.
+Ak nei, jeg har ei tabt det, skjondt
+saa tungt end Savnet er.
+Saa tag Dig sammen da med Kraft,
+Du er saa ungt et Blod;
+og Meget sig tilkæmpe kan
+det første, friske Mod.
+Ak nei, tilkæmpes kan det ei,
+jeg kan det aldrig naae.
+Det dvæler høit, det straaler klart
+som Stjernen i det Blaa.
+Men Stjerner vække ei Begjær
+med deres Straaløskat.
+Saa henrykt seer til dem man op
+i hver en lysklar Nat.
+Og henrykt seer vel jeg og op
+saa mangen signet Dag.
+
+Lad mig hengræde kun hver Nat,
+til selv jeg standser svag.
+
+T:Haab og Frygt
+F:Jeg misted saa Mange af mine Smaa
+SIDE:73
+
+Jeg misted saa Mange af mine Smaa,
+Jord dækker de lukkede Øine blaa,
+Jord dækker de sode smaa Hænder.
+Skal atter jeg prove i Angst og i Nod?
+Skal atter jeg kæmpe paa Liv og paa Død
+for den høieste Lykke, jeg kjender?
+En sværtynget Lykke omsnoet af Besvær,
+herendt og beleiret af Sorgernes Hær,
+omklamret af Uro og Moie.
+En Lykke som Solglimt paa skyggede Bund,
+saa lille, saa liflig paa dunkiere Grund,
+et Jordsmol, men født i det Hoie.
+Og om hun nu fulgte de Smaa, som gik hort,
+om Skrinet sig lukked saa snævert og sort
+over den, som mit Hjerte hegjærte?
+Hvad tor jeg vel haabe, hvad skal jeg vel troe?
+Hu Trivselens Herre, omstæng Du mit Bo,
+bevar mig for Femtedøds Smerte!
+
+T:En Hjertesorg
+F:De sagde, jeg var som Guld saa god
+SIDE:74-76
+
+D e sagde, jeg var som Guld saa god,
+kun med lidt heftigt Sind.
+De roste mig, hvor jeg gik og stod,
+og smilte kun, naar det vilde Blod
+pludseligt farved min Kind.
+De elsked mig Alle, hvorfor veed Gud;
+forgjæves jeg speider om Grund.
+Fra Vuggen og til jeg tidligt stod Brud,
+jeg hørte kun Kjærligheds bønlige Bud.
+Det dyssed min Vildskab i Blund.
+Og Han var langmodig og øm og mild;
+hans Lige ei fandtes paa Jord.
+Fem Børn jeg ham fødte.
+End et kom til.
+Det lignede mig, med Blodets lid;
+det voldte mig Marter stor.
+Jeg veed ikke selv; men bestandig han skreg
+og trivdes dog prægtigt derved.
+Saasnart jeg et Skridt kun fra Vuggen veg,
+naar Søvnen sig over mit Oielaag sneg,
+han vaagned — og endt var min Fred.
+
+De priste min Taalmod, og selv jeg fandt
+imellem, at den var stor.
+Alt fastere det mig til Barnet bandt;
+hvert Smil af ham var en Seir, jeg vandt:
+Han smilte jo kun til Moer.
+En Nat da var jeg saa dødsens træt,
+men dobbelt just Drengen skreg.
+Jeg bed ham Brystet, men han var mæt.
+Jeg pusled om ham og vuggede let,
+mens til Vanvid min Søvntrang steg.
+Mit Øie sank til, men han vaagnede vred;
+da brast min Taalmodigheds Traad.
+Vildt vuggede Haanden.
+Mit Hoved sank ned
+paa Puden.
+Snart sov jeg i dybeste Fred
+ved den end selvgyngende Baad.
+Jeg reiste mig brat ved en Lyd saa sær;
+jeg grebes af Morgenens Kuld.
+Daggryet kæmped med Lampens Skjær.
+I Vuggen laae Drengen blaafrossen her,
+og Pude og Lagen paa Gulv.
+Nu skreg han ei mere; han peb kun saa smaat.
+Tre Dage han laae i mit Skjød.
+Da rysted ham Krampen; hans Ansigt blev blaat.
+De sagde mig, Gud bavde gjort det saa godt.
+Men jeg saae, at Drengen var død.
+
+Paa Kirkegaarden er redt en Seng,
+der vugges ei Dynen af.
+Der sover min lille, min elskede Dreng.
+Men i mit Hjerte der brast en Streng:
+Jeg graved hans tidlige Grav.
+D u stækkede Fugl!
+I Markfuren skamfuld Du søge Dig Skjul.
+Engang Du henbruste paa Vingerne brede,
+engang Du vel vidste at værge Din Rede.
+Nu hælvtes Dig Reden, halvrantes Dit Kuld,
+Du stækkede Fugl!
+Hvordan gik det til,
+at Æren selv tabtes i blodige Spil?
+Hvor slængte Din Fortid Du hen, før Du kunde
+med Skjændselens Spindelvæv stille Din Vunde?
+Ei Stormod der var, selv ei Dødskampen vild.
+Hvordan gik det til?
+Dog, skeet er nu skeet.
+Yor Yaade og Vaande har Alle jo seet.
+
+T:(1865)
+F:I Pris er vi sunkne
+SIDE:76-77
+
+I Pris er vi sunkne.
+Med nedslagent Die
+vi under Forsmædelsens Vægt os maa bøie.
+I Skjændselens Fylde der fattes kun E t :
+At bære den let.
+Hvad gjor vi vel nu,
+at bode vort Tab og at mildne vor Blu?
+Hvad gjor Du, o Fugl med de stækkede Vinger,
+som aldrig med Seir vel Dig mere hjemsvinger?
+Med Tomhed i Hænde og Tabet i Hu,
+hvad gjor Du vel nu?
+Til Ungerne smaa,
+dem, Voldsmanden levned, Du vende Dig maa;
+ad Sandhedens Veie Du fore dem stille,
+Du lære dem kunne, Du lære dem ville,
+Du lære dem Flitter og Tant at forsmaae —
+saa vil det vel gaae.
+Saa vil det vel gaae,
+og langsomt vil Danmark af Dyndet opstaae.
+En Slægt vil da komme, som kraftigt kan virke,
+ei lefle med Saga og selvlavet Kirke,
+en Slægt, som med Selvfrygt for Himlen kan staae,
+— en Slægt, som kan slaae.
+
+Eventyrdigte.
+
+T:Fuglen
+F:Min Datter saa lille! Min Datter saa prud
+SIDE:78-86
+
+„Min Datter saa lille! Min Datter saa prud!
+Tag glad mod et glædeligt Ord.
+Dig fandt jeg en Moder, mig fæsted jeg Brud.
+Snart Lykken iblandt os nu boer."
+„Min Konge og Fader! Mig lystes ei ved
+den fremmede Moder at faae.
+Nei, giv mig den Guldring, saa blank og saa bred,
+som tidt bos min egen jeg saae.“
+Han sukker og henter det rundede Guld,
+for vidt end til trindspæde Arm.
+„Og hviler i Jorden Din Moder saa huld,
+Din Pias er dog næst ved min Barm." —
+„Min Herre og Husbond! Hun hører mig ei,
+Din Datter, saa stiv og saa sær.
+En King har hun ranet, den tilkommer mig,
+thi Dronningesmykket den er."
+„Du Terne, jeg tog til min Seng og mit Bord,
+Du lade min Datter med Fred.
+Thi krænker Du hende, selv kun med et Ord,
+skal tifold Du lide derved."
+
+Saa gik der en Tid, og det Kongebarn stod
+som frisk, knopspringende Mø.
+Men Dronningen var hende aldrig god,
+hun lured, som letfrosne Sø.
+Hun listed og lured, men snakked saa blidt;
+hun skjulte sit brændende Nag.
+For Faderen roste hun Datteren tidt.
+Da strøg han sit Skjæg med Behag. —
+„Min ædelig Husbond;
+Følg med i det Frie.
+Se Skyens guldkantede Rand. — “
+„Saamænd.
+Efter kongelig Daggjerning vi
+nu vandre ved svalende Strand. “
+„Ved Stranden? Der er jo saa tomt og saa bart.
+Nei, følg i den løvgrønne Lund.
+Der spiller end Solstraalen lifligt og klart,
+der ville vi tøve en Stund. —
+Min Konge! Se Blomsterne tæt for Jer Fod,
+se — ty s! Eders Datter det er.
+Hun hviler i Græsset, den Rose saa god.
+Kom! Sagte vi liste os nær.“ —
+Paa blomstrende Tue to Elskende sad
+blandt Skovens høitvoxende Straa;
+han holdt hendes Hænder, mens, straalende glad,
+hun ind ham i Øinene saae.
+
+Han sukked: „Hvor tør dog jeg fattige Svend
+berøre Din Kjortelflig blot?“
+hun slaaer om hans Pande sin Guldfletning hen
+„Saa keiser jeg Dig til min Drot.“
+„En Jæger!“ henaander med døende Røst
+den Dronning; men Faderen bleg
+med knyttede Haand og arbeidende Bryst
+staaer lænet til knudrede Eg.
+Som skræmmede Vildt nu de tryggeste To
+opspringe. Med knugende Haand
+hun holder ham fast, mens, i dødstrodsig Ro,
+han venter paa Lænker og Baand.
+Han venter ei længe. Blandt Tudser og Kryb
+han kastes i stinkende Hul.
+Men høit over mørke og muddrede Dyb
+hun sidder bag Laasen af Guld.
+Og Dronningen haangridsk nu for hende staaer.
+Den Jomfru sig reiser saa rank.
+„Ja, kunde Du skaffe os ensartet Kaar,
+saa fik Du vel Guldringen blank.
+Jeg fordrer ei Syn, og jeg fordrer ei Ord,
+ei Hilsen, ei Samværens Duft,
+kun eens for os Begge! Mig qvælende Jord,
+eller Ham livsqvægende Luft.“
+
+Og Dronningen tigged, og Dronningen bad,
+hun tirred, hun dulmed igjen.
+Hun vendte hans Kj ærlighed Hælvten til Had,
+hans Had slog Hælvten hun hen.
+To Taarne heelt op i de svimlende Skyer
+blev hygget, der skulde de boe.
+Hvor Rovfuglen flyver, og Duen kun flyer,
+sad ensomt de livsfangne To. —
+Da Fængselsdoren slog i med Knald,
+hang ned til Knæ hendes Haar.
+Nu naaer det med biede og belgende Fald
+fast Gulvet, hvorover hun gaaer.
+Hun stryger det hort, mens, tung i Sind,
+hun stirrer ad Yinduet ud.
+Da flyver saa lille en Fugl derind;
+dens Yinge var ramt af et Skud.
+Hun pleier den ivrigt.
+Men dee den maa.
+Den vædes af Taarernes Daah.
+Da taler den sagte og skjælvende saa:
+„O Jomfru! Jeg bringer Dig Haah.
+Hvi sygner saa hen Dit unge Liv
+her i det ensomste Bur?
+Dig lokker Forvandlingens skabende: Bliv!
+ud i den friske Natur.
+
+Du lægge to Fjer af min Vinge kun
+i Kors paa Dit Jomfubryst.
+Saa bliver Du Fugl i samme Stund,
+kan frit flyve bort med Lyst.“
+Den døde.
+Hun trykker med Haab og Gru
+det Fjerkors til Brystet fast.
+Da blev hun en Fugl, og med Længsels Hu
+hun floi til den Elskte ihast. —
+Han støtter sit Hoved til Gitterstang:
+„Hvor lider den Kongemø vel?
+Mon hun sidder fangen den Dag saa lang?
+Mon hun fortærer sin Sjæl?“
+Han standser.
+Med lokkende Jægerlyst
+han seer nu den flagrende Fugl.
+Han udstrækker Haanden saa tavst, saa tyst,
+og snart sidder der den i Skjul. —
+For Dronningen staaer den Slutter tvær;
+„Min Kongefange forsvandt.
+Der har Du de Nøgler, og jeg er her.
+Jeg veed, mit Hoved er Pant.“
+„Du file de Stænger.
+Vi sige saa,
+at selv hun styrted sig ned.
+Dog tie vi helst, mens vi kan og maa.
+Saalænge har man da Fred.
+
+Dog, hvad hende dyhest krænke kan,
+skal hun spørge, ihvor hun drog hen.
+Din Datter er smuk.
+Du sende paastand
+Din Datter til Jomfruens Ven.
+Hun listelig tale om Bryllupsfærd,
+om Dronningekrone saa skjon.
+Hun dolge kun svagt, at hun ham har kjær,
+der hensukker sit Liv uden Løn.“
+Og Pigen betænksom til Yærket skred.
+Kun af Yanvare robed hun Alt.
+Yel vidste hvert Barn og hver Bonde Besked
+Ham — vilde hun ei det fortalt.
+Men Jægeren sætter sin hvide Tand
+i Læben og vender sig hort.
+„Hun vinder en Krone, hun vinder et Land-,
+her maa vel jeg komme tilkort."
+Yel Fuglen udbryder i skj ærende Skrig,
+den pikker hans Haand og hans Mund.
+Han sidder saa stille, saa støbt som et Lig.
+Hans Hjerte frøs sammen til Bund.
+Tre Dage saaledes han klagelos sad.
+Han reiser sig mørk nu og mat.
+Men Slutterens Datter ham venter med Mad,
+har ei ham i Sorgen forladt.
+
+Hun smaasnakked jevnligt, skjendt bly som en Brud.
+Tilsidst hun dog muntred ham lidt.
+Da lyder ham pludseligt kongeligt Bud:
+„Vælg Hustru, saa bortgaaer Du frit.“
+Hun rodmer og skjælver ved Ordet, som hun
+ham bringer.
+Han drager sit Veir
+som Spanden fra Dybet. „End gronnes vel Lund
+til Jagt, har Du Jægeren kjær.“
+Da styrter sig Fuglen med hakkende Næb
+med Angestens Skrig til hans Bryst.
+„Ferst dræbe mig!” raaber den til ham.
+”0 dræb!“
+Han hører kun klingende Røst. —
+”Nu hurtig min Slutter! Du Tavse! Du Tro!
+Nu rask, min velpyntede Brud!
+Naar Kirken tilsammen har givet de To,
+da drages i Frihed han ud.
+Saa svor mig min Herre.
+Vel Datterens Aand
+Dit Bryllup skal beie. Nu flink!"
+Hun hilser til Bruden med naadige Haand
+og til ham med haanglimtende Blink. —
+Den blussende Brud sidder opreist og rank
+i Sengen.
+Paa Gulvet han staaer.
+„Og om end Lyksalighedsfartøiet sank,
+man derfor ei strax dog forgaaer."
+
+„O glem det, Du Søde!“ hun sukker saa øm.
+Han seer sig i Kammeret om.
+Alt er mig saa fremmed, Alt er som en Drøm.
+„Min Fugl! Naa, Du med mig da kom.“
+Han nærmer sig Sengen.
+Men Fuglen udslaaer
+sin Vinge, begynder en Sang.
+Først kun som et Dødssuk dens Toner ham naaer,
+men høiere stedse det klang.
+Snart fylder den Rummet med svulmende Magt,
+og Væggene sukke derved.
+Men fra den ophængte Brudedragt
+faldt Taarer paa Gulvet ned.
+De Myrter i Brudens vandsprængte Krands
+græd Taarer, som piblende Blod.
+Men midt paa Gulvet, med svimlende Sands,
+som Billedstøtte han stod.
+Og Fuglen omkredser hans Hoved tæt.
+Dog svagere bliver dens Sang,
+dens Flugt bliver tung, og dens Vinge træt,
+den synker med bristende Klang.
+Han varmer den Isnede ved sit Bryst,
+ved sin Mund med tusinde Kys.
+Dog lukker den Diet kun til saa tyst.
+Da griber ham Dødens Gys.
+
+Han flænger i Brystet saa dybt et Saar;
+Blodkilden er sprudlende varm.
+E t straalende Lys hen over ham slaaer,
+og Hun ligger frelst i hans Arm. —
+Af Huset udtræde de salige To
+i Maanens lyshellige Skjær.
+Henlænet mod Muren, i dybeste Ro
+de finde da Honningen der.
+Han lofter sit Hoved: „Hvem kommer vel der?
+Min Kongeborg har jeg forladt.
+Det var mig saa sælsomt - 7- thi sidder jeg her —
+som døde min Datter inat.“
+Men ned de sig kaste for Faderens Fod,
+fortælle ham Alt, hvad de led.
+Fortælle om Sorrig, fortælle om Blod,
+om Frelsen, som vandtes derved.
+Han stryger sit graanende Skjæg med sin Haand:
+„Jeg bliver nu gammel, forsand.
+Snart gaaer jeg i Barndom; alt sløves min Aand.
+Lad gaae da.
+For var jeg en Mand.
+Min Søn og min Datter! I reise Jer nu.
+I følge mig ind i min Borg.
+Jeg tænker min Dronning, saa snild udi Hu,
+kan trøste en Brud i sin Sorg.“
+
+T:Havfruen
+F:Saa vidt sig strækker det salte Hav
+SIDE:87-95
+
+Saa vidt sig strækker det salte Hav;
+paa Bunden Havkongen boer.
+Han sidder saa mørk i sit Slot af Rav;
+hans Datter, den Eneste, Lykken ham gav,
+forvolder ham Sorrig stor.
+Med beiet Hoved hun for ham staaer,
+fastpressede Hænder smaa.
+Til Gulvet hænger det lange Haar.
+Den blinkende Hale saa sagte slaaer
+i Sandet, som vilde den gaae.
+„Du kjender vor Skjæbne.
+Et Aar Du kan
+som Menneske boe paa Jord.
+Vil da han Dig følge i dybe Strand,
+han bliver som jeg en Havets Mand,
+og Jer Kj ærlighedslykke stor.
+Men holder hans Menneskeseighed Stik,
+da bliver Din Lod saa haard.
+Den lede Skikkelse, som Du fik,
+Du slipper ei, og er Skræk for hvert Blik;
+Du her som Trælkvinde gaaer.
+Thi vogt Dig vel.
+Du selv har jo sagt,
+at alt han en Fæstemø har.u —
+
+„O Fader! En Skat har jeg hende bragt,
+og nu hun viser ham kun Foragt.
+En Anden i Hjertet hun bar.“
+„Men husk: Om en Dag kun forsiide Du kom,
+Jeg faaer ham.
+Det har ingen Nød.“
+Saa bares af Bølgernes Hænder hun
+op til den tangbrune Strand.
+Med Halen i Vandet hun faldt i Blund,
+den deiligste Kvinde paa Land.
+Hun laae der kun i sin lille Særk.
+Hun spredte sit Haar derom.
+”En underlig Verden.
+Nu til mit Værk.
+Vær snild, min Aand, som min Elskov er st
+0 Lykke!
+Til Hjælp mig kom.“
+Saa sad hun som fattigt Barn ved hans Dør,
+skibbruden og kummerlig frelst.
+Han tog hende ind; hun blive der tør;
+men videre ei han om hende spor.
+1 Ensomhed grubled han helst.
+da rammer ham bittreste Død.” —
+„O Fader! Vi vente knap Aaret om!
+Jeg fanger ham nok! Tal aldrig om Dom!
+men vaagned i tidligste Morgenstund,
+
+Hun feied hans Gulv, hun laved hans Mad,
+hun pusled og hæged om Alt.
+Men tidt hun, naar Aftenen graanede, sad
+i Krogen og nynned et sorgfuldt Qvad.
+Det var ham som Duggen, der faldt.
+Hun glemmer sig selv, og med fuldeste Magt
+de fængslende Toner frembrod.
+Han studser. Med Diet paa angstfuld Yagt
+hun stammer; „Tilgiv — det var ei min Agt —“
+„Syng, Barn! Det vidunderligt lod.”
+Han lyttede ofte.
+Han tænkte iblandt:
+„Det Barn har en elskelig Sjæl.
+Hun svigter vist Ingen.” Og Tiden henrandt,
+mens, lønlig fornyet, hans Hjerte forvandt
+hver Sorg over bortflygtet Held.
+I Skoven nu knoppes hver Busk og Gren;
+og mylrende for hans Fod
+fremspire de Blomster.
+Han bryder en
+til Barnet, men standser som tryllet til Sten:
+For den deiligste Kvinde han stod.
+Hun tav, og han tigged.
+Hun bæved af Lyst,
+mens til Jorden hun kæmpende saae.
+Om nu hun ham fristed? Hun sukker saa tyst —
+da ligger hun fasttrykket tæt til hans Bryst.
+Ak nei! Det vente vel maa.
+
+Hun stod som hans Brud for den signende Præst.
+Hun tænkte: Se, nu er han Min.
+Nu tur jeg vel tale.
+Jeg lokked ham bedst
+idag vist.
+Men blev det nu Skilsmissens Pest?
+Nei! Endnu er Lykken dog min.
+Hun sad som lyksaligste Ægteviv.
+Saa underligt blev hendes Sind.
+Det var, som følte hun dobbelt Liv,
+som hørte hun udtalt et Skabelsens: Bliv.
+Hun rødmed og blegned om Kind.
+Det lysner saa svagt for hendes Blik,
+det rører sig dybt i Bryst.
+Da gaaer gjennem Hjertet et blodigt Stik:
+Imorgen udrinder det Tidsrum, hun fik,
+og med det maaskee hendes Lyst.
+Hun fører sin Husbond til blinkende Strand
+og spørger med fremtvungen Skjemt:
+„Og om Du nu her skulde vælge paastand
+Mig — eller det drømte Himmelens Land —
+hvem af de To blev da glemt ?“
+Han smiler i Lykkens saligste Ro:
+„Vel mig, at Dit Spergsmaal er Leg.
+Jeg frygter, jeg svigted min Gud og min Tro,
+at jeg tabte min Sjæl og den evige Ro,
+før mit Kjærlighedsløfte jeg sveg.“ —
+
+Med Hovedet lænet tæt til hans Bryst
+hun længe som drømmende staaer.
+Saa vandre de hjemad.
+Endnu er det lyst.
+„Den sidste A f t e n h u n sukker saa tyst,
+mens Hjertet dodsstille slaaer.
+Ved forste, graalyse Morgengry
+hun knæler alt for hans Seng.
+For Sol sig hæver, maa bort hun flye
+fra Elskovs Lyst, fra Lyksaligheds Ly,
+fra sin Himmel, til Hevndommen streng.
+Ei meer tor hun tove.
+Mod Lagnets Som
+hun trykker den bævende Mund.
+Saa iler vild, som i Feberdrøm,
+hun ned mod Havets brusende Strom
+og synker til dybe Bund. —
+Han søger Hustruen forst med Smil;
+hans Sind er solklart og let.
+Dog snart han rammes af Angstens Pil
+og farer omkring med Vanvids II,
+til han segner, til Døden træt.
+Han tover paa Stedet saa rum en Tid.
+Han drager til fremmede Land.
+I skumløste Nat og ved Dagen blid
+saa fjernt og saa nær han søger med Flid.
+Men Spor ei finde han kan.
+
+Tilsidst han kom, en forgræmmet Mand,
+tilbage til Fædrenebo.
+Hans Hus var ude, udyrket hans Land,
+ja selv den skvulpende Baad ved Strand
+laae aflægs i dovnende Ro.
+Han heiser sit Seil, han knuger sit Ror:
+„End engang vi pro ve den Fart.
+Og gaae vi tilbunds, er ei Ulykken stor;
+saa bortskylløs Støvet fra mugnende Jord,
+og Alting er klappet og klart.“
+Mod Aften han hviler af Kampen træt;
+han stirrer i Bølgerne ned.
+Før svulmed de mægtigt, nu kruses de let,
+men alt som han stirrer paa Krusningens Net,
+det loses til fuldeste Fred.
+Saa klart og saa stille.
+Til dybest Grund
+hans rolige Blik nu naaer.
+Der sidder en Kvinde med Taalmodsmund
+og sænket Oie; saa langsomt hun
+omdreier Kværnen, der staaer.
+Men tæt ved hende en Dreng saa trind
+snoer Tømmer af hendes Haar.
+Tre gamle Havkvinder styrte ind.
+De ruske i Drengen, de slaae hendes Kind,
+mens man seer, hvordan Mundene gaaer.
+
+Hun hæver de sorgfulde Hines Blaa
+som til den øverste Gud.
+Men vildt han skriger: Sin Hustru han saae,
+saae hende mishandlet af Hænder raa,
+og hurtigt han styrted sig ud.
+Han vaagnede hos sit Barn og sin Viv,
+han vaagned til himmelsk Lyst.
+Vel forte de Begge et trælsomt Liv,
+tidt maatte han skjuløs hag saltstride Siv,
+men Elskov var rigeste Trøst.
+Utalte Dage leve de saa,
+da mørknes paa Havets Bund.
+Is lukker for Bølgen.
+Ei Himlen blaa
+kan dæmre igjennem, men Lamper smaa
+er tændt i Korallernes Lund.
+En Aften udslukkes det fjerne Skjær,
+og fjerntfra høre de Skrig.
+„Hvad er det?” — „Julen! Hvert Menneske kjær,
+udbreder den Sorg kun og Rædsel her.
+Hver er som et levende Lig.”
+Hvor sælsomt! Han favner sit Barn og sin Viv.
+„Vi Tre hore hjemme paa Jord.”
+Da seer han en Stige, saa svai som et Siv;
+den strækker sig opad, den lover ham Liv.
+Op peger han, uden et Ord.
+
+M p r ø l N p
+Med Drengen i Favn og med Kvinden ved Haand
+han klavrer ad himmelvendt Bro.
+Det gled og det glipped. Men fast var hans Aand
+og smidigt hans Legem som natgamle Vaand.
+Hun fulgte i hengiven Tro.
+Op kom de.
+Den favntykke Isskorpe brast.
+Paa gnistrende Flade de staae.
+I saligste Uro, foruden Rast
+nedtindre de Stjerner, men straalende fast
+staaer en stor, mellem alle de smaa.
+„Se Juløstjernen!” Med oprakt Arm
+han synker paa Knæ, mens hun
+med Hænderne korslagt over sin Barm
+sig dybere beier med Tak saa varm
+mod dens Gjenskjær fra blinkende Bund.
+Paa Kysten kneiser en Kirke god,
+der brændte vel hundrede Lys.
+Tom var den, men Døren halvaaben stod,
+og ind de traadte paa varlig Fod
+opfyldte af helligt Gys.
+Med Drengen staaer han.
+Hun knæler ned,
+dyhtboiet, med Sjælen fuld.
+I Skjul under Haaret faldt Taaren hed,
+til Draahesoen som Strom hengled
+ad Kirkens stenflisede Gulv.
+
+Og Drengen han christned.
+En Draabe da
+paa Havfruen trillede ned.
+Det klang gjennem Kirken.
+Heit tonede fra
+dens Hvælving et saligt Halleluja,
+som hendøde i himmelske Fred. —
+Hun levede end en Tid saa lang
+i Lykke og Kj ærlighed stor.
+Men aldrig mere paa Jorden hun sang.
+Hun kunde kun lytte; i Hjertet det klang,
+saa stille som Englenes Chor.

--- a/1867.txt
+++ b/1867.txt
@@ -7,327 +7,75 @@ TITELBLAD:DIGTNINGER / AF / ILIA FIBIGER. // Med Forfatterindens Biographi og Po
 T:Speilet
 F:Der var engang et Ægtepar, som sad sammen paa
 SIDE:1-9
+TYPE:prose
 
-D er var engang et Ægtepar, som sad sammen paa
-deres Sølvbryllupsdag og saae tilbage paa de henrundne
-Aar.
-De var gaaet i Fred og Kjærlighed; Lykken
-havde fulgt dem i alle Foretagender.
-Dog sukkede
-Konen.
-Et Haab var uopfyldt: Vuggen, som hendes
-forsynlige Moder havde givet med i Udstyr, stod endnu
-ubrugt i en Krog, skamfuld skjult under det over
-bredte Lagen.
-„Hvad er alt Andet?“
-sagde hun.
-„Fattigfolk har Børn i Flokkevis. Havde vi et Barn,
-selv det fattigste af Alle , det var Mere end al vor
-Velstand. “ Manden vilde trøste hende, men hun drog
-Lagenet tilside, puslede og glattede Vuggepuderne, og
-hendes Taarer faldt paa dem som Perler, de langsomt
-indsugede.
-Uger gik og Maaneder, og Konen blev stille og
-tankefuld.
-Hun blev glad og bedrøvet; hun kunde
-ikke fatte sin Lykke. Men da Tiden var omme, fødte
+Der var engang et Ægtepar, som sad sammen paa deres Sølvbryllupsdag og saae tilbage paa de henrundne Aar. De var gaaet i Fred og Kjærlighed; Lykken havde fulgt dem i alle Foretagender. Dog sukkede Konen. Et Haab var uopfyldt: Vuggen, som hendes forsynlige Moder havde givet med i Udstyr, stod endnu ubrugt i en Krog, skamfuld skjult under det overbredte Lagen. „Hvad er alt Andet?“ sagde hun. „Fattigfolk har Børn i Flokkevis. Havde vi et Barn, selv det fattigste af Alle, det var Mere end al vor Velstand.“ Manden vilde trøste hende, men hun drog Lagenet tilside, puslede og glattede Vuggepuderne, og hendes Taarer faldt paa dem som Perler, de langsomt indsugede.
 
-hun et Pigebarn, friskt og fint som en Blomsterknup.
-Da var Forældrenes Glæde uden Grændser.
-De begyndte snart at lave til Barselgilde, men
-intet Menneske syntes dem værdigt til at bære Barnet.
-Rundt om boede fem Feer; de fire vare hoit elskede
-af Menneskene, den femte var frygtet, thi kun sjeldent
-feiede hun deres Ønsker.
-Ægtefolkene overveiede,
-hvem af de Fire de vel skulde vælge til Fadder. De
-havde gjerne hidkaldt dem Alle, men frygtede for at
-forterne den Femte.
-Da traf det sig saa heldigt, at
-denne just gjorde en Reise.
-Hurtig beredte de Alt,
-og Manden gik i Kisteklæder at bede de fire Feer til
-Fadder.
-De kom og lagde deres Gaver paa Vuggen:
-Glæde, Skjønhed, Haab og Kjærlighed. Dagen svandt
-i Fryd, og Feerne havde just taget Afsked, da Døren
-atter gik op, og den Bortreiste traad ind. Forældrene
-sprang forskrækket op.
-Konen rev Dugen af Bordet
-og bredte en ny paa, Manden nærmede sig med
-ydmyge Beklagelser over ikke at have truffet hende.
-Men Feen smilede venligt og nærmede sig Vuggen.
-„Ei hvilke glimrende Gaver!“ sagde hun, „det Barn
-vil voxe op i stor Fristelse.
-En Lykke er det, at I
-leve og kunne vogte paa hende. “ — Ak, sukkede
-Faderen, vi ere gamle og kunne vel ikke gjøre Reg
-ning paa at følge hende ret langt paa Veien. — Feen
-saae atter paa Barnet og sagde:
-„Meget Godt have
-mine Søstre givet hende, men Beskyttelsen mangler.
+    Uger gik og Maaneder, og Konen blev stille og tankefuld. Hun blev glad og bedrøvet; hun kunde ikke fatte sin Lykke. Men da Tiden var omme, fødte hun et Pigebarn, friskt og fint som en Blomsterknup. Da var Forældrenes Glæde uden Grændser.
 
-Hvad er Haab, hvad er Kjærlighed, naar de vende
-sig imod den Urette? Hvad er den blinde Lykke i
-det uvidende Barns Haand? En Skat,
-som hver
-Daare kan gribe og vende til hendes egen Fordær
-velse. “ Da græd Moderen bitterlig, men Feen sagde:
-„Jeg vil give hende en Talisman, som skal staae
-hende bi, om Naturens Gang kalder Eder tidligt fra
-hende. See dette lille Speil! Naar Beileren trænger
-sig frem med sin Kj ærlighed, lad hende da holde det
-for hans Øie.
-Da vil det vise sig , om han er den
-Rette. “
-Hun hængte Speilet om Barnets Hals og
-gik, fulgt af Forældrenes Velsignelser.
-Barnet voxede til, og aldrig fordunklede nogen
-laare dets Øie.
-Hun kom kun lidt blandt andre
-Børn , thi Ingen syntes Forældrene gode nok , men
-hjemme havde hun fuldt op af Morskab, og de faa
-udvalgte Legekammerater undredes over hendes Mun
-terhed og Frihed.
-Jomfrualderen nærmede sig ; da
-tog Forældrene hende en Dag imellem dem og under
-rettede hende om det lille * Speils Egenskab, hun
-endnu bar som et Legetoi om Halsen.
-Tankefuld
-stirrede Pigen i det; kun utydeligt saae hun sit
-Billed: Blomster og blinkende Stjerneskud gled gjeg-
-lende hen over det.
-Fra den Dag saae hun oftere
-i Speilet og undrede sig over de drømmeagtige Sy
-ner, som gik hen over dets Flade.
-En Dag vandrede hun i Skoven, som stødte til
-hendes Forældres Have-, da traadte en ung Mand
+    De begyndte snart at lave til Barselgilde, men intet Menneske syntes dem værdigt til at bære Barnet. Rundt om boede fem Feer; de fire vare høit elskede af Menneskene, den femte var frygtet, thi kun sjeldent føiede hun deres Ønsker. Ægtefolkene overveiede, hvem af de Fire de vel skulde vælge til Fadder. De havde gjerne hidkaldt dem Alle, men frygtede for at fortørne den Femte. Da traf det sig saa heldigt, at denne just gjorde en Reise. Hurtig beredte de Alt, og Manden gik i Kisteklæder at bede de fire Feer til Fadder.
 
-hende imøde.
-Pigen veg forskrækket tilbage, men
-ved det andet Blik forekom han hende saa bekjendt,
-at hun atter forvirret standsede.
-Han rodmede som
-hun, stammede og greb hendes Haand. Men hun rev
-sig løs og ilede hjem.
-Saaledes gik en lille Tid.
-Naar de Unge van
-drede sammen i Haven, saae de Gamle smilende efter
-dem og beraadsloge, om det vel snart kunde være
-paa Tide at raadspørge Speilet. — En Aftenstund
-sad de To i Skoven, tæt udenfor Havelaagen; han
-havde tilstaaet sin Kjærlighed, og det første Kys
-havde beseglet Pagten.
-Men som hun boiede sig for
-hans B lik, gled det blinkende Speil frem, som hun
-bar paa Brystet. Hvad er det? spurgte han og greb
-det spøgende.
-En Fee har givet mig det, svarede
-Pigen; det vil prøve min Beilers Troskab.
-Hun
-klemte sin Haand sammen om Speilet, men han kys
-sede Fingrene op og saae i det.
-Det blændede for hans Øie.
-Ikke sit, men Pi
-gens Billede saae han.« Dog kunde han ikke fast
-holde det: det var som tusinde Ildgnister gik over
-det, sittrende og forvirrende; tilsidst syntes det ham,
-som det Hele splintredes og henflød i Taage. Mat og
-kold om Hjertet vilde han med Magt vende sit Øie
-mod Pigen; da lød et Veraab fra Haven, og hun
-sprang forfærdet op. Husets Folk søgte hende; hendes
-Moder laae døende i Stuen.
+    De kom og lagde deres Gaver paa Vuggen: Glæde, Skjønhed, Haab og Kjærlighed. Dagen svandt i Fryd, og Feerne havde just taget Afsked, da Døren atter gik op, og den Bortreiste traad ind. Forældrene sprang forskrækket op. Konen rev Dugen af Bordet og bredte en ny paa, Manden nærmede sig med ydmyge Beklagelser over ikke at have truffet hende. Men Feen smilede venligt og nærmede sig Vuggen. „Ei hvilke glimrende Gaver!“ sagde hun, „det Barn vil voxe op i stor Fristelse. En Lykke er det, at I leve og kunne vogte paa hende.“ — Ak, sukkede Faderen, vi ere gamle og kunne vel ikke gjøre Regning paa at følge hende ret langt paa Veien. — Feen saae atter paa Barnet og sagde: „Meget Godt have mine Søstre givet hende, men Beskyttelsen mangler. Hvad er Haab, hvad er Kjærlighed, naar de vende sig imod den Urette? Hvad er den blinde Lykke i det uvidende Barns Haand? En Skat, som hver Daare kan gribe og vende til hendes egen Fordærvelse.“ Da græd Moderen bitterlig, men Feen sagde: „Jeg vil give hende en Talisman, som skal staae hende bi, om Naturens Gang kalder Eder tidligt fra hende. See dette lille Speil! Naar Beileren trænger sig frem med sin Kjærlighed, lad hende da holde det for hans Øie. Da vil det vise sig, om han er den Rette.“ Hun hængte Speilet om Barnets Hals og gik, fulgt af Forældrenes Velsignelser.
 
-Hun ilede ind. Han hørte ikke, hvad der taltes;
-sløv og forvirret fjernede han sig, da hun var borte.
-Den gamle Kone var rammet af et Slag og formaaede
-ikke at tale, men døende greb hun endnu efter Speilet
-om Datterens Hals. Faa Dage gik, saa fulgte Faderen
-hende, og den friske Grav gjemte Forældrenes trætte
-Lemmer. Pigen græd, men Feernes Gaver blomstrede
-i hendes Bryst; med Haab og tilsløret Glæde ventede
-hun, at han skulde komme.
-Da gik Dag for Dag, og Skoven gulnedes, Levet
-hvirvledes hen, og Sneen tyngede Grenene; Vinteren
-var der, men han kom ikke.
-Pigen saae i sit Speil
-og hensank i sælsomme Drømme; hun ventede og
-ventede, men han kom ikke. Da græd hun bittrere
-Taarer; de faldt paa Glasset og kaldte hans Billed
-frem.
-Det blev som en Leg.
-Taarerne mildnedes,
-og Billedet blev svagere; Stjerneskud og drømmeagtige
-Syner gled hen over det.
-Tiden gik, og Skoven grønnedes; nær og fjernt
-sang Fuglene under dens Kroner. Da længtes Pigen
-inderligt, og hun gik daglig under den grønne Hvæl
-ving, men Ingen mødte hende paa den kjendte Sti.
-Saa drog hun langveis bort at søge den Elskede.
-Men den svale Vind omstrøg hendes Kind, og tusind
-nye Blomster spirede frem for hendes Fod.
-Menne
-skene modtoge hende med Glæde og Kjærlighed og
-kappedes om at berede hende et Hjem. Da blev hun
+    Barnet voxede til, og aldrig fordunklede nogen Taare dets Øie. Hun kom kun lidt blandt andre Børn, thi Ingen syntes Forældrene gode nok, men hjemme havde hun fuldt op af Morskab, og de faa udvalgte Legekammerater undredes over hendes Munterhed og Frihed. Jomfrualderen nærmede sig; da tog Forældrene hende en Dag imellem dem og underrettede hende om det lille Speils Egenskab, hun endnu bar som et Legetøi om Halsen. Tankefuld stirrede Pigen i det; kun utydeligt saae hun sit Billed: Blomster og blinkende Stjerneskud gled gjøglende hen over det. Fra den Dag saae hun oftere i Speilet og undrede sig over de drømmeagtige Syner, som gik hen over dets Flade.
 
-let om Hjertet, som hun kunde omfatte den hele Ver
-den og drage den til sig i freidig Velvillie.
-Saaledes gik vel en god Tid; da begyndte Noget
-at længes i hendes Hjerte.
-Hun horte ikke. som
-for, ligegyldig paa Beilernes Ord; hun tænkte, hvor
-sødt det havde været at elske. Da saae hun mangen
-gang paa den Bedende og tænkte:
-Vidste jeg, han
-var den Rette, da kunde jeg vel elske ham. Og hun
-trak Speilet frem og bad ham see ret fast deri. Men
-Speilet drev sit Gjogløspil og forvirrede hans Sands;
-for eller senere trak han sig forlegen tilbage.
-hedrovedes efterhaanden Pigens Hjerte, og hun læng
-tes bort fra de troløse Mennesker.
-Men i Ensom
-hed opblomstrede atter Feernes Gaver, og hun fre
-dede om de altid spædere Spirer, der smykkede hen
-des Vei.
-Saaledes gik hun gjennem Livet, søgt og søgende,
-altid skuffet.
-Da hvilede hun sig i Ensomhed og
-saae hen over de mange, de lange Aar, som Intet havde
-efterladt hende. — Som hun saaledes sad, nærmede
-en Mand sig, alvorlig og god af Aasyn.
-Han un
-dredes over at finde hende i denne O rk, han satte
-sig hos hende og talede venligt til hende.
-Da vir
-kede Feernes Faddergave; han saae ikke Alderens
-Spor i hendes A nsigt, men han ynkedes over hendes
-Skrøbelighed, og hans Hjerte var fanget.
-Han op
-slog sin Bo i hendes Nærhed, og snart talede hans
-Ord, som hans Øine, om Kjærlighed.
+    En Dag vandrede hun i Skoven, som stødte til hendes Forældres Have; da traadte en ung Mand hende imøde. Pigen veg forskrækket tilbage, men ved det andet Blik forekom han hende saa bekjendt, at hun atter forvirret standsede. Han rødmede som hun, stammede og greb hendes Haand. Men hun rev sig løs og ilede hjem.
 
-Og Pigen skjulte Speilet i sin Klædnings Folder
-og trykkede sin Haand fast imod det.
-Men snart
-tænkte hun:
-Hvor turde jeg kalde ham Min, naar
-jeg vandt ham ved at undgaae Prøven ? Jeg vil vove
-det Sidste.
-Hun drog Speilet frem og holdt det
-skjælvende, med et bonligt Blik, hen for ham. Han
-greb hendes Haand og saae længe deri; da kyssede
-han Haanden, reiste sig langsomt, og gik.
-Og hun
-vidste, at han vilde ikke vende tilbage.
-Da stod medet den femte Fee for hende og be
-tragtede hende med et triumpherende Smil.
-Pigen
-loste Speilet af sin Hals, rakte hende det og sagde:
-lag Din Gave, som har bedraget mig for mit Liv.
-„Skrøbeligt var hvad Du tabte,“ svarede Feen.
-„Bag Havet ligger Din Lykkes Land. “ Og hun for
-lod hende smilende.
-Men Pigen sad for den synkende Sol, i den
-stille Nat; hun sad der endnu, da Dagen atter hæl
-dede.
-Hun prøvede ikke at reise sig; det var, som
-Alderen pludselig var falden paa hende med sin Bly
-vægt. Hun saae ud over den ode Slette og tænkte:
-Kunde jeg græde, saa mine Taarer svulmede op til
-et stort Hav; da seilede jeg over det og kom til min
-Lykkes Land. — Hendes Hjerte blev tungere; Sorgens
-Væld steg høiere, saa Draaberne langsomt fyldte
-Diet.
-Da nærmede et Barn sig med Skjørtet fuldt
-al Blomster
-„Kjender Du mig?" spurgte den Lille.
+    Saaledes gik en lille Tid. Naar de Unge vandrede sammen i Haven, saae de Gamle smilende efter dem og beraadsloge, om det vel snart kunde være paa Tide at raadspørge Speilet. — En Aftenstund sad de To i Skoven, tæt udenfor Havelaagen; han havde tilstaaet sin Kjærlighed, og det første Kys havde beseglet Pagten. Men som hun bøiede sig for hans Blik, gled det blinkende Speil frem, som hun bar paa Brystet. Hvad er det? spurgte han og greb det spøgende. En Fee har givet mig det, svarede Pigen; det vil prøve min Beilers Troskab. Hun klemte sin Haand sammen om Speilet, men han kyssede Fingrene op og saae i det.
 
-„Jeg er Din glade Barndom, som kommer for at græde
-med Dig.“
-Og det rystede sine Blomster ud for hendes Fod,
-satte sig og græd.
-Da strømmede Taarerne fra den
-gamle Piges D ine, saa et lille Vand samlede sig
-foran hende.
-Men en rosenkrandset Ungmo nærmede
-sig, trykkede sig mod hendes Bryst og hviskede:
-„Kjender Du mig? Jeg er den første Kjærligheds
-lyksalige Tid.
-Jeg kommer for at græde med Dig. “
-Og Begges Taarer strømmede, saa Vandet bredte sig
-som en stor Sø foran de Grædende.
-Da kom nær
-og fjernt, fra en hel Række af Aar, en hel Hærskare
-af Savn og sørgeklædte Timer.
-De bredte sig til
-begge Sider langs Søens Rand og græd stille i det
-stille Vand; dog steg det kun langsomt.
-Da rørtes
-der sagte ved Kvindens Skulder, og hun vendte sit
-Hoved.
-Der stod en tilsløret Skikkelse og rakte taus
-og bedende sin Haand imod hende. Men hun kjendte
-sit sidste Haab og drog den til sig.
-Den kastede
-sig ned med Hovedet paa hendes Knæ og græd, saa
-Søen svulmede uoverskuelig vidt, og hvert Savn og
-Sorg gled ned i dens Bølger.
-Erindringerne var slumret ind, men Kvinden
-sad i den dæmrende Nat og stirrede ud over Taa-
-rernes stille Hav.
-Da rørtes Vandet sagte, og midt
-ude hævede en Skikkelse sig. kjendt, som den alt
-engang drømte Drøm.
-Den vinkede hende med en
-stor Aakandeblomst, den holdt i Haanden. Hun reiste
+    Det blændede for hans Øie. Ikke sit, men Pigens Billede saae han. Dog kunde han ikke fastholde det: det var som tusinde Ildgnister gik over det, sittrende og forvirrende; tilsidst syntes det ham, som det Hele splintredes og henflød i Taage. Mat og kold om Hjertet vilde han med Magt vende sit Øie mod Pigen; da lød et Veraab fra Haven, og hun sprang forfærdet op. Husets Folk søgte hende; hendes Moder laae døende i Stuen.
 
-sig møisomt, men stod tvivlraadig ved Bredden. Da
-rev den Ventende Bladene af Blomsten og slyngede
-dem langt hen imod hende. De spredtes i en Stribe,
-som smaa hvide Stentoppe til Overgang over Bækken.
-Og Kvinden satte sin Pod paa det forste gyngende
-Blad; da gik hun lettere, og hendes Hoved hævede
-sig.
-Por hvert Skridt faldt en Vægt af Aarenes
-Byrde af, og ung og deilig som i sin forste Tid
-stod hun ude paa Vandet.
-Da saae hun under Fla
-den hans udrakte Haand, og tabende ethvert Fodfæste
-greb hun efter den. Men han omslyngede hende fast
-og drog hende med sig til den dybe Bund.
-Solen steg, og Vandet sank. Alt mere og mere
-svandt det, og med vidunderlig Fylde fremspirede
-Græs og Blomster i Dalen.
-Kun midt blev en Brond
-tilbage, saa dyb, saa dyb, at intet Oreatur kunde
-naae at drikke af dens Vand. Men stirrede Vandreren
-længe ned i den klare Grund, da paakom ham en
-inderlig Længsel, saa han med Magt maatte rive
-sig los for at vandre videre.
+    Hun ilede ind. Han hørte ikke, hvad der taltes; sløv og forvirret fjernede han sig, da hun var borte. Den gamle Kone var rammet af et Slag og formaaede ikke at tale, men døende greb hun endnu efter Speilet om Datterens Hals. Faa Dage gik, saa fulgte Faderen hende, og den friske Grav gjemte Forældrenes trætte Lemmer. Pigen græd, men Feernes Gaver blomstrede i hendes Bryst; med Haab og tilsløret Glæde ventede hun, at han skulde komme.
+
+    Da gik Dag for Dag, og Skoven gulnedes, Løvet hvirvledes hen, og Sneen tyngede Grenene; Vinteren var der, men han kom ikke. Pigen saae i sit Speil og hensank i sælsomme Drømme; hun ventede og ventede, men han kom ikke. Da græd hun bittrere Taarer; de faldt paa Glasset og kaldte hans Billed frem. Det blev som en Leg. Taarerne mildnedes, og Billedet blev svagere; Stjerneskud og drømmeagtige Syner gled hen over det.
+
+    Tiden gik, og Skoven grønnedes; nær og fjernt sang Fuglene under dens Kroner. Da længtes Pigen inderligt, og hun gik daglig under den grønne Hvælving, men Ingen mødte hende paa den kjendte Sti. Saa drog hun langveis bort at søge den Elskede. Men den svale Vind omstrøg hendes Kind, og tusind nye Blomster spirede frem for hendes Fod. Menneskene modtoge hende med Glæde og Kjærlighed og kappedes om at berede hende et Hjem. Da blev hun let om Hjertet, som hun kunde omfatte den hele Verden og drage den til sig i freidig Velvillie.
+
+    Saaledes gik vel en god Tid; da begyndte Noget at længes i hendes Hjerte. Hun hørte ikke som før, ligegyldig paa Beilernes Ord; hun tænkte, hvor sødt det havde været at elske. Da saae hun mangen Gang paa den Bedende og tænkte: Vidste jeg, han var den Rette, da kunde jeg vel elske ham. Og hun trak Speilet frem og bad ham see ret fast deri. Men Speilet drev sit Gjøglespil og forvirrede hans Sands; før eller senere trak han sig forlegen tilbage. Da bedrøvedes efterhaanden Pigens Hjerte, og hun længtes bort fra de troløse Mennesker. Men i Ensomhed opblomstrede atter Feernes Gaver, og hun fredede om de altid spædere Spirer, der smykkede hendes Vei.
+
+    Saaledes gik hun gjennem Livet, søgt og søgende, altid skuffet. Da hvilede hun sig i Ensomhed og saae hen over de mange, de lange Aar, som Intet havde efterladt hende. — Som hun saaledes sad, nærmede en Mand sig, alvorlig og god af Aasyn. Han undredes over at finde hende i denne Ørk, han satte sig hos hende og talede venligt til hende. Da virkede Feernes Faddergave; han saae ikke Alderens Spor i hendes Ansigt, men han ynkedes over hendes Skrøbelighed, og hans Hjerte var fanget. Han opslog sin Bo i hendes Nærhed, og snart talede hans Ord, som hans Øine, om Kjærlighed.
+
+    Og Pigen skjulte Speilet i sin Klædnings Folder og trykkede sin Haand fast imod det. Men snart tænkte hun: Hvor turde jeg kalde ham Min, naar jeg vandt ham ved at undgaae Prøven? Jeg vil vove det Sidste. Hun drog Speilet frem og holdt det skjælvende, med et bønligt Blik, hen for ham. Han greb hendes Haand og saae længe deri; da kyssede han Haanden, reiste sig langsomt, og gik. Og hun vidste, at han vilde ikke vende tilbage.
+
+    Da stod medet den femte Fee for hende og betragtede hende med et triumpherende Smil. Pigen løste Speilet af sin Hals, rakte hende det og sagde: Tag Din Gave, som har bedraget mig for mit Liv. — „Skrøbeligt var hvad Du tabte,“ svarede Feen. „Bag Havet ligger Din Lykkes Land.“ Og hun forlod hende smilende.
+
+    Men Pigen sad for den synkende Sol, i den stille Nat; hun sad der endnu, da Dagen atter hældede. Hun prøvede ikke at reise sig; det var, som Alderen pludselig var falden paa hende med sin Blyvægt. Hun saae ud over den øde Slette og tænkte: Kunde jeg græde, saa mine Taarer svulmede op til et stort Hav; da seilede jeg over det og kom til min Lykkes Land. — Hendes Hjerte blev tungere; Sorgens Væld steg høiere, saa Draaberne langsomt fyldte Øiet.
+
+    Da nærmede et Barn sig med Skjørtet fuldt af Blomster. „Kjender Du mig?“ spurgte den Lille. „Jeg er Din glade Barndom, som kommer for at græde med Dig.“
+
+    Og det rystede sine Blomster ud for hendes Fod, satte sig og græd. Da strømmede Taarerne fra den gamle Piges Øine, saa et lille Vand samlede sig foran hende. Men en rosenkrandset Ungmø nærmede sig, trykkede sig mod hendes Bryst og hviskede: „Kjender Du mig? Jeg er den første Kjærligheds lyksalige Tid. Jeg kommer for at græde med Dig.“ Og Begges Taarer strømmede, saa Vandet bredte sig som en stor Sø foran de Grædende. Da kom nær og fjernt, fra en hel Række af Aar, en hel Hærskare af Savn og sørgeklædte Timer. De bredte sig til begge Sider langs Søens Rand og græd stille i det stille Vand; dog steg det kun langsomt. Da rørtes der sagte ved Kvindens Skulder, og hun vendte sit Hoved. Der stod en tilsløret Skikkelse og rakte taus og bedende sin Haand imod hende. Men hun kjendte sit sidste Haab og drog den til sig. Den kastede sig ned med Hovedet paa hendes Knæ og græd, saa Søen svulmede uoverskuelig vidt, og hvert Savn og Sorg gled ned i dens Bølger.
+
+    Erindringerne var slumret ind, men Kvinden sad i den dæmrende Nat og stirrede ud over Taarernes stille Hav. Da rørtes Vandet sagte, og midt ude hævede en Skikkelse sig, kjendt, som den alt engang drømte Drøm. Den vinkede hende med en stor Aakandeblomst, den holdt i Haanden. Hun reiste sig møisomt, men stod tvivlraadig ved Bredden. Da rev den Ventende Bladene af Blomsten og slyngede dem langt hen imod hende. De spredtes i en Stribe, som smaa hvide Stentoppe til Overgang over Bækken. Og Kvinden satte sin Fod paa det første gyngende Blad; da gik hun lettere, og hendes Hoved hævede sig. For hvert Skridt faldt en Vægt af Aarenes Byrde af, og ung og deilig som i sin første Tid stod hun ude paa Vandet. Da saae hun under Fladen hans udrakte Haand, og tabende ethvert Fodfæste greb hun efter den. Men han omslyngede hende fast og drog hende med sig til den dybe Bund.
+
+    Solen steg, og Vandet sank. Alt mere og mere svandt det, og med vidunderlig Fylde fremspirede Græs og Blomster i Dalen. Kun midt blev en Brønd tilbage, saa dyb, saa dyb, at intet Creatur kunde naae at drikke af dens Vand. Men stirrede Vandreren længe ned i den klare Grund, da paakom ham en inderlig Længsel, saa han med Magt maatte rive sig løs for at vandre videre.
 
 T:Stemninger
 U:_1851—59._
 F:Hjælpeløse Hjerte
 SIDE:10-16
 
+<nonum>1.</nonum>
+
 Hjælpeløse Hjerte,
-holcl Dig rolig kun;
-bær ilen Din Smerte
+hold Dig rolig kun;
+bær iløn Din Smerte
 til Din sidste Stund.
+
 Herreløse Kvinde,
 Jordens Fryd forglem.
 Lær ihast at finde
 Veien til Dit Hjem.
+
 Trang den Vei mon falde,
 og min Fod er træt.
-Herre!
-Mild Du kalde
+Herre! Mild Du kalde
 den, som standser let.
-Herre!
-Mild Du række
+
+Herre! Mild Du række
 mig Din Haand saa god.
 Selv Du til Dig trække
 den, som staaer imod.
+
 Thi skjøndt stærkt jeg længes,
 skjøndt jeg Fred ei har,
 skjøndt mit Hjerte trænges
@@ -337,41 +85,50 @@ Dog sig Øiet vender
 efter Jordens Tant,
 og de matte Hænder
 gribe, hvad det fandt.
+
 Og skjøndt Blomstens Smykke
 falder af ihast,
-de begj ærlig trykke
+de begjærlig trykke
 sig om Tornen fast.
-Herre ! Les min Kvide!
+
+Herre! Løs min Kvide!
 Tag Du mig ved Haand.
 Selv jeg kan ei slide
-mig af Yerdens Baand.
-Tag mig mod min Yillie!
+mig af Verdens Baand.
+
+Tag mig mod min Villie!
 Lad mig græde ud
 og saa hvile stille
 hos min Herre og Gud.
 
+<nonum>2.</nonum>
+
 Min Fryd den er saa lille, min Sorg den er saa stor;
 mit Hjerte er som tynget af tre Skuffer Jord.
-Mit Hjerte saa betynget dog finder ingen Bo,
+Mit Hjerte saa betynget dog finder ingen Ro,
 thi Graven er ei gravet end, hvor det saa trygt skal boe.
+
 Hvor er den Glædens lyse, den underfulde Tid,
 da Livets Sol sig hæver, saa straalende og blid,
 da første Nyheds Morgendug i Glands indhyller Alt,
 og Livet er et Eventyr, nu førstegang fortalt?
+
 Hvor er, o svale Dæmring, Din Aftens sidste Stund,
 da Døden selv saa stille mig dysse skal i Blund
 og lægge mig i Fredens Arm og ved dens hulde Bryst,
 mens Haabet hvisker sagtelig om Salighedens Lyst.
+
 Nu staaer jeg midt imellem og er saa mat og svag;
 dog veed jeg, den vil ende, den lummerhede Dag.
 Og naar jeg tjener trofast kun, hvor ensom jeg er sat,
 saa venter mig en Hvile sød i Gravens dybe Nat.
+
 Saa venter mig den bedste, den evige Trøst,
-naar jeg engang skal høre min Herres milde Bøst:
-„Du stakkels syndige Skabning, kom, thi dog Du var
-mig kjær;
-blev Du paa Jord en Fremmed kun, saa vær da
-hjemme her.“
+naar jeg engang skal høre min Herres milde Røst:
+„Du stakkels syndige Skabning, kom, thi dog Du var mig kjær;
+blev Du paa Jord en Fremmed kun, saa vær da hjemme her.“
+
+<nonum>3.</nonum>
 
 Midtveis paa Livets lange Bane staaer
 idag jeg jo; de femogtredive Aar
@@ -379,61 +136,76 @@ tilbagelagt — hvor kan det muligt være?
 Dog har jeg vandret langt med Sorrig stor
 den tomme Vei hen over kolde Jord,
 der luktes over dem, som var mig kjære.
-Vel var de Tre.
-For En jeg serged kun;
-kun engang brod den frem fra Hjertets Grund,
+
+Vel var de Tre. For En jeg sørged kun;
+kun engang brød den frem fra Hjertets Grund,
 den dybe Sorg, opdæmmet der saa længe.
 Den meste svundne Tid den skylled bort,
 og derfor har jeg levet nu saa kort,
 thi nyt sig maatte Alt igjen fremtrænge.
+
 Og jeg er glad idag; jeg frygter ei
 meer for at gaae min underlige Vei;
-jeg troer, jeg tor vel være, som jeg skabtes.
+jeg troer, jeg tør vel være, som jeg skabtes.
 Kjærligheds Rigdom blev nu ei min Deel,
 men kan jeg, fattig, kun mig samle heel,
 saa vandt jeg dog, hvor Meget end der tabtes.
-Paa mit eget Hjertes Hoivande jeg svommer,
-og Verden mig synes saa skjon og saa rig;
-om Fred og om Lykke jeg sværme’nde drammer
+
+<nonum>4.</nonum>
+
+Paa mit eget Hjertes Høivande jeg svømmer,
+og Verden mig synes saa skjøn og saa rig;
+om Fred og om Lykke jeg sværmende drømmer
 — men sank jeg, var snart jeg et Lig.
+
+<nonum>5.</nonum>
 
 Ei meer jeg hjemløs er paa Jord,
 jeg har mig en Hvileplads fundet.
-Paa den jeg hygger, paa den jeg boer,
+Paa den jeg bygger, paa den jeg boer,
 da har jeg Freden vundet.
+
 Den spirer op som spæde Straa
 i den Krog, hvor jeg trak mig tilbage.
 Jeg bygger en lille Hytte derpaa;
 der bliver jeg alle Dage.
-Jeg hygger Hytte, boer deri,
+
+Jeg bygger Hytte, boer deri,
 mens udenfor Fuglene synge.
 Jeg gaaer ad Skovens halvtraadte Sti,
 hvor Blomster staae tæt i Klynge.
+
 Da binder jeg mig Krandse smaa
 og hænger dem trindt i min Hytte.
 Jeg sætter mig hen og seer derpaa:
 herfra jeg aldrig vil flytte.
+
 Engang en silde Aftenstund
 saa kommer vel Den, jeg venter.
-Han kysser mit Die, han kysser min Mund
-og hort til «in Himmel mig henter.
+Han kysser mit Øie, han kysser min Mund
+og bort til sin Himmel mig henter.
 
 Men hvor vel mon den Hytte staae,
 hvor blev den Byggegrund funden?
 Det var i Hjertets inderste Vraa,
 da Verdens Sorg var forvunden.
+
+<nonum>6.</nonum>
+
 Yndige Land,
 hvor i min Ungdom jeg boede og bygged!
-Bolgebeskyllet af kjolige Strand
-og af lovkronede Træer overskygget!
+Bølgebeskyllet af kjølige Strand
+og af løvkronede Træer overskygget!
 Kan jeg ei komme derhen?
 Kan jeg dog aldrig, dog aldrig didkomme igjen?
+
 Skygge der var,
 skraanende Dale, omhvælvet af høieste Himmel.
 Aftnen var liflig, og Natten saa klar;
 stille nedblinkede Stjernernes Vrimmel.
 Enkelt et Stjerneskud gik
 lovende hen for det ønskende, drømmende Blik.
+
 Kommer jeg did,
 naar min henvaklende Vandring i Livet er omme?
 Naar jeg har levet den tilmaalte Tid,
@@ -441,47 +213,54 @@ naar jeg gjør Opbrud ved Dødens velsignede Komme?
 Fører vel den mig derhen?
 Finder jeg der, hvad jeg drømmende eied, igjen?
 
+<nonum>7.</nonum>
+
 Jeg gaaer ei bort i Livets Vaar,
 end ikke i dets Sommer.
 Ak nei! jeg stormforreven staaer,
 naar Efteraaret kommer.
-Vel hvirvløs ned det sidste Blad,
-for jeg i Graven blunder.
+
+Vel hvirvles ned det sidste Blad,
+før jeg i Graven blunder.
 O, hvor vil jeg dog være glad,
 naar det mod Døden stunder.
+
 Da skal jeg gjemmes trygt og godt
 og sove sødt og længe.
 I Muld da staaer mit faste Slot,
 hvor Sorg ei kan indtrænge.
+
 Ei Sorg, ei Savn, ei Længselsve
-kan trænge ind i Borgen ;
+kan trænge ind i Borgen;
 og hvad der end paa Jord kan skee:
 mig rammer ikke Sorgen.
+
 Den har jo hele Verdens Rund,
 dens Rige gaaer saa vide.
-Men i den kjole Gjemmegrund
+Men i den kjøle Gjemmegrund
 der boer kun Søvnen blide.
 
 Jeg længes efter Søvnen sød
 alt med de milde Drømme.
 Thi kom kun snart, trofaste Død,
 Gud vil vist naadig dømme.
-Af Almuelivet.
-(
+
+SEKTION:Almuelivet
 
 T:Fra Jylland
 F:Aftnen var liflig, og Natten saa klar
 SIDE:17-18
 
-)
-orden for Limfjorden findes et Sted,
+Norden for Limfjorden findes et Sted,
 hvor sig en Lyngbanke blidt skraaner ned
 men imod østen den sandmagre Grund
 sænker sig brat mod smaastenede Bund.
+
 Med deres Hænder et Ægtepar der
-danned en Tilflugt for Yind og for Veir,
+danned en Tilflugt for Vind og for Veir,
 grov sig i Bakken møisommeligt ind,
 til der blev stort nok for nøisomme Sind.
+
 Reiste en Mur af selvsamlede Sten,
 Forsiden blev det, saa fast og saa pæn.
 Tætted og luned og pynted tilsidst;
@@ -490,23 +269,28 @@ Trivselen kom der ved Aarenes Frist,
 Der, hvor de bygged, de boede med Fred;
 Eiendomsretten dem Ingen bestred.
 Vidt om i Landet dog ofte de drog,
-Fedlen han streg, Tamburinen hun slog.
+Fedlen han strøg, Tamburinen hun slog.
+
 Selvlavet var den, en underlig Ting.
 Men i hvor vidt end de droge omkring,
 kjendte dog Alle de dygtige To,
 der, ret som Fuglene, selv bygged Bo.
+
 Engang jeg traf dem. Vi talede lidt,
 som det nu faldt sig, om Dat og om Dit.
-Og iblandt Andet jeg spor, om de bar
+Og iblandt Andet jeg spør, om de har
 ei noget Barn, da gier Manden det Svar:
+
 „Nei, i den Ting var vor Lykke jo svær:
-Fem vel vi havde, dog dede Enhver. “
+Fem vel vi havde, dog døde Enhver.“
 Sagtens jeg studsed, thi Konen faldt ind,
 slettende efter med varsomme Sind:
+
 „Jo, for den Fattige er det et Held;
 Jomfruen selv maa betænke det vel.
-Bredet til To er tidt knapt nok endda:
-Hvis vi var Flere — kvor kom det da fra?“
+Brødet til To er tidt knapt nok endda:
+Hvis vi var Flere — hvor kom det da fra?“
+
 Videre drog de med Kling og med Klang;
 jeg havde hørt kun en Fattigmandssang.
 Moderen glemmer sit Haab og sin Nød:
@@ -514,15 +298,16 @@ Jordgjemte Barn er — Besparen af Brød.
 
 T:En Vaagekone
 F:Med stille Sind
-SIDE:19-20
+SIDE:19-21
 
-M ed stille Sind
+Med stille Sind
 hun tripper ud, hun tripper ind,
 den gamle Vaagemoer.
 Hun tripper om den Nat saa lang;
 er Pinen haard, er Tiden trang,
 hun trippende ved Sengen staaer
 og hjælper, mens hun Utak faaer.
+
 Hun nikker tidt,
 og Hov’det vakler for hvert Skridt,
 som om det halv sad løst.
@@ -530,21 +315,23 @@ Hun ryster paa den runkne Haand,
 og hendes slidnedtrykte Aand
 omtaaget synes, dog hun veed,
 naar det kun gjælder, god Besked.
+
 Hun henter Vand
 om Morgnen, og ved fulde Spand
 hun faaer en god Passiar.
 Selvfemte hun ved Posten staaer,
 mens alle Munde tappert gaaer,
 og det, næst Caffen, er den Trøst,
-der bode maa paa Livets Brøst.
-Hun reder Seng,
-hun feier Gulv, er Alløs Dreng;
-hun sendes her og hist.
+der bøde maa paa Livets Brøst.
 
+Hun reder Seng,
+hun feier Gulv, er Alles Dreng;
+hun sendes her og hist.
 Naar endelig det Slid er endt,
 har næsten hver en Patient
 et Ærind end at give med.
 Er det besørget, faaer hun Fred.
+
 Saa gaaer i Slid
 hver Nat og Dagens halve Tid;
 hun maa vel slides op.
@@ -552,186 +339,198 @@ Hun falder af, hun blinker tidt,
 hun selv om Natten blunder lidt.
 Men stadig hun i Aaget gaaer,
 som vented hundred slige Aar.
+
 Hvad boer der vel
 paa Bunden af den gamle Sjæl,
-saa trælløslidt og sløv?
+saa trælleslidt og sløv?
 I Hverdagslivets støvgraa Dragt
 en stadig Sorg der holder Vagt.
 Den sank tilbunds, som Skatten rød
 i Muddergravens dunkle Skjød.
+
 Hun grubler paa,
 hvordan det skal den Datter gaae,
 hun fik i Ungdoms Tid.
 Det gik tilbage Aar for Aar,
 og nu selv Datt’ren „skreven staaer“.
-I Gaffen faldt en Taare tidt
+I Caffen faldt en Taare tidt
 ved Tanken, at det kom saa vidt.
 
-I Ned og Savn
+I Nød og Savn
 hun tyer dog ind til Moders Favn.
 Hun tyer til Moders Pung.
 Hun plyndrer hende for hver Hvid
 og skjælder tidt til samme Tid.
-Men Mod’ren sukker i sin Nod;
-„Hvor skal det gaae, naar jeg er ded?“
-I
+Men Mod’ren sukker i sin Nød;
+„Hvor skal det gaae, naar jeg er død?“
 
 T:En Episode
-F:I Nød og Savn
+F:Paa Hospitalet bæres ind
 SIDE:21-22
 
-)
-Paa Hospitalet hares ind
+Paa Hospitalet bæres ind
 en Kvinde, ung og fin.
-Hun syntes alt at hore til
+Hun syntes alt at høre til
 i Dødens snævre Skrin.
-Fra Stiftelsen hun kom.
-Sit Barn
+
+Fra Stiftelsen hun kom. Sit Barn
 hun der tilbage lod.
 Det døde, før det Lyset saae,
 mens Slaget endnu stod.
+
 Paa 17—18 lagdes hun,
 det stakkels unge Blod
 Og hvad hun led, det veed kun Gud;
 hun taug med taaligt Mod.
-Hun fremmed var.
-End ikke En
+
+Hun fremmed var. End ikke En
 for hendes Skyld kom did.
 Den „svenske Pige“ eied ei
 en Ven, og ei en Hvid.
 
 Men Stuelægen saae tilsidst
 dog hendes stille Nød.
-Han hende et Far Skilling gav
+Han hende et Par Skilling gav
 til The og til lidt Brød.
+
 Dag sneg sig hen for Dag; det blev
 af Maaneder et Tal.
-Saa var hun rask.
-Hun skrives ud.
-„Den Svenske" bort nu skal.
-Paa Lægens Der det pikker let,
+Saa var hun rask. Hun skrives ud.
+„Den Svenske“ bort nu skal.
+
+Paa Lægens Dør det pikker let,
 og med beskeden Færd
 indtræder hun at takke ham,
 hun mest maa takke her.
+
 Den unge Læge samler sig
 til et Formaningsord.
 Hun svarer blidt: „Vær uden Frygt:
-Min Lidelse var stor".
-Hvad gjor Du nu? — „Jeg tjene vil
-som før."
-Og har et Sted? —
-,,Nei Kors! Den svenske Kjælder kun.
+Min Lidelse var stor“.
+
+Hvad gjør Du nu? — „Jeg tjene vil
+som før.“ Og har et Sted? —
+„Nei Kors! Den svenske Kjælder kun.
 for mig jeg aaben veed.
+
 For otte Skilling der et Degn
 man være kan, og da
-jeg finder mig et Herskab vel." -
+jeg finder mig et Herskab vel.“ —
 Hvor faaer Du Penge fra?
 
 Hun seer ned paa sin hvide Haand
-med den Udtemtes Ro.
-„Jeg har endnu den'Ring, hvormed
+med den Udtømtes Ro.
+„Jeg har endnu den Ring, hvormed
 Han fæstede min Tro.“
-Og hermed gik hun.
-Dødens Svælg
+
+Og hermed gik hun. Dødens Svælg
 var hun gaaet tæt forbi.
 Hver jordisk Fryd og Frydens Frugt
 var sunket ned deri.
-(
 
 T:Sypigens Beretning
-F:Hun seer ned paa sin hvide Haand
+F:Nei, Frøkenen maa troe mig, det er saa surt et Liv
 SIDE:23-25
 
-)
 Nei, Frøkenen maa troe mig, det er saa surt et Liv
 at boe imellem simple Folk med deres Smuds og Kiv.
 Og jeg er fra min Barndom til ganske Andet vant:
 Min Faer var Constabel, og vort Hus var galant.
-Min Moer var Degnedatter.
-Den Tid er nu forhi.
+
+Min Moer var Degnedatter. Den Tid er nu forbi.
 Hun hviler længst i Jorden, for alle Sorger fri.
 Min lille Signe aldrig hun hørte Noget om,
 og det var ganske godt, maaskee, da hun ukaldet kom.
+
 Jeg har dog kun den Ene, mens mangen En har Tre;
 det gjør den største Forskjel, som vel Enhver kan see!
 Nei, Himlen mig bevare, thi Ære og Dyd
-det er paa Jord den hedste Trøst, det er den største
-Fryd.
+det er paa Jord den bedste Trøst, det er den største Fryd.
 
 Saa lærer jeg min Signe. Men, hvad jeg sige vil:
 Det er dog ganske grueligt, som ofte det gaaer til.
 Der boer nu Dør om Dør med os et Par, som bringer tidt
-mit Blod ikog. Jeg heftig er; mit Sind er ikke blidt.
+mit Blod i Kog. Jeg heftig er; mit Sind er ikke blidt.
+
 Før gik jeg ind at stifte Fred og skammed hende ud.
-Da blev hun lynegal engang og sagde —fri mig Gud! —
+Da blev hun lynegal engang og sagde — fri mig Gud! —
 jeg nævner ei de Ord, som hun tog i sin Mund.
 Hun skulde nødig sige Sligt, en saadan En, som hun!
-Nu henter jeg vor Vært.
-Han staaer som en Blok
+
+Nu henter jeg vor Vært. Han staaer som en Blok
 med Næverne i Siden kun og gloer, saa har hun nok.
-Hun vover ei at mukke. Men bag Værtens brede Byg
+Hun vover ei at mukke. Men bag Værtens brede Ryg
 staaer Manden saa og skjælder; der føler han sig tryg.
+
 Om hun er yngre? Jo, hun er i Alder just med mig.
-Vi gik i Skole sammen.
-Nu hilses vi ei.
+Vi gik i Skole sammen. Nu hilses vi ei.
 At trænge mig paa er ei min Character;
 og somme Ting kun nødig man hører og seer.
+
 Men tidt dog jeg sidder, naar hun tager paa Vei,
 og maa lytte derefter, om jeg vil eller ei.
 Min lille Signe trykker dybt sit Hoved i mit Skjød,
 og Beggeto vi græde ved at tænke paa hans Nød.
+
 Han var en gammel Skræddersvend, af dem, der passe Sit;
 en retskaffen Sjæl, men lidt sær i sit Snit.
 Han havde Alt i Orden; han i Ligkassen var,
 og mangen Daler hen han i Bikuben bar.
 
 Ja, Himlen raader underligt. Hvordan han fik den Ven,
-det kan jeg aldrig fatte.
-Det var en Dreiersvend.
+det kan jeg aldrig fatte. Det var en Dreiersvend.
 Han boede hos den Gamle. Det var hans Et og Alt;
 men han for al hans Godhed har ham skammelig betalt.
+
 Han prelled ham bestandig, lo ham ud paa hans Bag;
 han havde tusind Planer for, var med i vildest Lag.
 Han smidsked for hver Pige, han holdt dem for Nar,
 men allermest dog hende, som Skræddersvenden har.
-Hun tænkte nu saa sikkert, at han „vilde hende No’e t;“
+
+Hun tænkte nu saa sikkert, at han „vilde hende No’et;“
 men Ingenting han vilde, som jeg har altid troet.
 To Børn ved ham hun fik kun. Og paaengang hun spor,
-at han gifter en Enke, han har tjent som Markor.
+at han gifter en Enke, han har tjent som Markør.
+
 Hun gjorde da Spektakler, som Hver vel tænke kan.
-Han tyssed paa og lovede at skafle snart en Mand.
+Han tyssed paa og lovede at skaffe snart en Mand.
 Han taled nu for Skrædderen, det stakkels gamle Skrog,
 og viste ham, hvor rart det var, om han en Kone tog.
-Han friede selv for Vennen, og han Forlover var,
-Skjondt Skræddersvenden vred sig, saa blev de dog et Par.
-Den Gamle alt begyndte at åee til Sagen mildt;
-dafik han Prygl den tredie Dag, og al hans Fryd var spildt.
-d Nu hanker hun ham daglig, saa jeg tor sværge paa,
-n at mangengang det stakkels Skind er baade brun og blaa.
-d Nei, Himlen mig bevare for sligt Ægteskabs Lyst;
-H jeg og min lille Signe vi er hinandens Trost.
 
-T:Nattearbeid
-F:Hun er jo dog igrunden et faderløst Barn
-SIDE:26-27
+Han friede selv for Vennen, og han Forlover var,
+Skjøndt Skræddersvenden vred sig, saa blev de dog et Par.
+Den Gamle alt begyndte at see til Sagen mildt;
+da fik han Prygl den tredie Dag, og al hans Fryd var spildt.
+
+Nu banker hun ham daglig, saa jeg tør sværge paa,
+at mangengang det stakkels Skind er baade brun og blaa.
+Nei, Himlen mig bevare for sligt Ægteskabs Lyst;
+Jeg og min lille Signe vi er hinandens Trøst.
 
 Hun er jo dog igrunden et faderløst Barn.
 Hvad hjælper vel en Fader, naar han kun er et Skarn?
-Jeg vilde ikke „søge ham ;“ jeg holdt mig for god.
+Jeg vilde ikke „søge ham;“ jeg holdt mig for god.
 Før syer jeg og træller, til min Haand staaer i Blod.
+
 Gud unde mig kun Helsen, saa skaffer jeg vel Brød,
-men faldt jeg fra, da seer jeg kun for hende Sorg og Ned
-Nei, skal jeg bort, jeg heder Gud, at han vil kalde da
+men faldt jeg fra, da seer jeg kun for hende Sorg og Nød.
+Nei, skal jeg bort, jeg beder Gud, at han vil kalde da
 mig og min lille Signe paaengang herfra.
-(Nattfearbeid.)
+
+T:Nattearbeid
+F:Det lysner over Baggaardstag
+SIDE:26-28
+
 Det lysner over Baggaardstag,
 og Huset sover trygt.
 Nu kan jeg til mit Arbeid gaae
 i Mag og uden Frygt.
+
 En stakkels Pige trælle maa
-for Andre Nat og Dag-,
+for Andre Nat og Dag,
 hvordan hun faaer sit Eget gjort,
 det bliver hendes Sag.
+
 Men Gud skee Lov for Jens! Han er
 saa ærekjær og tro.
 Paa Søndag lyses trediegang,
@@ -740,23 +539,28 @@ saa skal vi fæste Bo.
 Gud signe ham! Og den, som her
 jeg stopper Puden til!
 Lidt mere Fyld! Det fattig Lam
-saa sodt da sove vil.
+saa sødt da sove vil.
+
 Paa Sopha hviler Fruen sig
-og stonner for hvert Skridt.
+og stønner for hvert Skridt.
 Men jeg maa bære Vand endnu
 og vadske Trappen tidt.
+
 Dog Gud seer ned og gier nok mig
 en Glut saa sund og trind,
 mens hun, som sidst, en Skrælling faaer,
 der skjælver for hver Vind.
-Til Nytaar hk jeg fire Mark
+
+Til Nytaar fik jeg fire Mark
 for Aarets sure Slid. —
 Naa da, hvor Dynen slunker ind!
 Den vidner om min Flid.
+
 Jeg faaer sye til. Dog, lidt endnu,
-skjendt Vuggen færdig er.
+skjøndt Vuggen færdig er.
 Til Jens kan jeg vel bjerge end
 en lille Pakke Fjer. —
+
 Nu Kosten fat og feiet op,
 og Sengen redt saa pænt.
 Jo, Stine hun er fix og net,
@@ -764,54 +568,58 @@ og hendes Kammer rent.
 
 Den Seng vil blive mig lidt haard
 den Tid, der er igjen.
-Dog gjør man Meer vel- for sit Barn
+Dog gjør man Meer vel for sit Barn
 og for sin Hjertensven. —
-(
 
 T:Et uægte Barn
-F:Den Seng vil blive mig lidt haard
-SIDE:28-32
+F:Hun var langt over Ungdoms Aar
+SIDE:28-33
 
-)
 Hun var langt over Ungdoms Aar,
 og hvast var hendes Sind.
-Det var som Hyhenrosens Hæk
-i Yintrens skarpe Yind.
+Det var som Hybenrosens Hæk
+i Vintrens skarpe Vind.
+
 Men aldrig havde og hun staaet
-i Sommerdragt, som den-,
+i Sommerdragt, som den,
 for hende hver en Livets Blomst
 som Knup var visnet hen.
+
 Hun voxed op som Pleiebarn,
 og der blev godt betalt.
 Hun i saa pæn en Skole gik
 og nemmed hurtig Alt.
+
 Hun mærked sig saa mangt et Vink,
 da svulmed Haabets Elv.
 Da hun blev confirmeert, det hed:
 Sørg nu Du for Dig selv.
 
-Saa tjente hun.
-Skjøndt hun var flink,
+Saa tjente hun. Skjøndt hun var flink,
 hun skiftede dog tidt.
-Hun passed ei blandt Folk.
-Der var
+Hun passed ei blandt Folk. Der var
 for Meget og for Lidt.
+
 Hun vidste, hendes Faders Plads
 var tidt ved Kongens Bord.
 Hun vidste, hendes Moder sov
 i Sognets Fattigjord.
+
 Hun gik engang om Condition,
 hun stod for Fruen snild.
 Da var det hendes Søster, som
 ei aned, hun var til.
-1 ilsidst hun til et Herskab kom,
+
+Tilsidst hun til et Herskab kom,
 det var nær Rungstedgaard.
 En Frue med to Døttre kun,
 der tjente hun et Aar.
+
 Hun blev der et, hun blev der to,
 hun blev der vel en Snes.
 Hun tjente tro, behersked snart
 saa strengt den lille Kreds.
+
 Hun tjente, som det sjeldent sees.
 Hun fandt jo der et Hjem.
 De taalte Alt. De vidste, hun
@@ -819,125 +627,141 @@ i Døden gik for dem.
 
 Dog var hun dem et Huskors svært.
 Men imod En hun kun
-var god og næsten altfor om:
+var god og næsten altfor øm:
 Den Ene var en Hund.
+
 For lang Tid siden kom iblandt
 en Slagter der med Kjød.
 Han hviskede til Pigen tidt,
-da blussed Kinden rod.
+da blussed Kinden rød.
+
 Hun klapped Hesten for hans Vogn,
 hun fored Hunden mild.
 Hun satte Manden selv tilbord
-ved lune Kjekkenild.
-Medet han borte blev.
-Men hun
+ved lune Kjøkkenild.
+
+Medet han borte blev. Men hun
 beholdt den lodne Hund.
 Forgjæves søgte Husets Folk
 at gjætte Sagens Grund.
-Hun tav.
-Og Dag og Aar gik hen;
-en Række.
-Hunden nu
+
+Hun tav. Og Dag og Aar gik hen;
+en Række. Hunden nu
 blev gammel, syg og styg og fæl;
 den var Enhver en Gru.
+
 Hun saae, hvad nænsom halv og halv
 forknyt man mildt fortav.
 Hun trykked Hunden til sit Bryst:
 „Snart aabner sig Din Grav.“
 
-En Morgen, kort for Solen steg,
+En Morgen, kort før Solen steg,
 hun med sin gamle Hund
 med uvant Haand roer ene ud
 paa blanke Øresund.
+
 Hun tager Aaren ind, og nu
 hun sysler med sit Værk.
 Et Fiskernet hun knyttet har
 af Traaden, tyk og stærk.
+
 Hun vikler det om Hunden fast;
 den knurrer kun saa smaat.
-I Hjørnet hinder hun en Sten,
+I Hjørnet binder hun en Sten,
 som ret kan tynge godt.
+
 Sin Psalmebog med Gyldensnit
 hun tager stille frem.
 „Du fulgte mig i Kirken tidt,
 følg Du min Ven nu hjem.
+
 Du fulgte mig i Ungdoms Aar,
 Du siden gjemtes hen.
 Naar I tilbunds nu Begge gaaer,
 vi sees ei meer igjen.“
-Hun tager frem en Perløsnor,
+
+Hun tager frem en Perlesnor,
 et Hjerte hænger ved.
 „Du fandt ei Fred paa vide Jord;
 find nu i Havet Fred.“
 
-ISMPMtMR
 Og af sit Øre tager hun
 en Slangering saa glat.
 „Jeg fik den i saa glad en Stund;
-det var min Barndoms Skat."
+det var min Barndoms Skat.“
+
 Snart er det Hele pakket til,
 og sorrigknuget hun
 nu trykker Hunden til sit Bryst
 og sin fortrukne Mund.
+
 Den blinker dorsk og snøfter qvalt
 med tyktomtaaget Aand,
 mens gjennem Maskerne den dog
 vil slikke hendes Haand.
+
 Da vælter hun den med et Skrig
-ud over Baadens Band
+ud over Baadens Rand
 og synker ned paa Bunden, mens
 den sank i dybe Vand.
+
 Men da hun atter reiste sig,
 ei mindste Spor hun saae;
-kun Morgensolens HimmelGlands,
+kun Morgensolens Himmelglands,
 som over Vandet laae.
+
 Hun styrer Baaden taus til Land,
 og taus hun vandrer hjem.
-Der speider Hver, men Ingen spor,
-hvor Hunden er igjen.
+Der speider Hver, men Ingen spør,
+hvor Hunden er igjem.
 
 Men dobbelt stiv og dobbelt hvas
 hun nu iblandt dem gaaer.
 For deres Skyld fik Hjertet jo
 det sidste, dybe Saar.
 
+SLUTSEKTION
+
 T:Christian Fibiger
 U:_1859._
 F:Nu hviler fra Dit lange Dagværk Du
-SIDE:32-34
+SIDE:33-34
 
 Nu hviler fra Dit lange Dagværk Du,
 velsignet gjennem Taarer af saa Mange.
 Din Sjæl var træt, til Hvile stod dens Hu,
 Livsbaandet holdt Dig, som det holdt en Fange.
+
 Det brast. Ei Bortgang var Dig Dødens Stund,
 den var Din Ankomst kun til Lysets Rige.
 Din Aand faldt her alt i et stakket Blund
 for klar og samlet til sin Gud at stige.
-Fred felge Dig.
-Du var en virksom Mand,
+
+Fred følge Dig. Du var en virksom Mand,
 til Livets Aftentaage dækked Aanden.
 Din Kraft var kløgtig, og Din Gudsfrygt sand,
 Hjertet var ømt og hjælperig var Haanden.
 
 Din Ungdoms Brud nu ved Din Kiste staaer;
 som trofast Hustru sad hun ved Dit Leie.
-Og Øine Børn med Sorg i Hjertet gaaer
+Og Dine Børn med Sorg i Hjertet gaaer
 halvspredte om paa Livets nye Veie.
+
 Og de, hvem Du en anden Fader var,
-de Brøderhorn, de vil Dig aldrig glemme.
+de Broderbørn, de vil Dig aldrig glemme.
 Blandt Minder fra en Fortid, lys og klar,
-vil Onke l C h r i s t i a n s Navn de helligt gjemme.
+vil Onkel Christians Navn de helligt gjemme.
 
 T:Jacob Scavenius Fibiger
 F:Simpel af Hjerte og trofast af Aand
 SIDE:34-35
 
 Simpel af Hjerte og trofast af Aand,
-knyttet til Øine ved ommeste Baand
+knyttet til Dine ved ømmeste Baand
 var Du, en Støtte for Børn og for Viv,
 selv dog et Barn i det daglige Liv.
-Landet paaskjonned sin dygtige Søn,
+
+Landet paaskjønned sin dygtige Søn,
 sparede ikke Beundringens Løn;
 hjemme han gik dog, som Ingenting var:
 aldrig sin Hæder tilskue han bar.
@@ -946,72 +770,72 @@ Hjemme han sad som et Barn ved sin Bog,
 grandskede ivrig de fremmede Sprog;
 glæded sig over hvert Ord, som han vandt,
 over de Tanker, som derved oprandt.
+
 Hjemme! Hvem var vel i Hjemmet som han?
 Halvt som et Barn og saa helt dog en Mand;
 glad som en Brudgom ved Kvinden, hvem alt
-liregang ti Aar han Sin havde kaldt.
+firegang ti Aar han Sin havde kaldt.
+
 Altid det Billed vil staae for min Sjæl,
 som Du sad hos os en Julenatsqveld:
 Isgraat var Haaret, men Ansigtet dog
 talte til Øiet med Englenes Sprog.
+
 Kun hos de Børn, som — saa spæde og smaa
 bæres paa Armen, det Udtryk jeg saae.
 O hvem der kunde saa hel og saa ren
 naae til sin Grav, til dens dækkende Sten!
 
-T:Dronning Ingeborgs Klage
+T:Dronning Ingeborgs<note>* Datter af Kong Magnus Ladulås i Sverrig, trolovet med Erik Menved 1288, gift med ham i Helsingborg 1296. Hun fødte sin Ægtefælle 14 Sønner, der dels vare dødfødte dels døde smaa. Den sidste Søn skal, 1 Maaneder gammel, være bleven dræbt ved at falde ud af Vognen, da Dronningen 1318 kjørte fra Abrahamstrup (nu Jægerspris) til Holbek. Af Sorg derover gik hun i St. Clara Kloster i Roeskilde, hvor hun døde 15de August 1319, tre Maaneder før Kongen.</note> Klage
 F:Hvor det lysner
 SIDE:36-42
 
-H vor det lysner!
-Lysner gjennem dunkelgrenne Lovtag,
-hvor jeg gjexnte mig for Dagens Klarhed,
-hvor jeg skjulte mine matte, slove,
+Hvor det lysner!
+Lysner gjennem dunkelgrønne Løvtag,
+hvor jeg gjemte mig for Dagens Klarhed,
+hvor jeg skjulte mine matte, sløve,
 halvudslukte Øine for dens Straaler.
+
 Se, det spiller!
 Spiller med et Lysglimt der paa Grunden.
 Sol, hvad vil Du? Kjender ei Du Skaansel?
 Spotter med Din Glands Du Danmarks Dronning,
-hun, den usløste blandt usle Kvinder?
+hun, den usleste blandt usle Kvinder?
+
 Engang! Engang!
 Ja, da var jeg ung og rig og haabfuld.
 Solen skinned, Folket jubled, Kongen,
 Danmarks Konge rakte glad mig Haanden,
 mens to Rigers Klokker klang til Bryllup.
-*) Datter af Kong Magnus Ladulås i Sverrig, trolovet med Erik
-Menved 1288, gift med ham i Helsingborg 1296. Hun fødte sin
-* Ægtefælle 14 Sønner, der dels vare dødfødte dels døde smaa.
-Den sidste Søn skal, 1 Maaneder gammel, være bleven dræbt
-ved at falde ud af Vognen, da Dronningen 1318 kjørte fra
-Abrahamstrup (nu Jægerspris) til Holbek.
-Af Sorg derover
-gik hun i St. Clara Kloster i Roeskilde, hvor hun døde 15de
-August 1319, tre Maaneder før Kongen.
 
 Han var Brudgom.
-O, saa straaløskjon som selve Solen
+O, saa straaleskjøn som selve Solen
 stod han ved min Side, Glandsomgivet,
-saa jeg voved knap at hæve Hiet,
-for at mode hans henrykte Blik.
+saa jeg voved knap at hæve Øiet,
+for at møde hans henrykte Blik.
+
 Dage svandt da.
 Saligt svandt de, hver en himmelsk Drøm kun.
 Og jeg sad der som en Fugl i Reden,
-mens min Mage kj ærlig den omkredste,
-sad og vented Kvindens hedste Skat.
+mens min Mage kjærlig den omkredste,
+sad og vented Kvindens bedste Skat.
+
 Hjerteskatten!
 Skat med Øine som den dybe Himmel,
 Skat med Læber smaa, med bitte Hænder,
-som op efter Moderharmen række,
+som op efter Moderbarmen række,
 som selv Hjertet let af Brystet rev.
-Sode Spæde!
-Ligger atter her Du i mit Skjod?
+
+Søde Spæde!
+Ligger atter her Du i mit Skjød?
 Favner jeg Dig med de matte Hænder,
 pusler jeg Dig let og leger med Dig,
-stiller hver Din Længsel og Begjær ?
+stiller hver Din Længsel og Begjær?
+
 Knuppen visned,
 den henvisned alt i fagrest Udspring.
-Tom stod Vuggen — Taarer væded Skjodet,
-og min Ægtemages Oie vendtes
+Tom stod Vuggen — Taarer væded Skjødet,
+og min Ægtemages Øie vendtes
 mørkt mod Jorden, hvor hans Yndling laae.
 
 Flere fulgte.
@@ -1019,21 +843,25 @@ Flere stod som Stjerner smaa paa Himlen
 i den maaneløse Nat og fyldte
 Huset med en Glands, som mig gjenfødte,
 som gjengav min Herre Liv og Lyst.
+
 Mange Taarer,
 tidlig fældede og silde rundne,
 fylde som en Vandflod Rummet mellem
 hine milde, fredopfyldte Dage
 og det Dødens Liv, jeg lever nu.
+
 Dog jeg seer dem,
 seer dem gjennem Taareflodens Bølger.
 Øine straale, lyse Lokker vifte,
 Rosenkinder smile, Læber aabnes,
 som de vilde nævne Modernavnet.
+
 Død, som barnløs,
 barnløs altid over Jorden vandrer,
 o, Du spotted med en Moders Smerte:
 En og En og En Du rev dem fra mig —
 En og En og En Du tog dem Alle.
+
 Tog dem Alle.
 Du tog Meer — Du tog min Husbonds Hjerte,
 saa han i sin Sorg sig mørk forhærded,
@@ -1045,104 +873,121 @@ i de smaa, de sortbetrukne Kister.
 Atter fyldte Haabet dog mit Hjerte,
 skjøndt jeg, angstbetagen, neppe voved
 det at troe, ja, voved knap at haabe.
+
 Eriks Øie
 hviled tvivlsomglad igjen dog paa mig,
 og som Solen bryder gjennem Skyen
 svandt hans Harm, da, lig den Første, atter
 Kongesønnen smilte i mit Skjød.
+
 Første! Sidste!
 Hjertets Vuggesang og Morgenlovsang!
-Ord, soin med en hellig Glands omstraale
+Ord, som med en hellig Glands omstraale
 Den, der først os aabned Lykkens Solland,
 Den, der Afskedshvile gav deri.
+
 Første! Sidste!
 Atter var jeg Eriks elskte Kvinde,
 Atter sad jeg, mens, som Straaet bølger
 sagte hen for Vinden, Mindet hvisked,
 sad jeg der med Lykken i min Favn.
+
 Sad jeg stille,
 sad jeg der med Lykken i min Favn. —
-Svandt Du, Solglimt, eller er det Diet,
+Svandt Du, Solglimt, eller er det Øiet,
 som, af Taarers Sørgeflor omhyllet,
 ikke skimter meer Dit svage Spil?
 
-Jlf ;•
 Solen skinned
 paa hin Dag, ei Sky fordunkled Himlen:
 Svaler svang sig høit igjennem Luften
 sikkert tumlende paa lette Vinger.
 Alting taled kun om Fryd og Tryghed.
+
 Spænd for Karmen!
-bed min Herre; Luften styrker Drengen,
-og Danfolket glædes, uaar det skuer
+bød min Herre; Luften styrker Drengen,
+og Danfolket glædes, naar det skuer
 Den, til hvem det alt sit Haab har knyttet,
 Den, det vil med Fryd til Konge kaare.
+
 Og jeg klædte
 glad min Skat i liden Silkekjortel,
 kyssed spæde Fod og gjemte vel den,
 vikled varlig ham i guldbaldyrte
 Svøb, at ingen Vind ham skulde skade.
+
 Høit han lo da.
 Høit han lo, da jeg fra Karmen viste
-ham til Folket, som trindtfra tilstremmed
+ham til Folket, som trindtfra tilstrømmed
 jublende, mens frydefuldt mit Hjerte
 hæved sig med Tak til Himlens Herre.
+
 Ve! Hvad var det?
 Dødens Slaphed sank i mine Haandled,
-Rædsels Lyn mit Oie blænded — Hjertet,
+Rædsels Lyn mit Øie blænded — Hjertet,
 isomskabt, dog i sin Isnen vidste
 hvad der skete, selv før det var skeet.
 
-Knust!
-Der laae han
+Knust! Der laae han
 blodig — knust mod Hjulet, knust mod Jorden.
 Alting standsed — Folkets Skrig sig reiste
 som en Mur imod mig — indelukket
 sad jeg, som i Vanvids Fangebur.
+
 I mit Skjød dog
 lagdes han, og end engang han sukked,
 engang end — og Alting var forbi.
 Karmen vendtes — hjemad gik det — hjemad —
 hjem med Eriks knuste Yndlings Lig.
+
 Laae jeg nede!
 Laae jeg tusind Favne dybt i Jorden!
 Kom med Lindring Orme der og gnaved
-Sorgens Gled ud af mit pinte Hjerte,
+Sorgens Glød ud af mit pinte Hjerte,
 Sorgens Spire af fortærte Bryst!
+
 Men jeg sidder
-her, hvor Levet, mæt af Sol og Regnskyl,
+her, hvor Løvet, mæt af Sol og Regnskyl,
 skygger over mig, mens Jorden, suget
-fuld af Nattens Taarer. som end glindse
-paa fjorfaldent Lev, for mig er lukt.
+fuld af Nattens Taarer, som end glindse
+paa fjorfaldent Løv, for mig er lukt.
+
 Kun to Græsstraa,
 Græsstraa smaa, som midt i Gangen opskjød,
-vifte stille.
-Jer betroer min Sorg jeg.
+vifte stille. Jer betroer min Sorg jeg.
 O saa mildt, saa mildt, saa ukjendt med den
 bittre Smerte, staae I for mit Blik.
 
-T:Sværmeri
-F:De hørte fortælle om Kongens Søn
-SIDE:42-43
-
-I il! i
 Hils dernede!
 Bed om Plads for en usalig Kvinde!
-Hils med Eders Rodder smaa og bed kun
+    Hils med Eders Rødder smaa og bed kun
 om en fattig Plads for Danmarks Dronning,
 om en Plet, hvor hun kan finde Ro.
+
 Jeg i Drømme
 seer igjen da vel hver Hjertets Yndling.
 Jeg, naar Livets Traad er bristet, atter,
 atter hist et venligt Blik vel vinder
 af den Elskte, som mig hader nu.
+
 Jeg vil bie.
 Jeg vil bede, naar mit Hjerte tystnes,
 naar min Tanke samler sig, saa klart jeg
 kjender selv, hvad det saa haardt omknuger,
-bede for hans Held og for min Dud.
+bede for hans Held og for min Død.
 
-Da bygged et Slot de blandt Roser ilon,
+SEKTION:Af en Børnebog
+
+T:Sværmeri
+F:De hørte fortælle om Kongens Søn
+SIDE:42-43
+
+De hørte fortælle om Kongens Søn,
+som sad med sin Brud mellem Roser iløn.
+De hørte om Kongens skinnende Slot,
+og Huset derhjemme det faldt dem saa smaat.
+
+Da bygged et Slot de blandt Roser iløn,
 der sidder nu Bruden hos Kongens Søn.
 Mens Fuglene synge, og Sol skinner klar,
 de To sidde der, det lyksaligste Par.
@@ -1152,25 +997,28 @@ F:Jeg ligger i min Moders Skjød
 SIDE:43
 
 Jeg ligger i min Moders Skjød
-og .seer i min Faders Die.
+og seer i min Faders Øie.
 Jeg hører min Søsters Stemme sød —
 maa det mig ei fornøie?
+
 Min Moder er en Frue prud,
 saa rig som ingen Anden;
 hun smykker sig i grønne Skrud
-#med Blomsterstads om Randen.
+med Blomsterstads om Randen.
+
 Min Fader er en Ridder stor
 — mod ham er hun en Terne —
-han spreder SolGlands over Jord,
+han spreder Solglands over Jord,
 hans Seng er redt med Stjerne.
+
 Min Søster er hver lille Fugl,
 hvis Sang mig maa fornøie,
 hver Blomst, der bryder Jordens Skjul,
-saa liflig for mit Die.
+saa liflig for mit Øie.
 
 En Brøder har jeg sagtens med,
 han tidt besværlig falder.
-Han eder min Familiefred:
+Han øder min Familiefred:
 man Menneske ham kalder.
 
 T:I Maaneskin
@@ -1181,14 +1029,17 @@ De sad en silde Aftenstund
 paa Trappens kolde Sten,
 mens Skyggen dækked Engens Bund,
 og Maanen skinned ren.
+
 Og Skyer kom, og Skyer gik,
 de drev ad Himlen hen,
-og Maanen, dækt et Oieblik,
+og Maanen, dækt et Øieblik,
 fremstraaled klar igjen.
+
 De skulde hjem, men gik ei hjem,
 det var en sælsom Lyst,
 det var, som Maanen vinkte dem
 til fremmed Land og Kyst.
+
 Da skred en modig Vandrer dem
 med tunge Trin forbi.
 Han ved sin Stav gik ensom frem
@@ -1196,25 +1047,30 @@ ad Nattens vilde Sti.
 
 Men med et Kuldegys de To
 hinanden tog i Favn,
-og sugte saa til sødest Ro
+og søgte saa til sødest Ro
 i Faderhusets Havn.
+
+SLUTSEKTION
 
 T:Niels Ebbesen
 F:Grev Geert han drager i Jylland op
-SIDE:45-48
+SIDE:45-47
 
 Grev Geert han drager i Jylland op
 med rige Riddere og Svende.
 Hvor findes i Danmark den Heltetrop,
 som Faren kan afvende?
+
 Hvor findes i Danmark en samlet Magt?
 Landet er halvt lagt øde.
 Til Undergang er det næsten bragt,
 skjøndt Skylden er mest hos de Døde.
+
 Nu deres Børn det undgjælde maa
 og de, som ei det forskylder.
 Tydsken tager, hvad han kan faae.
 Hver Rytter sin Pose fylder.
+
 Bondens Tag gaaer op i Røg,
 Oldinger husvilde vanke.
 Mord og Brand er kun en Spøg
@@ -1224,23 +1080,27 @@ Ridderne see det med bitter Harm.
 Hvad skal de mod Fjenden gjøre?
 Hvor de kan bringe en eneste Arm,
 han tyve mod dem kan føre.
-.Norden for Randers mødtes en Dag
+
+Norden for Randers mødtes en Dag
 Grev Geert med en Mand af de Danske.
 Men som de taltes ved om den Sag,
 den Ridder kasted sin Handske.
-„Spar Øine Trudsler.
-Jeg er ikke Den,
+
+„Spar Dine Trudsler. Jeg er ikke Den,
 der tvungen Ed Dig skal sværge.
-Du mindes det vel: Jeg kommer igjen !
+Du mindes det vel: Jeg kommer igjen!
 Se til Dig at værne og værge!“
+
 Greven sover i Randersby,
 midt i sin talrige Skare.
 Ridderen kommer foruden Sky,
 faa Svende kun med ham fare.
+
 Ridderen trænger i Gaarden ind;
 ved Bulderet vækkes den Herre.
 Han stirrer og blegner om solbrændt Kind:
 Mon det kan Ebbesen være?
+
 Ebbesen snart i hans Kammer staaer:
 Hvad hjælpe de talrige Skarer?
 Grev Geert faaer hurtigt sit Banesaar,
@@ -1250,30 +1110,35 @@ Da bredte sig atter et Morgenskjær
 hen over Danmarks Rige.
 Vei baned Ebbesens brede Sværd
 for en Konge, der søger sin Lige.
+
 Men førend Atterdags Sol oprandt,
 laae Ebbesen under Tue.
 Han Heltedøden i Kampen fandt,
 thi Tydsken var svær at kue. —
-Og siig, hvad Frelserløn han ned
+
+Og siig, hvad Frelserløn han nød
 for Seiren, han os mon vinde?
-Den Fattigste bod barn sin sidste Bid Brød,
+Den Fattigste bød ham sin sidste Bid Brød,
 og Folket ham reiser et Minde.
+
 Aarhundreder byggedes alt derpaa,
 mens Slægter kommer og svinde;
 det bygges i Slot og i laveste Vraa,
 det bygges af Mand og af Kvinde.
-Den Mindestotte ei styrtes kan;
+
+Den Mindestøtte ei styrtes kan;
 det er en uslukkelig Kjerte.
-H v e r D a n sk , der e lsk e r sit F ø d e l a n d ,
-b æ r N ie ls Ebbesens Navn i s it Hjerte.
+Hver Dansk, der elsker sit Fødeland,
+bær Niels Ebbesens Navn i sit Hjerte.
 
 T:Epigram
 F:Ingen Kvindesorg er saa stor
 SIDE:48
 
+Ingen Kvindesorg er saa stor,
 den svinder jo bort for Beilerord;
 ingen Kvindesorg er saa ringe,
-den kan jo Taarer i Diet bringe.
+den kan jo Taarer i Øiet bringe.
 
 T:Stjernen
 F:Og dersom nu en Stjerne sank
@@ -1283,31 +1148,37 @@ Og dersom nu en Stjerne sank
 til os fra Himlen ned,
 hvor faldt den vel, saa klar og blank,
 hvor valgte den sit Sted?
+
 Mon den igjennem klare Luft
 skjod ned i mørken Muld
 og spired op med liflig Duft
 en Blomst, saa underfuld?
+
 Mon den i Fuglens Rede fandt
 et stakket Ly og svang
 sig vinget op, naar Sol oprandt,
-med aldrig horte Sang ?
+med aldrig hørte Sang?
 
-Mon den sank ned i selvblaa Hav
+Mon den sank ned i sølvblaa Hav
 og blev en Perle ren,
 saa kostelig, at Kongen gav
 for den hver Ædelsten?
+
 O nei! Den kom, useet og tyst,
-til Stevets faldne Son
+til Støvets faldne Søn
 og gjemte sig i sorgfuldt Bryst
-og blev en ydmyg Bon.
+og blev en ydmyg Bøn.
+
 Og blev en Længsel, stærk og stor,
 der sprængte Syndens Baand,
 et Forsæt, der opsvang fra Jord
 den dybtnedtrykte Aand.
+
 Og hvilte der med stille Magt,
 imens han Kampen stred,
 og dulgte der sin Straalepragt,
 mens han mod Maalet skred.
+
 Men med hans sidste Suk den foer
 — et saligt Stjerneskud —
 mod Himlen op fra dunkle Jord
@@ -1315,7 +1186,7 @@ og bar hans Sjæl til Gud.
 
 T:Præstens Søn
 F:Tre Piger stode og hviltes ved
-SIDE:50-57
+SIDE:50-58
 
 Tre Piger stode og hviltes ved
 det Landsbyled,
@@ -1323,241 +1194,263 @@ det Landsbyled efter Qveld.
 De skulde hjem, men gik ikke hjem;
 det var, som Stedet fængslede dem
 — og Grunden kjendte de selv.
+
 De dæmrende Stjerner faae større Glands,
 mens som til Dands,
 til Dands beredte de staae.
 Da gaaer med lokkende Flagerflugt
 et Stjerneskud over Himlen smukt,
-og Pigernes ønsker det naae.
+og Pigernes Ønsker det naae.
+
 Men inderligt ønske de Hver især,
 skjøndt En og Hver,
-ja, Hver bar kun samme Bøn:
+ja, Hver har kun samme Bøn:
 „Før Aar og Dag han som Beiler staae;
 om Alt han bede, og Alt han faae,
 den Eneste, Præstens Søn!“
+
 Med Blussen og bankende Hjerte de
 det Varsel see,
 det Varsel om Fremtids Lyst.
-
-Med lenlig Fryd vil nu Hver gaae hjem;
+Med lønlig Fryd vil nu Hver gaae hjem;
 da drager der Noget ad Veien frem,
 hvor den dreier mod tangklædt Kyst.
+
 Det skrider tyst og tungt og sort
 ad Veien fort,
 ad Veien mod Landsbyen ned.
 Den dæmpede Mumlen, de tunge Trin
-fremhæres af Nattens sukkende Vind,
+frembæres af Nattens sukkende Vind,
 mens Toget drager afsted.
+
 Du rige Christ! En Baare! Se!
-O Ye! O Ve!
-O Ve! Her Klager og Ben!
+O Ve! O Ve!
+O Ve! Hør Klager og Bøn!
 En Druknet! en stakkels Fiskers Lig!
 De arme Folk! Hvem er det? Sig:
-— „Præstens eneste Sen.
+— „Præstens eneste Søn.
+
 Imorges han heiste sit Seil med Sang,
 som vidt henklang,
 henklang over skinnende Vig.
 Saa styred han bort, da Sol oprandt.
 Mod Aften hans kæntrede Baad vi fandt
 og fandt ham selv som et Lig.“
+
 Da synker en Taage for Pigernes Blik.
 De stille gik,
 gik stille Hver til sit Hjem.
-
 Med skjælvende Hjerte, paa vaklende Fod
-de suge til Sengen, saa taus og god,
+de søge til Sengen, saa taus og god,
 og der styrte Taarerne frem. —
+
 Tungtskridende Tid har i sit Fjed
-tidt Trosten med,
-tidt Trosten saa tæt i sit Spor.
-For Nodderne modne af Haslerne faldt,
+tidt Trøsten med,
+tidt Trøsten saa tæt i sit Spor.
+Før Nødderne modne af Haslerne faldt,
 har Smedens Datter en Beiler alt,
 og Jubel i Hjertet boer.
+
 En Fremmed var han kommen did.
 Hver Aften blid,
 hver Aften i Lunden de gaae.
-Dog se! Engang, efter sedest Lyst,
-laae hun ded med en blodig Plet paa sit Bryst.
+Dog se! Engang, efter sødest Lyst,
+laae hun død med en blodig Plet paa sit Bryst.
 Men ham ei mere man saae. —
+
 Det lider stærkt mod Juletid;
 den Fest saa blid,
 den Fest saa blid rykker nær.
-Og Alle har travlt,-men Degnens mest;
+Og Alle har travlt; men Degnens mest;
 der redes med Fryd til dobbelt Fest,
 til Bryllup for Datteren kjær.
+
 Der kom en Gjæst fra den store Stad,
 og Pigen glad,
 saa glad til den Fremmede saae.
-
 Nu bindes der paa hendes Brudekrands,
 Fiolerne stemmes alt til Dands:
 imorgen skal Bryllupet staae.
-Den Morgen kommer.
-„Vor unge Brud
+
+Den Morgen kommer. „Vor unge Brud
 vil sove ud,
-vil sove, men ei hun faaer Fred.”
+vil sove, men ei hun faaer Fred.“
 De Piger i Kamret finde et Lig,
 og Alle hidile ved deres Skrig.
 Kun Brudgommen kommer ei med. —
+
 Fra Himlen nedstraaler den blanke Sol,
 og bly Viol,
 Viol staaer i Græsset dulgt.
-End Mollerens Datter saa kummerfuld gaaer.
+End Møllerens Datter saa kummerfuld gaaer.
 Den Svend, hendes Fader fæsted iaar,
-har lonligt dog efter fulgt.
-Forst hores neppe hans stille Bon.
-Hos Præstens Son,
+har lønligt dog efter fulgt.
+
+Først høres neppe hans stille Bøn.
+Hos Præstens Søn,
 hos ham hendes Sjæl kun er.
 Men snart bortglider hans Billed svagt;
 for Somren end staaer i fuldest Pragt,
 har alt hun den Anden kjær.
+
 Og Bryllupet feires med Sang og Klang.
 Den Dag saa lang,
-
+den Dag saa lang er forbi.
 De sidde ved Aften om Brudebord;
 da føler Bruden en Længsel stor,
-som dreves bun ud i det Frie.
+som dreves hun ud i det Frie.
+
 Da Tumlen voxer, hun lister sig ud.
 Han følger sin Brud,
 han følger af festsmykte Hus.
 Men inde med Latter og Skjæmteord
 de Gjæster dem savne og ønske i Chor
 Godnat ved de klinkende Krus.
+
 Saa solklar oprinder den næste Dag.
 Med lunt Behag,
 Behag alt den Moder staaer
-for Kammerets Dør.
-Den er lukket fast.
+for Kammerets Dør. Den er lukket fast.
 Hun banker saa skjælmsk, hun banker med Hast,
 men intet Svar hun dog faaer.
+
 Da gribes hun af en isnende Skræk.
 Hun iler væk,
 Hun ilsomt faaer Manden derhen.
 Han sprænger ihast den lukte Dør:
 Kamret er tomt, og opredt som før
 Staaer Sengen, som vented den end.
+
 Der ledes i Have, i Hus, paa Loft,
 i Mark og Toft,
 i Mark og Toft og ved Kjær.
-
 Den hele Landsby gaaer søgende med;
 Unge og Gamle fare afsted
 i vildforstyrrede Færd.
+
 De gaae forbi den Kirkegaard,
 og Skaren staaer,
 staaer stille med gruende Sind.
 Hvad skinner saa hvidt paa Graven hist?
-Hvad skinner bag Bosenbuskens Qvist,
+Hvad skinner bag Rosenbuskens Qvist,
 som vugges i Sommervind?
+
 Med halvlukket Øie, med halvaaben Mund
 hun fin og rund,
 rund ligger i dybeste Blund.
-Krandsen hænger i Haaret lost;
+Krandsen hænger i Haaret løst;
 en Blodplet sees paa letblottede Bryst
-men et Smil om farvelos Mund.
+men et Smil om farveløs Mund.
+
 Moderen kaster sig med et Skrig
 over elskte Lig,
 trykker Liget fast til sit Bryst.
 „Mit Barn! hvad vil Du hos Præstens Søn?
 Har ei Du længe nok grædt iløn,
 og fandt Du tilsidt ikke Trøst?“
+
 Men Skaren udstøder et skingert Skrig.
 Den styrter sig,
 sig vildt mod omfredede Høi.
-
 Med Spader, med Skuffer, med Hænder man grov,
 Op heises Kisten i hidbragt Tov.
-Da stilløs den summende Støi.
-Den aabnes
-Med Rædsel Enhver nu seer
+Da stilles den summende Støi.
+
+Den aabnes. Med Rædsel Enhver nu seer
 jordfæstede Leer,
 jordfæstet alt for et Aar.
 Men i den gulnede Skjortes Flig
 halvfrisk en Urtekost dølger sig:
 den smykkede Bruden igaar.
+
 Tre Guldringe glimre paa Fingerled.
 Dem fik han ei med,
 ei med i sin tidlige Grav.
 Saa Mange kjende de Ringe smaa.
 Paa Jomfruhænder man før dem saae:
 Hver sin til en Beiler gav.
+
 „Ham er det! Præstens Søn! Han brød
 sin Grav, og død,
 død søgte han Livets Lyst.
-En Pæl i hans Hjerte!
-Vi give ham Fred!
+En Pæl i hans Hjerte! Vi give ham Fred!
 En Pæl! Vi ham mane i Jorden ned,
-hvor Ormene blive hans Trost.“
-„Holdt!“ lyder det.
-Præsten iblandt dem staaer.
+hvor Ormene blive hans Trøst.“
+
+„Holdt!“ lyder det. Præsten iblandt dem staaer.
 Hans hvide Haar,
 hans Haar er som reist af en Vind.
-
-Med brændende Oie, med udstrakt Haand
+Med brændende Øie, med udstrakt Haand
 han staaer der, en bydende Gravens Aand,
 med dødningblegeste Kind.
+
 Han træder op paa klumpede Muld,
 som dækkede huld,
 saa huldt hans aarsavnede Fryd.
 Han stirrer paa Kisten til sidste Farvel
-og læser en brændende Bon for hans Sjæl,
-Men trindtom hores ei Lyd.
+og læser en brændende Bøn for hans Sjæl,
+Men trindtom høres ei Lyd.
+
 „I lægge nu Bruden i Brudgoms Favn,
 i Jesu Navn,
 i Jesu Navn sænk dem ned.
-Men dybt I grave!
-Om Dage faa
+Men dybt I grave! Om Dage faa
 skal min trygtgjemmende Kiste staae
 paa deres, saa faae de vel Fred.“
+
 Graven er kastet, og med et Blik,
 der til Hjerte gik,
 til Hjerte gik Alle, sin Arm
 han rækker skjærmende over den.
 Saa synker han selv saa stille hen,
 bortsovet fra Livets Harm.
+
 Om Dage faa hans Kiste stod,
 en Vogter god,
 en Vogter god hos de To.
-
-Snart vandt sig om Graven et Blomsterflor
+Snart vandt sig om Graven et Blomsterflor;
 men dybt under Tuen kun Søvnen boer
-og j ordforglemmende Bo.
+og jordforglemmende Ro.
 
 T:Den Første
-F:Snart vandt sig om Graven et Blomsterflor
+F:Død og borte
 SIDE:58-59
 
-U ød og borte,
+Død og borte,
 gjemt i Jordens Skjød, det dybe sorte,
 gjemt for evig er mit Hjertes Skat.
-Yel jeg kjender
+Vel jeg kjender
 Livets Lov; hun ei tilbagevender.
 Dog jeg lønlig leder Dag og Nat
+
 Fra det Fjerne
 som en lille, halvtilsløret Stjerne
 lokker mig Dit Blik, i Døden slukt.
 Og jeg stirrer,
 til min Tanke sælsomt sig forvirrer:
-Nei, det Die kan ei være lukt.
+Nei, det Øie kan ei være lukt.
+
 Jeg maa lede.
 End paa Jorden findes vel min Glæde;
 gjemt den græder i en ussel Vraa.
 Børn der findes.
-
 Aldrig dog min Skat tilbagevindes —
 aldrig Dig jeg blandt de Mange saae.
+
 Huset fyldes.
-Alt, hvad Hjertet eier, bort alt skylløs,
+Alt, hvad Hjertet eier, bort alt skylles,
 mens Du smuldrer i Din lille Grav.
 Bryd Dit Gjemme!
 See, Du ventes der, hvor Du var hjemme!
 Alt er Dit, om Alt end bort jeg gav.
+
 Kom saa lille,
 kom saa spæd en Aften mørk og stille,
 gjem Dig i en Kurv alt for min Dør.
 Naar Du vender
-Diet mod mig, strax mit Barn jeg kjender,
+Øiet mod mig, strax mit Barn jeg kjender,
 og jeg bliver glad, som aldrig før.
+
 Slutte? Glemme?
 Nøies? — Nei, jeg vil min Tanke gjemme,
 men saa trygt jeg venter Dig endnu.
@@ -1567,179 +1460,196 @@ higer dog mod Dig min Længselshu.
 
 T:Spændt og Slapt
 F:Gamle Kvinde, Du, som sidder bøiet dybt mod Jord
-SIDE:60-61
+SIDE:60-62
 
-Oamle Kvinde, Du, som sidder bøiet dybt mod Jord!
-Seger Du i Muldets Furer tabte Tiders Spor?
-Staaer, usynlig for mit Die, Fædrenes Bedrift
+Gamle Kvinde, Du, som sidder bøiet dybt mod Jord!
+Søger Du i Muldets Furer tabte Tiders Spor?
+Staaer, usynlig for mit Øie, Fædrenes Bedrift
 der indristet, og Du tyder tro den gamle Skrift?
-„Vel jeg grubler, vel jeg seger, men end ei jeg fandt.
-Seger efter Spor af Blodet, som i Jord nedrandt.
+
+„Vel jeg grubler, vel jeg søger, men end ei jeg fandt.
+Søger efter Spor af Blodet, som i Jord nedrandt.
 Strækker efter Kampens Frugter ud min tomme Haand,
-seer og favner dog kun Savnets blodløslede Aand.Ci
-Kampen, Kjære? Ak, for Sløsvig! — Det en Hæder var,
+seer og favner dog kun Savnets blodløslede Aand.
+
+Kampen, Kjære? Ak, for Slesvig! — Det en Hæder var,
 og Forsonlighedens milde Frugter den jo bar.
-Ja, ved Isted faldt min Brøder. Krandset paa min Væg
-hænger han hos Preusens Fredrik, han med Storheds
-Præg.
-„Og ved Isted faldt min yngste, faldt min sidste Sen,
-mens den anden nær ved Sløsvig slumred alt i Len.
-Levedækt og grensværgjemt kan Begge slumre sedt,
-men jeg seer ei Frugt af Blodet, varmt og ungt og redt.„
-Freden, Kjære! Næringsfrihed, Sjælens sunde Bo,
+Ja, ved Isted faldt min Broder. Krandset paa min Væg
+hænger han hos Preusens Fredrik, han med Storheds Præg.
+
+„Og ved Isted faldt min yngste, faldt min sidste Søn,
+mens den anden nær ved Slesvig slumred alt i Løn.
+Løvedækt og grønsværgjemt kan Begge slumre sødt,
+men jeg seer ei Frugt af Blodet, varmt og ungt og rødt.“
+
+Freden, Kjære! Næringsfrihed, Sjælens sunde Ro,
 saa i Hus med fordums Fjender vi velvilligt boe.
-Tillid til den Magt, som styrer, Haab for Danmarks
-Held,
+Tillid til den Magt, som styrer, Haab for Danmarks Held,
 rolig Nyden af det Givne, sit og Andres Vel.
 
-..Andres Vel? Er Danmark trygt end — gid det være
-saa! —
+„Andres Vel? Er Danmark trygt end — gid det være saa! —
 andetsteds dog Frihedskampens røde Bølger gaae.
 Lidt vi vistnok kunde gjøre! Om end Blodets Guld
 spares maa, vi Sølvets Bistand række dem saa huld.“
+
 Sværme Kvinder nu for Polen? Ak, Du gammel er!
 Danmarks fagre Døttre har kun Nordens Ungdom kjær.
 Polen! Ja, var selv jeg falden — som let kunde skeet —
 i Begeistring! Men at nødes — nei, der blev Du Beet.
-„Fremmed er mig hver Din Yttring, fremmed hvert
-Dit Ord.
-Svandt da, hvad med Savn jeg søger, sporløst hort
-fra Jord?
-Sluktes Flammen? Løstes Aanden op i Veir og Yind?
+
+„Fremmed er mig hver Din Yttring, fremmed hvert Dit Ord.
+Svandt da, hvad med Savn jeg søger, sporløst bort fra Jord?
+Sluktes Flammen? Løstes Aanden op i Veir og Vind?
 Blev Livskilden til et Springvand for barnagtigt Sind?“
-Yil man see! Du drev nok gjerne mig til storslaaet
-Daad?
-Smile maa jeg, nægter dog ei Bistand Dig og Baad.
+
+Vil man see! Du drev nok gjerne mig til storslaaet Daad?
+Smile maa jeg, nægter dog ei Bistand Dig og Raad.
 Kjøb for dette Tremarkstykke Caffe og Tobak.
 Vil Du ikke, nu, saa kast det hen til Din Polak. —
+
 Kvinden seer paa Tremarkstykket; Lidt hun eier kun.
 Paa sit Bryst dog end en Mynt hun bærer, stor og rund.
 Prismedaillen! Hendes Søn, som under Løven sov,
 vandt som Kunstner jo saa tidligt første Løn og Lov.
 
-JWSiRMIrøfMi
 Begge Mynter hun indsvøber, bærer saa dem hen,
 krammer end saa fast med Haanden Hjertets gamle Ven.
 I Brevkassen ned de synke, klinge dump mod Bund,
-og hun M er det til Afsked dybt i Hjertets Grund.
+og hun føler det til Afsked dybt i Hjertets Grund.
+
 Men da Maanen klar og rund hun seer ved Aftentid,
 fyldes hendes gamle Øie af en Taare blid.
 „Snart med begge mine Sønner skal jeg sammen boe.
-Jeg har gjort det Lidt, jeg kunde. Himlen give Bo. ‘-
+Jeg har gjort det Lidt, jeg kunde. Himlen give Ro.“
 
 T:Prøven
-F:Jeg under Tøflen
-SIDE:62-70
+F:Der skjænkes Vin, der skjænkes Mjød
+SIDE:62-71
 
-D er skjænkes Yin, der skjænkes Mjød,
+<nonum>1.</nonum>
+
+Der skjænkes Vin, der skjænkes Mjød,
 og Borgens Herre staaer
 med Smil om Mund, med Krus i Haand
 ved Skaalen for den Lilievaand,
 der blev hans Hustru sød.
+
 Der skjænkes Mjød, der skjænkes Vin —
 fra Bord det driver ned —
 og Borgens Herre, vild i Hu,
 mod Kongegjæst sig vender nu,
 fremtrædende et Trin.
 
-„Jeg under Tøflen?
-Yel saa hør,
-— og Ed er hvert mit Ord — :
+„Jeg under Tøflen? Vel saa hør,
+— og Ed er hvert mit Ord —:
 Forlang hvad Prøve selv I vil,
 og kan I vinde dette Spil,
-min Hustru Jer tilhør. “
-„Hans Æresord!
-I Vidner er!“
+min Hustru Jer tilhør.“
+
+„Hans Æresord! I Vidner er!“
 udraaber Kongen brat.
 „Jeg bryder af min Krones Guld
 den bedste Sten, af Straaler fuld.
 Den er min Indsats her.
-Stort er det, hvad her spilløs om,
+
+Stort er det, hvad her spilles om,
 og Spillet være stort.
 Et Aar med hver en Hjerteqval
 Din Hustru Du hjemsøge skal,
 da fældes hendes Dom.
+
 Og hvis da hendes Haand saa fin
 end holder fast, hvis hun
 til Modstand aldrig ægges op,
 da staaer Du stolt paa Seirens Top.
 Hvis ikke — er hun Min.“
-En Gysen gjennem Kidderen gaaer.
+
+En Gysen gjennem Ridderen gaaer.
 Det drukne Mod forsvandt.
 Men hvert et Blik han stirre seer,
-mens Kongen staaer og lialvveis leer
+mens Kongen staaer og halvveis leer
 og han hans Haandslag faaer.
 
-„Nu mine Mænd!
-Op og afsted,
+„Nu mine Mænd! Op og afsted,
 at Intet robes her.
 Og Du, min Ven: En rolig Nat.
 Din Ære har i Pant Du sat,
-Dit Ord jeg tager med “
-Den unge Yiv saa huld og om
+Dit Ord jeg tager med.“
+
+<nonum>2.</nonum>
+
+Den unge Viv saa huld og øm
 sin Husbond træder nær.
 Den Haand, hun let paa hans har lagt,
 han kaster vredent bort med Magt.
 Mon det vel er en Drøm?
+
 Hvert Ord, hun siger, er nu galt,
 og hendes Taushed Trods.
 I hvor hun staaer, i hvor hun gaaer,
 hun Utak kun for Alting faaer;
 dog bærer mild hun Alt.
-Forst sogte hun med kjærlig Bøn,
-med sode Elskovsord
-at hoie hans forvendte Sind.
+
+Først søgte hun med kjærlig Bøn,
+med søde Elskovsord
+at bøie hans forvendte Sind.
 Da blev han som en Hvirvelvind.
-Nu græder hun ilon.
+Nu græder hun iløn.
 
 Men Kongen sender Bud og Brev:
 „Har Du Din Ed forglemt?
-Du staaer jo som en Bidder prud,
+Du staaer jo som en Ridder prud,
 har kun een Hustru og een Gud.
-For veegt Du Sagen drev."
+For veegt Du Sagen drev.“
+
 Da vender han med opbragt Hu
 sit Blik mod Terners Flok.
-En kjen, en næsvis lille Ting
-han giver Spanger, giver Bing,
+En kjøn, en næsvis lille Ting
+han giver Spanger, giver Ring,
 hun er hans Guddom nu.
-Han tager Sioret af sin Yiv
+
+Han tager Sløret af sin Viv
 og hendes Hovedguld.
-„Den Skjenneste det hører til.
+„Den Skjønneste det hører til.
 Du skjæmmer, hvad Dig pryde vil;
-her blomstrer Lyst og Liv."
+her blomstrer Lyst og Liv.“
+
 Men Kongen sender atter Bud:
 „Hvor er Din svorne Tro?
-Biv hendes Barn fra hende bort,
-saa kommer hendes Taal tilkort."
-Han seer ad Yindvet ud.
+Riv hendes Barn fra hende bort,
+saa kommer hendes Taal tilkort.“
+Han seer ad Vindvet ud.
+
 Da Kongen sidst var der som Gjæst,
 stod Som’ren i sin Pragt.
 Nu drysser Sneens hvide Dun
-og dækker Jorden til saa luu.
+og dækker Jorden til saa lun.
 Nu kommer Julens Fest.
 
 „Pak Drengen til.“ — Hvad skal min Dreng?
 — „Han er kun til Besvær.
-Han fjernes skal.“
-Lad ei det skee!
+Han fjernes skal.“ Lad ei det skee!
 Jeg døer, skal jeg om Natten see
 hans tomme lille Seng.
+
 „Den flyttes kan.“ — Saa sæt det ud!
 Se Sneens kolde Fnug!
-„Yæk skal han.“ — Lad mig følge med!
-Kun med!
-Og Eders Kjærlighed
+„Væk skal han.“ — Lad mig følge med!
+Kun med! Og Eders Kjærlighed
 jeg prise skal for Gud!
+
 For førstegang han fuldt nu seer
 den blege, svundne Kind.
 En Gysen gjennem ham vel gaaer,
 men ubønhørlig Æren staaer:
 Han vender sig og leer.
+
 De Græsstraa smaa med spædest Magt
 beseire mørke Muld.
 Da faaer han Brev: „Lyv Drengen død:
 Paa Reisen blegned Kinden rød!
 Besind Dig paa vor Pagt.“
+
 Han krammer Brevet i sin Haand
 og stirrer vildt til Jord.
 De Græsstraa bringe ham en Trøst:
@@ -1747,29 +1657,32 @@ De Græsstraa bringe ham en Trøst:
 da brister Pagtens Baand.“
 
 Men ved hans Budskab Kvinden staaer
-som Marmorstotte stiv.
+som Marmorstøtte stiv.
 Hun vakled, og til Jorden ned
 hun sank i Dødens laante Fred.
 Dog vaagned hun til Liv.
+
 Hun tæt laae trykket til hans Bryst;
-hans Die skinned vaadt.
+hans Øie skinned vaadt.
 Han satte Drengens Liv paa Spil:
-Det mindes hun, og troste vil
-med Blik og brudte Bost.
+Det mindes hun, og trøste vil
+med Blik og brudte Røst.
+
 Men som af Vanvid slagen nu
-han stoder hende hort.
+han støder hende bort.
 Med knyttet Haand han styrter ud
 og truer selv ad Himlens Gud,
 der taaler slig en Gru.
+
 Men end et Brev fra Kongen kom:
 „Har Du Din Ære glemt?
-Hun lever høit som Bidderviv:
+Hun lever høit som Ridderviv:
 Forstødt hun bjerge selv sit Liv.
 Saa kan der fældes Dom.“
+
 Han seer sig om med uvist Blik.
 Men Helveds Fyrste staaer
-Bi paa hans Vei.
-Og Æren fræk
+Ei paa hans Vei. Og Æren fræk
 betvinger den alt vakte Skræk.
 — Den sidste Offer fik.
 
@@ -1778,68 +1691,75 @@ Paa Vindelbroen end
 hun vender sig med udstrakt Haand
 og beder Fredens milde Aand
 omsvæve dette Sted.
+
 Hun standser først i dunkle Skov;
 Hun sank til grønklædt Grund.
 Med slappet Haand og henstrakt Fod
-hun hviler tæt ved Egens Bod.
+hun hviler tæt ved Egens Rod.
 Der laae hun, som hun sov.
+
 Og Kongen snart for hende staaer:
 „Jeg elsked længst iløn.
-Se, Kronen vinker!
-Følg mig nu.“
-Hun støder bort hans Haand med Grif,
+Se, Kronen vinker! Følg mig nu.“
+Hun støder bort hans Haand med Gru,
 og intet Svar han faaer.
+
 De Nonner kom med Trøstensord
 vil føre hende med.
-Hun følger ei.
-Hun bygger sig
+Hun følger ei. Hun bygger sig
 af Qvas en Hytte skrøbelig.
 I Skoven nu hun boer. —
 
+<nonum>3.</nonum>
+
 Men Prøvens Tid udrunden er,
 og Kongen, gram i Hu,
-har brudt af Kronens rode Guld
+har brudt af Kronens røde Guld
 den blanke Sten, af Straaler fuld,
 et Hertugdom vel værd.
+
 Hun sidder mat ved Egerod,
-de Nonner troste vil.
+de Nonner trøste vil.
 Men tabt i Drømme stirrer hun
 kun ind i Skovens dunkle Grund,
 som hun dem ei forstod.
+
 Da glimter det bag Skovens Træer;
 hun blinker mat derved.
 En smykket Skare nærmer sig,
 men forrest gaaer, bleg som et Lig,
-Den, hun ei dromte nær.
+Den, hun ei drømte nær.
+
 Han træder saa tvivlraadig frem.
 Med Magt han fatter Mod.
-Han knæler ned, med boiet Aand,
+Han knæler ned, med bøiet Aand,
 og kysser hendes tynde Haand
-og hendes nogne Fod.
-Han fatter sig.
-Han tager frem
-en Sten saa straalefuld.
+og hendes nøgne Fod.
 
+Han fatter sig. Han tager frem
+en Sten saa straalefuld.
 Han lægger den i hendes Skjød
-og blusser atter, stolt og rud:
+og blusser atter, stolt og rød:
 „Min Brud! Følg nu mig hjem.
-Jeg elsker Dig.
-Jeg elsked steds;
+
+Jeg elsker Dig. Jeg elsked steds;
 Din Dreng er ikke død.
-En Prøve var det.
-Snart Du staaer
+En Prøve var det. Snart Du staaer
 med Kongesten i dunkle Haar,
-den Første i Din Kreds. “
+den Første i Din Kreds.“
+
 Hun, mens han taled, langsomt sig
 har reist saa rank og stiv.
-Hun aabner Læhen, tier dog,
-mens Diet taler sælsomt Sprog,
+Hun aabner Læben, tier dog,
+mens Øiet taler sælsomt Sprog,
 som leved op et Lig.
+
 Han fører hastigt Drengen hen,
 men ei til ham hun seer.
 Hun slaaer med begge Hænder bort
 sit lange Haar og stirrer fort.
 Da blegner han igjen.
+
 „Det sorte Skrud! Det hvide Lin!“
 udbryder hun med Magt.
 „Skjær Haaret af! Og bring mig hid
@@ -1851,49 +1771,55 @@ hun synker dem i Favn.
 saa gaadefuldt blev hendes Blik,
 mens svagt et Suk fra Læben gik,
 og som et Lig hun laae. —
-Han vidt til fremmed Land drog hort,
+
+Han vidt til fremmed Land drog bort,
 og Drengen arved Alt.
-Men heit ved Træets hule Gren
-i Beden Kongens Ædelsten
-blev gjemt af Bavnen sort.
+Men høit ved Træets hule Gren
+i Reden Kongens Ædelsten
+blev gjemt af Ravnen sort.
 
 T:Glæde i Sorgen
-F:De glade Venner kalde Dig
-SIDE:71-72
+U:_Efter Goethe._
+F:Hvorfor er Du bedrøvet dog
+SIDE:71-73
 
-(Efter G o e th e .)
-Hvorfor er Du bedrevet dog,
+Hvorfor er Du bedrøvet dog,
 mens Alt er lyst og let?
-Paa Øine Øine seer jeg det:
+Paa Dine Øine seer jeg det:
 Du har jo nylig grædt.
+
 Og har i Enrum og jeg grædt,
 saa lad kun mig derom.
 Mens Taaren randt, til Hjertet der
-dog sedt en Lindring kom.
+dog sødt en Lindring kom.
 
-De glade Venner kalde Dig.:
+De glade Venner kalde Dig:
 O, kom dog til vort Bryst!
 Og hvad Du end kan have tabt,
-hos os Du finde Trost.
+hos os Du finde Trøst.
+
 I larmer om og aner ei,
 hvad Kval jeg lønlig bær.
-Ak nei, jeg har ei tabt det, skjondt
+Ak nei, jeg har ei tabt det, skjøndt
 saa tungt end Savnet er.
+
 Saa tag Dig sammen da med Kraft,
 Du er saa ungt et Blod;
 og Meget sig tilkæmpe kan
 det første, friske Mod.
+
 Ak nei, tilkæmpes kan det ei,
 jeg kan det aldrig naae.
 Det dvæler høit, det straaler klart
 som Stjernen i det Blaa.
+
 Men Stjerner vække ei Begjær
-med deres Straaløskat.
+med deres Straaleskat.
 Saa henrykt seer til dem man op
 i hver en lysklar Nat.
+
 Og henrykt seer vel jeg og op
 saa mangen signet Dag.
-
 Lad mig hengræde kun hver Nat,
 til selv jeg standser svag.
 
@@ -1903,47 +1829,51 @@ SIDE:73
 
 Jeg misted saa Mange af mine Smaa,
 Jord dækker de lukkede Øine blaa,
-Jord dækker de sode smaa Hænder.
-Skal atter jeg prove i Angst og i Nod?
+Jord dækker de søde smaa Hænder.
+Skal atter jeg prøve i Angst og i Nød?
 Skal atter jeg kæmpe paa Liv og paa Død
 for den høieste Lykke, jeg kjender?
+
 En sværtynget Lykke omsnoet af Besvær,
-herendt og beleiret af Sorgernes Hær,
+berendt og beleiret af Sorgernes Hær,
 omklamret af Uro og Moie.
 En Lykke som Solglimt paa skyggede Bund,
-saa lille, saa liflig paa dunkiere Grund,
-et Jordsmol, men født i det Hoie.
-Og om hun nu fulgte de Smaa, som gik hort,
+saa lille, saa liflig paa dunklere Grund,
+et Jordsmøl, men født i det Høie.
+
+Og om hun nu fulgte de Smaa, som gik bort,
 om Skrinet sig lukked saa snævert og sort
-over den, som mit Hjerte hegjærte?
-Hvad tor jeg vel haabe, hvad skal jeg vel troe?
-Hu Trivselens Herre, omstæng Du mit Bo,
+over den, som mit Hjerte begjærte?
+Hvad tør jeg vel haabe, hvad skal jeg vel troe?
+Du Trivselens Herre, omstæng Du mit Bo,
 bevar mig for Femtedøds Smerte!
 
 T:En Hjertesorg
 F:De sagde, jeg var som Guld saa god
 SIDE:74-76
 
-D e sagde, jeg var som Guld saa god,
+De sagde, jeg var som Guld saa god,
 kun med lidt heftigt Sind.
 De roste mig, hvor jeg gik og stod,
 og smilte kun, naar det vilde Blod
 pludseligt farved min Kind.
+
 De elsked mig Alle, hvorfor veed Gud;
 forgjæves jeg speider om Grund.
 Fra Vuggen og til jeg tidligt stod Brud,
 jeg hørte kun Kjærligheds bønlige Bud.
 Det dyssed min Vildskab i Blund.
+
 Og Han var langmodig og øm og mild;
 hans Lige ei fandtes paa Jord.
-Fem Børn jeg ham fødte.
-End et kom til.
-Det lignede mig, med Blodets lid;
+Fem Børn jeg ham fødte. End et kom til.
+Det lignede mig, med Blodets Ild;
 det voldte mig Marter stor.
+
 Jeg veed ikke selv; men bestandig han skreg
 og trivdes dog prægtigt derved.
 Saasnart jeg et Skridt kun fra Vuggen veg,
-naar Søvnen sig over mit Oielaag sneg,
+naar Søvnen sig over mit Øielaag sneg,
 han vaagned — og endt var min Fred.
 
 De priste min Taalmod, og selv jeg fandt
@@ -1951,27 +1881,29 @@ imellem, at den var stor.
 Alt fastere det mig til Barnet bandt;
 hvert Smil af ham var en Seir, jeg vandt:
 Han smilte jo kun til Moer.
+
 En Nat da var jeg saa dødsens træt,
 men dobbelt just Drengen skreg.
-Jeg bed ham Brystet, men han var mæt.
+Jeg bød ham Brystet, men han var mæt.
 Jeg pusled om ham og vuggede let,
 mens til Vanvid min Søvntrang steg.
+
 Mit Øie sank til, men han vaagnede vred;
 da brast min Taalmodigheds Traad.
-Vildt vuggede Haanden.
-Mit Hoved sank ned
-paa Puden.
-Snart sov jeg i dybeste Fred
+Vildt vuggede Haanden. Mit Hoved sank ned
+paa Puden. Snart sov jeg i dybeste Fred
 ved den end selvgyngende Baad.
+
 Jeg reiste mig brat ved en Lyd saa sær;
 jeg grebes af Morgenens Kuld.
 Daggryet kæmped med Lampens Skjær.
 I Vuggen laae Drengen blaafrossen her,
 og Pude og Lagen paa Gulv.
+
 Nu skreg han ei mere; han peb kun saa smaat.
 Tre Dage han laae i mit Skjød.
 Da rysted ham Krampen; hans Ansigt blev blaat.
-De sagde mig, Gud bavde gjort det saa godt.
+De sagde mig, Gud havde gjort det saa godt.
 Men jeg saae, at Drengen var død.
 
 Paa Kirkegaarden er redt en Seng,
@@ -1979,42 +1911,46 @@ der vugges ei Dynen af.
 Der sover min lille, min elskede Dreng.
 Men i mit Hjerte der brast en Streng:
 Jeg graved hans tidlige Grav.
-D u stækkede Fugl!
+
+T:(1865.)
+F:Du stækkede Fugl
+SIDE:76-77
+
+Du stækkede Fugl!
 I Markfuren skamfuld Du søge Dig Skjul.
 Engang Du henbruste paa Vingerne brede,
 engang Du vel vidste at værge Din Rede.
 Nu hælvtes Dig Reden, halvrantes Dit Kuld,
 Du stækkede Fugl!
+
 Hvordan gik det til,
 at Æren selv tabtes i blodige Spil?
 Hvor slængte Din Fortid Du hen, før Du kunde
 med Skjændselens Spindelvæv stille Din Vunde?
 Ei Stormod der var, selv ei Dødskampen vild.
 Hvordan gik det til?
+
 Dog, skeet er nu skeet.
-Yor Yaade og Vaande har Alle jo seet.
-
-T:(1865)
-F:I Pris er vi sunkne
-SIDE:76-77
-
-I Pris er vi sunkne.
-Med nedslagent Die
+Vor Vaade og Vaande har Alle jo seet.
+I Pris er vi sunkne. Med nedslagent Øie
 vi under Forsmædelsens Vægt os maa bøie.
-I Skjændselens Fylde der fattes kun E t :
+I Skjændselens Fylde der fattes kun Et:
 At bære den let.
-Hvad gjor vi vel nu,
-at bode vort Tab og at mildne vor Blu?
-Hvad gjor Du, o Fugl med de stækkede Vinger,
+
+Hvad gjør vi vel nu,
+at bøde vort Tab og at mildne vor Blu?
+Hvad gjør Du, o Fugl med de stækkede Vinger,
 som aldrig med Seir vel Dig mere hjemsvinger?
 Med Tomhed i Hænde og Tabet i Hu,
-hvad gjor Du vel nu?
+hvad gjør Du vel nu?
+
 Til Ungerne smaa,
 dem, Voldsmanden levned, Du vende Dig maa;
-ad Sandhedens Veie Du fore dem stille,
+ad Sandhedens Veie Du føre dem stille,
 Du lære dem kunne, Du lære dem ville,
 Du lære dem Flitter og Tant at forsmaae —
 saa vil det vel gaae.
+
 Saa vil det vel gaae,
 og langsomt vil Danmark af Dyndet opstaae.
 En Slægt vil da komme, som kraftigt kan virke,
@@ -2022,7 +1958,7 @@ ei lefle med Saga og selvlavet Kirke,
 en Slægt, som med Selvfrygt for Himlen kan staae,
 — en Slægt, som kan slaae.
 
-Eventyrdigte.
+SEKTION:Eventyrdigte
 
 T:Fuglen
 F:Min Datter saa lille! Min Datter saa prud
@@ -2031,46 +1967,53 @@ SIDE:78-86
 „Min Datter saa lille! Min Datter saa prud!
 Tag glad mod et glædeligt Ord.
 Dig fandt jeg en Moder, mig fæsted jeg Brud.
-Snart Lykken iblandt os nu boer."
+Snart Lykken iblandt os nu boer.“
+
 „Min Konge og Fader! Mig lystes ei ved
 den fremmede Moder at faae.
 Nei, giv mig den Guldring, saa blank og saa bred,
-som tidt bos min egen jeg saae.“
+som tidt hos min egen jeg saae.“
+
 Han sukker og henter det rundede Guld,
 for vidt end til trindspæde Arm.
 „Og hviler i Jorden Din Moder saa huld,
-Din Pias er dog næst ved min Barm." —
+Din Plads er dog næst ved min Barm.“ —
+
 „Min Herre og Husbond! Hun hører mig ei,
 Din Datter, saa stiv og saa sær.
-En King har hun ranet, den tilkommer mig,
-thi Dronningesmykket den er."
+En Ring har hun ranet, den tilkommer mig,
+thi Dronningesmykket den er.“
+
 „Du Terne, jeg tog til min Seng og mit Bord,
 Du lade min Datter med Fred.
 Thi krænker Du hende, selv kun med et Ord,
-skal tifold Du lide derved."
+skal tifold Du lide derved.“
 
 Saa gik der en Tid, og det Kongebarn stod
 som frisk, knopspringende Mø.
 Men Dronningen var hende aldrig god,
 hun lured, som letfrosne Sø.
+
 Hun listed og lured, men snakked saa blidt;
 hun skjulte sit brændende Nag.
 For Faderen roste hun Datteren tidt.
 Da strøg han sit Skjæg med Behag. —
-„Min ædelig Husbond;
-Følg med i det Frie.
-Se Skyens guldkantede Rand. — “
-„Saamænd.
-Efter kongelig Daggjerning vi
-nu vandre ved svalende Strand. “
+
+„Min ædelig Husbond; Følg med i det Frie.
+Se Skyens guldkantede Rand. —“
+„Saamænd. Efter kongelig Daggjerning vi
+nu vandre ved svalende Strand.“
+
 „Ved Stranden? Der er jo saa tomt og saa bart.
 Nei, følg i den løvgrønne Lund.
 Der spiller end Solstraalen lifligt og klart,
 der ville vi tøve en Stund. —
+
 Min Konge! Se Blomsterne tæt for Jer Fod,
-se — ty s! Eders Datter det er.
+se — tys! Eders Datter det er.
 Hun hviler i Græsset, den Rose saa god.
 Kom! Sagte vi liste os nær.“ —
+
 Paa blomstrende Tue to Elskende sad
 blandt Skovens høitvoxende Straa;
 han holdt hendes Hænder, mens, straalende glad,
@@ -2080,22 +2023,27 @@ Han sukked: „Hvor tør dog jeg fattige Svend
 berøre Din Kjortelflig blot?“
 hun slaaer om hans Pande sin Guldfletning hen
 „Saa keiser jeg Dig til min Drot.“
+
 „En Jæger!“ henaander med døende Røst
 den Dronning; men Faderen bleg
 med knyttede Haand og arbeidende Bryst
 staaer lænet til knudrede Eg.
+
 Som skræmmede Vildt nu de tryggeste To
 opspringe. Med knugende Haand
 hun holder ham fast, mens, i dødstrodsig Ro,
 han venter paa Lænker og Baand.
+
 Han venter ei længe. Blandt Tudser og Kryb
 han kastes i stinkende Hul.
 Men høit over mørke og muddrede Dyb
 hun sidder bag Laasen af Guld.
+
 Og Dronningen haangridsk nu for hende staaer.
 Den Jomfru sig reiser saa rank.
 „Ja, kunde Du skaffe os ensartet Kaar,
 saa fik Du vel Guldringen blank.
+
 Jeg fordrer ei Syn, og jeg fordrer ei Ord,
 ei Hilsen, ei Samværens Duft,
 kun eens for os Begge! Mig qvælende Jord,
@@ -2103,160 +2051,179 @@ eller Ham livsqvægende Luft.“
 
 Og Dronningen tigged, og Dronningen bad,
 hun tirred, hun dulmed igjen.
-Hun vendte hans Kj ærlighed Hælvten til Had,
+Hun vendte hans Kjærlighed Hælvten til Had,
 hans Had slog Hælvten hun hen.
+
 To Taarne heelt op i de svimlende Skyer
-blev hygget, der skulde de boe.
+blev bygget, der skulde de boe.
 Hvor Rovfuglen flyver, og Duen kun flyer,
 sad ensomt de livsfangne To. —
-Da Fængselsdoren slog i med Knald,
+
+Da Fængselsdøren slog i med Knald,
 hang ned til Knæ hendes Haar.
-Nu naaer det med biede og belgende Fald
+Nu naaer det med blege og bølgende Fald
 fast Gulvet, hvorover hun gaaer.
-Hun stryger det hort, mens, tung i Sind,
-hun stirrer ad Yinduet ud.
+
+Hun stryger det bort, mens, tung i Sind,
+hun stirrer ad Vinduet ud.
 Da flyver saa lille en Fugl derind;
-dens Yinge var ramt af et Skud.
-Hun pleier den ivrigt.
-Men dee den maa.
-Den vædes af Taarernes Daah.
+dens Vinge var ramt af et Skud.
+
+Hun pleier den ivrigt. Men døe den maa.
+Den vædes af Taarernes Daab.
 Da taler den sagte og skjælvende saa:
-„O Jomfru! Jeg bringer Dig Haah.
+„O Jomfru! Jeg bringer Dig Haab.
+
 Hvi sygner saa hen Dit unge Liv
 her i det ensomste Bur?
 Dig lokker Forvandlingens skabende: Bliv!
 ud i den friske Natur.
 
 Du lægge to Fjer af min Vinge kun
-i Kors paa Dit Jomfubryst.
+i Kors paa Dit Jomfrubryst.
 Saa bliver Du Fugl i samme Stund,
 kan frit flyve bort med Lyst.“
-Den døde.
-Hun trykker med Haab og Gru
+
+Den døde. Hun trykker med Haab og Gru
 det Fjerkors til Brystet fast.
 Da blev hun en Fugl, og med Længsels Hu
-hun floi til den Elskte ihast. —
+hun fløi til den Elskte ihast. —
+
 Han støtter sit Hoved til Gitterstang:
 „Hvor lider den Kongemø vel?
 Mon hun sidder fangen den Dag saa lang?
 Mon hun fortærer sin Sjæl?“
-Han standser.
-Med lokkende Jægerlyst
+
+Han standser. Med lokkende Jægerlyst
 han seer nu den flagrende Fugl.
 Han udstrækker Haanden saa tavst, saa tyst,
 og snart sidder der den i Skjul. —
+
 For Dronningen staaer den Slutter tvær;
 „Min Kongefange forsvandt.
 Der har Du de Nøgler, og jeg er her.
 Jeg veed, mit Hoved er Pant.“
-„Du file de Stænger.
-Vi sige saa,
+
+„Du file de Stænger. Vi sige saa,
 at selv hun styrted sig ned.
 Dog tie vi helst, mens vi kan og maa.
 Saalænge har man da Fred.
 
-Dog, hvad hende dyhest krænke kan,
+Dog, hvad hende dybest krænke kan,
 skal hun spørge, ihvor hun drog hen.
-Din Datter er smuk.
-Du sende paastand
+Din Datter er smuk. Du sende paastand
 Din Datter til Jomfruens Ven.
+
 Hun listelig tale om Bryllupsfærd,
-om Dronningekrone saa skjon.
-Hun dolge kun svagt, at hun ham har kjær,
+om Dronningekrone saa skjøn.
+Hun dølge kun svagt, at hun ham har kjær,
 der hensukker sit Liv uden Løn.“
-Og Pigen betænksom til Yærket skred.
-Kun af Yanvare robed hun Alt.
-Yel vidste hvert Barn og hver Bonde Besked
+
+Og Pigen betænksom til Værket skred.
+Kun af Vanvare røbed hun Alt.
+Vel vidste hvert Barn og hver Bonde Besked
 Ham — vilde hun ei det fortalt.
+
 Men Jægeren sætter sin hvide Tand
-i Læben og vender sig hort.
-„Hun vinder en Krone, hun vinder et Land-,
-her maa vel jeg komme tilkort."
-Yel Fuglen udbryder i skj ærende Skrig,
+i Læben og vender sig bort.
+„Hun vinder en Krone, hun vinder et Land;
+her maa vel jeg komme tilkort.“
+
+Vel Fuglen udbryder i skjærende Skrig,
 den pikker hans Haand og hans Mund.
 Han sidder saa stille, saa støbt som et Lig.
 Hans Hjerte frøs sammen til Bund.
-Tre Dage saaledes han klagelos sad.
+
+Tre Dage saaledes han klageløs sad.
 Han reiser sig mørk nu og mat.
 Men Slutterens Datter ham venter med Mad,
 har ei ham i Sorgen forladt.
 
-Hun smaasnakked jevnligt, skjendt bly som en Brud.
+Hun smaasnakked jevnligt, skjøndt bly som en Brud.
 Tilsidst hun dog muntred ham lidt.
 Da lyder ham pludseligt kongeligt Bud:
 „Vælg Hustru, saa bortgaaer Du frit.“
-Hun rodmer og skjælver ved Ordet, som hun
-ham bringer.
-Han drager sit Veir
-som Spanden fra Dybet. „End gronnes vel Lund
+
+Hun rødmer og skjælver ved Ordet, som hun
+ham bringer. Han drager sit Veir
+som Spanden fra Dybet. „End grønnes vel Lund
 til Jagt, har Du Jægeren kjær.“
+
 Da styrter sig Fuglen med hakkende Næb
 med Angestens Skrig til hans Bryst.
-„Ferst dræbe mig!” raaber den til ham.
-”0 dræb!“
+„Først dræbe mig!“ raaber den til ham. „O dræb!“
 Han hører kun klingende Røst. —
-”Nu hurtig min Slutter! Du Tavse! Du Tro!
+
+„Nu hurtig min Slutter! Du Tavse! Du Tro!
 Nu rask, min velpyntede Brud!
 Naar Kirken tilsammen har givet de To,
 da drages i Frihed han ud.
-Saa svor mig min Herre.
-Vel Datterens Aand
-Dit Bryllup skal beie. Nu flink!"
+
+Saa svor mig min Herre. Vel Datterens Aand
+Dit Bryllup skal bøie. Nu flink!“
 Hun hilser til Bruden med naadige Haand
 og til ham med haanglimtende Blink. —
+
 Den blussende Brud sidder opreist og rank
-i Sengen.
-Paa Gulvet han staaer.
+i Sengen. Paa Gulvet han staaer.
 „Og om end Lyksalighedsfartøiet sank,
-man derfor ei strax dog forgaaer."
+man derfor ei strax dog forgaaer.“
 
 „O glem det, Du Søde!“ hun sukker saa øm.
 Han seer sig i Kammeret om.
 Alt er mig saa fremmed, Alt er som en Drøm.
 „Min Fugl! Naa, Du med mig da kom.“
-Han nærmer sig Sengen.
-Men Fuglen udslaaer
+
+Han nærmer sig Sengen. Men Fuglen udslaaer
 sin Vinge, begynder en Sang.
 Først kun som et Dødssuk dens Toner ham naaer,
 men høiere stedse det klang.
+
 Snart fylder den Rummet med svulmende Magt,
 og Væggene sukke derved.
 Men fra den ophængte Brudedragt
 faldt Taarer paa Gulvet ned.
+
 De Myrter i Brudens vandsprængte Krands
 græd Taarer, som piblende Blod.
 Men midt paa Gulvet, med svimlende Sands,
 som Billedstøtte han stod.
+
 Og Fuglen omkredser hans Hoved tæt.
 Dog svagere bliver dens Sang,
 dens Flugt bliver tung, og dens Vinge træt,
 den synker med bristende Klang.
+
 Han varmer den Isnede ved sit Bryst,
 ved sin Mund med tusinde Kys.
-Dog lukker den Diet kun til saa tyst.
+Dog lukker den Øiet kun til saa tyst.
 Da griber ham Dødens Gys.
 
 Han flænger i Brystet saa dybt et Saar;
 Blodkilden er sprudlende varm.
-E t straalende Lys hen over ham slaaer,
+Et straalende Lys hen over ham slaaer,
 og Hun ligger frelst i hans Arm. —
+
 Af Huset udtræde de salige To
 i Maanens lyshellige Skjær.
 Henlænet mod Muren, i dybeste Ro
-de finde da Honningen der.
-Han lofter sit Hoved: „Hvem kommer vel der?
+de finde da Konningen der.
+
+Han løfter sit Hoved: „Hvem kommer vel der?
 Min Kongeborg har jeg forladt.
-Det var mig saa sælsomt - 7- thi sidder jeg her —
+Det var mig saa sælsomt — thi sidder jeg her —
 som døde min Datter inat.“
+
 Men ned de sig kaste for Faderens Fod,
 fortælle ham Alt, hvad de led.
 Fortælle om Sorrig, fortælle om Blod,
 om Frelsen, som vandtes derved.
+
 Han stryger sit graanende Skjæg med sin Haand:
 „Jeg bliver nu gammel, forsand.
 Snart gaaer jeg i Barndom; alt sløves min Aand.
-Lad gaae da.
-For var jeg en Mand.
+Lad gaae da. Før var jeg en Mand.
+
 Min Søn og min Datter! I reise Jer nu.
 I følge mig ind i min Borg.
 Jeg tænker min Dronning, saa snild udi Hu,
@@ -2271,77 +2238,80 @@ paa Bunden Havkongen boer.
 Han sidder saa mørk i sit Slot af Rav;
 hans Datter, den Eneste, Lykken ham gav,
 forvolder ham Sorrig stor.
-Med beiet Hoved hun for ham staaer,
+
+Med bøiet Hoved hun for ham staaer,
 fastpressede Hænder smaa.
 Til Gulvet hænger det lange Haar.
 Den blinkende Hale saa sagte slaaer
 i Sandet, som vilde den gaae.
-„Du kjender vor Skjæbne.
-Et Aar Du kan
+
+„Du kjender vor Skjæbne. Et Aar Du kan
 som Menneske boe paa Jord.
 Vil da han Dig følge i dybe Strand,
 han bliver som jeg en Havets Mand,
-og Jer Kj ærlighedslykke stor.
+og Jer Kjærlighedslykke stor.
+
 Men holder hans Menneskeseighed Stik,
 da bliver Din Lod saa haard.
 Den lede Skikkelse, som Du fik,
 Du slipper ei, og er Skræk for hvert Blik;
 Du her som Trælkvinde gaaer.
-Thi vogt Dig vel.
-Du selv har jo sagt,
-at alt han en Fæstemø har.u —
 
+Thi vogt Dig vel. Du selv har jo sagt,
+at alt han en Fæstemø har.“ —
 „O Fader! En Skat har jeg hende bragt,
 og nu hun viser ham kun Foragt.
 En Anden i Hjertet hun bar.“
-„Men husk: Om en Dag kun forsiide Du kom,
-Jeg faaer ham.
-Det har ingen Nød.“
+
+„Men husk: Om en Dag kun forsilde Du kom,
+da rammer ham bittreste Død.“ —
+„O Fader! Vi vente knap Aaret om!
+Jeg fanger ham nok! Tal aldrig om Dom!
+Jeg faaer ham. Det har ingen Nød.“
+
 Saa bares af Bølgernes Hænder hun
 op til den tangbrune Strand.
 Med Halen i Vandet hun faldt i Blund,
+men vaagned i tidligste Morgenstund,
 den deiligste Kvinde paa Land.
+
 Hun laae der kun i sin lille Særk.
 Hun spredte sit Haar derom.
-”En underlig Verden.
-Nu til mit Værk.
-Vær snild, min Aand, som min Elskov er st
-0 Lykke!
-Til Hjælp mig kom.“
+„En underlig Verden. Nu til mit Værk.
+Vær snild, min Aand, som min Elskov er stærk!
+O Lykke! Til Hjælp mig kom.“
+
 Saa sad hun som fattigt Barn ved hans Dør,
 skibbruden og kummerlig frelst.
 Han tog hende ind; hun blive der tør;
-men videre ei han om hende spor.
-1 Ensomhed grubled han helst.
-da rammer ham bittreste Død.” —
-„O Fader! Vi vente knap Aaret om!
-Jeg fanger ham nok! Tal aldrig om Dom!
-men vaagned i tidligste Morgenstund,
+men videre ei han om hende spør.
+I Ensomhed grubled han helst.
 
 Hun feied hans Gulv, hun laved hans Mad,
 hun pusled og hæged om Alt.
 Men tidt hun, naar Aftenen graanede, sad
 i Krogen og nynned et sorgfuldt Qvad.
 Det var ham som Duggen, der faldt.
+
 Hun glemmer sig selv, og med fuldeste Magt
-de fængslende Toner frembrod.
-Han studser. Med Diet paa angstfuld Yagt
+de fængslende Toner frembrød.
+Han studser. Med Øiet paa angstfuld Vagt
 hun stammer; „Tilgiv — det var ei min Agt —“
-„Syng, Barn! Det vidunderligt lod.”
-Han lyttede ofte.
-Han tænkte iblandt:
+„Syng, Barn! Det vidunderligt lød.“
+
+Han lyttede ofte. Han tænkte iblandt:
 „Det Barn har en elskelig Sjæl.
-Hun svigter vist Ingen.” Og Tiden henrandt,
+Hun svigter vist Ingen.“ Og Tiden henrandt,
 mens, lønlig fornyet, hans Hjerte forvandt
 hver Sorg over bortflygtet Held.
+
 I Skoven nu knoppes hver Busk og Gren;
 og mylrende for hans Fod
-fremspire de Blomster.
-Han bryder en
+fremspire de Blomster. Han bryder en
 til Barnet, men standser som tryllet til Sten:
 For den deiligste Kvinde han stod.
-Hun tav, og han tigged.
-Hun bæved af Lyst,
+
+Hun tav, og han tigged. Hun bæved af Lyst,
 mens til Jorden hun kæmpende saae.
 Om nu hun ham fristed? Hun sukker saa tyst —
 da ligger hun fasttrykket tæt til hans Bryst.
@@ -2349,152 +2319,164 @@ Ak nei! Det vente vel maa.
 
 Hun stod som hans Brud for den signende Præst.
 Hun tænkte: Se, nu er han Min.
-Nu tur jeg vel tale.
-Jeg lokked ham bedst
-idag vist.
-Men blev det nu Skilsmissens Pest?
+Nu tør jeg vel tale. Jeg lokked ham bedst
+idag vist. Men blev det nu Skilsmissens Fest?
 Nei! Endnu er Lykken dog min.
+
 Hun sad som lyksaligste Ægteviv.
 Saa underligt blev hendes Sind.
 Det var, som følte hun dobbelt Liv,
 som hørte hun udtalt et Skabelsens: Bliv.
 Hun rødmed og blegned om Kind.
+
 Det lysner saa svagt for hendes Blik,
 det rører sig dybt i Bryst.
 Da gaaer gjennem Hjertet et blodigt Stik:
 Imorgen udrinder det Tidsrum, hun fik,
 og med det maaskee hendes Lyst.
+
 Hun fører sin Husbond til blinkende Strand
 og spørger med fremtvungen Skjemt:
 „Og om Du nu her skulde vælge paastand
 Mig — eller det drømte Himmelens Land —
-hvem af de To blev da glemt ?“
+hvem af de To blev da glemt?“
+
 Han smiler i Lykkens saligste Ro:
-„Vel mig, at Dit Spergsmaal er Leg.
+„Vel mig, at Dit Spørgsmaal er Leg.
 Jeg frygter, jeg svigted min Gud og min Tro,
 at jeg tabte min Sjæl og den evige Ro,
 før mit Kjærlighedsløfte jeg sveg.“ —
 
 Med Hovedet lænet tæt til hans Bryst
 hun længe som drømmende staaer.
-Saa vandre de hjemad.
-Endnu er det lyst.
-„Den sidste A f t e n h u n sukker saa tyst,
-mens Hjertet dodsstille slaaer.
-Ved forste, graalyse Morgengry
+Saa vandre de hjemad. Endnu er det lyst.
+„Den sidste Aften“, hun sukker saa tyst,
+mens Hjertet dødsstille slaaer.
+
+Ved første, graalyse Morgengry
 hun knæler alt for hans Seng.
 For Sol sig hæver, maa bort hun flye
 fra Elskovs Lyst, fra Lyksaligheds Ly,
 fra sin Himmel, til Hevndommen streng.
-Ei meer tor hun tove.
-Mod Lagnets Som
+
+Ei meer tør hun tøve. Mod Lagnets Søm
 hun trykker den bævende Mund.
 Saa iler vild, som i Feberdrøm,
-hun ned mod Havets brusende Strom
+hun ned mod Havets brusende Strøm
 og synker til dybe Bund. —
-Han søger Hustruen forst med Smil;
+
+Han søger Hustruen først med Smil;
 hans Sind er solklart og let.
 Dog snart han rammes af Angstens Pil
-og farer omkring med Vanvids II,
+og farer omkring med Vanvids Ild,
 til han segner, til Døden træt.
-Han tover paa Stedet saa rum en Tid.
+
+Han tøver paa Stedet saa rum en Tid.
 Han drager til fremmede Land.
-I skumløste Nat og ved Dagen blid
+I skumleste Nat og ved Dagen blid
 saa fjernt og saa nær han søger med Flid.
 Men Spor ei finde han kan.
 
 Tilsidst han kom, en forgræmmet Mand,
 tilbage til Fædrenebo.
-Hans Hus var ude, udyrket hans Land,
+Hans Hus var øde, udyrket hans Land,
 ja selv den skvulpende Baad ved Strand
 laae aflægs i dovnende Ro.
+
 Han heiser sit Seil, han knuger sit Ror:
-„End engang vi pro ve den Fart.
+„End engang vi prøve den Fart.
 Og gaae vi tilbunds, er ei Ulykken stor;
-saa bortskylløs Støvet fra mugnende Jord,
+saa bortskylles Støvet fra mugnende Jord,
 og Alting er klappet og klart.“
+
 Mod Aften han hviler af Kampen træt;
 han stirrer i Bølgerne ned.
 Før svulmed de mægtigt, nu kruses de let,
 men alt som han stirrer paa Krusningens Net,
-det loses til fuldeste Fred.
-Saa klart og saa stille.
-Til dybest Grund
+det løses til fuldeste Fred.
+
+Saa klart og saa stille. Til dybest Grund
 hans rolige Blik nu naaer.
 Der sidder en Kvinde med Taalmodsmund
-og sænket Oie; saa langsomt hun
+og sænket Øie; saa langsomt hun
 omdreier Kværnen, der staaer.
+
 Men tæt ved hende en Dreng saa trind
 snoer Tømmer af hendes Haar.
 Tre gamle Havkvinder styrte ind.
 De ruske i Drengen, de slaae hendes Kind,
 mens man seer, hvordan Mundene gaaer.
 
-Hun hæver de sorgfulde Hines Blaa
+Hun hæver de sorgfulde Øines Blaa
 som til den øverste Gud.
 Men vildt han skriger: Sin Hustru han saae,
 saae hende mishandlet af Hænder raa,
 og hurtigt han styrted sig ud.
+
 Han vaagnede hos sit Barn og sin Viv,
 han vaagned til himmelsk Lyst.
-Vel forte de Begge et trælsomt Liv,
-tidt maatte han skjuløs hag saltstride Siv,
+Vel førte de Begge et trælsomt Liv,
+tidt maatte han skjules bag saltstride Siv,
 men Elskov var rigeste Trøst.
+
 Utalte Dage leve de saa,
 da mørknes paa Havets Bund.
-Is lukker for Bølgen.
-Ei Himlen blaa
+Is lukker for Bølgen. Ei Himlen blaa
 kan dæmre igjennem, men Lamper smaa
 er tændt i Korallernes Lund.
+
 En Aften udslukkes det fjerne Skjær,
 og fjerntfra høre de Skrig.
-„Hvad er det?” — „Julen! Hvert Menneske kjær,
+„Hvad er det?“ — „Julen! Hvert Menneske kjær,
 udbreder den Sorg kun og Rædsel her.
-Hver er som et levende Lig.”
+Hver er som et levende Lig.“
+
 Hvor sælsomt! Han favner sit Barn og sin Viv.
-„Vi Tre hore hjemme paa Jord.”
+„Vi Tre høre hjemme paa Jord.“
 Da seer han en Stige, saa svai som et Siv;
 den strækker sig opad, den lover ham Liv.
 Op peger han, uden et Ord.
 
-M p r ø l N p
 Med Drengen i Favn og med Kvinden ved Haand
 han klavrer ad himmelvendt Bro.
 Det gled og det glipped. Men fast var hans Aand
 og smidigt hans Legem som natgamle Vaand.
 Hun fulgte i hengiven Tro.
-Op kom de.
-Den favntykke Isskorpe brast.
+
+Op kom de. Den favntykke Isskorpe brast.
 Paa gnistrende Flade de staae.
 I saligste Uro, foruden Rast
 nedtindre de Stjerner, men straalende fast
 staaer en stor, mellem alle de smaa.
-„Se Juløstjernen!” Med oprakt Arm
+
+„Se Julestjernen!“ Med oprakt Arm
 han synker paa Knæ, mens hun
 med Hænderne korslagt over sin Barm
-sig dybere beier med Tak saa varm
+sig dybere bøier med Tak saa varm
 mod dens Gjenskjær fra blinkende Bund.
+
 Paa Kysten kneiser en Kirke god,
 der brændte vel hundrede Lys.
 Tom var den, men Døren halvaaben stod,
 og ind de traadte paa varlig Fod
 opfyldte af helligt Gys.
-Med Drengen staaer han.
-Hun knæler ned,
-dyhtboiet, med Sjælen fuld.
+
+Med Drengen staaer han. Hun knæler ned,
+dybtbøiet, med Sjælen fuld.
 I Skjul under Haaret faldt Taaren hed,
-til Draahesoen som Strom hengled
+til Draabesøen som Strøm hengled
 ad Kirkens stenflisede Gulv.
 
-Og Drengen han christned.
-En Draabe da
+Og Drengen han christned. En Draabe da
 paa Havfruen trillede ned.
-Det klang gjennem Kirken.
-Heit tonede fra
+Det klang gjennem Kirken. Høit tonede fra
 dens Hvælving et saligt Halleluja,
 som hendøde i himmelske Fred. —
+
 Hun levede end en Tid saa lang
-i Lykke og Kj ærlighed stor.
+i Lykke og Kjærlighed stor.
 Men aldrig mere paa Jorden hun sang.
 Hun kunde kun lytte; i Hjertet det klang,
 saa stille som Englenes Chor.
+
+SLUTSEKTION


### PR DESCRIPTION
- [x] Tekst
- [ ] XML
- [ ] Facsimiler
- [ ] Sync facsimiler
- [ ] Titelblad
- [ ] Gennemlæsning

## Ændringer

- tilføjer arbejdstransskriptionen af Ilia Fibigers *Digtninger* (1867) som `1867.txt`
- knytter transskriptionen til digter-id’et `fibiger-ilia`
- bevarer kilde-, faksimile- og sidemetadata fra det leverede tekstgrundlag

## Formål

Ændringen lægger grundlaget for, at værket kan korrekturlæses og konverteres trinvist til det eksisterende XML-skelet.

## Validering

- filen er kontrolleret som UTF-8
- indholdet er sammenlignet med den leverede kildefil; kun det manglende digter-id er udfyldt
- `git diff --check` er kørt uden fejl

Fixes #1268
