### PR TITLE
Indsæt seks verificerede originaltekster til Rahbek

### DIFF
--- a/fdirs/berquin/1802.xml
+++ b/fdirs/berquin/1802.xml
@@ -1,0 +1,100 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<kalliopework id="1802" author="berquin" status="incomplete" type="poetry">
+<workhead>
+    <title>Idylles et romances, à l’usage des enfans</title>
+    <year>1802</year>
+    <source>Arnaud Berquins <i>Œuvres complètes</i>, Bd. 28, André, Paris, 1802.</source>
+</workhead>
+<workbody>
+
+<text id="berquin2026072301">
+<head>
+    <title>Plaintes d’une femme abandonnée par son amant, auprès du berceau de son fils</title>
+    <firstline>Dors, mon enfant, clos ta paupière</firstline>
+    <source pages="85-87"/>
+    <quality>korrektur1,korrektur2,kilde,side</quality>
+</head>
+<body>
+<poetry>
+Dors, mon enfant, clos ta paupière,
+Tes cris me déchirent le cœur :
+Dors, mon enfant, ta pauvre mère
+A bien assez de sa douleur.
+
+Lorsque, par de douces tendresses,
+Ton père sut gagner ma foi,
+Il me sembloit, dans ses caresses,
+Naïf, innocent comme toi.
+Je le crus : où sont ses promesses ?
+Il oublie et son fils et moi.
+
+Dors, mon enfant, clos ta paupière ;
+Tes cris me déchirent le cœur, etc.
+
+Qu’à ton réveil, un doux sourire
+Me soulage dans mon tourment !
+De ton père, pour me séduire,
+Tel fut l’aimable enchantement.
+Qu’il connoissoit bien son empire,
+Et qu’il en use méchamment !
+
+Dors, mon enfant, clos ta paupière ;
+Tes cris me déchirent le cœur, etc.
+
+Le cruel, hélas ! il me quitte,
+Il me laisse sans nul appui.
+Je l’aimois tant avant sa fuite !
+Oh ! je l’aime encore aujourd’hui.
+Oui, dans quelque lieu qu’il habite,
+Mon amour habite avec lui.
+
+Dors, mon enfant, clos ta paupière ;
+Tes cris me déchirent le cœur, etc.
+
+Oui, le voilà, c’est son image
+Que tu retraces à mes yeux.
+Ta bouche aura son doux langage,
+Ton front son air vif et joyeux.
+Ne prends point son humeur volage,
+Mais garde ses traits gracieux.
+
+Dors, mon enfant, clos ta paupière ;
+Tes cris me déchirent le cœur, etc.
+
+Tu ne peux concevoir encore
+Ce qui m’arrache ces sanglots.
+Que le chagrin qui me dévore
+N’attaque jamais ton repos !
+Se plaindre de ceux qu’on adore,
+C’est le plus grand de tous les maux.
+
+Dors, mon enfant, clos ta paupière ;
+Tes cris me déchirent le cœur, etc.
+
+Sur la terre il n’est plus personne
+Qui se plaise à nous secourir.
+Lorsque ton père m’abandonne,
+À qui pourrois-je recourir ?
+Ah ! tous les chagrins qu’il me donne,
+Toi seul, tu les peux adoucir.
+
+Dors, mon enfant, clos ta paupière ;
+Tes cris me déchirent le cœur, etc.
+
+Mêlons nos tristes destinées,
+Et vivons ensemble toujours :
+Deux victimes infortunées
+Se doivent de tendres secours.
+J’ai soin de tes jeunes années,
+Tu prendras soin de mes vieux jours.
+
+Dors, mon enfant, clos ta paupière ;
+Tes cris me déchirent le cœur :
+Dors, mon enfant, ta pauvre mère
+A bien assez de sa douleur.
+</poetry>
+</body>
+</text>
+
+</workbody>
+</kalliopework>

--- a/fdirs/berquin/info.xml
+++ b/fdirs/berquin/info.xml
@@ -14,7 +14,7 @@
       <place>Paris</place>
     </dead>
   </period>
-  <works>1782</works>
+  <works>1782,1802</works>
   <identifiers>
     <wikidata>Q350566</wikidata>
     <wikipedia-en>Arnaud Berquin</wikipedia-en>

--- a/fdirs/burger/andre.xml
+++ b/fdirs/burger/andre.xml
@@ -6,6 +6,25 @@
 </workhead>
 <workbody>
 
+<text id="burger2026072301">
+<head>
+   <title>Trost</title>
+   <firstline>Wenn dich die Lästerzunge sticht</firstline>
+   <notes>
+       <note>Teksten følger Gottfried August Bürger: <i>Gedichte</i>, Bd. II, Bauer, Wien, 1816, p. 126.</note>
+   </notes>
+   <quality>korrektur1,korrektur2,kilde,side</quality>
+</head>
+<body>
+<poetry>
+Wenn dich die Lästerzunge sticht,
+So laß dir dieß zum Troste sagen:
+Die schlecht’sten Früchte sind es nicht,
+Woran die Wespen nagen.
+</poetry>
+</body>
+</text>
+
 <text id="burger2018041201">
 <head>
    <title>Leonore</title>

--- a/fdirs/kellgren/andre.xml
+++ b/fdirs/kellgren/andre.xml
@@ -115,6 +115,68 @@ Vid Serafers salighet.
 </body>
 </text>
 
+<text id="kellgren2026072301">
+<head>
+   <title>På musiken av Haydns Roxelane</title>
+   <firstline>Blodet brinner, hjärtat hoppar</firstline>
+   <notes>
+       <note>Teksten følger Johan Henric Kellgren: <i>Skrifter</i>, Svenska Akademien, 1995, Bd. I, pp. 109-110.</note>
+   </notes>
+   <quality>korrektur1,korrektur2,kilde,side</quality>
+</head>
+<body>
+<poetry>
+<nonum><center>Ynglingen.</center></nonum>
+
+Blodet brinner, hjärtat hoppar:
+Av den klämda druvans droppar
+Födes modet, födes snillets låga,
+Födas dygder och förmåga.
+Bacchus bjuder – hjältarne ljunga
+Bacchus bjuder – skalderne sjunga.
+Gudar, Gudar! om ej Nektarn fanns,
+Vad vore all Olympens glans.
+
+<nonum><center>Flickan.</center></nonum>
+
+Vet, den kraft som druvan gömmer,
+    Fåfängt sig berömmer
+Mot det rus din känsla tömmer,
+    Vid en flickas famn.
+Om du där ej söka vet
+Tröst för din odödlighet;
+Om ej kärlek lagren räcker,
+    Som din åtrå väcker;
+        Skall din möda
+        Sig föröda
+    För ett fruktlöst namn.
+
+<nonum><center>Ynglingen.</center></nonum>
+
+Klokt var Flickans tal, min Broder!
+Cytherée är nöjets moder.
+Yngling drick: men må du ej förgäta
+Hennes myrt i rankan fläta!
+Kärlek bjuder – hjältarne blekna:
+Kärlek bjuder – klipporne vekna:
+Ömsom dödens eller livets Gud
+I stålets brak och lyrans ljud.
+
+Snart åt valvets västra sida
+    Ses din stjärna skrida,
+Snart en mattad stråle sprida,
+    Snart hon evigt släcks.
+Njut den dag som åt dig ler;
+Tro ej hoppets morgon mer. –
+I Tartarens öcken, Bröder!
+    Ingen druva blöder,
+        Och mot famnen
+        Blotta hamnen
+    Av en Skönhet sträcks.
+</poetry>
+</body>
+</text>
+
 
 <text id="kellgren2020013001">
 <head>

--- a/fdirs/quinault/andre.xml
+++ b/fdirs/quinault/andre.xml
@@ -1,0 +1,30 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<kalliopework id="andre" author="quinault" status="incomplete" type="poetry">
+<workhead>
+    <title>Andre digte</title>
+</workhead>
+<workbody>
+
+<text id="quinault2026072301">
+<head>
+    <title>Madrigal</title>
+    <firstline>Vous juriez autrefois que cette onde rebelle</firstline>
+    <notes>
+        <note>Teksten følger artiklen »Opéra« i Diderot og d’Alemberts <i>Encyclopédie</i>, Genève, 1777-1779, p. 545.</note>
+    </notes>
+    <quality>korrektur1,korrektur2,kilde,side</quality>
+</head>
+<body>
+<poetry>
+Vous juriez autrefois que cette onde rebelle
+Se feroit vers sa source une route nouvelle,
+Plutôt qu’on ne verroit votre cœur dégagé;
+Voyez couler ces flots dans cette vaste plaine:
+C’est le même penchant qui toujours les entraîne.
+Leur cours ne change point, &amp; vous avez changé.
+</poetry>
+</body>
+</text>
+
+</workbody>
+</kalliopework>

--- a/fdirs/quinault/info.xml
+++ b/fdirs/quinault/info.xml
@@ -14,6 +14,7 @@
       <place>Paris</place>
     </dead>
   </period>
+  <works>andre</works>
   <identifiers>
     <wikidata>Q379947</wikidata>
     <wikipedia-da>Philippe Quinault</wikipedia-da>

--- a/fdirs/rahbek/1794.xml
+++ b/fdirs/rahbek/1794.xml
@@ -464,10 +464,9 @@ Ved din Elises ømme Bryst!
     <firstline>Hver, som hylder muntre Glæder</firstline>
     <notes>
         <note type="credits">Bidrag fra Margit Ammentorp.</note>
-        <note unknown-original-by="kellgren" />
+        <note>Gendigtning af Johan Henric Kellgrens <xref type="translation" poem="kellgren2026072301"/>.</note>
     </notes>
     <source pages="25-27"/>
-    <!-- TODO: Originalen findes ikke i Samlade skrifter (1796) eller Skrifter (1995), men måske i 1935-udgaven på https://litteraturbanken.se/forfattare/KellgrenJH/titlar -->
     <quality>korrektur1,korrektur2,kilde,side</quality>
 </head>
 <body>
@@ -1256,7 +1255,7 @@ Vi broderlige, nu hinanden give Hænder;
     <subtitle>efter Voss.</subtitle>
     <firstline>O hvor lykkelig er den</firstline>
     <notes>
-        <note unknown-original-by="voss" />
+        <note>Gendigtning af Friedrich Leopold zu Stolbergs <xref type="translation" poem="stolbergf2026072301"/>. Rahbeks forfatterangivelse »efter Voss« er fejlagtig.</note>
     </notes>
     <source pages="66-68"/>
     <quality>korrektur1,korrektur2,kilde,side</quality>
@@ -3497,7 +3496,7 @@ At du, min Ven! blev lykkelig.
     <firstline>Sov bedste Dreng! du sidste Glæde</firstline>
     <source pages="182-184"/>
     <notes>
-        <note unknown-original-by="berquin" />
+        <note>Gendigtning af Arnaud Berquins <xref type="translation" poem="berquin2026072301"/>.</note>
     </notes>
     <quality>korrektur1,korrektur2,kilde,side</quality>
 </head>

--- a/fdirs/rahbek/1802.xml
+++ b/fdirs/rahbek/1802.xml
@@ -1999,7 +1999,7 @@ Hun bliver evig hans, han evig hendes,
     <subtitle>(Efter Qvinault.)</subtitle>
     <firstline>Før skal, saa svor du Chloe, Bølgen tage</firstline>
     <notes>
-         <note unknown-original-by="quinault" />
+         <note>Gendigtning af Philippe Quinaults <xref type="translation" poem="quinault2026072301"/>.</note>
     </notes>
     <source pages="99"/>
     <quality>korrektur1,korrektur2,kilde,side</quality>

--- a/fdirs/rahbek/1817.xml
+++ b/fdirs/rahbek/1817.xml
@@ -822,7 +822,7 @@ Der paa hans Vei giöd Glæde ned.
    <toctitle>Bürger: Naar Klaffertungerne dig stikke</toctitle>
    <firstline>Naar Klaffertungerne dig stikke</firstline>
    <notes>
-      <note unknown-original-by="burger" />
+      <note>Gendigtning af Gottfried August Bürgers <xref type="translation" poem="burger2026072301"/>.</note>
    </notes>
    <quality>korrektur1,kilde,side</quality>
    <source pages="40"/>
@@ -2922,7 +2922,7 @@ Ofte Thorvald blev begrædt af dem.
     <subtitle>Af Walter Scott, efter en gammel engelsk Sang</subtitle>
     <firstline>Min tunge Lod jeg klage maa</firstline>
     <notes>
-        <note unknown-original-by="scott" />
+        <note>Gendigtning af Walter Scotts <xref type="translation" poem="scott2026072301"/>.</note>
     </notes>
     <source pages="122-124"/>
     <quality>korrektur1,kilde,side</quality>

--- a/fdirs/scott/andre.xml
+++ b/fdirs/scott/andre.xml
@@ -5,6 +5,75 @@
 </workhead>
 <workbody>
 
+<text id="scott2026072301">
+<head>
+   <title>The Resolve</title>
+   <subtitle>In Imitation of an Old English Poem.—1809</subtitle>
+   <firstline>My wayward fate I needs must plain</firstline>
+   <notes>
+       <note>Teksten følger Walter Scott: <i>The Poetical Works</i>, Bd. I, Lea &amp; Blanchard, Philadelphia, 1839, pp. 342-344.</note>
+   </notes>
+   <quality>korrektur1,korrektur2,kilde,side</quality>
+</head>
+<body>
+<poetry>
+My wayward fate I needs must plain,
+   Though bootless be the theme;
+I loved, and was beloved again,
+   Yet all was but a dream:
+For, as her love was quickly got,
+   So it was quickly gone;
+No more I'll bask in flame so hot,
+   But coldly dwell alone.
+
+Not maid more bright than maid was e'er
+   My fancy shall beguile,
+By flattering word, or feigned tear,
+   By gesture, look, or smile:
+No more I'll call the shaft fair shot,
+   Till it has fairly flown,
+Nor scorch me at a flame so hot;—
+   I'll rather freeze alone.
+
+Each ambush'd Cupid I'll defy,
+   In cheek, or chin, or brow,
+And deem the glance of woman's eye
+   As weak as woman's vow:
+I'll lightly hold the lady's heart,
+   That is but lightly won;
+I'll steel my breast to beauty's art,
+   And learn to live alone.
+
+The flaunting torch soon blazes out,
+   The diamond's ray abides;
+The flame its glory hurls about,
+   The gem its lustre hides;
+Such gem I fondly deem'd was mine,
+   And glow'd a diamond stone,
+But, since each eye may see it shine,
+   I'll darkling dwell alone.
+
+No waking dream shall tinge my thought
+   With dyes so bright and vain,
+No silken net, so slightly wrought,
+   Shall tangle me again:
+No more I'll pay so dear for wit,
+   I'll live upon mine own,
+Nor shall wild passion trouble it,—
+   I'll rather dwell alone.
+
+And thus I'll hush my heart to rest,—
+   “Thy loving labour's lost;
+Thou shalt no more be wildly blest,
+   To be so strangely crost:
+The widow'd turtles mateless die,
+   The phoenix is but one;
+They seek no loves—no more will I—
+   I'll rather dwell alone.”
+</poetry>
+</body>
+</text>
+
 <text id="scott2001081501">
 <head>
    <title>County Guy</title>

--- a/fdirs/stolbergf/andre.xml
+++ b/fdirs/stolbergf/andre.xml
@@ -6,6 +6,80 @@
 </workhead>
 <workbody>
 
+<text id="stolbergf2026072301">
+<head>
+   <title>Frauenlob</title>
+   <firstline>Traun, der Mann ist Neides werth</firstline>
+   <notes>
+       <note>Teksten følger <i>Sämmtliche Gedichte der Brüder Christian und Friedrich Leopold Grafen zu Stolberg</i>, ny forøget udgave, Frankfurt og Leipzig, 1783, pp. 19-20.</note>
+   </notes>
+   <quality>korrektur1,korrektur2,kilde,side</quality>
+</head>
+<body>
+<poetry>
+Traun, der Mann ist Neides werth,
+Dem sein Gott ein Weib bescheert,
+Schön und klug und tugendreich,
+Sonder Falsch, den Täublein gleich!
+
+Seiner Wonne Maaß ist groß!
+Seine Ruhe wechsellos!
+Denn kein Kummer nagt den Mann,
+Den solch Weiblein trösten kan!
+
+Gleich des Mondes Silberblick,
+Lächelt sie den Gram zurück;
+Küßt des Mannes Thränen auf,
+Streut mit Blumen seinen Lauf.
+
+Wenn ihn jäher Mut empört,
+Er nicht mehr des Freundes hört,
+Wenn von Zorn die Brust ihm glüht,
+Und sein Auge Feuer sprüht;
+
+O! dann schleicht sie weinend nach,
+Sänftigt ihn mit einem Ach!
+Also kühlt der Abendthau
+Die versengte Blumenau!
+
+Keine Mühe wird ihm schwer!
+Keine Stunde freudenleer!
+Denn nach jeder Arbeit Last
+Harret sein die süsse Rast.
+
+Engel fördern ihre Ruh,
+Drücken beider Augen zu!
+Ihrer keuschen Ehe Band
+Knüpfte Gottes Vaterhand!
+
+Gott giebt ihren Söhnen Mut,
+Für die Tugend reges Blut!
+Stärket ihren jungen Arm,
+Macht ihr Herz für Freiheit warm!
+
+Mit verschämten Reizen blühn
+Ihres Bettes Töchter! glühn
+Mit der Mutter Unschuld, rein
+Wie ein Quell im Sonnenschein!
+
+Drob erfreut der Vater sich,
+Drob die Mutter inniglich;
+Ihr vereintes Dankgebet
+Preist den Geber früh und spät!
+
+Gold hat keinen noch beglückt;
+Falscher Ehre Lorbeer drückt;
+Wer nach Würden hascht greift Sand;
+Wissenschaft ist oft ein Tand:
+
+Aber Weiber giebt uns Gott!
+Ohne sie ist Leben Tod!
+Weiber leichten jedes Joch,
+Lieben uns im Himmel noch!
+</poetry>
+</body>
+</text>
+
 <text id="stolberg2018052901">
 <head>
    <title>Die Natur</title>


### PR DESCRIPTION
## Resumé

Denne PR indsætter og forbinder seks Rahbek-originaler, som kan dokumenteres i konkrete tekstkilder:

- Johan Henric Kellgren: *På musiken av Haydns Roxelane*
- Gottfried August Bürger: *Trost*
- Friedrich Leopold zu Stolberg: *Frauenlob*
- Arnaud Berquin: *Plaintes d’une femme abandonnée par son amant, auprès du berceau de son fils*
- Philippe Quinault: *Madrigal*
- Walter Scott: *The Resolve*

De tilhørende Rahbek-noter er opdateret med `translation`-henvisninger, og Berquin- og Quinault-værkerne er føjet til forfatterregistrene.

## Kildekritiske afvigelser

Issue-oplægget kan ikke bruges ordret. Mest markant er Rahbeks »Elskovssang for Ægtemænd« ikke et Voß-digt, men en forkortet gendigtning af Stolbergs *Frauenlob*. Også de foreslåede førstelinjer til Kellgren, Berquin og Quinault afviger fra de faktiske kilder.

De resterende seks tekster er derfor ikke medtaget:

- Eschenburg-teksten er ikke fundet i en dokumenterbar udgave.
- Bürgers påståede *Lalage* findes ikke i de gennemgåede Bürger-udgaver.
- Den angivne *Punschlied* er ikke Voß’ kendte punschdigt.
- Horns tre tekster findes i *Små Skaldestycken* (1816), men bindet er ikke digitaliseret, og den angivne Runeberg-side indeholder ikke teksterne.

PR’en lukker derfor ikke issue #1312; den leverer den verificerbare del uden at indføre konstruerede originaltekster.

## Validering

- Relax NG-validering med `xmllint`
- `npm test -- --runInBand` — 49 testpakker og 2.309 tests passerer
- `npm run build` — produktionsbuild passerer

Relaterer til #1312.
