### PR TITLE
Giv målrettet fejl for tekster i ulistede værkfiler

### DIFF
--- a/__tests__/workfiles.test.js
+++ b/__tests__/workfiles.test.js
@@ -1,0 +1,23 @@
+import { findTextInUnlistedWork } from '../tools/build-static/workfiles.js';
+
+describe('unlisted work files', () => {
+  it('finds a referenced text in an unlisted work', () => {
+    const workFile = {
+      filename: 'fdirs/poet/new.xml',
+      infoFilename: 'fdirs/poet/info.xml',
+      content: '<kalliopework><text id="poet2026072301"/></kalliopework>',
+    };
+
+    expect(findTextInUnlistedWork('poet2026072301', [workFile])).toBe(workFile);
+  });
+
+  it('does not match a different text id', () => {
+    const workFile = {
+      filename: 'fdirs/poet/new.xml',
+      infoFilename: 'fdirs/poet/info.xml',
+      content: '<kalliopework><text id="poet2026072301"/></kalliopework>',
+    };
+
+    expect(findTextInUnlistedWork('poet2026072302', [workFile])).toBeUndefined();
+  });
+});

--- a/tools/build-static.js
+++ b/tools/build-static.js
@@ -112,6 +112,7 @@ import {
   sourceFilesForText,
   worksForPoet,
 } from './build-static/anthologies.js';
+import { findUnlistedWorkFiles } from './build-static/workfiles.js';
 
 const envFlag = (name) => {
   return ['1', 'true', 'yes'].includes(
@@ -132,6 +133,7 @@ let collected = {
   dict: new Map(),
   timeline: new Array(),
   person_or_keyword_reference: new Map(),
+  unlistedWorkFiles: [],
 };
 
 // Ready after second pass
@@ -1393,6 +1395,7 @@ const main = async () => {
   safeMkdir(`public/api`);
   collected.museums = await b('build_museums', build_museums, collected);
   collected.workids = await b('build_poet_workids', build_poet_workids);
+  collected.unlistedWorkFiles = findUnlistedWorkFiles(collected.workids);
   collected.poets = await b(
     'build_poets_first_pass',
     build_poets_first_pass,

--- a/tools/build-static/mentions.js
+++ b/tools/build-static/mentions.js
@@ -26,6 +26,7 @@ import { poetName, workLinkName } from './formatting.js';
 import { primaryTextVariantId } from './variants.js';
 import { loadExternalIdentifiers } from './external-identifiers.js';
 import { createProgressReporter } from './progress.js';
+import { findTextInUnlistedWork } from './workfiles.js';
 
 const person_mentions_dirty = new Set();
 
@@ -139,6 +140,17 @@ const build_person_or_keyword_refs = (collected) => {
                       register(filename, toPoetId, fromId, refType, toPoemId);
                     }
                   } else {
+                    const unlistedWork = findTextInUnlistedWork(
+                      toPoemId,
+                      collected.unlistedWorkFiles || [],
+                    );
+                    if (unlistedWork != null) {
+                      throw new Error(
+                        `${filename} ${fromId}: points to unknown text ${toPoemId}. ` +
+                        `The text is in ${unlistedWork.filename}, but that work ` +
+                        `is not listed in <works> in ${unlistedWork.infoFilename}.`,
+                      );
+                    }
                     throw new Error(
                       `${filename} ${fromId}: points to unknown text ${toPoemId}`
                     );

--- a/tools/build-static/workfiles.js
+++ b/tools/build-static/workfiles.js
@@ -1,0 +1,44 @@
+import fs from 'fs';
+import path from 'path';
+
+const findUnlistedWorkFiles = workids => {
+  const result = [];
+  const listedByPoet = new Map(workids);
+
+  fs.readdirSync('fdirs', { withFileTypes: true })
+    .filter(entry => entry.isDirectory())
+    .forEach(entry => {
+      const poetId = entry.name;
+      const listed = new Set(listedByPoet.get(poetId) || []);
+      const infoFilename = `fdirs/${poetId}/info.xml`;
+      fs.readdirSync(`fdirs/${poetId}`, { withFileTypes: true })
+        .filter(file => file.isFile() && file.name.endsWith('.xml'))
+        .forEach(file => {
+          const workId = path.basename(file.name, '.xml');
+          if (listed.has(workId)) {
+            return;
+          }
+          const filename = `fdirs/${poetId}/${file.name}`;
+          const content = fs.readFileSync(filename, 'utf8');
+          if (!/^\s*<kalliopework\b/.test(content)) {
+            return;
+          }
+          result.push({ filename, infoFilename, content });
+        });
+    });
+
+  return result;
+};
+
+const findTextInUnlistedWork = (textId, workFiles) => {
+  const escapedTextId = textId.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+  const textPattern = new RegExp(
+    `<(?:text|section)\\b[^>]*\\bid=["']${escapedTextId}["']`,
+  );
+  return workFiles.find(workFile => textPattern.test(workFile.content));
+};
+
+export {
+  findUnlistedWorkFiles,
+  findTextInUnlistedWork,
+};


### PR DESCRIPTION
## Hvad ændrer denne PR?

Buildet opdager nu, når en ukendt teksthenvisning peger på en tekst i en XML-værkfil, som ikke er nævnt i forfatterens `<works>` i `info.xml`. Fejlmeddelelsen viser både værkfilen og den relevante `info.xml`.

## Hvorfor?

Det inkrementelle static-build gennemløber kun værk-id'er fra `<works>`. En ny værkfil kan derfor blive ignoreret, hvorefter en henvisning til dens tekst senere fejler indirekte som `points to unknown text`.

Rettelsen ændrer ikke den autoritative værkliste eller optager automatisk ulistede filer i buildet.

## Validering

- `npm test -- --runInBand`
- `KALLIOPE_SKIP_ELASTICSEARCH=true KALLIOPE_SKIP_IMAGE_THUMBNAILS=true npm run build-static`

Fixes #1311
