### PR TITLE
Målret dirty-markering af referencer

### DIFF
--- a/__tests__/mentions.test.js
+++ b/__tests__/mentions.test.js
@@ -33,6 +33,7 @@ import {
 import {
   build_mentions_data,
   build_mentions_json,
+  collectPersonOrKeywordRefs,
 } from '../tools/build-static/mentions.js';
 
 const poet = (id, firstname, lastname) => ({
@@ -120,6 +121,32 @@ describe('mentions data', () => {
       ]),
     };
   };
+
+  it('produces unchanged person refs when only source whitespace changes', () => {
+    const entries = [
+      {
+        toKey: 'bango',
+        fromPoemId: 'aarestrup2001061401',
+        type: 'mention',
+      },
+    ];
+    const before = collectPersonOrKeywordRefs(
+      new Map([['fdirs/aarestrup/1863.xml', entries]])
+    );
+    const after = collectPersonOrKeywordRefs(
+      new Map([['fdirs/aarestrup/1863.xml', [...entries]]])
+    );
+
+    expect(after).toEqual(before);
+  });
+
+  it('removes stale person refs with the modified source file', () => {
+    const refs = collectPersonOrKeywordRefs(
+      new Map([['fdirs/aarestrup/1863.xml', []]])
+    );
+
+    expect(refs.has('bango')).toBe(false);
+  });
 
   it('viser oversættelser fra den primære variant', () => {
     const collected = buildCollected();

--- a/__tests__/textrefs.test.js
+++ b/__tests__/textrefs.test.js
@@ -1,4 +1,7 @@
-import { extractTextRefs } from '../tools/build-static/textrefs.js';
+import {
+  collectTextRefs,
+  extractTextRefs,
+} from '../tools/build-static/textrefs.js';
 
 describe('text refs', () => {
   it('groups ordinary refs and translations from xrefs', () => {
@@ -19,5 +22,34 @@ describe('text refs', () => {
       { toId: 'goethe2001111904', type: 'mention' },
       { toId: 'bibeljohannes01', type: 'mention' },
     ]);
+  });
+
+  it('produces unchanged destination refs when only source whitespace changes', () => {
+    const before = collectTextRefs(
+      new Map([
+        [
+          'fdirs/source/one.xml',
+          [{ fromId: 'source1', toId: 'target1', type: 'mention' }],
+        ],
+      ])
+    );
+    const after = collectTextRefs(
+      new Map([
+        [
+          'fdirs/source/one.xml',
+          [{ fromId: 'source1', toId: 'target1', type: 'mention' }],
+        ],
+      ])
+    );
+
+    expect(after).toEqual(before);
+  });
+
+  it('removes stale refs when a modified source no longer links to a target', () => {
+    const refs = collectTextRefs(
+      new Map([['fdirs/source/one.xml', []]])
+    );
+
+    expect(refs.has('target1')).toBe(false);
   });
 });

--- a/__tests__/textrefs.test.js
+++ b/__tests__/textrefs.test.js
@@ -1,9 +1,23 @@
+jest.mock('../tools/libs/caching.js', () => ({
+  isFileModified: jest.fn(() => false),
+  loadCachedJSON: jest.fn(() => null),
+  writeCachedJSON: jest.fn(),
+  force_reload: false,
+  markFileDirty: jest.fn(),
+}));
+
+import { markFileDirty } from '../tools/libs/caching.js';
 import {
   collectTextRefs,
   extractTextRefs,
+  markChangedTextRefDestinationsDirty,
 } from '../tools/build-static/textrefs.js';
 
 describe('text refs', () => {
+  beforeEach(() => {
+    markFileDirty.mockClear();
+  });
+
   it('groups ordinary refs and translations from xrefs', () => {
     expect(
       extractTextRefs(`
@@ -24,25 +38,42 @@ describe('text refs', () => {
     ]);
   });
 
-  it('produces unchanged destination refs when only source whitespace changes', () => {
-    const before = collectTextRefs(
-      new Map([
-        [
-          'fdirs/source/one.xml',
-          [{ fromId: 'source1', toId: 'target1', type: 'mention' }],
-        ],
-      ])
-    );
-    const after = collectTextRefs(
-      new Map([
-        [
-          'fdirs/source/one.xml',
-          [{ fromId: 'source1', toId: 'target1', type: 'mention' }],
-        ],
-      ])
-    );
+  it('does not dirty destinations when source refs are unchanged', () => {
+    const refs = new Map([
+      ['target1', { mention: ['source1'], translation: [] }],
+    ]);
+    const collected = {
+      texts: new Map([
+        ['target1', { poetId: 'target-poet', workId: 'target-work' }],
+      ]),
+    };
 
-    expect(after).toEqual(before);
+    markChangedTextRefDestinationsDirty(refs, refs, collected);
+
+    expect(markFileDirty).not.toHaveBeenCalled();
+  });
+
+  it('dirties only the destination whose source ref was removed', () => {
+    const before = new Map([
+      ['target1', { mention: ['source1'], translation: [] }],
+      ['target2', { mention: ['source2'], translation: [] }],
+    ]);
+    const after = new Map([
+      ['target2', { mention: ['source2'], translation: [] }],
+    ]);
+    const collected = {
+      texts: new Map([
+        ['target1', { poetId: 'target-poet', workId: 'target-work' }],
+        ['target2', { poetId: 'other-poet', workId: 'other-work' }],
+      ]),
+    };
+
+    markChangedTextRefDestinationsDirty(before, after, collected);
+
+    expect(markFileDirty).toHaveBeenCalledTimes(1);
+    expect(markFileDirty).toHaveBeenCalledWith(
+      'fdirs/target-poet/target-work.xml'
+    );
   });
 
   it('removes stale refs when a modified source no longer links to a target', () => {

--- a/tools/build-static/mentions.js
+++ b/tools/build-static/mentions.js
@@ -30,11 +30,56 @@ import { findTextInUnlistedWork } from './workfiles.js';
 
 const person_mentions_dirty = new Set();
 
+const refsEqual = (left, right) =>
+  JSON.stringify(left || { mention: [], translation: [] }) ===
+  JSON.stringify(right || { mention: [], translation: [] });
+
+const collectPersonOrKeywordRefs = refsByFile => {
+  const collectedRefs = new Map();
+  const register = ({ toKey, fromPoemId, type, toPoemId }) => {
+    const collection = collectedRefs.get(toKey) || {
+      mention: [],
+      translation: [],
+    };
+    if (type === 'mention') {
+      if (
+        collection.mention.indexOf(fromPoemId) === -1 &&
+        collection.translation.indexOf(fromPoemId) === -1
+      ) {
+        collection.mention.push(fromPoemId);
+      }
+    } else if (type === 'translation') {
+      const mentionIndex = collection.mention.indexOf(fromPoemId);
+      if (mentionIndex > -1) {
+        collection.mention.splice(mentionIndex, 1);
+      }
+      if (
+        !collection.translation.some(
+          t => t.translationPoemId === fromPoemId
+        )
+      ) {
+        collection.translation.push({
+          translationPoemId: fromPoemId,
+          translatedPoemId: toPoemId,
+        });
+      }
+    }
+    collectedRefs.set(toKey, collection);
+  };
+  refsByFile.forEach(refs => refs.forEach(register));
+  return collectedRefs;
+};
+
 const build_person_or_keyword_refs = (collected) => {
-  let person_or_keyword_refs = globalForceReload
-    ? new Map([])
-    : new Map(loadCachedJSON('collected.person_or_keyword_refs') || []);
-  const forced_reload = person_or_keyword_refs.size == 0;
+  const cachedRefs = new Map(
+    loadCachedJSON('collected.person_or_keyword_refs') || []
+  );
+  let refsByFile = globalForceReload
+    ? new Map()
+    : new Map(
+        loadCachedJSON('collected.person_or_keyword_refs_by_file') || []
+      );
+  const forced_reload = refsByFile.size === 0;
 
   let found_changes = false;
   const regexps = [
@@ -63,51 +108,28 @@ const build_person_or_keyword_refs = (collected) => {
     },
   ];
 
-  const register = (filename, toKey, fromPoemId, type, toPoemId) => {
-    const collection = person_or_keyword_refs.get(toKey) || {
-      mention: [],
-      translation: [],
-    };
-    if (type === 'mention') {
-      if (
-        collection.mention.indexOf(fromPoemId) === -1 &&
-        collection.translation.indexOf(fromPoemId) === -1
-      ) {
-        collection.mention.push(fromPoemId);
-      }
-    } else if (type === 'translation') {
-      const mentionIndex = collection.mention.indexOf(fromPoemId);
-      if (mentionIndex > -1) {
-        // If this is a translationed poem that were a mention earlier, remove it from mentions.
-        collection.mention.splice(mentionIndex, 1);
-      }
-      if (
-        !collection.translation.some((t) => t.translationPoemId === fromPoemId)
-      ) {
-        collection.translation.push({
-          translationPoemId: fromPoemId,
-          translatedPoemId: toPoemId,
-        });
-      }
-    } else {
-      throw new Error(
-        `${filename} ${fromPoemId}: has xref with unknown type ${type}`
-      );
-    }
-    person_or_keyword_refs.set(toKey, collection);
-    person_mentions_dirty.add(toKey);
-  };
+  const knownFiles = new Set();
   collected.workids.forEach((workIds, poetId) => {
     workIds.forEach((workId) => {
       const filename = `fdirs/${poetId}/${workId}.xml`;
       if (!fileExists(filename)) {
         return;
       }
+      knownFiles.add(filename);
       if (!forced_reload && !isFileModified(filename)) {
         return;
       } else {
         found_changes = true;
       }
+      const fileRefs = [];
+      const register = (toKey, fromPoemId, type, toPoemId) => {
+        if (type !== 'mention' && type !== 'translation') {
+          throw new Error(
+            `${filename} ${fromPoemId}: has xref with unknown type ${type}`
+          );
+        }
+        fileRefs.push({ toKey, fromPoemId, type, toPoemId });
+      };
       let doc = loadXMLDoc(filename);
       getElementsByTagNames(doc, ['text', 'section'])
         .filter((s) => safeGetAttr(s, 'id') != null)
@@ -137,7 +159,7 @@ const build_person_or_keyword_refs = (collected) => {
                     if (toPoetId !== fromPoetId) {
                       // Skip self-refs
                       linkedPoetIds.add(toPoetId);
-                      register(filename, toPoetId, fromId, refType, toPoemId);
+                      register(toPoetId, fromId, refType, toPoemId);
                     }
                   } else {
                     const unlistedWork = findTextInUnlistedWork(
@@ -157,10 +179,10 @@ const build_person_or_keyword_refs = (collected) => {
                   }
                 } else if (rule.type === 'person') {
                   const toPoetId = match[2];
-                  register(filename, toPoetId, fromId, 'mention');
+                  register(toPoetId, fromId, 'mention');
                 } else if (rule.type === 'unknown-original') {
                   const toPoetId = match[2];
-                  register(filename, toPoetId, fromId, 'translation', null);
+                  register(toPoetId, fromId, 'translation', null);
                 } else if (rule.type === 'pictureref') {
                   const pictureRef = match[1];
                   if (!pictureRef.match('/')) {
@@ -175,7 +197,7 @@ const build_person_or_keyword_refs = (collected) => {
                       `${filename} ${fromId}: points to unknown picture ${pictureRef}`
                     );
                   }
-                  register(filename, picture.artistId, fromId, 'mention');
+                  register(picture.artistId, fromId, 'mention');
                 }
               }
             });
@@ -192,16 +214,37 @@ const build_person_or_keyword_refs = (collected) => {
                   `${filename} ${fromId}: Overflødig keyword-reference ${keywordId}`
                 );
               }
-              register(filename, keywordId, fromId, 'mention');
+              register(keywordId, fromId, 'mention');
             });
           }
         });
+      refsByFile.set(filename, fileRefs);
     });
   });
+  Array.from(refsByFile.keys()).forEach(filename => {
+    if (!knownFiles.has(filename)) {
+      refsByFile.delete(filename);
+      found_changes = true;
+    }
+  });
+  const person_or_keyword_refs = collectPersonOrKeywordRefs(refsByFile);
   if (found_changes) {
+    const allKeys = new Set([
+      ...cachedRefs.keys(),
+      ...person_or_keyword_refs.keys(),
+    ]);
+    allKeys.forEach(key => {
+      if (!refsEqual(cachedRefs.get(key), person_or_keyword_refs.get(key))) {
+        person_mentions_dirty.add(key);
+      }
+    });
     writeCachedJSON(
       'collected.person_or_keyword_refs',
       Array.from(person_or_keyword_refs)
+    );
+    writeCachedJSON(
+      'collected.person_or_keyword_refs_by_file',
+      Array.from(refsByFile)
     );
   }
   collected.person_or_keyword_refs = person_or_keyword_refs;
@@ -394,4 +437,5 @@ export {
   build_person_or_keyword_refs,
   build_mentions_data,
   build_mentions_json,
+  collectPersonOrKeywordRefs,
 };

--- a/tools/build-static/textrefs.js
+++ b/tools/build-static/textrefs.js
@@ -33,12 +33,41 @@ const extractTextRefs = xml => {
   });
 };
 
-const markTextRefDestinationsDirty = (textrefs, collected) => {
-  const destinationWorkfiles = [];
-  textrefs.forEach((refs, toId) => {
+const collectTextRefs = refsByFile => {
+  const textrefs = new Map();
+  refsByFile.forEach(refs => {
+    refs.forEach(({ fromId, toId, type }) => {
+      const destinationRefs = textrefs.get(toId) || {
+        mention: [],
+        translation: [],
+      };
+      if (destinationRefs[type].indexOf(fromId) === -1) {
+        destinationRefs[type].push(fromId);
+      }
+      textrefs.set(toId, destinationRefs);
+    });
+  });
+  return textrefs;
+};
+
+const refsEqual = (left, right) =>
+  JSON.stringify(left || { mention: [], translation: [] }) ===
+  JSON.stringify(right || { mention: [], translation: [] });
+
+const markChangedTextRefDestinationsDirty = (
+  previousTextrefs,
+  textrefs,
+  collected
+) => {
+  const destinationWorkfiles = new Set();
+  const allIds = new Set([...previousTextrefs.keys(), ...textrefs.keys()]);
+  allIds.forEach(toId => {
+    if (refsEqual(previousTextrefs.get(toId), textrefs.get(toId))) {
+      return;
+    }
     const text = collected.texts.get(toId);
     if (text != null) {
-      destinationWorkfiles.push(sourceWorkFilename(text));
+      destinationWorkfiles.add(sourceWorkFilename(text));
     }
   });
   markFileDirty(...destinationWorkfiles);
@@ -46,28 +75,29 @@ const markTextRefDestinationsDirty = (textrefs, collected) => {
 
 const build_textrefs = collected => {
   const cachedTextrefs = loadCachedJSON('collected.textrefs') || [];
-  const hasLegacyTextrefs = cachedTextrefs.some(([, refs]) =>
-    Array.isArray(refs)
-  );
+  const previousTextrefs = new Map(cachedTextrefs);
   const codeModified = isFileModified('tools/build-static/textrefs.js');
-  let textrefs =
-    globalForceReload || hasLegacyTextrefs || codeModified
+  let refsByFile =
+    globalForceReload || codeModified
       ? new Map()
-      : new Map(cachedTextrefs);
-  const force_reload = textrefs.size == 0;
+      : new Map(loadCachedJSON('collected.textrefs_by_file') || []);
+  const force_reload = refsByFile.size === 0;
 
   let found_changes = false;
+  const knownFiles = new Set();
   collected.poets.forEach((poet, poetId) => {
     collected.workids.get(poetId).forEach(workId => {
       const filename = `fdirs/${poetId}/${workId}.xml`;
       if (!fileExists(filename)) {
         return;
       }
+      knownFiles.add(filename);
       if (!force_reload && !isFileModified(filename)) {
         return;
       } else {
         found_changes = true;
       }
+      const fileRefs = [];
       let doc = loadXMLDoc(filename);
       const texts = getElementsByTagNames(doc, ['text', 'section'])
         .filter(e => safeGetAttr(e, 'id') != null)
@@ -81,72 +111,45 @@ const build_textrefs = collected => {
           notes.forEach(note => {
             extractTextRefs(safeGetOuterXML(note)).forEach(ref => {
               const fromId = safeGetAttr(text, 'id');
-              const refs = textrefs.get(ref.toId) || {
-                mention: [],
-                translation: [],
-              };
-              if (refs[ref.type].indexOf(fromId) === -1) {
-                refs[ref.type].push(fromId);
-              }
-              textrefs.set(ref.toId, refs);
+              fileRefs.push({
+                fromId,
+                toId: ref.toId,
+                type: ref.type,
+              });
             });
           });
         });
+      refsByFile.set(filename, fileRefs);
     });
   });
+  Array.from(refsByFile.keys()).forEach(filename => {
+    if (!knownFiles.has(filename)) {
+      refsByFile.delete(filename);
+      found_changes = true;
+    }
+  });
+  const textrefs = collectTextRefs(refsByFile);
   if (found_changes) {
     writeCachedJSON('collected.textrefs', Array.from(textrefs));
-    markTextRefDestinationsDirty(new Map(cachedTextrefs), collected);
-    markTextRefDestinationsDirty(textrefs, collected);
+    writeCachedJSON('collected.textrefs_by_file', Array.from(refsByFile));
+    markChangedTextRefDestinationsDirty(
+      previousTextrefs,
+      textrefs,
+      collected
+    );
   }
   return textrefs;
 };
 
 const mark_ref_destinations_dirty = collected => {
-  if (globalForceReload) {
-    // All destination files are marked dirty already
-    return;
-  }
-
-  let destination_workfiles = [];
-  collected.poets.forEach((poet, poetId) => {
-    collected.workids.get(poetId).forEach(workId => {
-      const filename = `fdirs/${poetId}/${workId}.xml`;
-      if (!fileExists(filename)) {
-        return;
-      }
-      if (!isFileModified(filename)) {
-        return;
-      }
-      let doc = loadXMLDoc(filename);
-
-      getElementsByTagNames(doc, ['text', 'section'])
-        .filter(e => safeGetAttr(e, 'id') != null)
-        .forEach(text => {
-          const head = getChildByTagName(text, 'head');
-          const body = getChildByTagName(text, 'body');
-          const notes = [
-            ...getElementsByTagNames(head, ['note']),
-            ...getElementsByTagNames(body, ['note', 'footnote']),
-          ];
-          notes.forEach(note => {
-            extractTextRefs(safeGetOuterXML(note)).forEach(ref => {
-              const t = collected.texts.get(ref.toId);
-              if (t != null) {
-                const filename = sourceWorkFilename(t);
-                destination_workfiles.push(filename);
-              }
-            });
-          });
-        });
-    });
-  });
-  //console.log('Dirty files are: ', destination_workfiles);
-  markFileDirty(...destination_workfiles);
+  // build_textrefs compares the cached and current per-file references later
+  // in the build, before any outputs that depend on destination backlinks.
 };
 
 export {
   build_textrefs,
+  collectTextRefs,
   extractTextRefs,
+  markChangedTextRefDestinationsDirty,
   mark_ref_destinations_dirty,
 };

--- a/tools/build-static/textrefs.js
+++ b/tools/build-static/textrefs.js
@@ -70,7 +70,9 @@ const markChangedTextRefDestinationsDirty = (
       destinationWorkfiles.add(sourceWorkFilename(text));
     }
   });
-  markFileDirty(...destinationWorkfiles);
+  if (destinationWorkfiles.size > 0) {
+    markFileDirty(...destinationWorkfiles);
+  }
 };
 
 const build_textrefs = collected => {


### PR DESCRIPTION
## Ændringer

- Gemmer person-, keyword- og tekstreferencer pr. kildefil i build-cachen.
- Sammenligner gamle og nye aggregerede referencer, før destinationer markeres dirty.
- Fjerner forældede referencer, når links slettes fra en værkfil.
- Tilføjer regressionstests for whitespace-ændringer og slettede links.

## Baggrund

En ubetydelig whitespace-ændring i en stor værkfil kunne tidligere markere alle filens referencedestinationer — og i visse tilfælde næsten hele den globale referencecache — som dirty. Det medførte unødvendig genopbygning af hundredvis af digtere og tusindvis af tekster.

Efter ændringen genopbygges kun kildeforfatterens egne afledte filer samt destinationsdata, når selve referencelisten reelt ændres.

## Validering

- `npm test -- --runInBand`: 50 testsuiter og 2315 tests bestået.
- Whitespace-test i `fdirs/aarestrup/1863.xml`: kun Aarestrups egne filer blev genopbygget.
- Midlertidig fjernelse af et personlink: kun én destinations-`mentions.json` blev opdateret.
- Efterfølgende no-op-build skrev ingen afledte filer.
- `git diff --check` bestået.
