### PR TITLE
Tilføj digtere fra Poetisk Læsebog

### DIFF
--- a/fdirs/aarestrup/1863.xml
+++ b/fdirs/aarestrup/1863.xml
@@ -4108,7 +4108,7 @@ Haabet leve! Danmarks Skaal!
     <title>Til Ole Bang</title>
     <firstline>Mellem Lolliker tilhuse</firstline>
     <notes>
-        <note>Ole Bang er den ansete læge Oluf Lundt Bang (kaldet Ole Bang; 1788-1877), også virksom som skribent. Farfader til <a person="bang">Herman Bang</a>.</note>
+        <note><a person="bango">Ole Bang</a> er den ansete læge Oluf Lundt Bang (kaldet Ole Bang; 1788-1877), også virksom som skribent. Farfader til <a person="bang">Herman Bang</a>.</note>
     </notes>
     <dates>
         <written>1838-02-12</written>

--- a/fdirs/aarestrup/1976-4.xml
+++ b/fdirs/aarestrup/1976-4.xml
@@ -506,7 +506,7 @@ Det kan du aldrig miste.
    <title>Til O. Bang</title>
    <firstline>Mellem Lolliker tilhuse</firstline>
    <notes>
-      <note>O. Bang er den ansete læge Oluf Lundt Bang (kaldet Ole Bang; 1788-1877), også virksom som skribent. Farfader til <a person="bang">Herman Bang</a>.</note>
+      <note><a person="bango">O. Bang</a> er den ansete læge Oluf Lundt Bang (kaldet Ole Bang; 1788-1877), også virksom som skribent. Farfader til <a person="bang">Herman Bang</a>.</note>
    </notes>
    <quality>korrektur1,kilde,side</quality>
    <source pages="23-26"/>

--- a/fdirs/andersenniels/info.xml
+++ b/fdirs/andersenniels/info.xml
@@ -1,0 +1,20 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<person id="andersenniels" country="dk" lang="da" type="poet">
+  <name>
+    <firstname>Niels</firstname>
+    <lastname>Andersen</lastname>
+  </name>
+  <period>
+    <born>
+      <date>1819-08-27</date>
+      <place>Ørsted</place>
+    </born>
+    <dead>
+      <date>1835-02-04</date>
+      <place>Ørsted</place>
+    </dead>
+  </period>
+  <identifiers>
+    <litteraturpriser-dk>ANielsAndersenf1819</litteraturpriser-dk>
+  </identifiers>
+</person>

--- a/fdirs/bango/info.xml
+++ b/fdirs/bango/info.xml
@@ -1,0 +1,24 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<person id="bango" country="dk" lang="da" type="poet">
+  <name>
+    <firstname>Ole</firstname>
+    <lastname>Bang</lastname>
+    <christened>Oluf Lundt Bang</christened>
+  </name>
+  <period>
+    <born>
+      <date>1788-07-27</date>
+      <place>København</place>
+    </born>
+    <dead>
+      <date>1877-10-12</date>
+      <place>København</place>
+    </dead>
+  </period>
+  <identifiers>
+    <wikidata>Q5565283</wikidata>
+    <viaf>32777073</viaf>
+    <lex-dk>Ole_Bang</lex-dk>
+    <biografisk-leksikon-lex-dk>Ole_Bang_-_læge</biografisk-leksikon-lex-dk>
+  </identifiers>
+</person>

--- a/fdirs/barfodf/info.xml
+++ b/fdirs/barfodf/info.xml
@@ -1,0 +1,23 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<person id="barfodf" country="dk" lang="da" type="poet">
+  <name>
+    <firstname>Povl Frederik</firstname>
+    <lastname>Barfod</lastname>
+  </name>
+  <period>
+    <born>
+      <date>1811-04-07</date>
+      <place>Lyngby, Djursland</place>
+    </born>
+    <dead>
+      <date>1896-06-15</date>
+      <place>Frederiksberg</place>
+    </dead>
+  </period>
+  <identifiers>
+    <wikidata>Q795352</wikidata>
+    <viaf>45083663</viaf>
+    <biografisk-leksikon-lex-dk>Frederik_Barfod</biografisk-leksikon-lex-dk>
+    <runeberg-org>barfofre</runeberg-org>
+  </identifiers>
+</person>

--- a/fdirs/birch/info.xml
+++ b/fdirs/birch/info.xml
@@ -1,0 +1,23 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<person id="birch" country="dk" lang="da" type="poet">
+  <name>
+    <firstname>Frederik Sneedorff</firstname>
+    <lastname>Birch</lastname>
+  </name>
+  <period>
+    <born>
+      <date>1805-03-01</date>
+      <place>Maribo</place>
+    </born>
+    <dead>
+      <date>1869-03-11</date>
+      <place>Halling</place>
+    </dead>
+  </period>
+  <identifiers>
+    <wikidata>Q5576472</wikidata>
+    <viaf>267305131</viaf>
+    <biografisk-leksikon-lex-dk>Fr._Sneedorff_Birch</biografisk-leksikon-lex-dk>
+    <runeberg-org>sneedofr</runeberg-org>
+  </identifiers>
+</person>

--- a/fdirs/birchedahl/info.xml
+++ b/fdirs/birchedahl/info.xml
@@ -1,0 +1,25 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<person id="birchedahl" country="dk" lang="da" type="poet">
+  <name>
+    <firstname>Vilhelm</firstname>
+    <lastname>Birkedal</lastname>
+    <fullname>Schøller Parelius Vilhelm Birkedal</fullname>
+  </name>
+  <period>
+    <born>
+      <date>1809-12-07</date>
+      <place>Ålebækgård, Møn</place>
+    </born>
+    <dead>
+      <date>1892-07-26</date>
+      <place>Gentofte</place>
+    </dead>
+  </period>
+  <identifiers>
+    <wikidata>Q3429907</wikidata>
+    <viaf>308739530</viaf>
+    <lex-dk>Vilhelm_Birkedal</lex-dk>
+    <biografisk-leksikon-lex-dk>Vilhelm_Birkedal</biografisk-leksikon-lex-dk>
+    <runeberg-org>birkevil</runeberg-org>
+  </identifiers>
+</person>

--- a/fdirs/brinckseidelin/info.xml
+++ b/fdirs/brinckseidelin/info.xml
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<person id="brinckseidelin" country="dk" lang="da" type="poet">
+  <name>
+    <firstname>Hans Diderik de</firstname>
+    <lastname>Brinck-Seidelin</lastname>
+  </name>
+  <period>
+    <born>
+      <date>1780-01-18</date>
+      <place>Tølløse</place>
+    </born>
+    <dead>
+      <date>1831-05-09</date>
+      <place>Slagelse</place>
+    </dead>
+  </period>
+</person>

--- a/fdirs/florian/info.xml
+++ b/fdirs/florian/info.xml
@@ -1,0 +1,21 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<person id="florian" country="fr" lang="fr" type="poet">
+  <name>
+    <firstname>Jean-Pierre Claris de</firstname>
+    <lastname>Florian</lastname>
+  </name>
+  <period>
+    <born>
+      <date>1755-03-06</date>
+      <place>Logrian-Florian</place>
+    </born>
+    <dead>
+      <date>1794-09-13</date>
+      <place>Sceaux</place>
+    </dead>
+  </period>
+  <identifiers>
+    <wikidata>Q551740</wikidata>
+    <viaf>24601427</viaf>
+  </identifiers>
+</person>

--- a/fdirs/friispf/info.xml
+++ b/fdirs/friispf/info.xml
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<person id="friispf" country="dk" lang="da" type="poet">
+  <name>
+    <firstname>Peter Frederik</firstname>
+    <lastname>Friis</lastname>
+  </name>
+  <period>
+    <born>
+      <date>1791-10-11</date>
+      <place>København</place>
+    </born>
+    <dead>
+      <date>1864-02-06</date>
+      <place>København</place>
+    </dead>
+  </period>
+</person>

--- a/fdirs/garbrecht/info.xml
+++ b/fdirs/garbrecht/info.xml
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<person id="garbrecht" country="dk" lang="da" type="poet">
+  <name>
+    <firstname>Johan Gerhard Frederik</firstname>
+    <lastname>Garbrecht</lastname>
+  </name>
+  <period>
+    <born>
+      <date>1799-05-26</date>
+      <place>København</place>
+    </born>
+    <dead>
+      <date>1857-07-22</date>
+      <place>København</place>
+    </dead>
+  </period>
+</person>

--- a/fdirs/harms/info.xml
+++ b/fdirs/harms/info.xml
@@ -1,0 +1,22 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<person id="harms" country="de" lang="de" type="poet">
+  <name>
+    <firstname>Claus</firstname>
+    <lastname>Harms</lastname>
+  </name>
+  <period>
+    <born>
+      <date>1778-05-25</date>
+      <place>Fahrstedt</place>
+    </born>
+    <dead>
+      <date>1855-02-01</date>
+      <place>Kiel</place>
+    </dead>
+  </period>
+  <identifiers>
+    <wikidata>Q69117</wikidata>
+    <viaf>42629420</viaf>
+    <lex-dk>Claus_Harms</lex-dk>
+  </identifiers>
+</person>

--- a/fdirs/hjortvk/info.xml
+++ b/fdirs/hjortvk/info.xml
@@ -1,0 +1,21 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<person id="hjortvk" country="dk" lang="da" type="poet">
+  <name>
+    <firstname>Victor Christian</firstname>
+    <lastname>Hjort</lastname>
+  </name>
+  <period>
+    <born>
+      <date>1765-10-13</date>
+      <place>Gunderslevholm</place>
+    </born>
+    <dead>
+      <date>1818-07-26</date>
+      <place>Ribe</place>
+    </dead>
+  </period>
+  <identifiers>
+    <wikidata>Q5807726</wikidata>
+    <viaf>141483674</viaf>
+  </identifiers>
+</person>

--- a/fdirs/monrad/info.xml
+++ b/fdirs/monrad/info.xml
@@ -1,0 +1,23 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<person id="monrad" country="dk" lang="da" type="poet">
+  <name>
+    <firstname>Ditlev Gothardt</firstname>
+    <lastname>Monrad</lastname>
+  </name>
+  <period>
+    <born>
+      <date>1811-11-24</date>
+      <place>København</place>
+    </born>
+    <dead>
+      <date>1887-03-28</date>
+      <place>Nykøbing Falster</place>
+    </dead>
+  </period>
+  <identifiers>
+    <wikidata>Q694093</wikidata>
+    <viaf>72192281</viaf>
+    <lex-dk>D.G._Monrad</lex-dk>
+    <biografisk-leksikon-lex-dk>D.G._Monrad</biografisk-leksikon-lex-dk>
+  </identifiers>
+</person>

--- a/fdirs/sagen/info.xml
+++ b/fdirs/sagen/info.xml
@@ -1,0 +1,22 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<person id="sagen" country="no" lang="no" type="poet">
+  <name>
+    <firstname>Lyder Christian</firstname>
+    <lastname>Sagen</lastname>
+  </name>
+  <period>
+    <born>
+      <date>1777-03-13</date>
+      <place>Flekkefjord</place>
+    </born>
+    <dead>
+      <date>1850-06-16</date>
+      <place>Bergen</place>
+    </dead>
+  </period>
+  <identifiers>
+    <wikidata>Q4580437</wikidata>
+    <viaf>30437805</viaf>
+    <runeberg-org>sagenlyd</runeberg-org>
+  </identifiers>
+</person>

--- a/fdirs/sneedorffhc/info.xml
+++ b/fdirs/sneedorffhc/info.xml
@@ -1,0 +1,22 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<person id="sneedorffhc" country="dk" lang="da" type="poet">
+  <name>
+    <firstname>Hans Christian</firstname>
+    <lastname>Sneedorff</lastname>
+  </name>
+  <period>
+    <born>
+      <date>1759-05-22</date>
+      <place>København</place>
+    </born>
+    <dead>
+      <date>1824-10-13</date>
+      <place>København</place>
+    </dead>
+  </period>
+  <identifiers>
+    <wikidata>Q6182431</wikidata>
+    <biografisk-leksikon-lex-dk>Hans_Christian_Sneedorff</biografisk-leksikon-lex-dk>
+    <runeberg-org>sneedhan</runeberg-org>
+  </identifiers>
+</person>

--- a/fdirs/wintherm/info.xml
+++ b/fdirs/wintherm/info.xml
@@ -1,0 +1,23 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<person id="wintherm" country="dk" lang="da" type="poet">
+  <name>
+    <firstname>Mathias</firstname>
+    <lastname>Winther</lastname>
+  </name>
+  <period>
+    <born>
+      <date>1795-01-25</date>
+      <place>Gammellund, Vissenbjerg Sogn</place>
+    </born>
+    <dead>
+      <date>1834-02-26</date>
+      <place>København</place>
+    </dead>
+  </period>
+  <identifiers>
+    <wikidata>Q12326411</wikidata>
+    <viaf>76634015</viaf>
+    <biografisk-leksikon-lex-dk>Mathias_Winther</biografisk-leksikon-lex-dk>
+    <runeberg-org>winthmat</runeberg-org>
+  </identifiers>
+</person>


### PR DESCRIPTION
## Ændringer

- Tilføjer `info.xml` for 15 digtere fra *Poetisk Læsebog*.
- Fjerner de fejlagtige henvisninger til `andre.xml`.
- Tilføjer dokumenterede fulde datoer, steder og tilgængelige autoritets-id’er.
- Retter navne og fejlagtige årstal, blandt andet for Hans Diderik de Brinck-Seidelin.
- Omdøber Peter Frederik Friis’ mappe til `friispf`, så den matcher person-id’et.
- Linker Ole Bang-noterne i Aarestrups to tekstvarianter til den nye personside.

## Validering

- Alle berørte XML-filer er valideret med `xmllint`.
- `npm test -- --runInBand`: 48 testsuiter og 2303 tests bestået.
- Mappe- og person-id’er er kontrolleret for overensstemmelse.
