### PR TITLE
Strukturér referencer til ukendte originaltekster

### DIFF
--- a/__tests__/poets.test.js
+++ b/__tests__/poets.test.js
@@ -5,6 +5,10 @@ describe('poet language validation', () => {
     expect(isKnownPoetLanguage('grc')).toBe(true);
   });
 
+  it('allows Dutch poet language', () => {
+    expect(isKnownPoetLanguage('nl')).toBe(true);
+  });
+
   it('rejects unknown language codes', () => {
     expect(isKnownPoetLanguage('zz')).toBe(false);
   });

--- a/docs/xml-info-format.md
+++ b/docs/xml-info-format.md
@@ -66,6 +66,7 @@ Sprogkoder, som buildet accepterer i dag:
 - `la`
 - `fa`
 - `es`
+- `nl`
 - `un`
 - `it`
 

--- a/docs/xml-work-format.md
+++ b/docs/xml-work-format.md
@@ -365,6 +365,11 @@ Attributter paa `<note>`:
 - `lang`: sprog for noten; default er `da`.
 - `unknown-original-by`: digter-id. Giver noten typen `unknown-original` og bruges som oversaettelsesreference.
 
+Brug en tom `<note unknown-original-by="..."/>`, naar originalens ophavsmand er
+kendt, men originalteksten ikke findes i Kalliope. Naar originalteksten findes i
+Kalliope, bruges i stedet en `<xref type="translation" poem="..."/>` i en
+almindelig note.
+
 Noter i selve teksten kan skrives som `<note>` eller `<footnote>` i tekstblokkene:
 
 ```xml

--- a/fdirs/aarestrup/1976-5.xml
+++ b/fdirs/aarestrup/1976-5.xml
@@ -1050,9 +1050,9 @@ Ved et saa sødt Bedrag.
     <firstline>O ei den Elskovseed, du svor</firstline>
     <notes>
         <note>Gendigtning af »'Tis not your saying that you love«.</note>
+        <note unknown-original-by="behn" />
     </notes>
     <quality>korrektur1,kilde,side</quality>
-    <!-- TODO: Find originalen (Behn) -->
     <source pages="40"/>
 </head>
 <body>
@@ -3645,10 +3645,10 @@ Just i dette Øieblik.
     <firstline>Lykkelige Brudgom, skynd dig!</firstline>
     <notes>
         <note>Gendigtning af »Tu jam purpurea sola cubans toro«.</note>
+        <note unknown-original-by="grotius" />
         <!-- Den korrekte titel er Hugo Grotius: »Epithalamium Potteii« -->
     </notes>
     <quality>korrektur1,kilde,side</quality>
-    <!-- TODO: Find originalen (Grotius) -->
     <source pages="122-123"/>
 </head>
 <body>

--- a/fdirs/behn/info.xml
+++ b/fdirs/behn/info.xml
@@ -1,0 +1,22 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<person id="behn" country="gb" lang="en" type="poet">
+  <name>
+    <firstname>Aphra</firstname>
+    <lastname>Behn</lastname>
+  </name>
+  <period>
+    <born>
+      <date>1640</date>
+    </born>
+    <dead>
+      <date>1689-04-16</date>
+    </dead>
+  </period>
+  <identifiers>
+    <wikidata>Q231886</wikidata>
+    <wikipedia-en>Aphra Behn</wikipedia-en>
+    <wikipedia-fr>Aphra Behn</wikipedia-fr>
+    <wikipedia-de>Aphra Behn</wikipedia-de>
+    <viaf>19715508</viaf>
+  </identifiers>
+</person>

--- a/fdirs/blasco/info.xml
+++ b/fdirs/blasco/info.xml
@@ -1,0 +1,21 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<person id="blasco" country="un" lang="es" type="poet">
+  <name>
+    <firstname>Eusebio</firstname>
+    <lastname>Blasco</lastname>
+    <fullname>Eusebio Blasco Soler</fullname>
+  </name>
+  <period>
+    <born>
+      <date>1844-04-28</date>
+    </born>
+    <dead>
+      <date>1903-02-25</date>
+    </dead>
+  </period>
+  <identifiers>
+    <wikidata>Q3572677</wikidata>
+    <wikipedia-en>Eusebio Blasco</wikipedia-en>
+    <viaf>2458726</viaf>
+  </identifiers>
+</person>

--- a/fdirs/browne/info.xml
+++ b/fdirs/browne/info.xml
@@ -1,0 +1,20 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<person id="browne" country="gb" lang="en" type="poet">
+  <name>
+    <firstname>Mary Ann</firstname>
+    <lastname>Browne</lastname>
+  </name>
+  <period>
+    <born>
+      <date>1812-09-24</date>
+    </born>
+    <dead>
+      <date>1845-01-28</date>
+    </dead>
+  </period>
+  <identifiers>
+    <wikidata>Q18674185</wikidata>
+    <wikipedia-en>Mary Ann Browne</wikipedia-en>
+    <viaf>294350362</viaf>
+  </identifiers>
+</person>

--- a/fdirs/bruunmc/1797.xml
+++ b/fdirs/bruunmc/1797.xml
@@ -4823,7 +4823,9 @@ Og paa elysisk Rosenslette
         <line>Oversat efter <w>Coupignys</w> franske Original</line>
     </subtitle>
     <firstline>O, see den skjønneste blant dine Dage!</firstline>
-    <!-- TODO: Find André-François de Coupignys original -->
+    <notes>
+        <note unknown-original-by="coupigny" />
+    </notes>
     <source pages="230-232" facsimile-pages="242-244" />
     <quality>korrektur1,korrektur2,kilde,side</quality>
 </head>

--- a/fdirs/campoamor/info.xml
+++ b/fdirs/campoamor/info.xml
@@ -1,0 +1,23 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<person id="campoamor" country="un" lang="es" type="poet">
+  <name>
+    <firstname>Ramón de</firstname>
+    <lastname>Campoamor</lastname>
+    <fullname>Ramón de Campoamor y Campoosorio</fullname>
+  </name>
+  <period>
+    <born>
+      <date>1817-09-24</date>
+    </born>
+    <dead>
+      <date>1901-02-11</date>
+    </dead>
+  </period>
+  <identifiers>
+    <wikidata>Q64578</wikidata>
+    <wikipedia-en>Ramón de Campoamor y Campoosorio</wikipedia-en>
+    <wikipedia-fr>Ramón de Campoamor y Campoosorio</wikipedia-fr>
+    <wikipedia-de>Ramón de Campoamor y Campoosorio</wikipedia-de>
+    <viaf>2542317</viaf>
+  </identifiers>
+</person>

--- a/fdirs/coupigny/info.xml
+++ b/fdirs/coupigny/info.xml
@@ -1,0 +1,19 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<person id="coupigny" country="fr" lang="fr" type="poet">
+  <name>
+    <firstname>André-François de</firstname>
+    <lastname>Coupigny</lastname>
+  </name>
+  <period>
+    <born>
+      <date>1766-01-10</date>
+    </born>
+    <dead>
+      <date>1833-07-16</date>
+    </dead>
+  </period>
+  <identifiers>
+    <wikidata>Q23050168</wikidata>
+    <viaf>22151742</viaf>
+  </identifiers>
+</person>

--- a/fdirs/egan/info.xml
+++ b/fdirs/egan/info.xml
@@ -1,0 +1,19 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<person id="egan" country="us" lang="en" type="poet">
+  <name>
+    <firstname>Maurice Francis</firstname>
+    <lastname>Egan</lastname>
+  </name>
+  <period>
+    <born>
+      <date>1852-05-24</date>
+    </born>
+    <dead>
+      <date>1924-01-15</date>
+    </dead>
+  </period>
+  <identifiers>
+    <wikidata>Q6793122</wikidata>
+    <viaf>56701341</viaf>
+  </identifiers>
+</person>

--- a/fdirs/florian/info.xml
+++ b/fdirs/florian/info.xml
@@ -1,0 +1,19 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<person id="florian" country="fr" lang="fr" type="poet">
+  <name>
+    <firstname>Jean-Pierre Claris de</firstname>
+    <lastname>Florian</lastname>
+  </name>
+  <period>
+    <born>
+      <date>1755-03-06</date>
+    </born>
+    <dead>
+      <date>1794-09-13</date>
+    </dead>
+  </period>
+  <identifiers>
+    <wikidata>Q551740</wikidata>
+    <viaf>24601427</viaf>
+  </identifiers>
+</person>

--- a/fdirs/fonss/1900.xml
+++ b/fdirs/fonss/1900.xml
@@ -1899,7 +1899,9 @@ det er - mig selv.
     <subtitle>(Efter Adolf Frey, Schweitz)</subtitle>
     <firstline>Trommernes Buldren, Staalets Skratten</firstline>
     <source pages="71-72"/>
-    <!-- TODO: Find originalen. Adolf Frey. -->
+    <notes>
+        <note unknown-original-by="frey" />
+    </notes>
     <quality>korrektur1,korrektur2,side,side</quality>
 </head>
 <body>

--- a/fdirs/fonss/1919.xml
+++ b/fdirs/fonss/1919.xml
@@ -68,7 +68,9 @@ og Oprejsning Timen inde!
     <subtitle>(Efter Hebbel.)</subtitle>
     <firstline>De Blomster, som gror herinde</firstline>
     <source pages="7"/>
-    <!-- TODO: Find originalen. Hebbel er tysk digter med dansk statsborgerskab. Han har skrevet ét digt (lejlighedsdigt til kongen) på dansk iflg. Wikipedia. -->
+    <notes>
+        <note unknown-original-by="hebbel" />
+    </notes>
     <quality>korrektur1,kilde,side</quality>
 </head>
 <body>

--- a/fdirs/frey/info.xml
+++ b/fdirs/frey/info.xml
@@ -1,0 +1,22 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<person id="frey" country="un" lang="de" type="poet">
+  <name>
+    <firstname>Adolf</firstname>
+    <lastname>Frey</lastname>
+  </name>
+  <period>
+    <born>
+      <date>1855-02-18</date>
+    </born>
+    <dead>
+      <date>1920-02-12</date>
+    </dead>
+  </period>
+  <identifiers>
+    <wikidata>Q124151</wikidata>
+    <wikipedia-da>Adolf Frey</wikipedia-da>
+    <wikipedia-en>Adolf Frey (writer)</wikipedia-en>
+    <wikipedia-de>Adolf Frey</wikipedia-de>
+    <viaf>19766062</viaf>
+  </identifiers>
+</person>

--- a/fdirs/fumars/info.xml
+++ b/fdirs/fumars/info.xml
@@ -1,0 +1,19 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<person id="fumars" country="dk" lang="fr" type="poet">
+  <name>
+    <firstname>Étienne</firstname>
+    <lastname>Fumars</lastname>
+  </name>
+  <period>
+    <born>
+      <date>1743-10-22</date>
+    </born>
+    <dead>
+      <date>1806-11-30</date>
+    </dead>
+  </period>
+  <identifiers>
+    <wikidata>Q12341930</wikidata>
+    <viaf>215017015</viaf>
+  </identifiers>
+</person>

--- a/fdirs/grotius/info.xml
+++ b/fdirs/grotius/info.xml
@@ -1,0 +1,24 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<person id="grotius" country="un" lang="la" type="poet">
+  <name>
+    <firstname>Hugo</firstname>
+    <lastname>Grotius</lastname>
+    <fullname>Hugo de Groot</fullname>
+  </name>
+  <period>
+    <born>
+      <date>1583-04-10</date>
+    </born>
+    <dead>
+      <date>1645-08-28</date>
+    </dead>
+  </period>
+  <identifiers>
+    <wikidata>Q154959</wikidata>
+    <wikipedia-da>Hugo Grotius</wikipedia-da>
+    <wikipedia-en>Hugo Grotius</wikipedia-en>
+    <wikipedia-fr>Hugo Grotius</wikipedia-fr>
+    <wikipedia-de>Hugo Grotius</wikipedia-de>
+    <viaf>32005141</viaf>
+  </identifiers>
+</person>

--- a/fdirs/grundtvig/1868.xml
+++ b/fdirs/grundtvig/1868.xml
@@ -16137,10 +16137,10 @@ Giør Frelseren kronede Dage!
     <firstline>Bøi dig for din Konge, Sjæl!</firstline>
     <notes>
        <note>* Af Ingemanns "Glæd dig Zion, glæd dig Jord"</note>
+       <note unknown-original-by="ingemann" />
     </notes>
     <quality>korrektur1,kilde,side</quality>
     <source pages="398-399"/>
-    <!-- TODO: Link til Ingemanns original. -->
 </head>
 <body>
 <poetry>
@@ -16171,8 +16171,8 @@ Hosianna i det Høie!
     <firstline>Jeg som et Barn mig glæde vil</firstline>
     <notes>
        <note>* Ingemanns Jule-Sang med et Par Smaa-Ændringer</note>
+       <note unknown-original-by="ingemann" />
     </notes>
-    <!-- TODO: Link til Ingemanns original. -->
     <quality>korrektur1,kilde,side</quality>
     <source pages="399-400"/>
 </head>
@@ -22776,10 +22776,10 @@ Engle-Røst fra Graven toner!
     <firstline>Hørt det har jeg, Han opstod</firstline>
     <notes>
        <note>* Ogsaa Ingemanns uforandret</note>
+       <note unknown-original-by="ingemann" />
     </notes>
     <quality>korrektur1,kilde,side</quality>
     <source pages="560-561"/>
-<!--  TODO: Link til Ingemanns original. -->
 </head>
 <body>
 <poetry>
@@ -22821,7 +22821,7 @@ Salig, hellig og forklaret!
     <notes>
        <note>* Ingemanns uforandret</note>
        <note>Note til strofe 4, vers 6: Lær mig at troe hvad ei jeg saae, og Vidnesbyrd at lide paa</note>
-       <!--  TODO: Link til Ingemanns original. -->
+       <note unknown-original-by="ingemann" />
     </notes>
     <quality>korrektur1,kilde,side</quality>
     <source pages="561-562"/>
@@ -27503,10 +27503,10 @@ Sandhedens Vidne og Kiærligheds Tolk!
     <firstline>Fra Himlen Herrens Aand nedfoer</firstline>
     <notes>
        <note>* Ingemanns Pindse-Sang uforandret</note>
+       <note unknown-original-by="ingemann" />
     </notes>
     <quality>korrektur1,kilde,side</quality>
     <source pages="668-669"/>
-<!--  TODO: Link til Ingemanns original. -->
 </head>
 <body>
 <poetry>

--- a/fdirs/hebbel/info.xml
+++ b/fdirs/hebbel/info.xml
@@ -1,0 +1,20 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<person id="hebbel" country="de" lang="de" type="poet">
+  <name>
+    <firstname>Friedrich</firstname>
+    <lastname>Hebbel</lastname>
+    <fullname>Christian Friedrich Hebbel</fullname>
+  </name>
+  <period>
+    <born>
+      <date>1813-03-18</date>
+    </born>
+    <dead>
+      <date>1863-12-13</date>
+    </dead>
+  </period>
+  <identifiers>
+    <wikidata>Q57182</wikidata>
+    <viaf>9861617</viaf>
+  </identifiers>
+</person>

--- a/fdirs/henriksen/1916.xml
+++ b/fdirs/henriksen/1916.xml
@@ -851,7 +851,9 @@ fornemme Efterarets Løvfaldsfryd.
     <firstline>Der blæser en Sydstorm af værste Art</firstline>
     <source pages="44-45"/>
     <quality>korrektur1,korrektur2,kilde,side</quality>
-    <!-- TODO: Find originalen (Schoenaich-Carolath) -->
+    <notes>
+        <note unknown-original-by="schoenaich" />
+    </notes>
 </head>
 <body>
 <poetry>
@@ -893,7 +895,9 @@ Vi hilser Dig, Gudestrand!
     <firstline>Du smalle Ring, Du gyldne Ring</firstline>
     <source pages="46-47"/>
     <quality>korrektur1,korrektur2,kilde,side</quality>
-    <!-- TODO: Find originalen (Vierordt) -->
+    <notes>
+        <note unknown-original-by="vierordt" />
+    </notes>
 </head>
 <body>
 <poetry>
@@ -945,7 +949,9 @@ det helligt-rene Troskabspant.
     <firstline>Og gaarr Du i modløs Tøven</firstline>
     <source pages="48-50"/>
     <quality>korrektur1,korrektur2,kilde,side</quality>
-    <!-- TODO: Find originalen (Lienhard) -->
+    <notes>
+        <note unknown-original-by="lienhard" />
+    </notes>
 </head>
 <body>
 <poetry>
@@ -1236,7 +1242,9 @@ der drog ham med Toner og Sus.
     <subtitle>Ynglingen til Jomfruen:</subtitle>
     <firstline>Det var i Jordens sidste Vaar</firstline>
     <source pages="61-63"/>
-    <!-- TODO: Find originalen (Karlfeldt). -->
+    <notes>
+        <note unknown-original-by="karlfeldt" />
+    </notes>
     <!-- http://www.karlfeldt.org/bibliotek/diktarkivet -->
     <quality>korrektur1,korrektur2,kilde,side</quality>
 </head>

--- a/fdirs/imbert/info.xml
+++ b/fdirs/imbert/info.xml
@@ -1,0 +1,19 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<person id="imbert" country="fr" lang="fr" type="poet">
+  <name>
+    <firstname>Barthélemy</firstname>
+    <lastname>Imbert</lastname>
+  </name>
+  <period>
+    <born>
+      <date>1747-03-16</date>
+    </born>
+    <dead>
+      <date>1790-08-23</date>
+    </dead>
+  </period>
+  <identifiers>
+    <wikidata>Q2885973</wikidata>
+    <viaf>66600460</viaf>
+  </identifiers>
+</person>

--- a/fdirs/jerningham/info.xml
+++ b/fdirs/jerningham/info.xml
@@ -1,0 +1,19 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<person id="jerningham" country="gb" lang="en" type="poet">
+  <name>
+    <firstname>Edward</firstname>
+    <lastname>Jerningham</lastname>
+  </name>
+  <period>
+    <born>
+      <date>1737</date>
+    </born>
+    <dead>
+      <date>1812-11-17</date>
+    </dead>
+  </period>
+  <identifiers>
+    <wikidata>Q18528200</wikidata>
+    <viaf>47117177</viaf>
+  </identifiers>
+</person>

--- a/fdirs/lange/1876.xml
+++ b/fdirs/lange/1876.xml
@@ -126,7 +126,9 @@ Og aldrig skilles fra din Faders Ære.
     <title>Barnebruden</title>
     <firstline>Dig, o Himmelens Søn! lyseste Guddom, Dig</firstline>
     <source pages="8-9"/>
-    <!-- TODO: Find originalen (Johan Nervander) -->
+    <notes>
+        <note unknown-original-by="nervander" />
+    </notes>
     <quality>korrektur1,kilde,side</quality>
 </head>
 <body>

--- a/fdirs/lienhard/info.xml
+++ b/fdirs/lienhard/info.xml
@@ -1,0 +1,23 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<person id="lienhard" country="de" lang="de" type="poet">
+  <name>
+    <firstname>Fritz</firstname>
+    <lastname>Lienhard</lastname>
+    <fullname>Friedrich Lienhard</fullname>
+  </name>
+  <period>
+    <born>
+      <date>1865-10-04</date>
+    </born>
+    <dead>
+      <date>1929-04-30</date>
+    </dead>
+  </period>
+  <identifiers>
+    <wikidata>Q91729</wikidata>
+    <wikipedia-en>Friedrich Lienhard</wikipedia-en>
+    <wikipedia-fr>Friedrich Lienhard</wikipedia-fr>
+    <wikipedia-de>Friedrich Lienhard</wikipedia-de>
+    <viaf>19691165</viaf>
+  </identifiers>
+</person>

--- a/fdirs/macfie/info.xml
+++ b/fdirs/macfie/info.xml
@@ -1,0 +1,19 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<person id="macfie" country="gb" lang="en" type="poet">
+  <name>
+    <firstname>Ronald Campbell</firstname>
+    <lastname>Macfie</lastname>
+  </name>
+  <period>
+    <born>
+      <date>1867</date>
+    </born>
+    <dead>
+      <date>1931</date>
+    </dead>
+  </period>
+  <identifiers>
+    <wikidata>Q7364723</wikidata>
+    <viaf>57960728</viaf>
+  </identifiers>
+</person>

--- a/fdirs/mahlmann/info.xml
+++ b/fdirs/mahlmann/info.xml
@@ -1,0 +1,19 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<person id="mahlmann" country="de" lang="de" type="poet">
+  <name>
+    <firstname>Siegfried August</firstname>
+    <lastname>Mahlmann</lastname>
+  </name>
+  <period>
+    <born>
+      <date>1771-05-13</date>
+    </born>
+    <dead>
+      <date>1826-12-16</date>
+    </dead>
+  </period>
+  <identifiers>
+    <wikidata>Q99881</wikidata>
+    <viaf>71658750</viaf>
+  </identifiers>
+</person>

--- a/fdirs/matthison/1897.xml
+++ b/fdirs/matthison/1897.xml
@@ -901,7 +901,9 @@ og døved hver en Klang.
     </subtitle>
     <firstline>Din ranke, mørke Skønhed er uden nogen Lige</firstline>
     <source pages="38-39"/>
-    <!-- TODO: Find Macfies original -->
+    <notes>
+        <note unknown-original-by="macfie" />
+    </notes>
     <quality>korrektur1,kilde,side</quality>
 </head>
 <body>
@@ -1062,7 +1064,9 @@ og alle dets Strænge til Sange stemt.
     </subtitle>
     <firstline>Sig, hvorfor tier Graven - hvi ligger den forladt</firstline>
     <source pages="44-46"/>
-    <!-- TODO: Find Houghtons original -->
+    <notes>
+        <note unknown-original-by="houghton" />
+    </notes>
     <quality>korrektur1,kilde,side</quality>
 </head>
 <body>

--- a/fdirs/matthison/1915.xml
+++ b/fdirs/matthison/1915.xml
@@ -1745,7 +1745,9 @@ sprang tvende Hjerter læk.
     <subtitle>(Efter Maurice Francis Egan)</subtitle>
     <firstline>En stilfuld Park, Bymure stænger den</firstline>
     <source pages="56"/>
-    <!-- TODO: Find Egans original -->
+    <notes>
+        <note unknown-original-by="egan" />
+    </notes>
     <keywords>christian4,sonnet</keywords>
     <quality>korrektur1,kilde,side</quality>
 </head>
@@ -1811,7 +1813,9 @@ ak! og Saligheden med!
     <subtitle>(Efter N. Lenau)</subtitle>
     <firstline>Natuglen skriger trist i øde Klippekløfter</firstline>
     <source pages="58-59"/>
-    <!-- TODO: Find Lenaus original -->
+    <notes>
+        <note unknown-original-by="lenau" />
+    </notes>
     <quality>korrektur1,kilde,side</quality>
 </head>
 <body>

--- a/fdirs/nervander/info.xml
+++ b/fdirs/nervander/info.xml
@@ -1,0 +1,22 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<person id="nervander" country="un" lang="sv" type="poet">
+  <name>
+    <firstname>Johan Jakob</firstname>
+    <lastname>Nervander</lastname>
+  </name>
+  <period>
+    <born>
+      <date>1805-02-23</date>
+    </born>
+    <dead>
+      <date>1848-03-15</date>
+    </dead>
+  </period>
+  <identifiers>
+    <wikidata>Q3180415</wikidata>
+    <wikipedia-en>Johan Jakob Nervander</wikipedia-en>
+    <wikipedia-fr>Johan Jakob Nervander</wikipedia-fr>
+    <wikipedia-de>Johan Jakob Nervander</wikipedia-de>
+    <viaf>42640850</viaf>
+  </identifiers>
+</person>

--- a/fdirs/nivernais/info.xml
+++ b/fdirs/nivernais/info.xml
@@ -1,0 +1,19 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<person id="nivernais" country="fr" lang="fr" type="poet">
+  <name>
+    <firstname>Louis-Jules Mancini-Mazarini, duc de</firstname>
+    <lastname>Nivernais</lastname>
+  </name>
+  <period>
+    <born>
+      <date>1716-12-16</date>
+    </born>
+    <dead>
+      <date>1798-02-25</date>
+    </dead>
+  </period>
+  <identifiers>
+    <wikidata>Q347372</wikidata>
+    <viaf>9979313</viaf>
+  </identifiers>
+</person>

--- a/fdirs/perk/info.xml
+++ b/fdirs/perk/info.xml
@@ -1,0 +1,22 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<person id="perk" country="un" lang="nl" type="poet">
+  <name>
+    <firstname>Jacques</firstname>
+    <lastname>Perk</lastname>
+    <fullname>Jacques Fabrice Herman Perk</fullname>
+  </name>
+  <period>
+    <born>
+      <date>1859-06-10</date>
+    </born>
+    <dead>
+      <date>1881-11-01</date>
+    </dead>
+  </period>
+  <identifiers>
+    <wikidata>Q1622474</wikidata>
+    <wikipedia-en>Jacques Perk</wikipedia-en>
+    <wikipedia-de>Jacques Perk</wikipedia-de>
+    <viaf>29706401</viaf>
+  </identifiers>
+</person>

--- a/fdirs/preetzmann/1867d.xml
+++ b/fdirs/preetzmann/1867d.xml
@@ -4425,7 +4425,9 @@ Det var saa tungt at gaae tilbage
     <toctitle>Kjærlighed (Robert Southey)</toctitle>
     <firstline>Synd er det, hvem der os fortæller</firstline>
     <source pages="163-164"/>
-    <!-- TODO: Find originalen (Robert Southey) -->
+    <notes>
+        <note unknown-original-by="southey" />
+    </notes>
     <quality>korrektur1,kilde,side</quality>
 </head>
 <body>
@@ -4466,7 +4468,9 @@ For hendes Graad og vaagne Nætter,
     <toctitle>Den Forskudte (Mary Ann Browne)</toctitle>
     <firstline>Mit Haar før Tiden graaned alt</firstline>
     <source pages="165-167"/>
-    <!-- TODO: Find originalen (Mary Ann Browne) -->
+    <notes>
+        <note unknown-original-by="browne" />
+    </notes>
     <quality>korrektur1,kilde,side</quality>
 </head>
 <body>

--- a/fdirs/prudhomme/info.xml
+++ b/fdirs/prudhomme/info.xml
@@ -1,0 +1,24 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<person id="prudhomme" country="fr" lang="fr" type="poet">
+  <name>
+    <firstname>Sully</firstname>
+    <lastname>Prudhomme</lastname>
+    <fullname>René François Armand Prudhomme</fullname>
+  </name>
+  <period>
+    <born>
+      <date>1839-03-16</date>
+    </born>
+    <dead>
+      <date>1907-09-07</date>
+    </dead>
+  </period>
+  <identifiers>
+    <wikidata>Q42247</wikidata>
+    <wikipedia-da>Sully Prudhomme</wikipedia-da>
+    <wikipedia-en>Sully Prudhomme</wikipedia-en>
+    <wikipedia-fr>Sully Prudhomme</wikipedia-fr>
+    <wikipedia-de>Sully Prudhomme</wikipedia-de>
+    <viaf>89565335</viaf>
+  </identifiers>
+</person>

--- a/fdirs/rahbek/1817.xml
+++ b/fdirs/rahbek/1817.xml
@@ -884,7 +884,9 @@ Kun hvor du er ei, findes Held.
     <subtitle>Efter Imbert</subtitle>
     <firstline>Hvorfor klage, hvorfor græde</firstline>
     <source pages="42"/>
-    <!-- TODO: Find original (Imbert) -->
+    <notes>
+        <note unknown-original-by="imbert" />
+    </notes>
     <quality>korrektur1,kilde,side</quality>
 </head>
 <body>
@@ -1287,7 +1289,9 @@ Ad Sagnet, som Klokkerne mindes.
     <subtitle>Fabel efter Nivernois</subtitle>
     <firstline>En Konge havde sig engang en Nar</firstline>
     <source pages="60-61"/>
-    <!-- TODO: Find originalen (Nivernois) -->
+    <notes>
+        <note unknown-original-by="nivernais" />
+    </notes>
     <quality>korrektur1,kilde,side</quality>
 </head>
 <body>
@@ -1489,7 +1493,9 @@ Farvel, elskte Harpe! min eneste Skat!
     <subtitle>Efter Florian</subtitle>
     <firstline>Forgiæves Fængslets Muur gientager</firstline>
     <source pages="69-70"/>
-    <!-- TODO: Find original (Florian) -->
+    <notes>
+        <note unknown-original-by="florian" />
+    </notes>
     <quality>korrektur1,kilde,side</quality>
 </head>
 <body>
@@ -1676,7 +1682,9 @@ Ham vil den aldrig være glædelig.
     <subtitle>Efter Jerningham</subtitle>
     <firstline>Til Templet söger sorgfuld Hob i Bön</firstline>
     <source pages="76-82"/>
-    <!-- TODO: Find original (Jerningham) -->
+    <notes>
+        <note unknown-original-by="jerningham" />
+    </notes>
     <quality>korrektur1,kilde,side</quality>
 </head>
 <body>
@@ -2000,7 +2008,9 @@ Ja dette svage Hierte troer:
     <subtitle>Oratorium efter Mahlmann</subtitle>
     <firstline>Du har dine Stötter opbygget dig</firstline>
     <source pages="89-92"/>
-    <!-- TODO: Find original (Mahlman) -->
+    <notes>
+        <note unknown-original-by="mahlmann" />
+    </notes>
     <quality>korrektur1,kilde,side</quality>
 </head>
 <body>
@@ -2641,7 +2651,9 @@ Og det er denne, som du har beholder.
     <subtitle>Fabel efter Fumars</subtitle>
     <firstline>Nedstegen Phæbus er i Thetis Favn</firstline>
     <source pages="110"/>
-    <!-- TODO: Find original (Fumars) -->
+    <notes>
+        <note unknown-original-by="fumars" />
+    </notes>
     <quality>korrektur1,kilde,side</quality>
 </head>
 <body>
@@ -2666,9 +2678,9 @@ Höit Maanen vi, men aldrig Solen see.
     <firstline>Der gives en Plads i det kiölige Rum</firstline>
     <notes>
         <note>* En Lövhytte i Toppen af en herlig Eeg i Kraagerup Hauge, hvis Eiers Kone, Fru Fr. Brun den yngre, Sangen er tilegnet.</note>
+        <note unknown-original-by="brunf" />
     </notes>
     <source pages="111-112"/>
-    <!-- TODO: Find original (Frue Fr. Brun)-->
     <quality>korrektur1,kilde,side</quality>
 </head>
 <body>
@@ -2717,7 +2729,9 @@ Et daarende Haab du ei elske mig op!
     <subtitle>Efter Steenhammars svenske Original</subtitle>
     <firstline>Storme vildt om Thorvalds Leie hviner</firstline>
     <source pages="113-121"/>
-    <!-- TODO: Find original (Stenhammer) -->
+    <notes>
+        <note unknown-original-by="stenhammar" />
+    </notes>
     <quality>korrektur1,kilde,side</quality>
 </head>
 <body>

--- a/fdirs/rosenbergpa/1910.xml
+++ b/fdirs/rosenbergpa/1910.xml
@@ -5829,9 +5829,9 @@ Er Naaden aldrig fjern.
     <firstline>Nys paa Telegrafkontoret</firstline>
     <notes>
         <note>Eusebio Blasco Soler (1844–1903), spansk journalist, digter og dramatiker.</note>
+        <note unknown-original-by="blasco" />
     </notes>
     <source pages="272-273"/>
-    <!-- TODO: Find originalen. Eusebio Blasco Soler. -->
     <quality>korrektur1,kilde,side</quality>
 </head>
 <body>
@@ -5879,9 +5879,9 @@ Mens Depeschen hen han lagde:
     <firstline>Gule Blomter har du plukket</firstline>
     <notes>
         <note>Ramón de Campoamor y Campoosorio (1817-1901), spansk digter.</note>
+        <note unknown-original-by="campoamor" />
     </notes>
     <source pages="274-275"/>
-    <!-- TODO: Find originalen. Ramón de Campoamor y Campoosorio. -->
     <quality>korrektur1,kilde,side</quality>
 </head>
 <body>
@@ -5930,9 +5930,9 @@ Intet mer, min lille Elskte!
     <firstline>Den synkende Sol staar gylden bag Skyernes blaagraa Volde</firstline>
     <notes>
         <note>Eusebio Blasco Soler (1844–1903), spansk journalist, digter og dramatiker.</note>
+        <note unknown-original-by="blasco" />
     </notes>
     <source pages="276-286"/>
-    <!-- TODO: Find originalen. Eusebio Blasco Soler. -->
     <quality>korrektur1,kilde,side</quality>
 </head>
 <body>
@@ -6286,7 +6286,9 @@ Hilser jeg Gryet og Dagen.
     <subtitle>(Efter Jacques Perk)</subtitle>
     <firstline>Gud, sagde Duen, Gud er rund og fager</firstline>
     <source pages="294-295"/>
-    <!-- TODO: Find originalen. Jacques Perk. -->
+    <notes>
+        <note unknown-original-by="perk" />
+    </notes>
     <keywords>sonnet</keywords>
     <quality>korrektur1,kilde,side</quality>
 </head>

--- a/fdirs/schoenaich/info.xml
+++ b/fdirs/schoenaich/info.xml
@@ -1,0 +1,22 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<person id="schoenaich" country="de" lang="de" type="poet">
+  <name>
+    <firstname>Emil von</firstname>
+    <lastname>Schoenaich-Carolath</lastname>
+  </name>
+  <period>
+    <born>
+      <date>1852-04-08</date>
+    </born>
+    <dead>
+      <date>1908-04-30</date>
+    </dead>
+  </period>
+  <identifiers>
+    <wikidata>Q99689</wikidata>
+    <wikipedia-da>Emil von Schoenaich-Carolath</wikipedia-da>
+    <wikipedia-fr>Emil von Schönaich-Carolath</wikipedia-fr>
+    <wikipedia-de>Emil von Schoenaich-Carolath</wikipedia-de>
+    <viaf>2610336</viaf>
+  </identifiers>
+</person>

--- a/fdirs/stenhammar/info.xml
+++ b/fdirs/stenhammar/info.xml
@@ -1,0 +1,19 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<person id="stenhammar" country="se" lang="sv" type="poet">
+  <name>
+    <firstname>Johan</firstname>
+    <lastname>Stenhammar</lastname>
+  </name>
+  <period>
+    <born>
+      <date>1769-06-17</date>
+    </born>
+    <dead>
+      <date>1799-01-31</date>
+    </dead>
+  </period>
+  <identifiers>
+    <wikidata>Q655653</wikidata>
+    <viaf>59350331</viaf>
+  </identifiers>
+</person>

--- a/fdirs/vierordt/info.xml
+++ b/fdirs/vierordt/info.xml
@@ -1,0 +1,20 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<person id="vierordt" country="de" lang="de" type="poet">
+  <name>
+    <firstname>Heinrich</firstname>
+    <lastname>Vierordt</lastname>
+  </name>
+  <period>
+    <born>
+      <date>1855-10-01</date>
+    </born>
+    <dead>
+      <date>1945-06-17</date>
+    </dead>
+  </period>
+  <identifiers>
+    <wikidata>Q71814760</wikidata>
+    <wikipedia-de>Heinrich Vierordt (Schriftsteller)</wikipedia-de>
+    <viaf>22942428</viaf>
+  </identifiers>
+</person>

--- a/fdirs/waage/1899.xml
+++ b/fdirs/waage/1899.xml
@@ -317,7 +317,9 @@ om smalle Skuldre og om tynde Lægge.
     <firstline>De sidder sødt i deres Bluser</firstline>
     <source pages="19-20"/>
     <quality>korrektur1,kilde,side</quality>
-    <!-- TODO: Find originalen (Prud'homme)-->
+    <notes>
+        <note unknown-original-by="prudhomme" />
+    </notes>
 </head>
 <body>
 <poetry>

--- a/tools/build-static/poets.js
+++ b/tools/build-static/poets.js
@@ -36,6 +36,7 @@ const knownPoetLanguages = new Set([
   'grc',
   'fa',
   'es',
+  'nl',
   'un',
   'it',
 ]);


### PR DESCRIPTION
## Resumé

Denne ændring erstatter løse TODO-kommentarer med strukturerede referencer til kendte originalforfattere, uden at påstå at selve originalteksten er fundet.

## Ændringer

- opretter 23 minimale digterposter med biografiske metadata og eksterne identifikatorer
- erstatter relevante TODO-kommentarer med `<note unknown-original-by="…"/>`
- genbruger eksisterende digterposter for blandt andre Ingemann, Houghton, Lenau, Southey, Brun og Karlfeldt
- tilføjer nederlandsk (`nl`) som accepteret digtersprog for Jacques Perk
- dokumenterer forskellen mellem `unknown-original-by` og translation-`xref`
- tilføjer test af nederlandsk sprogmetadata

## Effekt

Oversættelserne bliver søgbare som omtaler af originalforfatterne og får automatisk noten »Oversættelse af et ukendt digt af …«. De nye digterposter kan bygges uden importerede værker.

De fortsatte undersøgelser er registreret i #1321 og #1322.

## Validering

- XML-skemaerne for nye digterposter og ændrede værkfiler
- `npm test -- --runInBand` — 52 testsuiter og 2350 tests bestået
- `npm run build-static` — 710 Elasticsearch-dokumenter bygget
- stikprøve af genererede `unknown-original`-noter og omtaledata
