### PR TITLE
Tilføj Wikidata-id’er til ti kunstværker

### DIFF
--- a/content/artwork.xml
+++ b/content/artwork.xml
@@ -6,7 +6,7 @@
     <picture id="nidarosdomen-westfront-1839" year="1839">
         August Meyer: <i>Nidarosdomens vestfront</i>, 1839, stik.
     </picture>
-    <picture id="skovgaard-vordingborg-1865" year="1865" museum="smk" invnr="KMS1731">
+    <picture id="skovgaard-vordingborg-1865" wikidata="Q20413899" year="1865" museum="smk" invnr="KMS1731">
         P.C. Skovgaard: <i>Parti ved Iselingen. I baggrunden Vordingborg Kirke og Gåsetårnet. Septemberaften</i>, 1865, olie på lærred, 51,8 × 66,2 cm. Statens Museum for Kunst.
     </picture>
     <picture id="cranach-luther" subject="luther">
@@ -24,10 +24,10 @@
         <!-- metadata checked: 2026-07-16 -->
     </picture> <!-- https://en.wikipedia.org/wiki/Sacred_and_Profane_Love -->
     <picture id="rivett-carnac-edward-fitzgerald-oval" museum="npg" year="1873">Eva Rivett-Carnac: <i>Edward Fitzgerald</i>, miniature efter et fotografi fra 1873.</picture>
-    <picture id="vouet-muses-urania-calliope-1634" year="1634 ca.">
+    <picture id="vouet-muses-urania-calliope-1634" wikidata="Q20177132" year="1634 ca.">
         Simon Vouet (Frankrig, 1590-1649): <i>The Muses Urania and Calliope</i>, ca. 1634, olie på panel, 79,8 × 125 cm. National Gallery of Art, Washington, D.C.
     </picture>
-    <picture id="pajou-calliope-1763" year="1763 ca.">
+    <picture id="pajou-calliope-1763" wikidata="Q63809302" year="1763 ca.">
         Augustin Pajou (Frankrig, 1730-1809): <i>Calliope</i>, ca. 1763, marmor, 158 × 60,8 × 46,1 cm. Samuel H. Kress Collection.
     </picture>
 </pictures>

--- a/fdirs/bache/artwork.xml
+++ b/fdirs/bache/artwork.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <pictures>
-  <picture id="1882-finderup" year="1882" museum="fnm">
+  <picture id="1882-finderup" wikidata="Q21096564" year="1882" museum="fnm">
     <i>De sammensvorne rider fra Finderup efter mordet på Erik Klipping Skt. Cæcilienat 1286</i>, 1882, olie på lærred.
   </picture>
   <picture id="1887-christian4-kroningstog" year="1887" museum="fnm">
@@ -9,7 +9,7 @@
   <picture id="1886-sankelmark" wikidata="Q38713295" year="1886" museum="ribe" invnr="RKMm0009">
     <i>Oberst Max Müller ved Sankelmark Sø den 6. februar 1864</i>, 1886, olie på lærred, 84 × 60 cm.
   </picture>
-  <picture id="1894-soldaternes-hjemkomst" year="1894" museum="fnm">
+  <picture id="1894-soldaternes-hjemkomst" wikidata="Q131293077" year="1894" museum="fnm">
     <i>Soldaternes hjemkomst til København</i>, 1894, olie på lærred.
   </picture>
   <picture id="1896-general-schleppengrell" year="1896" museum="fnm">

--- a/fdirs/kroyer/artwork.xml
+++ b/fdirs/kroyer/artwork.xml
@@ -6,8 +6,8 @@
     <picture id="1879-franske-arbejdere" wikidata="Q20440119" year="1879" museum="ribe" invnr="RKMm0492">
         <i>Franske arbejdere i hulvej</i>, 1879, olie på lærred, 80 × 100 cm.
     </picture>
-    <picture id="1880-hattemagere" year="1880" museum="hirschsprungske">
-        <i>Italienske landsbyhattemagere. Sora</i>, 1883, olie på lærred, 135,5 × 10 cm.
+    <picture id="1880-hattemagere" wikidata="Q21041874" year="1880" museum="hirschsprungske">
+        <i>Italienske landsbyhattemagere. Sora</i>, 1880, olie på lærred, 135,5 × 10 cm.
     </picture>
     <picture id="1883-brandes-3" subject="brandes" year="1883">
         <i>Georg Brandes</i>, 1883.
@@ -15,17 +15,17 @@
     <picture id="1885-emil-poulsen" year="1885" museum="nivaagaard" objid="p-s-kroeyer-1">
         <i>Dobbeltportræt af kgl. skuespiller Emil Poulsen (1842-1911) og hustru Anna, f. Næser (1849-1934)</i>, 1885, pastel på papir, 57 × 68 cm.
     </picture>
-    <picture id="1888-hip-hip-hurra" year="1888">
+    <picture id="1888-hip-hip-hurra" wikidata="Q3135789" year="1888">
         <i>Hip, hip, hurra! Kunstnerfest på Skagen</i>, 1888, olie på lærred, 134,5 × 165,5 cm. Göteborgs konstmuseum.
     </picture>
-    <picture id="1888-kroyer" subject="kroyer" year="1888" museum="digitalmuseum.no" objid="021045726602">
+    <picture id="1888-kroyer" wikidata="Q21009035" subject="kroyer" year="1888" museum="digitalmuseum.no" objid="021045726602">
         <i>Selvportræt</i>, 1888, olie på lærred, 40 × 50 cm. Stavanger kunstmuseum.
     </picture>
     <picture id="1895-fra-koebenhavns-boers" subject="kroyer" year="1895">
         <i>Fra Københavns Børs</i>, 1895, olie på lærred, 254 × 409 cm. Børsen.
     </picture>
-    <picture id="1900-brandes-2" subject="brandes" year="1900" museum="hirschsprungske">
-        <i>Georg Brandes som foredragsholder</i>, 1900, olie på træ, 42,9 × 3,1 cm.
+    <picture id="1900-brandes-2" wikidata="Q105870942" subject="brandes" year="1901" museum="hirschsprungske">
+        <i>Georg Brandes som foredragsholder</i>, 1901, olie på træ, 42,9 × 3,1 cm.
     </picture>
     <picture id="1900-brandes-1" subject="brandes" year="1900" museum="hirschsprungske">
         <i>Kritikeren og forfatteren Georg Brandes</i>, 1900. Skitse til maleri tilhørende Dagbladet Politiken.
@@ -58,7 +58,7 @@
     <picture id="lie-1" subject="lie" year="1902" museum="hirschsprungske">
         <i>Den norske forfatter Jonas Lie</i>, 1902. Skitse til maleri tilhørende Det norske Selskab i Oslo.
     </picture>
-    <picture id="1906-sankt-hans" subject="drachmann" year="1906" museum="skagen">
+    <picture id="1906-sankt-hans" wikidata="Q12334558" subject="drachmann" year="1906" museum="skagen">
         <i>Sankt Hansblus på Skagen strand</i>, 1906, olie på lærred, 149,5×257cm.
     </picture>
 </pictures>


### PR DESCRIPTION
## Hvad ændres

- tilføjer Wikidata-id’er til ti eksisterende kunstværker af P.C. Skovgaard, Simon Vouet, Augustin Pajou, P.S. Krøyer og Otto Bache
- retter billedtekstens årstal for *Italienske landsbyhattemagere. Sora* fra 1883 til 1880
- retter årstal og billedtekst for *Georg Brandes som foredragsholder* fra 1900 til 1901

## Hvorfor

Værkerne kan identificeres sikkert eller meget stærkt ud fra kombinationen af titel, kunstner, år, museum, mål og i flere tilfælde inventarnummer. Wikidata-id’erne samler Kalliopes lokale billedmetadata med de tilsvarende eksterne værkposter.

## Virkning

De berørte kunstværker får direkte Wikidata-henvisninger. Eksisterende picture-id’er og artwork-referencer bevares, så ændringen kræver ingen migrationsarbejde i de tekster, der bruger billederne.

## Validering

- `xmllint` på de tre ændrede XML-filer
- kontrolleret, at Vouet- og Pajou-posterne kun forekommer én gang
- `npm test -- --runInBand` — 2.357 tests består
- `npm run build-static` består
- `git diff --check` består
