### PR TITLE
Lokaliser datoformatering

### DIFF
--- a/__tests__/formatteddate.js
+++ b/__tests__/formatteddate.js
@@ -47,6 +47,11 @@ it('it formats dates including negative years', () => {
   expect(formattedDate('-100-02-03')).toEqual('3/2 100 f.Kr.');
   expect(formattedDate('-8000-02-03')).toEqual('3/2 8000 f.Kr.');
   expect(formattedDate('ca 1818')).toEqual('c.1818');
+  expect(formattedDate('-100-02-03', 'en')).toEqual('3/2 100 BC');
+  expect(formattedDate('-100-02-03', 'fr')).toEqual('3/2 100 av. J.-C.');
+  expect(formattedDate('-100-02-03', 'de')).toEqual('3/2 100 v. Chr.');
+  expect(formattedDate('ca 1818', 'fr')).toEqual('v.1818');
+  expect(formattedDate('ca 1818', 'de')).toEqual('ca.1818');
 });
 
 it('it formats single years', () => {

--- a/common/dates.js
+++ b/common/dates.js
@@ -67,7 +67,7 @@ const parseDate = (date) => {
   return { prefix, year, month, day };
 };
 
-const formattedDate = (date) => {
+const formattedDate = (date, lang = 'da') => {
   if (date == null) {
     return null;
   }
@@ -75,8 +75,11 @@ const formattedDate = (date) => {
 
   let result = null;
 
+  if (prefix != null) {
+    prefix = yearTranslation(lang).circa;
+  }
   if (year < 0) {
-    year = formatYearEra(Math.abs(year), 'bce');
+    year = formatYearEra(Math.abs(year), 'bce', lang);
   }
 
   if (day != null && month != null && year != null) {

--- a/pages/bio.js
+++ b/pages/bio.js
@@ -29,7 +29,7 @@ const dateAndPlace = (datePlace, lang, age) => {
   if (datePlace.date === '?') {
     result.push(_('Ukendt år', lang));
   } else {
-    result.push(formattedDate(datePlace.date));
+    result.push(formattedDate(datePlace.date, lang));
   }
   if (datePlace.place != null) {
     result.push(

--- a/pages/index.js
+++ b/pages/index.js
@@ -27,7 +27,7 @@ const TodaysEvents = ({ events }) => {
         <div
           className="today-date"
           title={_('{yearsAgo} år siden i dag', lang, { yearsAgo })}>
-          {formattedDate(item.date)}
+          {formattedDate(item.date, lang)}
         </div>
       );
       const html = (
@@ -107,7 +107,7 @@ const News = ({ news }) => {
               lang={lang}
             />
           </div>
-          <div className="news-date">{formattedDate(date)}</div>
+          <div className="news-date">{formattedDate(date, lang)}</div>
           <style jsx>{`
             div.news-item {
               margin-bottom: 20px;

--- a/pages/work.js
+++ b/pages/work.js
@@ -61,7 +61,7 @@ const WorkPage = (props) => {
   const modifiedDate =
     modified != null ? (
       <div className="modified">
-        {_('Sidst ændret', lang)} {formattedDate(modified)}.
+        {_('Sidst ændret', lang)} {formattedDate(modified, lang)}.
       </div>
     ) : null;
   let sidebar = null;


### PR DESCRIPTION
## Ændringer

- Udvid `formattedDate` med en `lang`-parameter, der som standard er `da`.
- Lokaliser betegnelser for cirka og år før Kristus på dansk, engelsk, tysk og fransk.
- Send grænsefladens aktuelle sprog med fra biografier, forsiden og værksider.
- Tilføj testdækning for de nye sprogvarianter.

## Baggrund og virkning

`formattedDate` brugte tidligere altid den danske betegnelse `f.Kr.` og den danske cirka-markør, fordi funktionen hverken modtog eller videresendte grænsefladens sprog.

Dansk visning og rækkefølgen dag/måned/år er uændret. På de øvrige sprog vises eksempelvis `BC`, `v. Chr.` eller `av. J.-C.` i stedet for `f.Kr.`.

## Validering

- `npm test -- --runInBand` — 2.357 tests består.
- `npm run build` — produktionsbuilden består.

Fixes #1143
