### PR TITLE
Standardisér navngivningen i timeline-buildet

### DIFF
--- a/__tests__/timeline.test.js
+++ b/__tests__/timeline.test.js
@@ -1,25 +1,25 @@
 import {
-  compare_normalized_date,
-  normalize_timeline_date,
-  sorted_timeline,
+  compareNormalizedDate,
+  normalizeTimelineDate,
+  sortedTimeline,
 } from '../tools/build-static/timeline.js';
 
 describe('timeline helpers', () => {
   it('normalizes partial and approximate dates', () => {
-    expect(normalize_timeline_date('1818')).toBe('1818-01-01');
-    expect(normalize_timeline_date('1818-06')).toBe('1818-06-01');
-    expect(normalize_timeline_date('1818-06-07')).toBe('1818-06-07');
-    expect(normalize_timeline_date('ca. 1818')).toBe('1818-01-01');
-    expect(normalize_timeline_date('c. 1818-06')).toBe('1818-06-01');
-    expect(normalize_timeline_date('-1818')).toBe('-1818-01-01');
+    expect(normalizeTimelineDate('1818')).toBe('1818-01-01');
+    expect(normalizeTimelineDate('1818-06')).toBe('1818-06-01');
+    expect(normalizeTimelineDate('1818-06-07')).toBe('1818-06-07');
+    expect(normalizeTimelineDate('ca. 1818')).toBe('1818-01-01');
+    expect(normalizeTimelineDate('c. 1818-06')).toBe('1818-06-01');
+    expect(normalizeTimelineDate('-1818')).toBe('-1818-01-01');
   });
 
   it('compares normalized dates correctly', () => {
-    expect(compare_normalized_date('1818-01-01', '1819-01-01')).toBe(-1);
-    expect(compare_normalized_date('1819-01-01', '1818-01-01')).toBe(1);
-    expect(compare_normalized_date('1818-06-01', '1818-07-01')).toBe(-1);
-    expect(compare_normalized_date('-1818-01-01', '1818-01-01')).toBe(-1);
-    expect(compare_normalized_date('1818-01-01', '1818-01-01')).toBe(0);
+    expect(compareNormalizedDate('1818-01-01', '1819-01-01')).toBe(-1);
+    expect(compareNormalizedDate('1819-01-01', '1818-01-01')).toBe(1);
+    expect(compareNormalizedDate('1818-06-01', '1818-07-01')).toBe(-1);
+    expect(compareNormalizedDate('-1818-01-01', '1818-01-01')).toBe(-1);
+    expect(compareNormalizedDate('1818-01-01', '1818-01-01')).toBe(0);
   });
 
   it('sorts timelines in place by normalized date', () => {
@@ -30,7 +30,7 @@ describe('timeline helpers', () => {
       { normalized_date: '-0100-01-01', id: 'd' },
     ];
 
-    const sorted = sorted_timeline(timeline);
+    const sorted = sortedTimeline(timeline);
 
     expect(sorted).toBe(timeline);
     expect(sorted.map((item) => item.id)).toEqual(['d', 'a', 'b', 'c']);

--- a/docs/style-guide.md
+++ b/docs/style-guide.md
@@ -10,6 +10,10 @@ Denne guide samler projektets faste konventioner, især dem der er nemme at glem
 
 ## JavaScript
 
+- Brug camelCase til nye JavaScript-identifikatorer (funktioner, variable og
+  interne properties). Bevar `snake_case` på serialiserede XML-/JSON-felter og
+  andre eksterne kontrakter; introducér ikke nye `snake_case`-symboler i
+  JavaScript.
 - Brug aldrig implicit boolean coercion. Sammenlign eksplicit med den forventede
   værdi, fx `value != null`, `items.length > 0` eller `flag === true`.
 - Brug `??` til fallback for `null` og `undefined`; brug ikke `value || fallback`,

--- a/tools/build-static.js
+++ b/tools/build-static.js
@@ -100,8 +100,8 @@ import {
 } from './build-static/textrefs.js';
 import { build_anniversaries_ical } from './build-static/ical.js';
 import {
-  build_global_timeline,
-  build_poet_timeline_json,
+  buildGlobalTimeline,
+  buildPoetTimelineJson,
 } from './build-static/timeline.js';
 import {
   ANTHOLOGY_WORK_ID,
@@ -234,7 +234,7 @@ const build_bio_json = async (collected) => {
         data.content_html = htmlToXml(safeGetInnerXML(body), collected);
         data.content_lang = 'da';
       }
-      data.timeline = await build_poet_timeline_json(poet, collected);
+      data.timeline = await buildPoetTimelineJson(poet, collected);
       data.portraits = await build_portraits_json(poet, collected);
       const destFilename = `public/api/${poet.id}/bio.json`;
       writeJSON(destFilename, data);
@@ -1447,8 +1447,8 @@ const main = async () => {
   await b('works_second_pass', works_second_pass, collected);
   await b('build_works_toc', build_works_toc, collected);
   collected.timeline = await b(
-    'build_global_timeline',
-    build_global_timeline,
+    'buildGlobalTimeline',
+    buildGlobalTimeline,
     collected,
   );
   await b('build_bio_json', build_bio_json, collected);

--- a/tools/build-static/timeline.js
+++ b/tools/build-static/timeline.js
@@ -14,16 +14,13 @@ import {
 import { get_picture } from './parsing.js';
 import { mapLimit } from './concurrency.js';
 
-const normalize_timeline_date = normalizeTimelineDate;
-const compare_normalized_date = compareNormalizedDate;
-
-const sorted_timeline = (timeline) => {
+const sortedTimeline = (timeline) => {
   return timeline.sort((a, b) =>
-    compare_normalized_date(a.normalized_date, b.normalized_date)
+    compareNormalizedDate(a.normalized_date, b.normalized_date)
   );
 };
 
-const load_timeline = async (filename, collected) => {
+const loadTimeline = async (filename, collected) => {
   let doc = loadXMLDoc(filename);
   if (doc == null) {
     return [];
@@ -67,7 +64,7 @@ const load_timeline = async (filename, collected) => {
   );
 };
 
-const cover_picture = async (poetId, workId, collected) => {
+const coverPicture = async (poetId, workId, collected) => {
   const filename = `fdirs/${poetId}/${workId}.xml`;
   const doc = loadXMLDoc(filename);
   if (doc == null) {
@@ -92,11 +89,11 @@ const cover_picture = async (poetId, workId, collected) => {
   return get_picture(pictureNode, `/images/${poetId}`, collected, onError);
 };
 
-const build_global_timeline = async (collected) => {
-  return load_timeline('content/events.xml', collected);
+const buildGlobalTimeline = async (collected) => {
+  return loadTimeline('content/events.xml', collected);
 };
 
-const build_poet_timeline_json = async (poet, collected) => {
+const buildPoetTimelineJson = async (poet, collected) => {
   const inonToString = (inon, lang) => {
     const translations = {
       'da*in': 'i',
@@ -122,31 +119,31 @@ const build_poet_timeline_json = async (poet, collected) => {
         const workName = work.has_content
           ? `<a work="${poet.id}/${workId}">${work.title}</a>`
           : work.title;
-        const coverPicture = await cover_picture(poet.id, workId, collected);
+        const coverPictureData = await coverPicture(poet.id, workId, collected);
         const contentHtml = [
           [`${poet.name.lastname}: ${workName}.`, { html: true }],
         ];
         const textItem = {
           date: work.published,
-          normalized_date: normalize_timeline_date(work.published),
+          normalized_date: normalizeTimelineDate(work.published),
           type: 'text',
           content_lang: 'da',
           is_history_item: false,
           content_html: contentHtml,
         };
-        if (coverPicture == null) {
+        if (coverPictureData == null) {
           return [textItem];
         }
         return [
           {
             date: work.published,
-            normalized_date: normalize_timeline_date(work.published),
+            normalized_date: normalizeTimelineDate(work.published),
             type: 'image',
             is_history_item: false,
-            src: coverPicture.src,
-            content_lang: coverPicture.content_lang,
-            lang: coverPicture.lang,
-            content_html: coverPicture.content_html,
+            src: coverPictureData.src,
+            content_lang: coverPictureData.content_lang,
+            lang: coverPictureData.lang,
+            content_html: coverPictureData.content_html,
             miniature_content_html: contentHtml,
           },
         ];
@@ -166,7 +163,7 @@ const build_poet_timeline_json = async (poet, collected) => {
       ).replace(/\.*$/, '.'); // Kbh. giver ekstra punktum.
       items.push({
         date: poet.period.born.date,
-        normalized_date: normalize_timeline_date(poet.period.born.date),
+        normalized_date: normalizeTimelineDate(poet.period.born.date),
         type: 'text',
         is_history_item: false,
         content_lang: 'da',
@@ -186,7 +183,7 @@ const build_poet_timeline_json = async (poet, collected) => {
       ).replace(/\.*$/, '.'); // Kbh. giver ekstra punktum.;
       items.push({
         date: poet.period.dead.date,
-        normalized_date: normalize_timeline_date(poet.period.dead.date),
+        normalized_date: normalizeTimelineDate(poet.period.dead.date),
         type: 'text',
         is_history_item: false,
         content_lang: 'da',
@@ -195,35 +192,35 @@ const build_poet_timeline_json = async (poet, collected) => {
         ],
       });
     }
-    let poet_events = (
-      await load_timeline(`fdirs/${poet.id}/events.xml`, collected)
+    let poetEvents = (
+      await loadTimeline(`fdirs/${poet.id}/events.xml`, collected)
     ).map((e) => {
       e.is_history_item = false;
-      e.normalized_date = normalize_timeline_date(e.date);
+      e.normalized_date = normalizeTimelineDate(e.date);
       return e;
     });
-    items = [...items, ...poet_events];
-    items = sorted_timeline(items);
+    items = [...items, ...poetEvents];
+    items = sortedTimeline(items);
   }
   if (items.length >= 2) {
-    const start_date = items[0].normalized_date;
-    let end_date = items[items.length - 1].normalized_date;
+    const startDate = items[0].normalized_date;
+    let endDate = items[items.length - 1].normalized_date;
     if (poet.period.dead.date !== '?') {
-      end_date = normalize_timeline_date(poet.period.dead.date);
+      endDate = normalizeTimelineDate(poet.period.dead.date);
     }
     let globalItems = collected.timeline
       .map((e) => {
-        e.normalized_date = normalize_timeline_date(e.date);
+        e.normalized_date = normalizeTimelineDate(e.date);
         return e;
       })
       .filter((e) => {
         return (
-          compare_normalized_date(e.normalized_date, start_date) === 1 &&
-          compare_normalized_date(e.normalized_date, end_date) === -1
+          compareNormalizedDate(e.normalized_date, startDate) === 1 &&
+          compareNormalizedDate(e.normalized_date, endDate) === -1
         );
       });
     items = [...globalItems, ...items];
-    items = sorted_timeline(items);
+    items = sortedTimeline(items);
   }
   if (items.length == 1) {
     // We only have a single born or dead event. Not an interesting timeline,
@@ -234,9 +231,9 @@ const build_poet_timeline_json = async (poet, collected) => {
 };
 
 export {
-  build_global_timeline,
-  build_poet_timeline_json,
-  normalize_timeline_date,
-  compare_normalized_date,
-  sorted_timeline,
+  buildGlobalTimeline,
+  buildPoetTimelineJson,
+  normalizeTimelineDate,
+  compareNormalizedDate,
+  sortedTimeline,
 };


### PR DESCRIPTION
## Hvad ændrer PR’en?

- Standardiserer interne JavaScript-identifikatorer i timeline-buildet til camelCase.
- Opdaterer imports, kald og tests til de nye navne.
- Bevarer `snake_case` i serialiserede JSON-felter og andre eksterne kontrakter.
- Dokumenterer camelCase som projektets standard i `docs/style-guide.md`.

## Hvorfor?

Timeline-modulet blandede camelCase-imports med lokale snake_case-aliaser og navne. Det gjorde navngivningen unødigt inkonsekvent.

## Validering

- `npm test -- --runInBand` (52 test-suiter, 2.357 tests)
- `npm run build-static`
- `git diff --check`

Fixes #1335
