### PR TITLE
Saml projektets dokumentationsvejledning

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -2,15 +2,19 @@
 
 Disse regler gælder for AI-agenter og automatiserede assistenter, der arbejder i dette repository.
 
-- Skriv altid GitHub issue-titler, issue-beskrivelser, PR-titler og PR-beskrivelser på dansk, medmindre brugeren eksplicit beder om et andet sprog.
+## Dokumentation
+
+- Læs `docs/style-guide.md` før alle ændringer i repositoryet og før oprettelse
+  eller opdatering af issues og PRs.
+- Læs derefter den specialdokumentation, som stilguiden henviser til for det
+  relevante område.
+
+## Git og GitHub
+
 - Når en PR skal lukke et GitHub issue automatisk, skal PR-beskrivelsen bruge GitHubs engelske closing keyword, fx `Fixes #123`. Skriv ikke `Lukker #123`, fordi GitHub ikke auto-lukker issues på dansk.
-- Læg portræt- og kunstgrafik under `public/images/<id>/`. Læg aldrig billedfiler under `fdirs/`.
-- `fdirs/<id>/portraits.xml` må referere lokale portrætter med `src="..."` og `square-src="..."`, men filerne skal findes i `public/images/<id>/`.
-- Tekstfiler i repoet skal være UTF-8. Indfør ikke Latin-1/ISO-8859-1 encoded filer.
-- Commit ikke lokale scratch-filer eller untracked arbejdsfiler, medmindre brugeren eksplicit beder om det.
-- Branch-navne må ikke begynde med `codex`.
+- Branch-navne må ikke indeholde `/` eller have et teknisk prefix. Brug et kort,
+  beskrivende navn som `robert-burns-ikon`.
 - Commit, push eller amend aldrig kodeændringer, før brugeren eksplicit har læst ændringen og bedt om commit/push. Det gælder også opdateringer til eksisterende PR-branches.
-- Læs `docs/style-guide.md` før du opretter issues, PRs eller ændringer i data-/billedstrukturen.
 - Ved `gh issue view ... --comments` kan GitHub CLI i non-TTY give tomt tekstoutput for issues uden kommentarer. Brug enten `--json number,title,state,body,comments` eller kør kommandoen med TTY, når issue-indholdet skal læses.
 - Når du opretter eller opdaterer en PR, behøver du ikke vente på GitHubs CI, medmindre brugeren eksplicit beder om det.
 - Når brugeren beder dig merge en PR, skal det ske som squash merge.

--- a/docs/kalliope-icons-design.md
+++ b/docs/kalliope-icons-design.md
@@ -1,5 +1,8 @@
 # Kalliopes dagsikoner
 
+Se også `docs/style-guide.md` for projektets generelle billed- og
+dokumentationsregler.
+
 ## Formål
 
 Kalliopes ikon i sidens header kan skifte på udvalgte mærkedage. Ikonerne er

--- a/docs/style-guide.md
+++ b/docs/style-guide.md
@@ -1,6 +1,23 @@
 # Kalliope Styleguide
 
-Denne guide samler projektets faste konventioner, især dem der er nemme at glemme i små ændringer.
+Denne guide er den autoritative indgang til projektets faste konventioner.
+Agenternes arbejdsproces ligger i `AGENTS.md`; format- og domænedetaljer ligger
+i specialdokumenterne nedenfor.
+
+## Dokumentationsvejviser
+
+Læs den relevante specialdokumentation før ændringer på området:
+
+- `docs/kalliope-icons-design.md` ved ændringer i dagsikoner eller
+  portrætprioriteringer for **I dag**
+- `docs/xml-info-format.md` ved ændringer i `fdirs/<id>/info.xml`
+- `docs/xml-portraits-format.md` ved ændringer i `portraits.xml`,
+  portrætreferencer eller kvadratiske portrætter
+- `docs/xml-work-format.md` ved ændringer i XML-værkfiler
+- `docs/kalliope-xml-design-v1.1.md` ved ændringer i XML-modellen for
+  publikationer, antologier og tekstforekomster
+- `docs/kalliope-masterplan.md` ved arbejde med korpusets afgrænsning,
+  kilder, redaktionelle principper eller den langsigtede datastruktur
 
 ## GitHub
 
@@ -29,6 +46,8 @@ Denne guide samler projektets faste konventioner, især dem der er nemme at glem
 - `fdirs/<id>/portraits.xml` refererer lokale filer med filnavn, fx `src="p1.jpg"` og `square-src="p1-square.jpg"`.
 - Den faktiske fil for `fdirs/<id>/portraits.xml` skal derfor være `public/images/<id>/p1.jpg`.
 - Square portraits er normalt manuelt beskårne kvadratiske billeder og skal også ligge i `public/images/<id>/`.
+- Følg `docs/kalliope-icons-design.md` for dagsikonernes placering, navngivning,
+  hvide baggrund og sammenhæng med portrætprioriteringer.
 
 ## XML-data
 
@@ -38,7 +57,10 @@ Denne guide samler projektets faste konventioner, især dem der er nemme at glem
   samme sprog.
 - Brug eksisterende attributter og formater; ukendte `<picture>`-attributter er build-fejl.
 - Alle tekst- og XML-filer skal være UTF-8 encoded. Konvertér gamle Latin-1/ISO-8859-1-filer i stedet for at videreføre dem.
-- Se også `docs/xml-portraits-format.md` for detaljer om `portraits.xml`.
+- Følg `docs/xml-info-format.md`, `docs/xml-portraits-format.md` eller
+  `docs/xml-work-format.md` for det konkrete filformat.
+- Følg `docs/kalliope-xml-design-v1.1.md` ved ændringer i den overordnede
+  publikations- og antologimodel.
 
 ## Arbejdsfiler
 


### PR DESCRIPTION
## Ændringer

- gør `docs/style-guide.md` til den autoritative indgang til projektets konventioner
- tilføjer en vejviser til de specialiserede design- og formatdokumenter
- afgrænser `AGENTS.md` til agenternes dokumentationsrækkefølge og Git/GitHub-proces
- kræver branch-navne uden `/` og uden tekniske prefixes
- linker dagsikondokumentet tilbage til stilguiden

## Formål

Projektreglerne var delvist duplikeret mellem `AGENTS.md` og stilguiden. Den nye struktur giver hver regel én autoritativ placering og en tydelig læserækkefølge:

`AGENTS.md` → `docs/style-guide.md` → relevant specialdokument.

Det gør dokumentationen lettere at vedligeholde og øger sandsynligheden for, at både mennesker og AI-agenter læser de relevante instruktioner.

## Validering

- `git diff --check`
- kontrolleret at alle dokumentlinks i stilguidens vejviser findes
