### PR TITLE
Ryd modstridende Open Graph-metadata

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -12,6 +12,7 @@ Disse regler gælder for AI-agenter og automatiserede assistenter, der arbejder 
 - Commit, push eller amend aldrig kodeændringer, før brugeren eksplicit har læst ændringen og bedt om commit/push. Det gælder også opdateringer til eksisterende PR-branches.
 - Læs `docs/style-guide.md` før du opretter issues, PRs eller ændringer i data-/billedstrukturen.
 - Ved `gh issue view ... --comments` kan GitHub CLI i non-TTY give tomt tekstoutput for issues uden kommentarer. Brug enten `--json number,title,state,body,comments` eller kør kommandoen med TTY, når issue-indholdet skal læses.
+- Hvis `gh auth status` melder et ugyldigt token, samtidig med at `gh api` melder en forbindelsesfejl, skal GitHub-forbindelsen testes uden sandboxens netværksbegrænsning, før brugeren bedes logge ind igen. En blokeret API-forbindelse kan ellers fejlagtigt ligne et udløbet token.
 - Når du opretter eller opdaterer en PR, behøver du ikke vente på GitHubs CI, medmindre brugeren eksplicit beder om det.
 - Når brugeren beder dig merge en PR, skal det ske som squash merge.
 - Ved `gh pr create`, `gh issue create`, `gh pr comment` og `gh issue comment` skal brødteksten skrives til en midlertidig fil og sendes med `--body-file`. Skriv ikke markdown direkte i shell-argumenter, fordi backticks og anden shell-syntaks kan blive evalueret som kommandoer.

--- a/__tests__/head.test.js
+++ b/__tests__/head.test.js
@@ -63,4 +63,32 @@ describe('side metadata', () => {
       '<meta property="og:site_name" content="Kalliope"/>'
     );
   });
+
+  it('uses a concise default description and a large X image', () => {
+    const html = renderToStaticMarkup(<Head />);
+    const description =
+      'Kalliope samler ældre dansk lyrik og biografiske oplysninger om danske digtere i en voksende digital database.';
+
+    expect(description.length).toBeLessThanOrEqual(125);
+    expect(html).toContain(
+      `<meta name="description" content="${description}"/>`
+    );
+    expect(html).toContain(
+      `<meta property="og:description" content="${description}"/>`
+    );
+    expect(html).toContain(
+      '<meta name="twitter:card" content="summary_large_image"/>'
+    );
+  });
+
+  it('uses the supplied page description', () => {
+    const html = renderToStaticMarkup(<Head description="En kort tekst." />);
+
+    expect(html).toContain(
+      '<meta name="description" content="En kort tekst."/>'
+    );
+    expect(html).toContain(
+      '<meta property="og:description" content="En kort tekst."/>'
+    );
+  });
 });

--- a/__tests__/head.test.js
+++ b/__tests__/head.test.js
@@ -27,4 +27,40 @@ describe('side metadata', () => {
     );
     expect(html).not.toContain('antologierdk2026071901a');
   });
+
+  it('prefixes relative Open Graph images', () => {
+    const html = renderToStaticMarkup(<Head ogImage="/images/poet.jpg" />);
+
+    expect(html).toContain(
+      '<meta property="og:image" content="https://kalliope.org/images/poet.jpg"/>'
+    );
+    expect(html).toContain(
+      '<meta name="twitter:image" content="https://kalliope.org/images/poet.jpg"/>'
+    );
+  });
+
+  it('keeps absolute HTTP(S) Open Graph images unchanged', () => {
+    const httpsHTML = renderToStaticMarkup(
+      <Head ogImage="https://example.com/poet.jpg" />
+    );
+    const httpHTML = renderToStaticMarkup(
+      <Head ogImage="http://example.com/poet.jpg" />
+    );
+
+    expect(httpsHTML).toContain(
+      '<meta property="og:image" content="https://example.com/poet.jpg"/>'
+    );
+    expect(httpHTML).toContain(
+      '<meta property="og:image" content="http://example.com/poet.jpg"/>'
+    );
+  });
+
+  it('emits a single site name', () => {
+    const html = renderToStaticMarkup(<Head />);
+
+    expect(html.match(/property="og:site_name"/g)).toHaveLength(1);
+    expect(html).toContain(
+      '<meta property="og:site_name" content="Kalliope"/>'
+    );
+  });
 });

--- a/__tests__/opengraph.test.js
+++ b/__tests__/opengraph.test.js
@@ -13,6 +13,10 @@ describe('opengraph helpers', () => {
     expect(trimmedDescription(null)).toBeNull();
   });
 
+  it('limits descriptions to 125 characters', () => {
+    expect(trimmedDescription([['a'.repeat(200), {}]])).toHaveLength(125);
+  });
+
   it('builds a poet image url when a square portrait exists', () => {
     expect(
       poetImage({

--- a/common/opengraph.js
+++ b/common/opengraph.js
@@ -13,7 +13,7 @@ export const trimmedDescription = (content_html) => {
     .replace(/\s\s/g, ' ');
   result = result.replace(/\n/g, ' ').replace(/<br\/>/g, ' ');
   result = result.replace(/<[^>]*>/g, ''); // Remove remaining tags
-  return result.substr(0, 600);
+  return result.slice(0, 125);
 };
 
 export const poetImage = (poet) => {

--- a/components/head.js
+++ b/components/head.js
@@ -4,7 +4,6 @@ import { supportedLanguages } from '../common/languages.js';
 const urlPrefix = 'https://kalliope.org';
 const defaultDescription =
   'Kalliope er en database indeholdende ældre dansk lyrik samt biografiske oplysninger om danske digtere. Målet er intet mindre end at samle hele den ældre danske lyrik, men indtil videre indeholder Kalliope et forhåbentligt repræsentativt, og stadigt voksende, udvalg af den danske digtning.';
-const defaultOGURL = urlPrefix;
 const defaultOGImage = `${urlPrefix}/touch-icon.png`;
 const criticalFonts = [
   '/fonts/alegreya-sans/alegreya-sans-normal-400-latin.woff2',
@@ -15,7 +14,6 @@ const Head = ({
   ogTitle,
   headTitle,
   description,
-  url,
   ogImage,
   requestPath,
   canonicalPath,
@@ -32,12 +30,12 @@ const Head = ({
       />
     );
   });
-  let ogImageAbsolute = ogImage != null ? ogImage : defaultOGImage;
-  if (!ogImageAbsolute.indexOf('http') === 0) {
+  let ogImageAbsolute = ogImage ?? defaultOGImage;
+  if (/^https?:\/\//.test(ogImageAbsolute) === false) {
     ogImageAbsolute = `${urlPrefix}${ogImageAbsolute}`;
   }
   let hreflangs = [];
-  const metadataPath = canonicalPath || requestPath;
+  const metadataPath = canonicalPath ?? requestPath;
   if (metadataPath != null) {
     hreflangs = supportedLanguages.map((lang) => {
       const alternatePath = metadataPath.replace(/^\/../, '/' + lang);
@@ -57,8 +55,8 @@ const Head = ({
   return (
     <NextHead>
       <meta charSet="UTF-8" />
-      <title>{headTitle || ogTitle || ''}</title>
-      <meta name="description" content={description || defaultDescription} />
+      <title>{headTitle ?? ogTitle ?? ''}</title>
+      <meta name="description" content={description ?? defaultDescription} />
       <meta name="viewport" content="width=device-width, initial-scale=1" />
       {noIndex ? <meta name="robots" content="noindex,follow" /> : null}
       <link rel="icon" sizes="180x180" href="/apple-touch-icon-180x180.png" />
@@ -80,19 +78,17 @@ const Head = ({
       {canonical}
       {hreflangs}
       <meta name="theme-color" content="rgb(139, 56, 65)" />
-      <meta property="og:site_name" content="www.kalliope.org" />
-      {/*<meta property="og:url" content={url || defaultOGURL} />*/}
-      <meta property="og:title" content={ogTitle || headTitle || ''} />
+      <meta property="og:site_name" content="Kalliope" />
+      <meta property="og:title" content={ogTitle ?? headTitle ?? ''} />
       <meta
         property="og:description"
-        content={description || defaultDescription}
+        content={description ?? defaultDescription}
       />
       <meta name="twitter:site" content="@kalliope_org" />
       <meta name="twitter:card" content="summary" />
       <meta name="twitter:image" content={ogImageAbsolute} />
       <meta property="og:image" content={ogImageAbsolute} />
       <meta property="og:image:width" content="600" />
-      <meta property="og:site_name" content="Kalliope" />
       <meta property="og:type" content="website" />
       {ogURL}
     </NextHead>

--- a/components/head.js
+++ b/components/head.js
@@ -3,7 +3,7 @@ import { supportedLanguages } from '../common/languages.js';
 
 const urlPrefix = 'https://kalliope.org';
 const defaultDescription =
-  'Kalliope er en database indeholdende ældre dansk lyrik samt biografiske oplysninger om danske digtere. Målet er intet mindre end at samle hele den ældre danske lyrik, men indtil videre indeholder Kalliope et forhåbentligt repræsentativt, og stadigt voksende, udvalg af den danske digtning.';
+  'Kalliope samler ældre dansk lyrik og biografiske oplysninger om danske digtere i en voksende digital database.';
 const defaultOGImage = `${urlPrefix}/touch-icon.png`;
 const criticalFonts = [
   '/fonts/alegreya-sans/alegreya-sans-normal-400-latin.woff2',
@@ -85,7 +85,7 @@ const Head = ({
         content={description ?? defaultDescription}
       />
       <meta name="twitter:site" content="@kalliope_org" />
-      <meta name="twitter:card" content="summary" />
+      <meta name="twitter:card" content="summary_large_image" />
       <meta name="twitter:image" content={ogImageAbsolute} />
       <meta property="og:image" content={ogImageAbsolute} />
       <meta property="og:image:width" content="600" />

--- a/components/page.js
+++ b/components/page.js
@@ -166,7 +166,7 @@ const Page = (props) => {
         headTitle={headTitle}
         ogTitle={ogTitle}
         ogImage={ogImage}
-        ogDescription={ogDescription}
+        description={ogDescription}
         requestPath={requestPath}
         canonicalPath={canonicalPath}
         noIndex={noIndex}


### PR DESCRIPTION
## Ændringer

- gør relative Open Graph-billedstier absolutte med Kalliope-domænet
- bevarer absolutte HTTP(S)-billed-URL’er uændret
- udsender kun ét `og:site_name` med værdien `Kalliope`
- forbinder sidernes beregnede beskrivelser korrekt med metadata
- begrænser beskrivelser til 125 tegn og forkorter standardbeskrivelsen
- bruger `summary_large_image` til X-kort
- tilføjer tests for billeder, beskrivelser og entydigt site-navn
- dokumenterer korrekt fejlsøgning af misvisende `gh auth status`-fejl

## Baggrund

Den tidligere `indexOf`-betingelse kunne aldrig blive sand, fordi resultatet
blev konverteret til en boolean før sammenligningen med `0`. Derfor kunne
crawlere modtage relative billed-URL’er. Komponenten udsendte samtidig to
modstridende værdier for `og:site_name`.

Sidespecifikke beskrivelser blev desuden sendt under et prop-navn, som
`Head`-komponenten ikke læste. Siderne faldt derfor tilbage til en for lang
standardbeskrivelse.

## Konsekvens

Open Graph-, X- og søgemaskinemetadata får nu entydige værdier, absolutte
billed-URL’er og korte, sidespecifikke beskrivelser.

## Validering

- `npm test -- --runInBand` (53 testsuiter, 2384 tests)
- `git diff --check`

Fixes #1331
