### PR TITLE
Link billeder til registrerede museer

### DIFF
--- a/content/artwork.xml
+++ b/content/artwork.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <pictures>
-    <picture id="christian4-isaacsz-1612" subject="christian4" year="1612 ca." wikidata="Q119823057">
+    <picture id="christian4-isaacsz-1612" subject="christian4" year="1612 ca." wikidata="Q119823057" museum="fnm">
         Pieter Isaacsz: <i>Christian IV</i>, ca. 1612, olie på panel. Det Nationalhistoriske Museum på Frederiksborg Slot.
     </picture>
     <picture id="nidarosdomen-westfront-1839" year="1839">

--- a/content/events.xml
+++ b/content/events.xml
@@ -301,7 +301,7 @@
      <html>Den franske oplysningsfilosof og forfatter Denis Diderot født. (død 1784)</html>
    </entry>
    <entry date="1719" type="image">
-       <picture src="kunst/balthasar-denner-tordenskiold.jpg">
+       <picture src="kunst/balthasar-denner-tordenskiold.jpg" museum="fnm">
            Balthasar Denner: <i>Peter Wessel Tordenskiold</i>, 1719. Det Nationalhistoriske Museum på Frederiksborg Slot.
        </picture>
    </entry>
@@ -392,7 +392,7 @@
      <html><a poet="heibergpa">P. A. Heiberg</a> idømmes landsforvisning pga. artiklerne »Politisk Dispache« og »Sprog-Granskning«.</html>
    </entry>
    <entry date="1801-4-2" type="image">
-       <picture src="kunst/lorentzen_slaget_paa_rheden.jpg">
+       <picture src="kunst/lorentzen_slaget_paa_rheden.jpg" museum="fnm">
          C. A. Lorentzen: <i>Slaget paa Rheden 2. april 1801</i>, 1802, Frederiksborg Museum.
        </picture>
    </entry>

--- a/content/keywords/heksameter.xml
+++ b/content/keywords/heksameter.xml
@@ -4,7 +4,7 @@
     <title>Heksameter</title>
     <author>Henrik Nielsen</author>
     <pictures>
-        <picture src="homer.jpg"><i>Portræt af Homer</i>, Romersk kopi af græsk original fra omkring 150 f.Kr. Louvre.</picture>
+        <picture src="homer.jpg" museum="louvre"><i>Portræt af Homer</i>, Romersk kopi af græsk original fra omkring 150 f.Kr. Louvre.</picture>
     </pictures>
     <related>verseformer</related>
     <related>aleksandrin</related>

--- a/content/keywords/sentimentalismen.xml
+++ b/content/keywords/sentimentalismen.xml
@@ -3,7 +3,7 @@
   <head>
     <title>Sentimentalismen</title>
     <pictures>
-        <picture src="reynolds-sterne.jpg">Joshua Reynolds: <i>Lawrence Sterne</i>, 1760, National Portrait Gallery, London.</picture>
+        <picture src="reynolds-sterne.jpg" museum="npg">Joshua Reynolds: <i>Lawrence Sterne</i>, 1760, National Portrait Gallery, London.</picture>
     </pictures>
   </head>
   <body>

--- a/content/keywords/symbolismen.xml
+++ b/content/keywords/symbolismen.xml
@@ -4,7 +4,7 @@
     <title>Symbolismen</title>
     <pictures>
       <picture portrait="baudelaire/p1" />
-      <picture src="monet.st-lazare.jpg">Claude Monet: <i>Saint-Lazare Station</i>, 1877, olie på lærred, 54,3 × 73,6 cm, National Gallery, London.</picture>
+      <picture src="monet.st-lazare.jpg" museum="nationalgallery">Claude Monet: <i>Saint-Lazare Station</i>, 1877, olie på lærred, 54,3 × 73,6 cm, National Gallery, London.</picture>
     </pictures>
   </head>
   <body>

--- a/fdirs/aarestrup/1863.xml
+++ b/fdirs/aarestrup/1863.xml
@@ -902,7 +902,7 @@ Og Piger strømme, for at see dig, til mig.
    <title>Hemisphærerne</title>
    <firstline>Den Himmel, jeg har henrykt kaaret</firstline>
    <pictures>
-      <picture src="aarestrup1825-37a8-p1.jpg">Manuskript fra Det Kongelige Bibliotek.</picture>
+      <picture src="aarestrup1825-37a8-p1.jpg" museum="kb">Manuskript fra Det Kongelige Bibliotek.</picture>
    </pictures>
    <quality>korrektur1,korrektur2,kilde,side</quality>
    <source pages="23-24"/>
@@ -6146,7 +6146,7 @@ En Bitterhed, hvis Ret jeg ei benegter.
    <title>Politisk Indsigt</title>
    <firstline>Jeg ynder frit Erhverv for frie Hænder</firstline>
    <pictures>
-      <picture src="aarestrup1999032903-p1.jpg">Manuskript fra Det Kongelige Bibliotek.</picture>
+      <picture src="aarestrup1999032903-p1.jpg" museum="kb">Manuskript fra Det Kongelige Bibliotek.</picture>
    </pictures>
     <dates>
         <written>1848-10-10</written>

--- a/fdirs/aarestrup/1976-2.xml
+++ b/fdirs/aarestrup/1976-2.xml
@@ -2790,7 +2790,7 @@ Mig Evigheden i det Timelige.
    <title>Hemisphærerne</title>
    <firstline>Den Himmel, jeg har henrykt kaaret</firstline>
    <pictures>
-      <picture src="aarestrup1825-37a8-p1.jpg">Manuskript fra Det Kongelige Bibliotek.</picture>
+      <picture src="aarestrup1825-37a8-p1.jpg" museum="kb">Manuskript fra Det Kongelige Bibliotek.</picture>
    </pictures>
    <source pages="97"/>
    <quality>korrektur1,korrektur2,kilde,side</quality>

--- a/fdirs/aarestrup/1976-4.xml
+++ b/fdirs/aarestrup/1976-4.xml
@@ -2327,7 +2327,7 @@ En Bitterhed, hvis Ret jeg ei benegter.
    <title>Politisk Indsigt</title>
    <firstline>Jeg ynder frit Erhverv for frie Hænder</firstline>
    <pictures>
-      <picture src="aarestrup1999032903-p1.jpg">Manuskript fra Det Kongelige Bibliotek.</picture>
+      <picture src="aarestrup1999032903-p1.jpg" museum="kb">Manuskript fra Det Kongelige Bibliotek.</picture>
    </pictures>
    <quality>korrektur1,kilde,side</quality>
    <keywords>sonnet</keywords>

--- a/fdirs/abrahamson/portraits.xml
+++ b/fdirs/abrahamson/portraits.xml
@@ -4,7 +4,7 @@
   </picture>
   <picture src="p2.jpg">
   </picture>
-  <picture src="p3-oval.jpg" primary="true" square-src="p3-square.jpg">
+  <picture src="p3-oval.jpg" primary="true" square-src="p3-square.jpg" museum="kb">
     G.L. Lahde: <i>Werner Abrahamson</i>, kobberstik, 1805. Det Kongelige Bibliotek.
   </picture>
   <picture src="p3.jpg">

--- a/fdirs/arentzen/portraits.xml
+++ b/fdirs/arentzen/portraits.xml
@@ -1,9 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <pictures>
-  <picture src="p1.jpg" primary="true" square-src="p1-square.jpg">
+  <picture src="p1.jpg" primary="true" square-src="p1-square.jpg" museum="kb">
     Budtz Müller &amp; Co. (fotograf): <i>Kristian Arentzen</i>, Det Kongelige Bibliotek.
   </picture>
-  <picture src="p2.jpg">
+  <picture src="p2.jpg" museum="kb">
       <i>Kristian Arentzen</i>, fotografi, ukendt år. Det Kongelige Bibliotek.
   </picture>
 </pictures>

--- a/fdirs/berntsen/portraits.xml
+++ b/fdirs/berntsen/portraits.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <pictures>
-  <picture src="p1.jpg" primary="true" square-src="p1-square.jpg">
+  <picture src="p1.jpg" primary="true" square-src="p1-square.jpg" museum="kb">
       <i>Aage Berntsen</i>, Det kongelige Bibliotek.
   </picture>
 </pictures>

--- a/fdirs/blake/artwork.xml
+++ b/fdirs/blake/artwork.xml
@@ -13,7 +13,7 @@
   <picture id="1824-inscription" year="1824-1-03" museum="tate" invnr="N03352">
       <i>The Inscription over the Gate</i>, 1824-27, blyant, blæk og vandfarve på papir, 527 × 374 mm.
   </picture>
-  <picture id="1824-francesca-da-rimini" year="1824-1-05">
+  <picture id="1824-francesca-da-rimini" year="1824-1-05" museum="tate">
       <i>The Circle of the Lustful: Francesca da Rimini (‘The Whirlwind of Lovers’)</i>, 1824-27, blyant, blæk og vandfarve på papir, 243 × 335 mm. Tate Gallery, London.
   </picture>
   <picture id="1824-cerberus" year="1824-1-06" museum="tate" invnr="N03354">

--- a/fdirs/blicherclausen/portraits.xml
+++ b/fdirs/blicherclausen/portraits.xml
@@ -1,9 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <pictures>
-  <picture src="p1-oval.jpg" primary="true" square-src="p1-square.jpg">
+  <picture src="p1-oval.jpg" primary="true" square-src="p1-square.jpg" museum="kb">
       J. Petersen &amp; Søn: <i>Jenny Blicher-Clausen</i>, 1888, fotografi. Det Kongelige Bibliotek.
   </picture>
-  <picture src="p2.jpg">
+  <picture src="p2.jpg" museum="kb">
       <i>Jenny Blicher-Clausen</i>, ukendt år, fotografi. Det Kongelige Bibliotek.
   </picture>
 </pictures>

--- a/fdirs/dam/portraits.xml
+++ b/fdirs/dam/portraits.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <pictures>
-  <picture src="p1.jpg" primary="true" square-src="p1-square.jpg">
+  <picture src="p1.jpg" primary="true" square-src="p1-square.jpg" museum="kb">
       <i>Johannes Dam</i>, fotografi, ukendt år. Det Kongelige Bibliotek.
   </picture>
 </pictures>

--- a/fdirs/drachmann/1875.xml
+++ b/fdirs/drachmann/1875.xml
@@ -3441,7 +3441,7 @@ I La Plataflodens Vande.
     <firstline>Som Baaden, der sagte glider</firstline>
     <source pages="139-141"/>
     <pictures>
-        <picture src="drachmann2018012928-p1.jpg">Marc Gabriel Charles Gleyre: <i>Le Soir Ou Les Illusions Perdues</i>, ca. 1843, olie på lærred, 238 × 157 cm. Louvre.</picture>
+        <picture src="drachmann2018012928-p1.jpg" museum="louvre">Marc Gabriel Charles Gleyre: <i>Le Soir Ou Les Illusions Perdues</i>, ca. 1843, olie på lærred, 238 × 157 cm. Louvre.</picture>
     </pictures>
     <quality>korrektur1,korrektur2,kilde,side</quality>
 </head>

--- a/fdirs/fibiger/portraits.xml
+++ b/fdirs/fibiger/portraits.xml
@@ -1,9 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <pictures>
-  <picture src="p1.jpg" primary="true" square-src="p1-square.jpg">
+  <picture src="p1.jpg" primary="true" square-src="p1-square.jpg" museum="kb">
       Budtz Müller &amp; Co.: <i>Johannes Fibiger</i>, ukendt år, fotografi. Det Kongelige Bibliotek.
   </picture>
-  <picture src="p2.jpg">
+  <picture src="p2.jpg" museum="kb">
       <i>Johannes Fibiger</i>, ukendt år, fotografi. Det Kongelige Bibliotek.
   </picture>
 </pictures>

--- a/fdirs/heibergjly/portraits.xml
+++ b/fdirs/heibergjly/portraits.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <pictures>
-  <picture src="p1.jpg" primary="true" square-src="p1-square.jpg">
+  <picture src="p1.jpg" primary="true" square-src="p1-square.jpg" museum="kb">
       Frederik Riise (fotograf): <i>J. L. Heiberg</i>, ukendt år, fotografi. Det Kongelige Bibliotek.
   </picture>
 </pictures>

--- a/fdirs/hertzh/1851a.xml
+++ b/fdirs/hertzh/1851a.xml
@@ -1732,7 +1732,7 @@ Og hvis som Julie du mildt mig hørte!
     </notes>
     <source pages="69-71"/>
     <pictures>
-        <picture src="hertz2018021820-p1.jpg"><i>Venus de' Medici</i>, græsk, 1. årh. fvt., marmor. Galleria degli Uffizi.</picture>
+        <picture src="hertz2018021820-p1.jpg" museum="uffizi"><i>Venus de' Medici</i>, græsk, 1. årh. fvt., marmor. Galleria degli Uffizi.</picture>
     </pictures>
     <quality>korrektur1,kilde,side</quality>
 </head>

--- a/fdirs/holst/portraits.xml
+++ b/fdirs/holst/portraits.xml
@@ -2,7 +2,7 @@
 <pictures>
   <picture src="p1.jpg">
   </picture>
-  <picture src="p2.jpg" primary="true" square-src="p2-square.jpg">
+  <picture src="p2.jpg" primary="true" square-src="p2-square.jpg" museum="kb">
       Georg E. Hansen (fotograf): <i>H. P. Holst</i>, ca. 1865. Det Kongelige Bibliotek.
   </picture>
 </pictures>

--- a/fdirs/holstein/portraits.xml
+++ b/fdirs/holstein/portraits.xml
@@ -1,9 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <pictures>
-  <picture src="p1.jpg" primary="true" square-src="p1-square.jpg">
+  <picture src="p1.jpg" primary="true" square-src="p1-square.jpg" museum="kb">
       <i>Ludvig Holstein</i>, fotografi. Det Kongelige Bibliotek.
   </picture>
-  <picture src="p2.jpg">
+  <picture src="p2.jpg" museum="kb">
       <i>Johannes V. Jensen og fagfællen Ludvig Holstein</i>, fotografi, ukendt år. Det Kongelige Bibliotek.
   </picture>
 </pictures>

--- a/fdirs/ipsen/portraits.xml
+++ b/fdirs/ipsen/portraits.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <pictures>
-  <picture src="p1.jpg" primary="true" square-src="p1-square.jpg">
+  <picture src="p1.jpg" primary="true" square-src="p1-square.jpg" museum="kb">
       Frederik Riise (fotograf): <i>Alfred Ipsen</i>, ukendt år. Det Kongelige Bibliotek.
   </picture>
 </pictures>

--- a/fdirs/jensenca/artwork.xml
+++ b/fdirs/jensenca/artwork.xml
@@ -9,7 +9,7 @@
   <picture id="broendsted-1827" year="1827" museum="glyptoteket">
     <i>Peter Oluf Brøndsted</i>, 1827.
   </picture>
-  <picture id="grundtvig-1831" subject="grundtvig" year="1831">
+  <picture id="grundtvig-1831" subject="grundtvig" year="1831" museum="glyptoteket">
     <i>N.F.S. Grundtvig</i>, 1831, olie på lærred, 23×18 cm. Ny Carlsberg Glyptotek. <!-- Portrættet er antagelig udført på bestilling af Grundtvigtilhængeren, baron Henrik Stampe, Nysø, og det blev på dennes dødsboauktion i 1876 erhvervet af Carl Jacobsen. // Kunstindex Danmark -->
   </picture>
   <picture id="oehlenschlaeger-1832" subject="oehlenschlaeger" year="1832">
@@ -30,7 +30,7 @@
   <picture id="oehlenschlaeger-1834" year="1834" subject="oehlenschlaeger">
       <i>Adam Oehlenschläger</i>, 1834, olie på lærred, 26,5×22,5 cm. Kunstmuseet Brundlund Slot, Aabenraa.
   </picture>
-  <picture id="bissen-1835" subject="bissen" year="1835">
+  <picture id="bissen-1835" subject="bissen" year="1835" museum="glyptoteket">
       <i>Herman Wilhelm Bissen</i>, 1835, olie på lærred, 25×21 cm. Ny Carlsberg Glyptotek. <!-- invnr. 1734 -->
   </picture>
   <picture id="herholdt-1835" wikidata="Q20354175" year="1835" museum="smk" invnr="KMS3129">

--- a/fdirs/lange/portraits.xml
+++ b/fdirs/lange/portraits.xml
@@ -2,7 +2,7 @@
 <pictures>
   <picture src="p1.jpg" primary="true" square-src="p1-square.jpg">
   </picture>
-  <picture src="p2.jpg">
+  <picture src="p2.jpg" museum="fnm">
       August Tholander: <i>Thor Lange</i>, 1881. Frederiksborg Nationalhistorisk Museum.
   </picture>
 </pictures>

--- a/fdirs/lembcke/portraits.xml
+++ b/fdirs/lembcke/portraits.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <pictures>
-  <picture src="p1.jpg" primary="true" square-src="p1-square.jpg">
+  <picture src="p1.jpg" primary="true" square-src="p1-square.jpg" museum="kb">
       J. Petersen &amp; Co.s Atelier (fotograf): <i>Edvard Lembcke</i>, ukendt år. Det Kongelige Bibliotek.
   </picture>
 </pictures>

--- a/fdirs/luetken/1940.xml
+++ b/fdirs/luetken/1940.xml
@@ -250,7 +250,7 @@ over Dagens Synd.
     <firstline>En Haand blev stille</firstline>
     <source pages="23-24"/>
     <pictures>
-        <picture src="luetken2018011709-p1.jpg">Frejlif Olsen (1868-1936), journalist og chefredaktør af Ekstra Bladet. Fotografi, Det Kongelige Bibliotek.</picture>
+        <picture src="luetken2018011709-p1.jpg" museum="kb">Frejlif Olsen (1868-1936), journalist og chefredaktør af Ekstra Bladet. Fotografi, Det Kongelige Bibliotek.</picture>
     </pictures>
     <quality>korrektur1,kilde,side</quality>
 </head>

--- a/fdirs/marstrand/artwork.xml
+++ b/fdirs/marstrand/artwork.xml
@@ -47,7 +47,7 @@
       <i>Per Degn synger for en snaps</i>, 1865, olie på lærred,  35×30cm.
       <!-- Scene fra Holbergs Erasmus Montanus, (1. akt, scene 4), hvor Per Degn får et glas brændevin af Jeppe Berg og Nille, hvorefter han bryder ud i sang. -->
   </picture>
-  <picture id="christian4-1863" year="1863" subject="christian4">
+  <picture id="christian4-1863" year="1863" subject="christian4" museum="glyptoteket">
       <i>Christian IV om bord på 'Trefoldigheden' under slaget i Kielerbugten 1. juli 1644</i>, ca. 1863, olie på lærred,  115×162cm. Ny Carlsberg Glyptotek.
       <!-- https://www.kulturarv.dk/kid/VisVaerk.do?vaerkId=105119 -->
       <!-- Frederiksborg Slot har også en kopi af dette maleri fra 1865. Måske er vores fotografi i virkeligheden af denne kopi? -->

--- a/fdirs/matthison/portraits.xml
+++ b/fdirs/matthison/portraits.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <pictures>
-  <picture src="p1.jpg" primary="true" square-src="p1-square.jpg">
+  <picture src="p1.jpg" primary="true" square-src="p1-square.jpg" museum="kb">
       M. Cruse (fotograf): <i>Aage Matthison-Hansen</i>, Det Kongelige Bibliotek.
   </picture>
 </pictures>

--- a/fdirs/michaelis/portraits.xml
+++ b/fdirs/michaelis/portraits.xml
@@ -1,12 +1,12 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <pictures>
-  <picture src="p1.jpg" primary="true" square-src="p1-square.jpg">
+  <picture src="p1.jpg" primary="true" square-src="p1-square.jpg" museum="kb">
     Fanny Fahl (fotograf): <i>Sophus Michaelis</i>, før 1898. Det Kongelige Bibliotek.
   </picture>
-  <picture src="p2-oval.jpg">
+  <picture src="p2-oval.jpg" museum="kb">
     Johannes Olsen (fotograf): <i>Sophus Michaelis</i>, ca. 1895. Det Kongelige Bibliotek.
   </picture>
-  <picture src="p2.jpg">
+  <picture src="p2.jpg" museum="kb">
     Johannes Olsen (fotograf): <i>Sophus Michaelis</i>, ca. 1895. Det Kongelige Bibliotek.
   </picture>
 </pictures>

--- a/fdirs/michelangelo/portraits.xml
+++ b/fdirs/michelangelo/portraits.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <pictures>
-  <picture src="p1.jpg" primary="true" square-src="p1-square.jpg">
+  <picture src="p1.jpg" primary="true" square-src="p1-square.jpg" museum="uffizi">
     Marcello Venusti: <i>Portrait of Michelangelo at the Time of the Sistine Chapel</i>, ca. 1504-06, olie på panel, Galleria degli Uffizi.
   </picture>
   <picture src="p2.jpg">

--- a/fdirs/moellern/portraits.xml
+++ b/fdirs/moellern/portraits.xml
@@ -1,9 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <pictures>
-  <picture src="p1-oval.jpg" primary="true" square-src="p1-square.jpg">
+  <picture src="p1-oval.jpg" primary="true" square-src="p1-square.jpg" museum="kb">
       Frederik Riise (fotograf): <i>Niels Møller</i>, 1908?. Det Kongelige Bibliotek.
   </picture>
-  <picture src="p2-oval.jpg">
+  <picture src="p2-oval.jpg" museum="kb">
       Johannes Olsen (fotograf): <i>Niels Møller</i>, ukendt år. Det Kongelige Bibliotek.
   </picture>
 </pictures>

--- a/fdirs/munk/portraits.xml
+++ b/fdirs/munk/portraits.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <pictures>
-  <picture src="p1.jpg" primary="true" square-src="p1-square.jpg">
+  <picture src="p1.jpg" primary="true" square-src="p1-square.jpg" museum="kb">
     <i>Kaj Munk</i>, fotografi. Det Kongelige Bibliotek.
     <!--http://www.kb.dk/images/billed/2010/okt/billeder/object79332/da/-->
   </picture>

--- a/fdirs/mylius/portraits.xml
+++ b/fdirs/mylius/portraits.xml
@@ -1,9 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <pictures>
-  <picture src="p1.jpg" primary="true" square-src="p1-square.jpg">
+  <picture src="p1.jpg" primary="true" square-src="p1-square.jpg" museum="kb">
     Achton Friis: <i>Ludvig Mylius-Erichsen</i>, tegning, ca. 1906. Det Kongelige Bibliotek.
   </picture>
-  <picture src="p2.jpg">
+  <picture src="p2.jpg" museum="kb">
     <i>Ludvig Mylius-Erichsen</i>, ca. 1900. Det Kongelige Bibliotek.
   </picture>
 </pictures>

--- a/fdirs/nansen/portraits.xml
+++ b/fdirs/nansen/portraits.xml
@@ -1,9 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <pictures>
-  <picture src="p1.jpg" primary="true" square-src="p1-square.jpg">
+  <picture src="p1.jpg" primary="true" square-src="p1-square.jpg" museum="kb">
     Even Neuhaus (fotograf): <i>Peter Nansen</i>. Det Kongelige Bibliotek.
   </picture>
-  <picture src="p2.jpg">
+  <picture src="p2.jpg" museum="kb">
     Christensen &amp; Zahrtmann(fotograf): <i>Peter Nansen</i>, ca. 1898. Det Kongelige Bibliotek.
   </picture>
 </pictures>

--- a/fdirs/nielsenlc/portraits.xml
+++ b/fdirs/nielsenlc/portraits.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <pictures>
-  <picture src="p1.jpg" primary="true" square-src="p1-square.jpg">
+  <picture src="p1.jpg" primary="true" square-src="p1-square.jpg" museum="kb">
       <i>L.C. Nielsen</i>, ca. 1920, fotografi. Det Kongelige Bibliotek.
   </picture>
 </pictures>

--- a/fdirs/petrarca/portraits.xml
+++ b/fdirs/petrarca/portraits.xml
@@ -5,7 +5,7 @@
   <picture src="p2.jpg">
       Robert Hart: <i>Francis Petrarch</i>, kobberstik efter et maleri af Raffaello Morghan, ca. 1850.
   </picture>
-  <picture src="p3.jpg">
+  <picture src="p3.jpg" museum="uffizi">
       Andrea del Castagno: <i>Francesco Petrarca</i>, ca. 1450. Galleria degli Uffizi, Firenze.
   </picture>
 </pictures>

--- a/fdirs/plough/portraits.xml
+++ b/fdirs/plough/portraits.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <pictures>
-  <picture src="p1.jpg" primary="true" square-src="p1-square.jpg">
+  <picture src="p1.jpg" primary="true" square-src="p1-square.jpg" museum="kb">
     Budtz Müller &amp; Co. (fotograf): <i>Carl Ploug</i>. Det Kongelige Bibliotek.
   </picture>
   <picture artwork="bissen/ploug-1857-2"/>

--- a/fdirs/rodeg/portraits.xml
+++ b/fdirs/rodeg/portraits.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <pictures>
-  <picture src="p1.jpg" square-src="p1-square.jpg">
+  <picture src="p1.jpg" square-src="p1-square.jpg" museum="kb">
    Ludvig Grundtvig (1836-1901, fotograf): <i>Gotfred Rode</i>, Det Kongelige Bibliotek.
   </picture>
   <picture artwork="hansenc/rodeg-1" primary="true" square-src="p2-square.jpg" />

--- a/fdirs/rodeh/portraits.xml
+++ b/fdirs/rodeh/portraits.xml
@@ -3,14 +3,14 @@
   <picture src="p1.jpg" primary="true" square-src="p1-square.jpg" year="1908">
       Edvard Munch: <i>Portræt af den danske forfatter Helge Rode</i>, 1908, olie på lærred, 198 × 96 cm, Moderna Museet, Stockholm.
   </picture>
-  <picture src="p2.jpg">
+  <picture src="p2.jpg" museum="kb">
       Ebbe Rode: <i>Helge Rode</i>, ukendt år, tegning. Det Kongelige Bibliotek. ,,Skuespilleren Ebbe Rodes (1910-1998) tegning af sin far.''
   </picture>
   <picture src="p4.jpg" year="1919">
       Ludvig Peter Karsten: <i>Helge Rode</i>, 1919, olie på lærred, 208 × 85 cm.
       <!-- http://www.artnet.com/artists/ludvig-peter-karsten/helge-rode-5jRXhJ8X5BrdTj9K442ZcA2 -->
   </picture>
-  <picture src="p3.jpg">
+  <picture src="p3.jpg" museum="kb">
       <i>Helge Rode</i>, ukendt år, fotografi. Det Kongelige Bibliotek.
   </picture>
 </pictures>

--- a/fdirs/roerdam/portraits.xml
+++ b/fdirs/roerdam/portraits.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <pictures>
-  <picture src="p1.jpg" primary="true" square-src="p1-square.jpg">
+  <picture src="p1.jpg" primary="true" square-src="p1-square.jpg" museum="kb">
       Lars Peter Elfelt (fotograf): <i>Valdemar Rørdam</i>, før 1931, fotografi. Det Kongelige Bibliotek. <!-- Fotografen levede 1866-1931. -->
   </picture>
 </pictures>

--- a/fdirs/schiller/portraits.xml
+++ b/fdirs/schiller/portraits.xml
@@ -6,7 +6,7 @@
   <picture src="p1.jpg" primary="true" square-src="p1-square.jpg" year="1793">
     Ludovike Simanowiz (1759-1827): <i>Friedrich Schiller</i>, mellem 1793 og 1794.
   </picture>
-  <picture src="p4.jpg" year="1804">
+  <picture src="p4.jpg" year="1804" museum="smb">
     F.G. Weitsch: <i>Schiller</i>, 1804, tegning. Staatliche Museen, Berlin.
   </picture>
   <picture src="p7.jpg" year="1808">

--- a/fdirs/strandberg/portraits.xml
+++ b/fdirs/strandberg/portraits.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <pictures>
-  <picture src="p1.jpg" primary="true" square-src="p1-square.jpg">
+  <picture src="p1.jpg" primary="true" square-src="p1-square.jpg" museum="kb">
       Christian Neuhaus (1833-1907, fotograf): <i>Julius Strandberg</i>, 1875. Det Kongelige Bibliotek.
   </picture>
 </pictures>


### PR DESCRIPTION
## Ændringer

- knytter 54 billeder i 41 XML-filer til museer, der allerede er registreret i
  `content/museums.xml`
- giver billederne interne museumslinks i billedteksten
- retter blandt andet Petrarca-billedet på sonnet-siden
- udelader bevidst et billede af selve Thorvaldsens Museum, fordi billedteksten
  ikke dokumenterer ejerskab

## Baggrund

Museerne stod allerede i billedteksterne, men `museum`-attributten manglede.
Derfor blev museets navn ikke gjort linkbart af billedrenderingen.

Direkte objektlinks og yderligere `wikidata`-metadata følges op i #1350.

## Validering

- `npm test -- --runInBand`: 53 testsuiter og 2.384 tests består
- `npm run build-static`: XML-, artwork-, museums- og sidegenerering består;
  kommandoen stopper efterfølgende ved miljøets utilgængelige
  Elasticsearch-forbindelse (`EPERM`)
- `git diff --check` består
