### PR TITLE
Link billeder til nye museer og samlinger

### DIFF
--- a/content/artwork.xml
+++ b/content/artwork.xml
@@ -19,15 +19,15 @@
         Carl Løffler: <i>Skuespilleren Anna Nielsen</i>, ca. 1836, olie på lærred, 23,3 × 20,7 cm.
         <!-- metadata checked: 2026-07-16 -->
     </picture>
-    <picture id="tizian-amor-sacro-e-amor-profano-1515" wikidata="Q794077">
+    <picture id="tizian-amor-sacro-e-amor-profano-1515" wikidata="Q794077" museum="borghese">
         Tizian: <i>L'Amor sacro e Amor profano</i>, ca. 1515, olie på træ, 118×279 cm. Galleria Borghese, Rom.
         <!-- metadata checked: 2026-07-16 -->
     </picture> <!-- https://en.wikipedia.org/wiki/Sacred_and_Profane_Love -->
     <picture id="rivett-carnac-edward-fitzgerald-oval" museum="npg" year="1873">Eva Rivett-Carnac: <i>Edward Fitzgerald</i>, miniature efter et fotografi fra 1873.</picture>
-    <picture id="vouet-muses-urania-calliope-1634" wikidata="Q20177132" year="1634 ca.">
+    <picture id="vouet-muses-urania-calliope-1634" wikidata="Q20177132" year="1634 ca." museum="nga">
         Simon Vouet (Frankrig, 1590-1649): <i>The Muses Urania and Calliope</i>, ca. 1634, olie på panel, 79,8 × 125 cm. National Gallery of Art, Washington, D.C.
     </picture>
-    <picture id="pajou-calliope-1763" wikidata="Q63809302" year="1763 ca.">
+    <picture id="pajou-calliope-1763" wikidata="Q63809302" year="1763 ca." museum="nga" objid="41722" invnr="1952.5.107">
         Augustin Pajou (Frankrig, 1730-1809): <i>Calliope</i>, ca. 1763, marmor, 158 × 60,8 × 46,1 cm. Samuel H. Kress Collection.
     </picture>
 </pictures>

--- a/content/keywords/enhedstanken.xml
+++ b/content/keywords/enhedstanken.xml
@@ -4,8 +4,8 @@
     <title>Enhedstanken</title>
     <pictures>
         <picture artwork="lorentzen/1808-steffens" />
-        <picture src="friedrich1.jpg">Caspar David Friedrich: <i>Kreuz im Gebirge</i>, 1812, olie på lærred, 45 × 38 cm. Museum Kunstpalast, Düsseldorf.</picture>
-        <picture src="ribera-platon.jpg">José de Ribera: <i>Platon</i>, 1637. Musée de Picardie, Amiens.</picture>
+        <picture src="friedrich1.jpg" museum="kunstpalast">Caspar David Friedrich: <i>Kreuz im Gebirge</i>, 1812, olie på lærred, 45 × 38 cm. Museum Kunstpalast, Düsseldorf.</picture>
+        <picture src="ribera-platon.jpg" museum="picardie">José de Ribera: <i>Platon</i>, 1637. Musée de Picardie, Amiens.</picture>
     </pictures>
     <related>romantikken</related>
   </head>

--- a/content/keywords/romantismen.xml
+++ b/content/keywords/romantismen.xml
@@ -3,7 +3,7 @@
   <head>
     <title>Romantisme</title>
     <pictures>
-        <picture src="friedrich7.jpg">Den romantiske udlængsel ifølge Caspar David Friedrich: <i>View from the Artist's Studio, Right Window</i>, 1805-1806. 31 × 24 cm. Sepia på papir. Wien Kunsthistorisches Museum.</picture>
+        <picture src="friedrich7.jpg" museum="khm">Den romantiske udlængsel ifølge Caspar David Friedrich: <i>View from the Artist's Studio, Right Window</i>, 1805-1806. 31 × 24 cm. Sepia på papir. Wien Kunsthistorisches Museum.</picture>
     <picture portrait="hugo/p3" />
     <picture src="ingres8.jpg" wikidata="Q1978815" museum="louvre">
       Jean Auguste Dominique Ingres: <i>Grande Odalisque</i>, 1814. Musée du Louvre.

--- a/content/museums.xml
+++ b/content/museums.xml
@@ -106,4 +106,181 @@
     <link>https://www.tate.org.uk/</link>
     <deep-link>https://www.tate.org.uk/art/artworks/${invNr}</deep-link>
   </museum>
+  <museum id="borghese">
+    <name>Galleria Borghese</name>
+  </museum>
+  <museum id="nga">
+    <name>National Gallery of Art, Washington</name>
+    <deep-link>https://www.nga.gov/artworks/${objId}</deep-link>
+  </museum>
+  <museum id="kunstpalast">
+    <name>Kunstpalast, Düsseldorf</name>
+  </museum>
+  <museum id="picardie">
+    <name>Musée de Picardie</name>
+  </museum>
+  <museum id="khm">
+    <name>Kunsthistorisches Museum Wien</name>
+  </museum>
+  <museum id="vatican">
+    <name>Musei Vaticani</name>
+  </museum>
+  <museum id="kelvingrove">
+    <name>Kelvingrove Art Gallery and Museum</name>
+  </museum>
+  <museum id="high">
+    <name>High Museum of Art</name>
+  </museum>
+  <museum id="hunterian">
+    <name>The Hunterian, University of Glasgow</name>
+  </museum>
+  <museum id="ima">
+    <name>Indianapolis Museum of Art at Newfields</name>
+  </museum>
+  <museum id="branitz">
+    <name>Fürst-Pückler-Museum Park und Schloss Branitz</name>
+  </museum>
+  <museum id="orsay">
+    <name>Musée d'Orsay</name>
+  </museum>
+  <museum id="norton">
+    <name>Norton Museum of Art</name>
+  </museum>
+  <museum id="oslo">
+    <name>Oslo Museum</name>
+  </museum>
+  <museum id="ngv">
+    <name>National Gallery of Victoria</name>
+  </museum>
+  <museum id="ashmolean">
+    <name>Ashmolean Museum</name>
+  </museum>
+  <museum id="prado">
+    <name>Museo Nacional del Prado</name>
+  </museum>
+  <museum id="scotnpg">
+    <name>Scottish National Portrait Gallery</name>
+  </museum>
+  <museum id="willumsens">
+    <name>J.F. Willumsens Museum</name>
+  </museum>
+  <museum id="falkenberg">
+    <name>Falkenbergs museum</name>
+  </museum>
+  <museum id="capodimonte">
+    <name>Museo e Real Bosco di Capodimonte</name>
+  </museum>
+  <museum id="kunsten">
+    <name>Kunsten Museum of Modern Art Aalborg</name>
+  </museum>
+  <museum id="staedel">
+    <name>Städel Museum</name>
+  </museum>
+  <museum id="dhm">
+    <name>Deutsches Historisches Museum</name>
+  </museum>
+  <museum id="neuepinakothek">
+    <name>Neue Pinakothek</name>
+  </museum>
+  <museum id="lascala">
+    <name>Museo Teatrale alla Scala</name>
+  </museum>
+  <museum id="munch">
+    <name>MUNCH</name>
+  </museum>
+  <museum id="hamburgerkunsthalle">
+    <name>Hamburger Kunsthalle</name>
+  </museum>
+  <museum id="barberinicorsini">
+    <name>Gallerie Nazionali d'Arte Antica</name>
+  </museum>
+  <museum id="pushkin">
+    <name>The Pushkin State Museum of Fine Arts</name>
+  </museum>
+  <museum id="capitolini">
+    <name>Musei Capitolini</name>
+  </museum>
+  <museum id="fabre">
+    <name>Musée Fabre</name>
+  </museum>
+  <museum id="reventlow">
+    <name>Reventlow-Museet Pederstrup</name>
+  </museum>
+  <museum id="hcandersen">
+    <name>H.C. Andersens Hus</name>
+  </museum>
+  <museum id="johanneslarsen">
+    <name>Johannes Larsen Museet</name>
+  </museum>
+  <museum id="dulwich">
+    <name>Dulwich Picture Gallery</name>
+  </museum>
+  <museum id="kirstenkjaer">
+    <name>Kirsten Kjærs Museum</name>
+  </museum>
+  <museum id="bolognaarchaeological">
+    <name>Museo Civico Archeologico di Bologna</name>
+  </museum>
+  <museum id="kolumba">
+    <name>Kolumba</name>
+  </museum>
+  <museum id="conde">
+    <name>Musée Condé</name>
+  </museum>
+  <museum id="operaduomo">
+    <name>Museo dell'Opera del Duomo</name>
+  </museum>
+  <museum id="novalis">
+    <name>Novalis-Museum Schloss Oberwiederstedt</name>
+  </museum>
+  <museum id="behnhaus">
+    <name>Museum Behnhaus Drägerhaus</name>
+  </museum>
+  <museum id="moderna">
+    <name>Moderna Museet</name>
+  </museum>
+  <museum id="britishmuseum">
+    <name>The British Museum</name>
+  </museum>
+  <museum id="tesse">
+    <name>Musée de Tessé</name>
+  </museum>
+  <museum id="skd">
+    <name>Staatliche Kunstsammlungen Dresden</name>
+  </museum>
+  <museum id="met">
+    <name>The Metropolitan Museum of Art</name>
+  </museum>
+  <museum id="leeds">
+    <name>Leeds Art Gallery</name>
+  </museum>
+  <museum id="ago">
+    <name>Art Gallery of Ontario</name>
+  </museum>
+  <museum id="helsinkiuni">
+    <name>Helsinki University Museum</name>
+  </museum>
+  <museum id="smithsoniannpg">
+    <name>National Portrait Gallery, Smithsonian Institution</name>
+  </museum>
+  <museum id="brou">
+    <name>Musée du monastère royal de Brou</name>
+  </museum>
+  <museum id="wallace">
+    <name>The Wallace Collection</name>
+    <deep-link>https://wallacelive.wallacecollection.org/eMP/eMuseumPlus?module=collection&amp;objectId=${objId}&amp;service=ExternalInterface</deep-link>
+  </museum>
+  <museum id="nlw">
+    <name>National Library of Wales</name>
+  </museum>
+  <museum id="schack">
+    <name>Sammlung Schack</name>
+    <deep-link>https://www.sammlung.pinakothek.de/de/artwork/${objId}</deep-link>
+  </museum>
+  <museum id="sydvestjyske">
+    <name>Sydvestjyske Museer</name>
+  </museum>
+  <museum id="cornell">
+    <name>Cornell University Library</name>
+  </museum>
 </museums>

--- a/fdirs/aarestrup/1976-1.xml
+++ b/fdirs/aarestrup/1976-1.xml
@@ -248,7 +248,7 @@ Og fra Norden lød, dæmpet, den tragiske Sang -
       <note>Om statuen: ''Romerske kopi af græsk original fra ca. 100 f.kr. eller romersk original. Fundet 1506 på Esquilinhøjen i Rom og straks identificeret med en skulpturgruppe af den trojanske præst Laokoon og hans sønner, som ifølge Plinius den Ældre var opstillet i kejser Titus' palads'', <i>Græsk kunst</i>, Gads Forlag, 1999, p. 242.</note>
    </notes>
    <pictures>
-      <picture src="aarestrup1999041505.jpg">Hagesandros, Athenodoros og Polydoros af Rhodos: <i>Laokoon og hans sønner</i>, 175-150 f.Kr., Museo Pio Clementino, Vatikanet.</picture>
+      <picture src="aarestrup1999041505.jpg" museum="vatican">Hagesandros, Athenodoros og Polydoros af Rhodos: <i>Laokoon og hans sønner</i>, 175-150 f.Kr., Museo Pio Clementino, Vatikanet.</picture>
    </pictures>
    <quality>korrektur1,korrektur2,kilde,side</quality>
    <keywords>rom</keywords>

--- a/fdirs/ahlmann/1910.xml
+++ b/fdirs/ahlmann/1910.xml
@@ -1843,7 +1843,7 @@ bagved den vældige, hærgede Fugl.
     <firstline>Carlyle, du strenge Mester, saa er jeg atter her</firstline>
     <source pages="78-79"/>
     <pictures>
-        <picture src="ahlmann2023071529-p1.jpg">James McNeill Whistler: <i>Arrangement in Grey and Black, No. 2: Portrait of Thomas Carlyle</i>, olie på lærred, 171 × 143,5 cm, 1872-73, Kelvingrove Art Gallery and Museum, Glasgow.</picture>
+        <picture src="ahlmann2023071529-p1.jpg" museum="kelvingrove">James McNeill Whistler: <i>Arrangement in Grey and Black, No. 2: Portrait of Thomas Carlyle</i>, olie på lærred, 171 × 143,5 cm, 1872-73, Kelvingrove Art Gallery and Museum, Glasgow.</picture>
     </pictures>
     <quality>korrektur1,kilde,side</quality>
 </head>

--- a/fdirs/alfieri/portraits.xml
+++ b/fdirs/alfieri/portraits.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <pictures>
-  <picture src="p1.jpg" primary="true" square-src="p1-square.jpg">
+  <picture src="p1.jpg" primary="true" square-src="p1-square.jpg" museum="high">
     François-Xavier Fabre: <i>Vittorio Alfieri</i>, 1794, olie på lærred. High Museum of Art, Atlanta.
   </picture>
   <picture src="p2.jpg">

--- a/fdirs/arbuthnot/portraits.xml
+++ b/fdirs/arbuthnot/portraits.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <pictures>
-  <picture src="p1.jpg" primary="true" square-src="p1-square.jpg" year="1723">
+  <picture src="p1.jpg" primary="true" square-src="p1-square.jpg" year="1723" museum="hunterian">
       Godfrey Kneller: <i>Portrait of John Arbuthnot (1667-1735), the physician</i>, 1723, olie på lærred, 75,5 × 63 cm. Hunterian Museum and Art Gallery, University of Glasgow.
   </picture>
 </pictures>

--- a/fdirs/ariosto/portraits.xml
+++ b/fdirs/ariosto/portraits.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <pictures>
-  <picture src="p1.jpg" primary="true" square-src="p1-square.jpg">
+  <picture src="p1.jpg" primary="true" square-src="p1-square.jpg" museum="ima">
       Tizian: <i>Ritratto dell'Ariosto</i>, ca. 1515, olie på lærred, 59,5 × 45,5 cm. Indianapolis Museum of Art.
   </picture>
 </pictures>

--- a/fdirs/bagger/1845.xml
+++ b/fdirs/bagger/1845.xml
@@ -1975,7 +1975,7 @@ Gjør af mig hvadhelst Du behager!''
         <!-- https://www.tagesspiegel.de/wissen/die-abessinierin-im-gefolge-fuerst-puecklers-das-raetsel-der-machbuba/20793600.html -->
     </notes>
    <pictures>
-       <picture src="bagger2017120424-p1.jpg">Ukendt kunster: <i>Machbuba</i>, 1840. Fürst-Pückler-Museum Park und Schloss Branitz.</picture>
+       <picture src="bagger2017120424-p1.jpg" museum="branitz">Ukendt kunster: <i>Machbuba</i>, 1840. Fürst-Pückler-Museum Park und Schloss Branitz.</picture>
    </pictures>
     <source pages="148-149"/>
     <quality>korrektur1,kilde,side</quality>

--- a/fdirs/baudelaire/portraits.xml
+++ b/fdirs/baudelaire/portraits.xml
@@ -3,10 +3,10 @@
   <picture src="p1.jpg" primary="true" square-src="p1-square.jpg">
     Étienne Carjat (fotograf): <i>Charles Baudelaire</i>, ca. 1862, kulfotografi.
   </picture>
-  <picture src="p2.jpg">
+  <picture src="p2.jpg" museum="orsay">
     Félix Nadar: <i>Charles Baudelaire au fauteuil</i>, 1855, fotografi, Musée d'Orsay, Paris.
   </picture>
-  <picture src="p3.jpg">
+  <picture src="p3.jpg" museum="norton">
     Raymond Duchamp-Villon (1876-1918): <i>Portrait of Baudelaire</i>, 1911, bronze, Norton Museum, West Palm Beach, Florida.
   </picture>
   <picture src="p4.jpg">

--- a/fdirs/bjerregaard/portraits.xml
+++ b/fdirs/bjerregaard/portraits.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <pictures>
-  <picture src="p1.jpg" primary="true" square-src="p1-square.jpg">
+  <picture src="p1.jpg" primary="true" square-src="p1-square.jpg" museum="oslo">
       Jacob Munch: <i>Henrik Anker Bjerregaard</i>, ca. 1820, olie på lærred. Oslo Museum.
       <!-- http://www.oslobilder.no/OMU/OB.00109 -->
   </picture>

--- a/fdirs/blake/artwork.xml
+++ b/fdirs/blake/artwork.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <pictures>
-  <picture id="1824-tree-beasts" year="1824-1-01">
+  <picture id="1824-tree-beasts" year="1824-1-01" museum="ngv">
       <i>Dante Running from the Three Beasts</i>, 1824-27, blyant, blæk og vandfarve på papir, 370×528 mm. National Gallery of Victoria, Melbourne, Australia.
       <!-- http://www.blakearchive.org/copy/but812.1?descId=but812.1.wc.01 -->
       <!-- Canto I  -->
@@ -30,7 +30,7 @@
   <picture id="1824-beatrice-adressing-dante" wikidata="Q3637289" year="1824-2-29" museum="tate" invnr="N03369">
       <i>Beatrice Addressing Dante from the Car</i>, 1824-27, blyant, blæk og vandfarve på papir, 372×527 mm.
   </picture>
-  <picture id="1824-deity-from" year="1824-3-28">
+  <picture id="1824-deity-from" year="1824-3-28" museum="ashmolean">
       <i>The Deity, from whom proceed the Nine Spheres</i>, 1824-27, blyant, blæk og vandfarve på papir. Ashmolean Museum, University of Oxford.
   </picture>
 </pictures>

--- a/fdirs/boennelycke/1921.xml
+++ b/fdirs/boennelycke/1921.xml
@@ -93,7 +93,7 @@ er din unge Kærlighed. -
     <firstline>Berust af Kyssenes Aande</firstline>
     <source pages="12-14"/>
     <pictures>
-        <picture src="boennelycke2024091702-p1.jpg">Paolo Veronese: <i>Venus og Adonis</i>, olie på lærred, 163 × 192 cm, Museo del Prado</picture>
+        <picture src="boennelycke2024091702-p1.jpg" museum="prado">Paolo Veronese: <i>Venus og Adonis</i>, olie på lærred, 163 × 192 cm, Museo del Prado</picture>
         <!-- https://en.wikipedia.org/wiki/File:Venus_y_Adonis_(Veronese).jpg -->
     </pictures>
     <quality>korrektur1,kilde,side</quality>

--- a/fdirs/burns/portraits.xml
+++ b/fdirs/burns/portraits.xml
@@ -1,9 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <pictures>
-  <picture src="p1-oval.jpg" primary="true" square-src="p1-square.jpg">
+  <picture src="p1-oval.jpg" primary="true" square-src="p1-square.jpg" museum="scotnpg">
     Alexander Nasmyth (1758–1840): <i>Robert Burns</i>, 1787. Scottish National Portrait Gallery.
   </picture>
-  <picture src="p1.jpg">
+  <picture src="p1.jpg" museum="scotnpg">
     Alexander Nasmyth (1758–1840): <i>Robert Burns</i>, 1787. Scottish National Portrait Gallery.
   </picture>
 </pictures>

--- a/fdirs/claussen/portraits.xml
+++ b/fdirs/claussen/portraits.xml
@@ -3,7 +3,7 @@
   <picture src="p4.jpg">
     René Boivin (fotograf): <i>Sophus Claussen</i>, 1911.
   </picture>
-  <picture src="p1.jpg" primary="true" square-src="p1-square.jpg">
+  <picture src="p1.jpg" primary="true" square-src="p1-square.jpg" museum="willumsens">
     J. F. Willumsen: <i>Portræt af Sophus Claussen</i>, 1915. Willumsens Museum, Frederikssund.
   </picture>
   <picture src="p2.jpg">

--- a/fdirs/dalin/portraits.xml
+++ b/fdirs/dalin/portraits.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <pictures>
-  <picture src="p1.jpg" primary="true" square-src="p1-square.jpg">
+  <picture src="p1.jpg" primary="true" square-src="p1-square.jpg" museum="falkenberg">
     Johan Henrik Scheffel (1690-1781): <i>Olof von Dalin</i>, ukendt år. Falkenbergs museum.
   </picture>
 </pictures>

--- a/fdirs/dante/commedia.xml
+++ b/fdirs/dante/commedia.xml
@@ -648,7 +648,7 @@ fuor de la queta, ne l'aura che trema.
    <indextitle>Canto V</indextitle>
    <firstline>Così discesi del cerchio primaio</firstline>
    <pictures>
-       <picture src="dante2005050105-p2.jpg">
+       <picture src="dante2005050105-p2.jpg" museum="wallace" objid="65250" invnr="P316">
            Ary Scheffer (1795-1858): <i>Francesca da Rimini</i>, 1835, olie på lærred, 166,5×234 cm. The Wallace Collection, London.
        </picture>
        <picture src="dante2005050105-p1.jpg">
@@ -1090,7 +1090,7 @@ con li occhi vòlti a chi del fango ingozza.
          Eugène Delacroix: <i>La Barque de Dante</i>, 1822, olie på lærred, 189×246 cm.
          <!-- metadata checked: 2026-07-16 -->
        </picture>
-       <picture src="dante2005050108-p2.jpg" wikidata="Q2665048">
+       <picture src="dante2005050108-p2.jpg" wikidata="Q2665048" museum="orsay">
          William-Adolphe Bouguereau: <i>Dante et Virgile</i>, 1850, olie på lærred, 280.5×225.3 cm. Musée d'Orsay.
          <!-- metadata checked: 2026-07-16 -->
        </picture>
@@ -4748,7 +4748,7 @@ né sì chinato, lì fece dimora,
    <indextitle>Canto XXXII</indextitle>
    <firstline>S'io avessi le rime aspre e chiocce</firstline>
    <pictures>
-       <picture src="dante2005050132-p1.jpg">Gustave Doré: <i>Dante et Vergil dans le neuvième cercle de l'enfer</i>, 1861, olie på lærred, 315×450 cm. Musée municipal de Bourg-en-Bresse.</picture>
+      <picture src="dante2005050132-p1.jpg" museum="brou" invnr="982.234">Gustave Doré: <i>Dante et Vergil dans le neuvième cercle de l'enfer</i>, 1861, olie på lærred, 315×450 cm. Musée du monastère royal de Brou, Bourg-en-Bresse.</picture>
    </pictures>
 </head>
 <body>

--- a/fdirs/dellacasa/portraits.xml
+++ b/fdirs/dellacasa/portraits.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <pictures>
-  <picture src="p1.jpg" primary="true" square-src="p1-square.jpg">
+  <picture src="p1.jpg" primary="true" square-src="p1-square.jpg" museum="nga">
      Pontormo (1494-1557): <i>Monsignor della Casa</i>, 1541-44, olie på panel, 102×78,9 cm. National Gallery of Art, Washington, D.C.  <!-- https://commons.wikimedia.org/wiki/File:Jacopo_Pontormo_057.jpg -->
   </picture>
 </pictures>

--- a/fdirs/drachmann/1881.xml
+++ b/fdirs/drachmann/1881.xml
@@ -925,7 +925,7 @@ At elske Jord - og Støv - og Skarn.
    <firstline>Ind i det uhyre Rum, hvori Tanken sig taber</firstline>
    <pictures>
       <picture src="drachmann200107158-p2.jpg">Michelangelo: <i>Leda</i> (1529/30)</picture>
-      <picture src="drachmann200107158-p1.jpg">Correggio: <i>Jupiter og Io</i> (1531-32), olie på lærred. Kunsthistorisches Museum, Wien.</picture>
+      <picture src="drachmann200107158-p1.jpg" museum="khm">Correggio: <i>Jupiter og Io</i> (1531-32), olie på lærred. Kunsthistorisches Museum, Wien.</picture>
    </pictures>
    <quality>korrektur1,kilde</quality>
 </head>

--- a/fdirs/fonss/1900.xml
+++ b/fdirs/fonss/1900.xml
@@ -491,7 +491,7 @@ som lukker Dig i Mindets Verden ind.
     <toctitle><num>II.</num>Et Steds i Napolimuseets Sale</toctitle>
     <firstline>Et Steds i Napolimuseets Sale</firstline>
     <pictures>
-        <picture src="fonss2018041909-p1.jpg">Titian: <i>Danaë</i>, 1544-46, olie på lærred, 120 × 172 cm. Museo di Capodimonte, Napoli.</picture> <!-- https://en.wikipedia.org/wiki/Danaë_(Titian_series)#/media/File:Tizian_011.jpg -->
+        <picture src="fonss2018041909-p1.jpg" museum="capodimonte">Titian: <i>Danaë</i>, 1544-46, olie på lærred, 120 × 172 cm. Museo di Capodimonte, Napoli.</picture> <!-- https://en.wikipedia.org/wiki/Danaë_(Titian_series)#/media/File:Tizian_011.jpg -->
     </pictures>
     <source pages="19"/>
     <keywords>sonnet</keywords>

--- a/fdirs/gertner/artwork.xml
+++ b/fdirs/gertner/artwork.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <pictures>
-  <picture id="1842-thorvaldsen" subject="thorvaldsen" year="1842">
+  <picture id="1842-thorvaldsen" subject="thorvaldsen" year="1842" museum="kunsten">
       <i>Thorvaldsen ved Oehlenschlägers buste</i>, 1842. Kunsten Museum of Modern Art Aalborg.
   </picture>
   <picture id="1843-welhaven" subject="welhaven" year="1851">

--- a/fdirs/gilfillan/portraits.xml
+++ b/fdirs/gilfillan/portraits.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <pictures>
-  <picture src="p1.jpg" primary="true" square-src="p1-square.jpg">
+  <picture src="p1.jpg" primary="true" square-src="p1-square.jpg" museum="scotnpg">
     William Home Lizars efter William Wallace: <i>Robert Gilfillan</i>, kobberstik. Scottish National Portrait Gallery.
   </picture>
 </pictures>

--- a/fdirs/goethe/portraits.xml
+++ b/fdirs/goethe/portraits.xml
@@ -1,15 +1,15 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <pictures>
-    <picture src="p7.jpg" year="1787">
+    <picture src="p7.jpg" year="1787" museum="staedel">
         Johann Heinrich Wilhelm Tischbein: <i>Goethe in der Campagna</i>, Rom, 1787, olie på lærred, 164 × 206 cm. Städel Museum, Frankfurt.
     </picture>
-    <picture src="p6.jpg" year="1810">
+    <picture src="p6.jpg" year="1810" museum="dhm">
         Gerhard von Kügelgen (1772-1820): <i>Johann Wolfgang von Goethe</i>, Dresden, 1810, olie på lærred, 73,8 × 63,5 cm. Deutsches Historisches Museum, Berlin.
     </picture>
     <picture src="p3.jpg" primary="true" square-src="p3-square.jpg" year="1822">
         Heinrich Christoph Kolbe: <i>Goethe</i>, 1822, olie på lærred. Goethe-Nationalmuseum, Weimar.
     </picture>
-    <picture src="p8.jpg" year="1828">
+    <picture src="p8.jpg" year="1828" museum="neuepinakothek">
         Joseph Karl Stieler (1781-1858): <i>Johann Wolfgang von Goethe</i>, 1828, olie på lærred, 78 × 63,8 cm. Neue Pinakothek, München.
     </picture>
 </pictures>

--- a/fdirs/goldoni/portraits.xml
+++ b/fdirs/goldoni/portraits.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <pictures>
-  <picture src="p1.jpg" primary="true" square-src="p1-square.jpg">
+  <picture src="p1.jpg" primary="true" square-src="p1-square.jpg" museum="lascala">
     Ukendt kunstner: <i>Ritratto di Goldoni</i>, ca. 1750, pastel. Museo Teatrale alla Scala, Milano.
   </picture>
 </pictures>

--- a/fdirs/goldstein/portraits.xml
+++ b/fdirs/goldstein/portraits.xml
@@ -3,7 +3,7 @@
   <picture src="p1.jpg" primary="true" square-src="p1-square.jpg">
       Edvard Munch: <i>Emanuel Goldstein</i>.
   </picture>
-  <picture src="p2.jpg">
+  <picture src="p2.jpg" museum="munch">
       Edvard Munch: <i>Panterhode. Goldstein som panter</i>, 1908-1909, kul på velinpapir, 164 × 223 mm. Munch Museet, Oslo.
   </picture>
 </pictures>

--- a/fdirs/hegelund/portraits.xml
+++ b/fdirs/hegelund/portraits.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <pictures>
-  <picture src="p1.jpg" primary="true" square-src="p1-square.jpg">
+  <picture src="p1.jpg" primary="true" square-src="p1-square.jpg" museum="sydvestjyske">
     Ukendt kunstner: <i>Peder Jensen Hegelund</i>. Den Antikvariske Samling, Ribe.
   </picture>
 </pictures>

--- a/fdirs/heine/portraits.xml
+++ b/fdirs/heine/portraits.xml
@@ -4,7 +4,7 @@
   </picture>
   <picture src="p2.jpg">
   </picture>
-  <picture src="p3.jpg" primary="true" square-src="p3-square.jpg">
+  <picture src="p3.jpg" primary="true" square-src="p3-square.jpg" museum="hamburgerkunsthalle">
     Moritz Daniel Oppenheim: <i>Heinrich Heine</i>, 1831. Kunsthalle Hamburg
   </picture>
 </pictures>

--- a/fdirs/hemans/portraits.xml
+++ b/fdirs/hemans/portraits.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <pictures>
-  <picture src="p1.jpg" primary="true" square-src="p1-square.jpg" year="1820">
+  <picture src="p1.jpg" primary="true" square-src="p1-square.jpg" year="1820" museum="nlw" objid="PB7174">
       <i>Felicia Dorothea Hemans</i>, ca. 1820, litografi. Welsh Portrait Collection, National Library of Wales.<!-- PB7174 -->
   </picture>
 </pictures>

--- a/fdirs/hertzh/1851a.xml
+++ b/fdirs/hertzh/1851a.xml
@@ -3902,8 +3902,8 @@ Boer jeg. Skynd dig og kom! - Huset er vist dig bekjendt.
     <firstline>Den skjønne Fornarina</firstline>
     <source pages="162-163"/>
     <pictures>
-        <picture src="hertz2018021838-p1.jpg">Raphael: <i>La Fornarina</i>, 1518-19, olie på panel, 85×60cm. Galleria Nazionale d'Arte Antica, Rom.</picture>
-        <picture src="hertz2018021838-p2.jpg">Giulio Romano: <i>Fornarina</i>, ca. 1520, olie på panel, 111×92cm. The Pushkin State Museum of Fine Arts, Moskva.</picture>
+        <picture src="hertz2018021838-p1.jpg" museum="barberinicorsini">Raphael: <i>La Fornarina</i>, 1518-19, olie på panel, 85×60cm. Galleria Nazionale d'Arte Antica, Rom.</picture>
+        <picture src="hertz2018021838-p2.jpg" museum="pushkin">Giulio Romano: <i>Fornarina</i>, ca. 1520, olie på panel, 111×92cm. The Pushkin State Museum of Fine Arts, Moskva.</picture>
     </pictures>
     <quality>korrektur1,kilde,side</quality>
 </head>

--- a/fdirs/holst/1843.xml
+++ b/fdirs/holst/1843.xml
@@ -252,7 +252,7 @@ Til Rom efter Bryllupsvisen.
       <note type="credits">Bidrag fra Sven Sørensen.</note>
    </notes>
    <pictures>
-      <picture src="holst2001042501.jpg"><i>Il galata morente</i>, Musei Capitolini, Rom.</picture>
+      <picture src="holst2001042501.jpg" museum="capitolini"><i>Il galata morente</i>, Musei Capitolini, Rom.</picture>
    </pictures>
    <quality>korrektur1</quality>
    <keywords>heksameter</keywords>

--- a/fdirs/hugo/1829.xml
+++ b/fdirs/hugo/1829.xml
@@ -215,7 +215,7 @@ Il faut des perles au poignard !
         <note>Mottoet stammer fra en fransk oversættelse af persiske <a poet="saadi">Saadi</a> : <i>Gulistan</i> (1258).</note>
         </notes>
     <pictures>
-        <picture src="hugo2018111003-p1.jpg">
+        <picture src="hugo2018111003-p1.jpg" museum="fabre">
             Alexandre Cabanel: <i>Albaydé</i>, 1848, olie på lærred, 98×80 cm. Musée Fabre, Montpellier.</picture>
         <!-- https://commons.wikimedia.org/wiki/File:Alexandre_Cabanel_-_Albayde.jpg -->
         <!-- 'Albaydé' (1848) by Alexandre Cabanel. Oil on canvas. 98 × 80 cm (38.6 × 31.5 in). Location: Musée Fabre, Montpellier, France (le Midi, or southern France). // This portrait is included in the feature, 'The Portrait Gallery' by Sasha Soren, author of 'Random Magic.' // About the portrait: A lush and sensual tableau, depicting an enigmatic woman, whom we gradually realize has already died. Curiouser still, she’s never actually lived; the portrait is based, not on a real woman, but a character - Albaydé. She appears in writer Victor Hugo’s book of poems, 'Les Orientales' (1829). // The character of Albaydé is mentioned in 'Les tronçons du serpent' ('Sections of the Serpent'). The narrator of the poem pities a snake torn into pieces, but - somewhat surreally - the dying serpent speaks to him, saying: Ta plaie est plus cruelle/Car ton Albaydé dans la tombe a fermé/Ses beaux yeux de gazelle. (Your wound is more cruel than mine/ because in the tomb has your Albaydé closed/her beautiful eyes, that were like those of a gazelle.) // Found by @RandomMagicTour - Sasha Soren -->

--- a/fdirs/jensenca/artwork.xml
+++ b/fdirs/jensenca/artwork.xml
@@ -3,7 +3,7 @@
   <picture id="ingemann-1818" year="1818-19" subject="ingemann" museum="fnm">
     <i>B.S. Ingemann</i>, 1818-19.
   </picture>
-  <picture id="schimmelmann-1827" year="1827">
+  <picture id="schimmelmann-1827" year="1827" museum="reventlow">
       <i>Geheimestatsminister Heinrich Ernst greve Schimmelmann</i>, 1827, olie på lærred, 63,2×50cm. Museum Lolland-Falster (Reventlow Museet).<!-- inv. nr. 003 -->
   </picture>
   <picture id="broendsted-1827" year="1827" museum="glyptoteket">
@@ -36,7 +36,7 @@
   <picture id="herholdt-1835" wikidata="Q20354175" year="1835" museum="smk" invnr="KMS3129">
     <i>Professor dr. med. J.D. Herholdt</i>, 1835, olie på lærred. 23,5 × 19 cm.
   </picture>
-  <picture id="andersen-1836" subject="andersen" year="1836">
+  <picture id="andersen-1836" subject="andersen" year="1836" museum="hcandersen">
     <i>H.C. Andersen</i>, 1836. H.C. Andersen Museet, Odense.
   </picture>
   <picture id="boedtcher-1836" subject="boedtcher" year="1836" invnr="B444" museum="thorvaldsens">

--- a/fdirs/jensenjv/portraits.xml
+++ b/fdirs/jensenjv/portraits.xml
@@ -9,7 +9,7 @@
   <picture src="p2.jpg" year="1927" museum="kb" objid="79801">
       Ludvig Find: <i>Johannes V. Jensen</i>, 1927, tryk. Det kongelig Bibliotek.
   </picture>
-  <picture src="p3.jpg" year="1935">
+  <picture src="p3.jpg" year="1935" museum="johanneslarsen">
       Fritz Syberg: <i>Johannes V. Jensen</i>, 1936. Johannes Larsen Museet.
   </picture>
 </pictures>

--- a/fdirs/juel/artwork.xml
+++ b/fdirs/juel/artwork.xml
@@ -21,7 +21,7 @@
     <picture id="rothe-oval" year="1780 ca." subject="rothe" museum="fnm" invnr="a-4152">
         <i>Tyge Jesper Rothe</i>, ca. 1780, olie på lærred.
     </picture>
-    <picture id="christian7-1-oval" year="1782" subject="christian7">
+    <picture id="christian7-1-oval" year="1782" subject="christian7" museum="reventlow">
         <i>Christian VII</i>, 1782, olie på lærred, 73,5×54,5cm. Reventlow-Museet.
     </picture>
     <picture id="emilie-kilde-1784" year="1784">

--- a/fdirs/lovelace/portraits.xml
+++ b/fdirs/lovelace/portraits.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <pictures>
-  <picture src="p1.jpg" primary="true" square-src="p1-square.jpg">
+  <picture src="p1.jpg" primary="true" square-src="p1-square.jpg" museum="dulwich">
     William Dobson (1610-1646): <i>Richard Lovelace</i>, Dulwich Picture Gallery, London.
   </picture>
 </pictures>

--- a/fdirs/luetken/portraits.xml
+++ b/fdirs/luetken/portraits.xml
@@ -8,7 +8,7 @@
       <!-- http://www.lauritz.com/da/auktion/soeren-hjorth-nielsen-1901-1983-og-per-ulrich-1915-1994-2/i2134665/# -->
       <!-- Der er stadig copyright på dette billede -->
   </picture>
-  <picture src="p3.jpg">
+  <picture src="p3.jpg" museum="kirstenkjaer">
       Kirsten Kjær (1893-1985): <i>Hulda Lütken</i>, 1942. Kirsten Kjær Museum, Frøstrup.
       <!-- Der er stadig copyright på dette billede -->
   </picture>

--- a/fdirs/mallarme/portraits.xml
+++ b/fdirs/mallarme/portraits.xml
@@ -6,7 +6,7 @@
   <picture src="p2.jpg">
     Paul Nadar (fotograf): <i>Stéphane Mallarmé</i>, 1896.
   </picture>
-  <picture src="p3.jpg">
+  <picture src="p3.jpg" museum="orsay">
     Édouard Manet (1832–1883): <i>Stéphane Mallarmé</i>, 1876, olie på lærred. Musée d'Orsay.
   </picture>
 </pictures>

--- a/fdirs/matthison/1900.xml
+++ b/fdirs/matthison/1900.xml
@@ -703,7 +703,7 @@ paa Nattens dunkle Himmel.
     <firstline>Vildt, vildt, vildt bryder Blæsten om Land</firstline>
     <source pages="33"/>
     <pictures>
-        <picture src="matthison2019051717-p1.jpg">Arnold Böcklin: <i>Villa am Meer II</i>, 1865, olie på lærred. Sammlung Schack, München.</picture>
+        <picture src="matthison2019051717-p1.jpg" museum="schack" objid="k2xnZJgxPd" invnr="11536">Arnold Böcklin: <i>Villa am Meer II</i>, 1865, olie på lærred. Sammlung Schack, München.</picture>
     </pictures>
     <quality>korrektur1,kilde,side</quality>
 </head>

--- a/fdirs/michaelis/1900.xml
+++ b/fdirs/michaelis/1900.xml
@@ -44,7 +44,7 @@ og naaet den sidste store Horisont.
     <firstline>Barsk er din Ynde. Din buede Læbe ej kender til Latter</firstline>
     <source pages="9-10"/>
     <pictures>
-        <picture src="michaelis201709151-p1.jpg"><i>L'Athena Lemnia</i>, marmor, græsk, ca. 451-448 f.Kr., Museo civico archeologico, Bologna.</picture>
+        <picture src="michaelis201709151-p1.jpg" museum="bolognaarchaeological"><i>L'Athena Lemnia</i>, marmor, græsk, ca. 451-448 f.Kr., Museo civico archeologico, Bologna.</picture>
     </pictures>
     <quality>korrektur1,korrektur2,kilde,side</quality>
 </head>
@@ -258,7 +258,7 @@ Det er Slaven, der retter sin trodsige Krop
     <firstline>Milde Kölner-Moder med din lille Mund</firstline>
     <source pages="18-19"/>
     <pictures>
-        <picture src="michaelis201709156-p1.jpg">Stefan Lochner (ca. 1410-1451): <i>Madonna med Violen</i>, før 1450, 121.5 × 102 cm. Kolumba Museum, Köln.</picture>
+        <picture src="michaelis201709156-p1.jpg" museum="kolumba">Stefan Lochner (ca. 1410-1451): <i>Madonna med Violen</i>, før 1450, 121.5 × 102 cm. Kolumba Museum, Köln.</picture>
     </pictures>
     <quality>korrektur1,korrektur2,kilde,side</quality>
 </head>

--- a/fdirs/moliere/portraits.xml
+++ b/fdirs/moliere/portraits.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <pictures>
-  <picture src="p2-oval.jpg" primary="true" square-src="p2-square.jpg">
+  <picture src="p2-oval.jpg" primary="true" square-src="p2-square.jpg" museum="conde">
     Pierre Mignard: <i>Molière</i>, ca. 1658. Musée Condé.
   </picture>
 </pictures>

--- a/fdirs/musset/portraits.xml
+++ b/fdirs/musset/portraits.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <pictures>
-  <picture src="p1-oval.jpg" primary="true" square-src="p1-square.jpg">
+  <picture src="p1-oval.jpg" primary="true" square-src="p1-square.jpg" museum="orsay">
       Charles Landelle (1821-1908): <i>Portrait d'Alfred de Musset</i>, 1854, pastel, 53,5 × 46 cm. Musée d'Orsay.
       <!-- http://www.musee-orsay.fr/en/collections/index-of-works/notice.html?nnumid=018083 -->
   </picture>

--- a/fdirs/nielsenlc/1905.xml
+++ b/fdirs/nielsenlc/1905.xml
@@ -170,7 +170,7 @@ med Roser vi smykkede vor Ransel!
    <firstline>Vi kommer syngende langvejs fra</firstline>
    <source pages="8-9"/>
    <pictures>
-       <picture src="nielsenlc2017100903-p1.jpg">Luca della Robbia (1399/1400-1482): udsnit af <i>Cantoria di Luca della Robbia</i>, 1431-1438, bassorelief. Museo dell'Opera del Duomo, Firenze.</picture>
+       <picture src="nielsenlc2017100903-p1.jpg" museum="operaduomo">Luca della Robbia (1399/1400-1482): udsnit af <i>Cantoria di Luca della Robbia</i>, 1431-1438, bassorelief. Museo dell'Opera del Duomo, Firenze.</picture>
    </pictures>
    <!-- https://it.wikipedia.org/wiki/Cantoria_di_Luca_della_Robbia -->
    <quality>korrektur1,kilde,side</quality>

--- a/fdirs/novalis/portraits.xml
+++ b/fdirs/novalis/portraits.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <pictures>
-  <picture src="p1.jpg" primary="true" square-src="p1-square.jpg">
+  <picture src="p1.jpg" primary="true" square-src="p1-square.jpg" museum="novalis">
     Franz Gareis (1775–1803): <i>Novalis</i>, ca. 1799. Forschungsstätte für Frühromantik und Novalis-Museum, Schloss Oberwiederstedt.
   </picture>
 </pictures>

--- a/fdirs/overbeck/portraits.xml
+++ b/fdirs/overbeck/portraits.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <pictures>
-  <picture src="p1.jpg" primary="true" square-src="p1-square.jpg">
+  <picture src="p1.jpg" primary="true" square-src="p1-square.jpg" museum="behnhaus">
       Rudolph Suhrlandt (1781–1862): <i>Christian Adolph Overbeck</i>, 1818, olie på lærred, 84 × 67,5 cm. Museum Behnhaus Drägerhaus, Lübeck.
   </picture>
 </pictures>

--- a/fdirs/pram/1782.xml
+++ b/fdirs/pram/1782.xml
@@ -73,7 +73,7 @@ Nordens Digtere bebrejdes deres Taushed. Vore afdöde Skialde Tullin, Stenersen,
     <source pages="13-40"/>
     <pictures>
         <picture artwork="juel/emilie-kilde-1784" />
-        <picture src="pram2018071803-p1.jpg">
+        <picture src="pram2018071803-p1.jpg" museum="hamburgerkunsthalle">
             Caspar David Friedrich: <i>Emilias Kilde, 5. Mai 1797</i>, fjer, akvarel, 21,8 × 16,7 cm. Hamburger Kunsthalle, Kupferstichkabinett.
         </picture>
         <picture artwork="jensenca/schimmelmann-1827">

--- a/fdirs/ramsay/portraits.xml
+++ b/fdirs/ramsay/portraits.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <pictures>
-  <picture src="p1.jpg" primary="true" square-src="p1-square.jpg">
+  <picture src="p1.jpg" primary="true" square-src="p1-square.jpg" museum="scotnpg">
     William Aikman: <i>Allan Ramsay</i>, 1722, olie på lærred, 75,7 × 64 cm. Scottish National Portrait Gallery.
   </picture>
 </pictures>

--- a/fdirs/reboul/portraits.xml
+++ b/fdirs/reboul/portraits.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <pictures>
-  <picture src="p1.jpg" primary="true" square-src="p1-square.jpg" year="1857">
+  <picture src="p1.jpg" primary="true" square-src="p1-square.jpg" year="1857" museum="orsay">
     Antoine Crespon: <i>Jean Reboul</i>, albuminpapir på karton, Musée d'Orsay, Paris.
     <!-- https://www.musee-orsay.fr/fr/oeuvres/jean-reboul-ne-nimes-en-1796-mort-en-1864-poete-dit-le-boulanger-nimois-auteur-de-lange-et-lenfant-64668 -->
   </picture>

--- a/fdirs/rimbaud/portraits.xml
+++ b/fdirs/rimbaud/portraits.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <pictures>
-  <picture src="p1.jpg" primary="true" square-src="p1-square.jpg">
+  <picture src="p1.jpg" primary="true" square-src="p1-square.jpg" museum="orsay">
     Henri Fantin-Latour: <i>Un coin du table</i>, 1872, oliemaleri. Musée d'Orsay, Paris. Rimbaud er siddende nummer to fra venstre.
   </picture>
   <picture src="p2.jpg">

--- a/fdirs/rodeh/portraits.xml
+++ b/fdirs/rodeh/portraits.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <pictures>
-  <picture src="p1.jpg" primary="true" square-src="p1-square.jpg" year="1908">
+  <picture src="p1.jpg" primary="true" square-src="p1-square.jpg" year="1908" museum="moderna">
       Edvard Munch: <i>Portræt af den danske forfatter Helge Rode</i>, 1908, olie på lærred, 198 × 96 cm, Moderna Museet, Stockholm.
   </picture>
   <picture src="p2.jpg">

--- a/fdirs/roemer/portraits.xml
+++ b/fdirs/roemer/portraits.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <pictures>
-  <picture src="p1.jpg" primary="true" square-src="p1-square.jpg">
-    Jacob Koninck den yngre: <i>Ole Rømer</i>, ca. 1700, Museum of National History, London.
+  <picture src="p1.jpg" primary="true" square-src="p1-square.jpg" museum="fnm">
+      Jacob Koninck den yngre: <i>Ole Rømer</i>, ca. 1700. Frederiksborg Nationalhistorisk Museum.
   </picture>
 </pictures>

--- a/fdirs/rossettic/portraits.xml
+++ b/fdirs/rossettic/portraits.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <pictures>
-  <picture src="p1.jpg" primary="true" square-src="p1-square.jpg">
+  <picture src="p1.jpg" primary="true" square-src="p1-square.jpg" museum="britishmuseum">
     Dante Gabriel Rossetti: <i>Christina Rossetti</i>, kultegning med hvidt, 1848. British Museum.
   </picture>
 </pictures>

--- a/fdirs/scarron/portraits.xml
+++ b/fdirs/scarron/portraits.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <pictures>
-  <picture src="p1.jpg" primary="true" square-src="p1-square.jpg">
+  <picture src="p1.jpg" primary="true" square-src="p1-square.jpg" museum="tesse">
       Ukendt maler: <i>Paul Scarron</i>, 17. årh. Musée de Tessé, Le Mans, Frankrig.
   </picture>
 </pictures>

--- a/fdirs/schiller/portraits.xml
+++ b/fdirs/schiller/portraits.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <pictures>
-  <picture src="p3.jpg" year="1791">
+  <picture src="p3.jpg" year="1791" museum="skd">
       Anton Graff: <i>Portrait Friedrich Schiller</i>, begyndt 1786, færdiggjort 1791, olie på lærred, 71 × 57 cm. Städtische Galerie Dresden.
   </picture>
   <picture src="p1.jpg" primary="true" square-src="p1-square.jpg" year="1793">

--- a/fdirs/scott/portraits.xml
+++ b/fdirs/scott/portraits.xml
@@ -4,7 +4,7 @@
   </picture>
   <picture src="p2.jpg">
   </picture>
-  <picture src="p3.jpg" primary="true" square-src="p3-square.jpg">
+  <picture src="p3.jpg" primary="true" square-src="p3-square.jpg" museum="scotnpg">
     Sir Henry Raeburn: <i>Portrait of Walter Scott</i>, 1822, olie på lærred. Scottish National Portrait Gallery, Edinburgh.
   </picture>
 </pictures>

--- a/fdirs/sprague/portraits.xml
+++ b/fdirs/sprague/portraits.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <pictures>
-  <picture src="p1.jpg" primary="true" square-src="p1-square.jpg">
+  <picture src="p1.jpg" primary="true" square-src="p1-square.jpg" museum="met">
       Southworth &amp; Hawes: <i>Charles Sprague</i>, daguerreotypi, ca. 1850. The Metropolitan Museum of Art.
   </picture>
 </pictures>

--- a/fdirs/tennyson/1842.xml
+++ b/fdirs/tennyson/1842.xml
@@ -14,9 +14,9 @@
    <indextitle>The Lady of Shallot</indextitle>
    <firstline>On either side the river lie</firstline>
    <pictures>
-      <picture src="tennyson1999041201-p1.jpg">John William Waterhouse (<year>1849</year>-<year>1917</year>): »The Lady of Shalott (looking at Lancelot)« (<year>1894</year>), oliemaleri, 142 × 86 cm, City Art Gallery, Leeds.</picture>
+      <picture src="tennyson1999041201-p1.jpg" museum="leeds">John William Waterhouse (<year>1849</year>-<year>1917</year>): »The Lady of Shalott (looking at Lancelot)« (<year>1894</year>), oliemaleri, 142 × 86 cm, City Art Gallery, Leeds.</picture>
       <picture src="tennyson1999041201-p2.jpg" wikidata="Q2445726" museum="tate" invnr="N01543">John William Waterhouse (<year>1849</year>-<year>1917</year>): »The Lady of Shalott (on boat)« (<year>1888</year>), oliemaleri, 153 × 200 cm.</picture>
-      <picture src="tennyson1999041201-p3.jpg">John William Waterhouse (<year>1849</year>-<year>1917</year>): »"I am half sick of shadows," said the Lady of Shalott« (<year>1916</year>), oliemaleri, 100 × 74 cm, Art Gallery of Ontario, Toronto.</picture>
+      <picture src="tennyson1999041201-p3.jpg" museum="ago">John William Waterhouse (<year>1849</year>-<year>1917</year>): »"I am half sick of shadows," said the Lady of Shalott« (<year>1916</year>), oliemaleri, 100 × 74 cm, Art Gallery of Ontario, Toronto.</picture>
    </pictures>
    <quality>korrektur1</quality>
 </head>

--- a/fdirs/topelius/portraits.xml
+++ b/fdirs/topelius/portraits.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <pictures>
-  <picture src="p1.jpg" primary="true" square-src="p1-square.jpg">
+  <picture src="p1.jpg" primary="true" square-src="p1-square.jpg" museum="helsinkiuni">
     Albert Edelfelt (1854-1905): <i>Zacharias Topelius</i>, 1889. Helsingin yliopistomuseo (Helsinki University Museum).
   </picture>
 </pictures>

--- a/fdirs/welhaven/portraits.xml
+++ b/fdirs/welhaven/portraits.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <pictures>
     <picture artwork="gertner/1843-welhaven" />
-    <picture src="p2.jpg" primary="true" square-src="p2-square.jpg">
+    <picture src="p2.jpg" primary="true" square-src="p2-square.jpg" museum="oslo">
         Carl Peter Lehmann: <i>Johan Sebastian Welhaven</i>, 1842. Oslo Museum.
     </picture>
     <picture src="p3.jpg">

--- a/fdirs/whitman/portraits.xml
+++ b/fdirs/whitman/portraits.xml
@@ -2,7 +2,7 @@
 <pictures>
   <picture src="p1.jpg" primary="true" square-src="p1-square.jpg">
   </picture>
-  <picture src="p2.jpg">
+  <picture src="p2.jpg" museum="smithsoniannpg">
     Mathew Brady Studio: <i>Walt Whitman</i>, ca. 1870. National Portrait Gallery, Smithsonian Institution, Washington DC.
   </picture>
   <picture src="p3.jpg">

--- a/fdirs/wordsworth/portraits.xml
+++ b/fdirs/wordsworth/portraits.xml
@@ -4,8 +4,8 @@
   </picture>
   <picture src="p2.jpg">
   </picture>
-  <picture src="p3.jpg" year="1788">
-    William Shuter: <i>William Wordsworth</i>, 1788, Cornell's Wordsworth Collection.
+  <picture src="p3.jpg" year="1798" museum="cornell">
+    William Shuter: <i>William Wordsworth</i>, 1798, Cornell's Wordsworth Collection.
   </picture>
   <picture src="p4.jpg" year="1831">
     <i>William Wordsworth</i>, stik fra 1831 af et portræt af Benjamin Robert Haydon.


### PR DESCRIPTION
## Ændringer

- opretter 58 nye museer og samlinger i `content/museums.xml`
- knytter 73 billeder til de nye eller allerede registrerede institutioner
- tilføjer verificerede objekt- og inventarnumre for enkelte billeder, hvor de
  officielle kataloger gav entydige oplysninger
- retter Ole Rømers portræt fra den fejlagtige placering “Museum of National
  History, London” til Frederiksborg Nationalhistorisk Museum
- retter William Shuters Wordsworth-portræt fra 1788 til 1798 efter Cornell
  University Librarys samlingsbeskrivelse

## Baggrund

Fase 1 dækkede museer, som allerede var registreret i Kalliope. Denne anden
oprydning dækker billedtekster, der angav andre identificerbare museer,
gallerier, biblioteker og offentlige samlinger.

Den brede afsluttende audit finder ingen resterende sikre museumskandidater uden
`museum`-metadata. Private samlinger og titelblades omtale af bogsamlinger er
bevidst ikke registreret.

## Validering

- `npm test -- --runInBand`: 53 testsuiter og 2.384 tests består
- `npm run build-static`: XML-, artwork-, museums- og sidegenerering består;
  kommandoen stopper efterfølgende ved miljøets utilgængelige
  Elasticsearch-forbindelse (`EPERM`)
- audit af billedtekster med museum-, galleri-, biblioteks- og samlingsnavne er
  ren
- `git diff --check` består
