### PR TITLE
Fjern dobbelte museumsnavne fra billedtekster

### DIFF
--- a/__tests__/museum-captions.test.js
+++ b/__tests__/museum-captions.test.js
@@ -1,0 +1,62 @@
+import fs from 'fs';
+import path from 'path';
+
+const picturePattern =
+  /<picture\b[^>]*\bmuseum="([^"]+)"[^>]*>([\s\S]*?)<\/picture>/g;
+const museumPattern =
+  /<museum\b[^>]*\bid="([^"]+)"[^>]*>[\s\S]*?<name>([^<]+)<\/name>[\s\S]*?<\/museum>/g;
+
+const walkXmlFiles = directory => {
+  const files = [];
+  const visit = current => {
+    fs.readdirSync(current, { withFileTypes: true }).forEach(entry => {
+      const filename = path.join(current, entry.name);
+      if (entry.isDirectory()) {
+        visit(filename);
+      } else if (entry.isFile() && entry.name.endsWith('.xml')) {
+        files.push(filename);
+      }
+    });
+  };
+  visit(directory);
+  return files;
+};
+
+const normalizeText = value =>
+  value
+    .replace(/<[^>]+>/g, ' ')
+    .replace(/\s+/g, ' ')
+    .trim()
+    .toLocaleLowerCase('da');
+
+describe('museum captions', () => {
+  it('derives museum names from metadata instead of descriptions', () => {
+    const museumsXml = fs.readFileSync('content/museums.xml', 'utf8');
+    const museumNames = new Map(
+      Array.from(museumsXml.matchAll(museumPattern)).map(match => [
+        match[1],
+        normalizeText(match[2]),
+      ])
+    );
+    const duplicates = [];
+
+    ['content', 'fdirs']
+      .flatMap(walkXmlFiles)
+      .forEach(filename => {
+        const xml = fs.readFileSync(filename, 'utf8');
+        Array.from(xml.matchAll(picturePattern)).forEach(match => {
+          const museumId = match[1];
+          const museumName = museumNames.get(museumId);
+          if (museumName == null || museumName.length < 6) {
+            return;
+          }
+          const description = normalizeText(match[2]);
+          if (description.includes(museumName)) {
+            duplicates.push(`${filename}: museum="${museumId}"`);
+          }
+        });
+      });
+
+    expect(duplicates).toEqual([]);
+  });
+});

--- a/content/artwork.xml
+++ b/content/artwork.xml
@@ -7,7 +7,7 @@
         August Meyer: <i>Nidarosdomens vestfront</i>, 1839, stik.
     </picture>
     <picture id="skovgaard-vordingborg-1865" wikidata="Q20413899" year="1865" museum="smk" invnr="KMS1731">
-        P.C. Skovgaard: <i>Parti ved Iselingen. I baggrunden Vordingborg Kirke og Gåsetårnet. Septemberaften</i>, 1865, olie på lærred, 51,8 × 66,2 cm. Statens Museum for Kunst.
+        P.C. Skovgaard: <i>Parti ved Iselingen. I baggrunden Vordingborg Kirke og Gåsetårnet. Septemberaften</i>, 1865, olie på lærred, 51,8 × 66,2 cm.
     </picture>
     <picture id="cranach-luther" subject="luther">
         Lucas Cranach der Ältere (ca. 1472-1553): <i>Martin Luther</i>, ukendt år.
@@ -20,12 +20,12 @@
         <!-- metadata checked: 2026-07-16 -->
     </picture>
     <picture id="tizian-amor-sacro-e-amor-profano-1515" wikidata="Q794077" museum="borghese">
-        Tizian: <i>L'Amor sacro e Amor profano</i>, ca. 1515, olie på træ, 118×279 cm. Galleria Borghese, Rom.
+        Tizian: <i>L'Amor sacro e Amor profano</i>, ca. 1515, olie på træ, 118×279 cm.
         <!-- metadata checked: 2026-07-16 -->
     </picture> <!-- https://en.wikipedia.org/wiki/Sacred_and_Profane_Love -->
     <picture id="rivett-carnac-edward-fitzgerald-oval" museum="npg" year="1873">Eva Rivett-Carnac: <i>Edward Fitzgerald</i>, miniature efter et fotografi fra 1873.</picture>
     <picture id="vouet-muses-urania-calliope-1634" wikidata="Q20177132" year="1634 ca." museum="nga">
-        Simon Vouet (Frankrig, 1590-1649): <i>The Muses Urania and Calliope</i>, ca. 1634, olie på panel, 79,8 × 125 cm. National Gallery of Art, Washington, D.C.
+        Simon Vouet (Frankrig, 1590-1649): <i>The Muses Urania and Calliope</i>, ca. 1634, olie på panel, 79,8 × 125 cm.
     </picture>
     <picture id="pajou-calliope-1763" wikidata="Q63809302" year="1763 ca." museum="nga" objid="41722" invnr="1952.5.107">
         Augustin Pajou (Frankrig, 1730-1809): <i>Calliope</i>, ca. 1763, marmor, 158 × 60,8 × 46,1 cm. Samuel H. Kress Collection.

--- a/content/keywords/enhedstanken.xml
+++ b/content/keywords/enhedstanken.xml
@@ -4,8 +4,8 @@
     <title>Enhedstanken</title>
     <pictures>
         <picture artwork="lorentzen/1808-steffens" />
-        <picture src="friedrich1.jpg" museum="kunstpalast">Caspar David Friedrich: <i>Kreuz im Gebirge</i>, 1812, olie på lærred, 45 × 38 cm. Museum Kunstpalast, Düsseldorf.</picture>
-        <picture src="ribera-platon.jpg" museum="picardie">José de Ribera: <i>Platon</i>, 1637. Musée de Picardie, Amiens.</picture>
+        <picture src="friedrich1.jpg" museum="kunstpalast">Caspar David Friedrich: <i>Kreuz im Gebirge</i>, 1812, olie på lærred, 45 × 38 cm.</picture>
+        <picture src="ribera-platon.jpg" museum="picardie">José de Ribera: <i>Platon</i>, 1637.</picture>
     </pictures>
     <related>romantikken</related>
   </head>

--- a/content/keywords/romantismen.xml
+++ b/content/keywords/romantismen.xml
@@ -3,10 +3,10 @@
   <head>
     <title>Romantisme</title>
     <pictures>
-        <picture src="friedrich7.jpg" museum="khm">Den romantiske udlængsel ifølge Caspar David Friedrich: <i>View from the Artist's Studio, Right Window</i>, 1805-1806. 31 × 24 cm. Sepia på papir. Wien Kunsthistorisches Museum.</picture>
+        <picture src="friedrich7.jpg" museum="khm">Den romantiske udlængsel ifølge Caspar David Friedrich: <i>View from the Artist's Studio, Right Window</i>, 1805-1806. 31 × 24 cm. Sepia på papir.</picture>
     <picture portrait="hugo/p3" />
     <picture src="ingres8.jpg" wikidata="Q1978815" museum="louvre">
-      Jean Auguste Dominique Ingres: <i>Grande Odalisque</i>, 1814. Musée du Louvre.
+      Jean Auguste Dominique Ingres: <i>Grande Odalisque</i>, 1814.
       <!-- metadata checked: 2026-07-16 -->
     </picture>
     <picture portrait="heine/p3" />

--- a/fdirs/aarestrup/1976-1.xml
+++ b/fdirs/aarestrup/1976-1.xml
@@ -248,7 +248,7 @@ Og fra Norden lød, dæmpet, den tragiske Sang -
       <note>Om statuen: ''Romerske kopi af græsk original fra ca. 100 f.kr. eller romersk original. Fundet 1506 på Esquilinhøjen i Rom og straks identificeret med en skulpturgruppe af den trojanske præst Laokoon og hans sønner, som ifølge Plinius den Ældre var opstillet i kejser Titus' palads'', <i>Græsk kunst</i>, Gads Forlag, 1999, p. 242.</note>
    </notes>
    <pictures>
-      <picture src="aarestrup1999041505.jpg" museum="vatican">Hagesandros, Athenodoros og Polydoros af Rhodos: <i>Laokoon og hans sønner</i>, 175-150 f.Kr., Museo Pio Clementino, Vatikanet.</picture>
+      <picture src="aarestrup1999041505.jpg" museum="vatican">Hagesandros, Athenodoros og Polydoros af Rhodos: <i>Laokoon og hans sønner</i>, 175-150 f.Kr.</picture>
    </pictures>
    <quality>korrektur1,korrektur2,kilde,side</quality>
    <keywords>rom</keywords>

--- a/fdirs/ahlmann/1910.xml
+++ b/fdirs/ahlmann/1910.xml
@@ -1843,7 +1843,7 @@ bagved den vældige, hærgede Fugl.
     <firstline>Carlyle, du strenge Mester, saa er jeg atter her</firstline>
     <source pages="78-79"/>
     <pictures>
-        <picture src="ahlmann2023071529-p1.jpg" museum="kelvingrove">James McNeill Whistler: <i>Arrangement in Grey and Black, No. 2: Portrait of Thomas Carlyle</i>, olie på lærred, 171 × 143,5 cm, 1872-73, Kelvingrove Art Gallery and Museum, Glasgow.</picture>
+        <picture src="ahlmann2023071529-p1.jpg" museum="kelvingrove">James McNeill Whistler: <i>Arrangement in Grey and Black, No. 2: Portrait of Thomas Carlyle</i>, olie på lærred, 171 × 143,5 cm, 1872-73.</picture>
     </pictures>
     <quality>korrektur1,kilde,side</quality>
 </head>

--- a/fdirs/alfieri/portraits.xml
+++ b/fdirs/alfieri/portraits.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <pictures>
   <picture src="p1.jpg" primary="true" square-src="p1-square.jpg" museum="high">
-    François-Xavier Fabre: <i>Vittorio Alfieri</i>, 1794, olie på lærred. High Museum of Art, Atlanta.
+    François-Xavier Fabre: <i>Vittorio Alfieri</i>, 1794, olie på lærred.
   </picture>
   <picture src="p2.jpg">
     François-Xavier Fabre: <i>Vittorio Alfieri</i>, 1797, olie på lærred. Fondazione Centro Studi Alfieriani, Asti.

--- a/fdirs/arbuthnot/portraits.xml
+++ b/fdirs/arbuthnot/portraits.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <pictures>
   <picture src="p1.jpg" primary="true" square-src="p1-square.jpg" year="1723" museum="hunterian">
-      Godfrey Kneller: <i>Portrait of John Arbuthnot (1667-1735), the physician</i>, 1723, olie på lærred, 75,5 × 63 cm. Hunterian Museum and Art Gallery, University of Glasgow.
+      Godfrey Kneller: <i>Portrait of John Arbuthnot (1667-1735), the physician</i>, 1723, olie på lærred, 75,5 × 63 cm.
   </picture>
 </pictures>

--- a/fdirs/ariosto/portraits.xml
+++ b/fdirs/ariosto/portraits.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <pictures>
   <picture src="p1.jpg" primary="true" square-src="p1-square.jpg" museum="ima">
-      Tizian: <i>Ritratto dell'Ariosto</i>, ca. 1515, olie på lærred, 59,5 × 45,5 cm. Indianapolis Museum of Art.
+      Tizian: <i>Ritratto dell'Ariosto</i>, ca. 1515, olie på lærred, 59,5 × 45,5 cm.
   </picture>
 </pictures>

--- a/fdirs/arnesen-kall/portraits.xml
+++ b/fdirs/arnesen-kall/portraits.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <pictures>
   <picture src="p1.jpg" primary="true" square-src="p1-square.jpg" museum="kb">
-    Ukendt fotograf: <i>Benedicte Arnesen Kall</i>, u.å., fotografi. Det Kongelige Bibliotek.
+    Ukendt fotograf: <i>Benedicte Arnesen Kall</i>, u.å., fotografi.
   </picture>
 </pictures>

--- a/fdirs/bagger/1845.xml
+++ b/fdirs/bagger/1845.xml
@@ -1975,7 +1975,7 @@ Gjør af mig hvadhelst Du behager!''
         <!-- https://www.tagesspiegel.de/wissen/die-abessinierin-im-gefolge-fuerst-puecklers-das-raetsel-der-machbuba/20793600.html -->
     </notes>
    <pictures>
-       <picture src="bagger2017120424-p1.jpg" museum="branitz">Ukendt kunster: <i>Machbuba</i>, 1840. Fürst-Pückler-Museum Park und Schloss Branitz.</picture>
+       <picture src="bagger2017120424-p1.jpg" museum="branitz">Ukendt kunster: <i>Machbuba</i>, 1840.</picture>
    </pictures>
     <source pages="148-149"/>
     <quality>korrektur1,kilde,side</quality>

--- a/fdirs/baudelaire/portraits.xml
+++ b/fdirs/baudelaire/portraits.xml
@@ -4,10 +4,10 @@
     Étienne Carjat (fotograf): <i>Charles Baudelaire</i>, ca. 1862, kulfotografi.
   </picture>
   <picture src="p2.jpg" museum="orsay">
-    Félix Nadar: <i>Charles Baudelaire au fauteuil</i>, 1855, fotografi, Musée d'Orsay, Paris.
+    Félix Nadar: <i>Charles Baudelaire au fauteuil</i>, 1855, fotografi.
   </picture>
   <picture src="p3.jpg" museum="norton">
-    Raymond Duchamp-Villon (1876-1918): <i>Portrait of Baudelaire</i>, 1911, bronze, Norton Museum, West Palm Beach, Florida.
+    Raymond Duchamp-Villon (1876-1918): <i>Portrait of Baudelaire</i>, 1911, bronze.
   </picture>
   <picture src="p4.jpg">
   </picture>

--- a/fdirs/birkedal/portraits.xml
+++ b/fdirs/birkedal/portraits.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <pictures>
   <picture src="p1.jpg" primary="true" square-src="p1-square.jpg" museum="kb" objid="448874">
-      Thora  Hallager (fotograf): <i>Vilhelm Birkedal</i>, ukendt år. Det kongelige Bibliotel.
+      Thora  Hallager (fotograf): <i>Vilhelm Birkedal</i>, ukendt år.
   </picture>
 </pictures>

--- a/fdirs/bjerregaard/portraits.xml
+++ b/fdirs/bjerregaard/portraits.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <pictures>
   <picture src="p1.jpg" primary="true" square-src="p1-square.jpg" museum="oslo">
-      Jacob Munch: <i>Henrik Anker Bjerregaard</i>, ca. 1820, olie på lærred. Oslo Museum.
+      Jacob Munch: <i>Henrik Anker Bjerregaard</i>, ca. 1820, olie på lærred.
       <!-- http://www.oslobilder.no/OMU/OB.00109 -->
   </picture>
 </pictures>

--- a/fdirs/blake/artwork.xml
+++ b/fdirs/blake/artwork.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <pictures>
   <picture id="1824-tree-beasts" year="1824-1-01" museum="ngv">
-      <i>Dante Running from the Three Beasts</i>, 1824-27, blyant, blæk og vandfarve på papir, 370×528 mm. National Gallery of Victoria, Melbourne, Australia.
+      <i>Dante Running from the Three Beasts</i>, 1824-27, blyant, blæk og vandfarve på papir, 370×528 mm.
       <!-- http://www.blakearchive.org/copy/but812.1?descId=but812.1.wc.01 -->
       <!-- Canto I  -->
   </picture>
@@ -31,6 +31,6 @@
       <i>Beatrice Addressing Dante from the Car</i>, 1824-27, blyant, blæk og vandfarve på papir, 372×527 mm.
   </picture>
   <picture id="1824-deity-from" year="1824-3-28" museum="ashmolean">
-      <i>The Deity, from whom proceed the Nine Spheres</i>, 1824-27, blyant, blæk og vandfarve på papir. Ashmolean Museum, University of Oxford.
+      <i>The Deity, from whom proceed the Nine Spheres</i>, 1824-27, blyant, blæk og vandfarve på papir.
   </picture>
 </pictures>

--- a/fdirs/boedtcher/1940.xml
+++ b/fdirs/boedtcher/1940.xml
@@ -6642,7 +6642,7 @@ Min Linas Navn fra Harpens bedste Streng.
    <firstline>Rask flyder Lapseblodet som en Elv</firstline>
    <pictures>
        <picture src="boedtcher2002122509-p1.jpg" museum="kb" objid="472085">
-           Carl Winsløv: <i>Henrik Christian Gottlieb Proft</i>, H.P. Hansen (xylograf), ukendt år. Det Kongelige Bibliotek.
+           Carl Winsløv: <i>Henrik Christian Gottlieb Proft</i>, H.P. Hansen (xylograf), ukendt år.
        </picture>
    </pictures>
    <notes>
@@ -6668,7 +6668,7 @@ Men glemmer kun sig selv.
    <indextitle>Epigram</indextitle>
    <firstline>Iil ej for rask med en tjenstfærdig Haand</firstline>
    <pictures>
-       <picture src="boedtcher2002122510-p1.jpg" museum="kb" objid="447502">George Henricus Rosenkilde (fotograf): <i>Ludvig Bødtcher</i>, ukendt år, Det kongelige Bibliotek</picture>
+       <picture src="boedtcher2002122510-p1.jpg" museum="kb" objid="447502">George Henricus Rosenkilde (fotograf): <i>Ludvig Bødtcher</i>, ukendt år.</picture>
    </pictures>
    <notes>
        <note>* if. A. Dolleris (vistnok personlig Meddelse fra L. B.) er Strofen oprindelig Slutningsstrofe i Digtet <a poem="boedtcher2018101005">,,Drømmeren''</a>. Senere anvendt af Bødtcher som Portrætunderskrift (facsimileret); Fotografiet bl. a. paa Det kgl. Bibliotek (fra Georg Brandes' Bo; jf. Brandes, Danske Digtere (1877) S. 129); et andet Eksemplar findes paa Frederiksborg-Museet. Fotografiet bærer Mærket: G. Rosenstand, Viingaardstræde No. 1, hvilken Adresse if. Kbh. Vejviser tilhører Aarene 1863-73.</note>

--- a/fdirs/boennelycke/1921.xml
+++ b/fdirs/boennelycke/1921.xml
@@ -93,7 +93,7 @@ er din unge Kærlighed. -
     <firstline>Berust af Kyssenes Aande</firstline>
     <source pages="12-14"/>
     <pictures>
-        <picture src="boennelycke2024091702-p1.jpg" museum="prado">Paolo Veronese: <i>Venus og Adonis</i>, olie på lærred, 163 × 192 cm, Museo del Prado</picture>
+        <picture src="boennelycke2024091702-p1.jpg" museum="prado">Paolo Veronese: <i>Venus og Adonis</i>, olie på lærred, 163 × 192 cm.</picture>
         <!-- https://en.wikipedia.org/wiki/File:Venus_y_Adonis_(Veronese).jpg -->
     </pictures>
     <quality>korrektur1,kilde,side</quality>

--- a/fdirs/bregendahl/portraits.xml
+++ b/fdirs/bregendahl/portraits.xml
@@ -1,9 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <pictures>
   <picture src="p2.jpg" museum="kb" objid="481724">
-      Marie Jakobe Brandt-Rehberg (fotograf, 1866-1930): <i>Marie Bregendahl</i>, u. å. Det Kongelige Bibliotek.
+      Marie Jakobe Brandt-Rehberg (fotograf, 1866-1930): <i>Marie Bregendahl</i>, u. å.
   </picture>
   <picture src="p1.jpg" primary="true" square-src="p1-square.jpg" museum="kb" objid="481735">
-      K. Rasmussen (fotograf): <i>Marie Bregendahl</i>, u. å. Det Kongelige Bibliotek.
+      K. Rasmussen (fotograf): <i>Marie Bregendahl</i>, u. å.
   </picture>
 </pictures>

--- a/fdirs/burns/portraits.xml
+++ b/fdirs/burns/portraits.xml
@@ -1,9 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <pictures>
   <picture src="p1-oval.jpg" primary="true" square-src="p1-square.jpg" museum="scotnpg">
-    Alexander Nasmyth (1758–1840): <i>Robert Burns</i>, 1787. Scottish National Portrait Gallery.
+    Alexander Nasmyth (1758–1840): <i>Robert Burns</i>, 1787.
   </picture>
   <picture src="p1.jpg" museum="scotnpg">
-    Alexander Nasmyth (1758–1840): <i>Robert Burns</i>, 1787. Scottish National Portrait Gallery.
+    Alexander Nasmyth (1758–1840): <i>Robert Burns</i>, 1787.
   </picture>
 </pictures>

--- a/fdirs/claussen/portraits.xml
+++ b/fdirs/claussen/portraits.xml
@@ -4,7 +4,7 @@
     René Boivin (fotograf): <i>Sophus Claussen</i>, 1911.
   </picture>
   <picture src="p1.jpg" primary="true" square-src="p1-square.jpg" museum="willumsens">
-    J. F. Willumsen: <i>Portræt af Sophus Claussen</i>, 1915. Willumsens Museum, Frederikssund.
+    J. F. Willumsen: <i>Portræt af Sophus Claussen</i>, 1915.
   </picture>
   <picture src="p2.jpg">
     Sophus Claussen: <i>Selvportræt</i>, 1923-24, Gyldendal.

--- a/fdirs/dalin/portraits.xml
+++ b/fdirs/dalin/portraits.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <pictures>
   <picture src="p1.jpg" primary="true" square-src="p1-square.jpg" museum="falkenberg">
-    Johan Henrik Scheffel (1690-1781): <i>Olof von Dalin</i>, ukendt år. Falkenbergs museum.
+    Johan Henrik Scheffel (1690-1781): <i>Olof von Dalin</i>, ukendt år.
   </picture>
 </pictures>

--- a/fdirs/dante/commedia.xml
+++ b/fdirs/dante/commedia.xml
@@ -649,7 +649,7 @@ fuor de la queta, ne l'aura che trema.
    <firstline>Così discesi del cerchio primaio</firstline>
    <pictures>
        <picture src="dante2005050105-p2.jpg" museum="wallace" objid="65250" invnr="P316">
-           Ary Scheffer (1795-1858): <i>Francesca da Rimini</i>, 1835, olie på lærred, 166,5×234 cm. The Wallace Collection, London.
+           Ary Scheffer (1795-1858): <i>Francesca da Rimini</i>, 1835, olie på lærred, 166,5×234 cm.
        </picture>
        <picture src="dante2005050105-p1.jpg">
            Gustave Doré: <i>Paolo and Francesca da Rimini</i>, 1863, olie på lærred, 279,4×194,3 cm. Privateje.
@@ -1091,7 +1091,7 @@ con li occhi vòlti a chi del fango ingozza.
          <!-- metadata checked: 2026-07-16 -->
        </picture>
        <picture src="dante2005050108-p2.jpg" wikidata="Q2665048" museum="orsay">
-         William-Adolphe Bouguereau: <i>Dante et Virgile</i>, 1850, olie på lærred, 280.5×225.3 cm. Musée d'Orsay.
+         William-Adolphe Bouguereau: <i>Dante et Virgile</i>, 1850, olie på lærred, 280.5×225.3 cm.
          <!-- metadata checked: 2026-07-16 -->
        </picture>
    </pictures>
@@ -4748,7 +4748,7 @@ né sì chinato, lì fece dimora,
    <indextitle>Canto XXXII</indextitle>
    <firstline>S'io avessi le rime aspre e chiocce</firstline>
    <pictures>
-      <picture src="dante2005050132-p1.jpg" museum="brou" invnr="982.234">Gustave Doré: <i>Dante et Vergil dans le neuvième cercle de l'enfer</i>, 1861, olie på lærred, 315×450 cm. Musée du monastère royal de Brou, Bourg-en-Bresse.</picture>
+      <picture src="dante2005050132-p1.jpg" museum="brou" invnr="982.234">Gustave Doré: <i>Dante et Vergil dans le neuvième cercle de l'enfer</i>, 1861, olie på lærred, 315×450 cm.</picture>
    </pictures>
 </head>
 <body>

--- a/fdirs/dellacasa/portraits.xml
+++ b/fdirs/dellacasa/portraits.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <pictures>
   <picture src="p1.jpg" primary="true" square-src="p1-square.jpg" museum="nga">
-     Pontormo (1494-1557): <i>Monsignor della Casa</i>, 1541-44, olie på panel, 102×78,9 cm. National Gallery of Art, Washington, D.C.  <!-- https://commons.wikimedia.org/wiki/File:Jacopo_Pontormo_057.jpg -->
+     Pontormo (1494-1557): <i>Monsignor della Casa</i>, 1541-44, olie på panel, 102×78,9 cm. <!-- https://commons.wikimedia.org/wiki/File:Jacopo_Pontormo_057.jpg -->
   </picture>
 </pictures>

--- a/fdirs/drachmann/1879.xml
+++ b/fdirs/drachmann/1879.xml
@@ -4602,7 +4602,7 @@ mens Sol gaar bag den danske Scene ned.
     <subtitle>(Til G. O. Cederströms Maleri.)</subtitle>
     <firstline>Blød og tavs er Bjærgets Sti</firstline>
     <pictures>
-        <picture src="drachmann1999111027-p1.jpg" museum="natmus.se" objid="18366">Gustaf Cederström (1845-1933): <i>Karl XII:s likfärd</i>, 1878, oliemaleri, 256 × 370 cm. Nationalmuseum, Stockholm.</picture>
+        <picture src="drachmann1999111027-p1.jpg" museum="natmus.se" objid="18366">Gustaf Cederström (1845-1933): <i>Karl XII:s likfärd</i>, 1878, oliemaleri, 256 × 370 cm.</picture>
     </pictures>
     <source pages="174-177"/>
     <quality>korrektur1,kilde,side</quality>

--- a/fdirs/drachmann/1881.xml
+++ b/fdirs/drachmann/1881.xml
@@ -925,7 +925,7 @@ At elske Jord - og Støv - og Skarn.
    <firstline>Ind i det uhyre Rum, hvori Tanken sig taber</firstline>
    <pictures>
       <picture src="drachmann200107158-p2.jpg">Michelangelo: <i>Leda</i> (1529/30)</picture>
-      <picture src="drachmann200107158-p1.jpg" museum="khm">Correggio: <i>Jupiter og Io</i> (1531-32), olie på lærred. Kunsthistorisches Museum, Wien.</picture>
+      <picture src="drachmann200107158-p1.jpg" museum="khm">Correggio: <i>Jupiter og Io</i> (1531-32), olie på lærred.</picture>
    </pictures>
    <quality>korrektur1,kilde</quality>
 </head>

--- a/fdirs/esmann/portraits.xml
+++ b/fdirs/esmann/portraits.xml
@@ -1,9 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <pictures>
   <picture src="p3.jpg" primary="true" square-src="p3-square.jpg" objid="451026" museum="kb">
-      Frederik Riise (fotograf): <i>Gustav Esmann</i>. Det kongelig Bibliotek.
+      Frederik Riise (fotograf): <i>Gustav Esmann</i>.
   </picture>
   <picture src="p2.jpg" objid="451023" museum="kb">
-      Sophus Juncker-Jensen (fotograf): <i>Gustav Esmann</i>. Det kongelig Bibliotek.
+      Sophus Juncker-Jensen (fotograf): <i>Gustav Esmann</i>.
   </picture>
 </pictures>

--- a/fdirs/fonss/1900.xml
+++ b/fdirs/fonss/1900.xml
@@ -491,7 +491,7 @@ som lukker Dig i Mindets Verden ind.
     <toctitle><num>II.</num>Et Steds i Napolimuseets Sale</toctitle>
     <firstline>Et Steds i Napolimuseets Sale</firstline>
     <pictures>
-        <picture src="fonss2018041909-p1.jpg" museum="capodimonte">Titian: <i>Danaë</i>, 1544-46, olie på lærred, 120 × 172 cm. Museo di Capodimonte, Napoli.</picture> <!-- https://en.wikipedia.org/wiki/Danaë_(Titian_series)#/media/File:Tizian_011.jpg -->
+        <picture src="fonss2018041909-p1.jpg" museum="capodimonte">Titian: <i>Danaë</i>, 1544-46, olie på lærred, 120 × 172 cm.</picture> <!-- https://en.wikipedia.org/wiki/Danaë_(Titian_series)#/media/File:Tizian_011.jpg -->
     </pictures>
     <source pages="19"/>
     <keywords>sonnet</keywords>

--- a/fdirs/franzen/portraits.xml
+++ b/fdirs/franzen/portraits.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <pictures>
   <picture src="p1.jpg" primary="true" square-src="p1-square.jpg" museum="natmus.se" objid="40327">
-      Johan Gustaf Sandberg: <i>Frans Mikael Franzén, 1772-1847, biskop, skald</i>, 1828, olie på panel, 23 × 18 cm. National Museum, Gripsholm Slot.
+      Johan Gustaf Sandberg: <i>Frans Mikael Franzén, 1772-1847, biskop, skald</i>, 1828, olie på panel, 23 × 18 cm.
   </picture>
 </pictures>

--- a/fdirs/gertner/artwork.xml
+++ b/fdirs/gertner/artwork.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <pictures>
   <picture id="1842-thorvaldsen" subject="thorvaldsen" year="1842" museum="kunsten">
-      <i>Thorvaldsen ved Oehlenschlägers buste</i>, 1842. Kunsten Museum of Modern Art Aalborg.
+      <i>Thorvaldsen ved Oehlenschlägers buste</i>, 1842.
   </picture>
   <picture id="1843-welhaven" subject="welhaven" year="1851">
       <i>Johan Sebastian Welhaven</i>, sortkridtstegning, 1843.

--- a/fdirs/gilfillan/portraits.xml
+++ b/fdirs/gilfillan/portraits.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <pictures>
   <picture src="p1.jpg" primary="true" square-src="p1-square.jpg" museum="scotnpg">
-    William Home Lizars efter William Wallace: <i>Robert Gilfillan</i>, kobberstik. Scottish National Portrait Gallery.
+    William Home Lizars efter William Wallace: <i>Robert Gilfillan</i>, kobberstik.
   </picture>
 </pictures>

--- a/fdirs/goethe/portraits.xml
+++ b/fdirs/goethe/portraits.xml
@@ -1,15 +1,15 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <pictures>
     <picture src="p7.jpg" year="1787" museum="staedel">
-        Johann Heinrich Wilhelm Tischbein: <i>Goethe in der Campagna</i>, Rom, 1787, olie på lærred, 164 × 206 cm. Städel Museum, Frankfurt.
+        Johann Heinrich Wilhelm Tischbein: <i>Goethe in der Campagna</i>, Rom, 1787, olie på lærred, 164 × 206 cm.
     </picture>
     <picture src="p6.jpg" year="1810" museum="dhm">
-        Gerhard von Kügelgen (1772-1820): <i>Johann Wolfgang von Goethe</i>, Dresden, 1810, olie på lærred, 73,8 × 63,5 cm. Deutsches Historisches Museum, Berlin.
+        Gerhard von Kügelgen (1772-1820): <i>Johann Wolfgang von Goethe</i>, Dresden, 1810, olie på lærred, 73,8 × 63,5 cm.
     </picture>
     <picture src="p3.jpg" primary="true" square-src="p3-square.jpg" year="1822">
         Heinrich Christoph Kolbe: <i>Goethe</i>, 1822, olie på lærred. Goethe-Nationalmuseum, Weimar.
     </picture>
     <picture src="p8.jpg" year="1828" museum="neuepinakothek">
-        Joseph Karl Stieler (1781-1858): <i>Johann Wolfgang von Goethe</i>, 1828, olie på lærred, 78 × 63,8 cm. Neue Pinakothek, München.
+        Joseph Karl Stieler (1781-1858): <i>Johann Wolfgang von Goethe</i>, 1828, olie på lærred, 78 × 63,8 cm.
     </picture>
 </pictures>

--- a/fdirs/goldoni/portraits.xml
+++ b/fdirs/goldoni/portraits.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <pictures>
   <picture src="p1.jpg" primary="true" square-src="p1-square.jpg" museum="lascala">
-    Ukendt kunstner: <i>Ritratto di Goldoni</i>, ca. 1750, pastel. Museo Teatrale alla Scala, Milano.
+    Ukendt kunstner: <i>Ritratto di Goldoni</i>, ca. 1750, pastel.
   </picture>
 </pictures>

--- a/fdirs/goldstein/portraits.xml
+++ b/fdirs/goldstein/portraits.xml
@@ -4,6 +4,6 @@
       Edvard Munch: <i>Emanuel Goldstein</i>.
   </picture>
   <picture src="p2.jpg" museum="munch">
-      Edvard Munch: <i>Panterhode. Goldstein som panter</i>, 1908-1909, kul på velinpapir, 164 × 223 mm. Munch Museet, Oslo.
+      Edvard Munch: <i>Panterhode. Goldstein som panter</i>, 1908-1909, kul på velinpapir, 164 × 223 mm.
   </picture>
 </pictures>

--- a/fdirs/hanseno/portraits.xml
+++ b/fdirs/hanseno/portraits.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <pictures>
   <picture src="p1.jpg" primary="true" square-src="p1-square.jpg" museum="kb" objid="456500">
-      S. Rydbergs Eftf. (fotograf): <i>Olaf Jonas Hansen</i>, ukendt år. Det Kongelige Bibliotek.
+      S. Rydbergs Eftf. (fotograf): <i>Olaf Jonas Hansen</i>, ukendt år.
   </picture>
 </pictures>

--- a/fdirs/hauch/portraits.xml
+++ b/fdirs/hauch/portraits.xml
@@ -10,12 +10,12 @@
     <i>Carsten Hauch</i>, tegnet og litograferet af Emil Bærentzen.
   </picture>
   <picture src="p6.jpg" primary="true" square-src="p6-square.jpg" museum="kb" objid="499">
-    Budtz Müller &amp; Co. (fotograf): <i>Carsten Hauch</i>, 1868 (?), Det Kongelige Bibliotek.
+    Budtz Müller &amp; Co. (fotograf): <i>Carsten Hauch</i>, 1868 (?).
   </picture>
   <picture src="p7.jpg" museum="kb" objid="6100">
-    Georg Hansen (fotograf): <i>Carsten Hauch</i>, Det Kongelige Bibliotek.
+    Georg Hansen (fotograf): <i>Carsten Hauch</i>.
   </picture>
   <picture src="p8.jpg" museum="kb" objid="38458">
-    Rudolph Striegler (fotograf): <i>Carsten Hauch</i>, Det Kongelige Bibliotek.
+    Rudolph Striegler (fotograf): <i>Carsten Hauch</i>.
   </picture>
 </pictures>

--- a/fdirs/hegelund/portraits.xml
+++ b/fdirs/hegelund/portraits.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <pictures>
   <picture src="p1.jpg" primary="true" square-src="p1-square.jpg" museum="sydvestjyske">
-    Ukendt kunstner: <i>Peder Jensen Hegelund</i>. Den Antikvariske Samling, Ribe.
+    Ukendt kunstner: <i>Peder Jensen Hegelund</i>.
   </picture>
 </pictures>

--- a/fdirs/heine/portraits.xml
+++ b/fdirs/heine/portraits.xml
@@ -5,6 +5,6 @@
   <picture src="p2.jpg">
   </picture>
   <picture src="p3.jpg" primary="true" square-src="p3-square.jpg" museum="hamburgerkunsthalle">
-    Moritz Daniel Oppenheim: <i>Heinrich Heine</i>, 1831. Kunsthalle Hamburg
+    Moritz Daniel Oppenheim: <i>Heinrich Heine</i>, 1831.
   </picture>
 </pictures>

--- a/fdirs/hemans/portraits.xml
+++ b/fdirs/hemans/portraits.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <pictures>
   <picture src="p1.jpg" primary="true" square-src="p1-square.jpg" year="1820" museum="nlw" objid="PB7174">
-      <i>Felicia Dorothea Hemans</i>, ca. 1820, litografi. Welsh Portrait Collection, National Library of Wales.<!-- PB7174 -->
+      <i>Felicia Dorothea Hemans</i>, ca. 1820, litografi. Welsh Portrait Collection.<!-- PB7174 -->
   </picture>
 </pictures>

--- a/fdirs/hertzh/1851a.xml
+++ b/fdirs/hertzh/1851a.xml
@@ -3902,8 +3902,8 @@ Boer jeg. Skynd dig og kom! - Huset er vist dig bekjendt.
     <firstline>Den skjønne Fornarina</firstline>
     <source pages="162-163"/>
     <pictures>
-        <picture src="hertz2018021838-p1.jpg" museum="barberinicorsini">Raphael: <i>La Fornarina</i>, 1518-19, olie på panel, 85×60cm. Galleria Nazionale d'Arte Antica, Rom.</picture>
-        <picture src="hertz2018021838-p2.jpg" museum="pushkin">Giulio Romano: <i>Fornarina</i>, ca. 1520, olie på panel, 111×92cm. The Pushkin State Museum of Fine Arts, Moskva.</picture>
+        <picture src="hertz2018021838-p1.jpg" museum="barberinicorsini">Raphael: <i>La Fornarina</i>, 1518-19, olie på panel, 85×60cm.</picture>
+        <picture src="hertz2018021838-p2.jpg" museum="pushkin">Giulio Romano: <i>Fornarina</i>, ca. 1520, olie på panel, 111×92cm.</picture>
     </pictures>
     <quality>korrektur1,kilde,side</quality>
 </head>

--- a/fdirs/holst/1843.xml
+++ b/fdirs/holst/1843.xml
@@ -252,7 +252,7 @@ Til Rom efter Bryllupsvisen.
       <note type="credits">Bidrag fra Sven Sørensen.</note>
    </notes>
    <pictures>
-      <picture src="holst2001042501.jpg" museum="capitolini"><i>Il galata morente</i>, Musei Capitolini, Rom.</picture>
+      <picture src="holst2001042501.jpg" museum="capitolini"><i>Il galata morente</i>.</picture>
    </pictures>
    <quality>korrektur1</quality>
    <keywords>heksameter</keywords>

--- a/fdirs/hugo/1829.xml
+++ b/fdirs/hugo/1829.xml
@@ -216,7 +216,7 @@ Il faut des perles au poignard !
         </notes>
     <pictures>
         <picture src="hugo2018111003-p1.jpg" museum="fabre">
-            Alexandre Cabanel: <i>Albaydé</i>, 1848, olie på lærred, 98×80 cm. Musée Fabre, Montpellier.</picture>
+            Alexandre Cabanel: <i>Albaydé</i>, 1848, olie på lærred, 98×80 cm.</picture>
         <!-- https://commons.wikimedia.org/wiki/File:Alexandre_Cabanel_-_Albayde.jpg -->
         <!-- 'Albaydé' (1848) by Alexandre Cabanel. Oil on canvas. 98 × 80 cm (38.6 × 31.5 in). Location: Musée Fabre, Montpellier, France (le Midi, or southern France). // This portrait is included in the feature, 'The Portrait Gallery' by Sasha Soren, author of 'Random Magic.' // About the portrait: A lush and sensual tableau, depicting an enigmatic woman, whom we gradually realize has already died. Curiouser still, she’s never actually lived; the portrait is based, not on a real woman, but a character - Albaydé. She appears in writer Victor Hugo’s book of poems, 'Les Orientales' (1829). // The character of Albaydé is mentioned in 'Les tronçons du serpent' ('Sections of the Serpent'). The narrator of the poem pities a snake torn into pieces, but - somewhat surreally - the dying serpent speaks to him, saying: Ta plaie est plus cruelle/Car ton Albaydé dans la tombe a fermé/Ses beaux yeux de gazelle. (Your wound is more cruel than mine/ because in the tomb has your Albaydé closed/her beautiful eyes, that were like those of a gazelle.) // Found by @RandomMagicTour - Sasha Soren -->
     </pictures>

--- a/fdirs/jensenca/artwork.xml
+++ b/fdirs/jensenca/artwork.xml
@@ -4,7 +4,7 @@
     <i>B.S. Ingemann</i>, 1818-19.
   </picture>
   <picture id="schimmelmann-1827" year="1827" museum="reventlow">
-      <i>Geheimestatsminister Heinrich Ernst greve Schimmelmann</i>, 1827, olie på lærred, 63,2×50cm. Museum Lolland-Falster (Reventlow Museet).<!-- inv. nr. 003 -->
+      <i>Geheimestatsminister Heinrich Ernst greve Schimmelmann</i>, 1827, olie på lærred, 63,2×50cm.<!-- inv. nr. 003 -->
   </picture>
   <picture id="broendsted-1827" year="1827" museum="glyptoteket">
     <i>Peter Oluf Brøndsted</i>, 1827.
@@ -37,7 +37,7 @@
     <i>Professor dr. med. J.D. Herholdt</i>, 1835, olie på lærred. 23,5 × 19 cm.
   </picture>
   <picture id="andersen-1836" subject="andersen" year="1836" museum="hcandersen">
-    <i>H.C. Andersen</i>, 1836. H.C. Andersen Museet, Odense.
+    <i>H.C. Andersen</i>, 1836.
   </picture>
   <picture id="boedtcher-1836" subject="boedtcher" year="1836" invnr="B444" museum="thorvaldsens">
     <i>Ludvig Bødtcher</i>, 1836, olie på lærred, 36×28,8 cm.

--- a/fdirs/jensenjv/portraits.xml
+++ b/fdirs/jensenjv/portraits.xml
@@ -7,9 +7,9 @@
       Ludvig Find: <i>Johannes V. Jensen</i>.
   </picture>
   <picture src="p2.jpg" year="1927" museum="kb" objid="79801">
-      Ludvig Find: <i>Johannes V. Jensen</i>, 1927, tryk. Det kongelig Bibliotek.
+      Ludvig Find: <i>Johannes V. Jensen</i>, 1927, tryk.
   </picture>
   <picture src="p3.jpg" year="1935" museum="johanneslarsen">
-      Fritz Syberg: <i>Johannes V. Jensen</i>, 1936. Johannes Larsen Museet.
+      Fritz Syberg: <i>Johannes V. Jensen</i>, 1936.
   </picture>
 </pictures>

--- a/fdirs/juel/artwork.xml
+++ b/fdirs/juel/artwork.xml
@@ -22,7 +22,7 @@
         <i>Tyge Jesper Rothe</i>, ca. 1780, olie på lærred.
     </picture>
     <picture id="christian7-1-oval" year="1782" subject="christian7" museum="reventlow">
-        <i>Christian VII</i>, 1782, olie på lærred, 73,5×54,5cm. Reventlow-Museet.
+        <i>Christian VII</i>, 1782, olie på lærred, 73,5×54,5cm.
     </picture>
     <picture id="emilie-kilde-1784" year="1784">
         <i>Emilie Kilde</i>, 1784, olie på lærred, 49×37,5cm. Brandts, Odense.

--- a/fdirs/levy/portraits.xml
+++ b/fdirs/levy/portraits.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <pictures>
-    <picture src="p1.jpg" primary="true" square-src="p1-square.jpg" museum="kb" objid="466910">Sigurd Trier (1876-1920, fotograf): <i>Louis Levy</i>, u.å., fotografi. Det Kongelige Bibliotek.</picture>
-    <picture src="p2.jpg" museum="kb" objid="466920" year="1939">Simma Korzen (fotograf): <i>Louis Levy</i>, 1939, fotografi. Det Kongelige Bibliotek.</picture>
+    <picture src="p1.jpg" primary="true" square-src="p1-square.jpg" museum="kb" objid="466910">Sigurd Trier (1876-1920, fotograf): <i>Louis Levy</i>, u.å., fotografi.</picture>
+    <picture src="p2.jpg" museum="kb" objid="466920" year="1939">Simma Korzen (fotograf): <i>Louis Levy</i>, 1939, fotografi.</picture>
 </pictures>

--- a/fdirs/lovelace/portraits.xml
+++ b/fdirs/lovelace/portraits.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <pictures>
   <picture src="p1.jpg" primary="true" square-src="p1-square.jpg" museum="dulwich">
-    William Dobson (1610-1646): <i>Richard Lovelace</i>, Dulwich Picture Gallery, London.
+    William Dobson (1610-1646): <i>Richard Lovelace</i>.
   </picture>
 </pictures>

--- a/fdirs/luetken/portraits.xml
+++ b/fdirs/luetken/portraits.xml
@@ -9,7 +9,7 @@
       <!-- Der er stadig copyright på dette billede -->
   </picture>
   <picture src="p3.jpg" museum="kirstenkjaer">
-      Kirsten Kjær (1893-1985): <i>Hulda Lütken</i>, 1942. Kirsten Kjær Museum, Frøstrup.
+      Kirsten Kjær (1893-1985): <i>Hulda Lütken</i>, 1942.
       <!-- Der er stadig copyright på dette billede -->
   </picture>
 </pictures>

--- a/fdirs/mallarme/portraits.xml
+++ b/fdirs/mallarme/portraits.xml
@@ -7,6 +7,6 @@
     Paul Nadar (fotograf): <i>Stéphane Mallarmé</i>, 1896.
   </picture>
   <picture src="p3.jpg" museum="orsay">
-    Édouard Manet (1832–1883): <i>Stéphane Mallarmé</i>, 1876, olie på lærred. Musée d'Orsay.
+    Édouard Manet (1832–1883): <i>Stéphane Mallarmé</i>, 1876, olie på lærred.
   </picture>
 </pictures>

--- a/fdirs/matthison/1900.xml
+++ b/fdirs/matthison/1900.xml
@@ -703,7 +703,7 @@ paa Nattens dunkle Himmel.
     <firstline>Vildt, vildt, vildt bryder Blæsten om Land</firstline>
     <source pages="33"/>
     <pictures>
-        <picture src="matthison2019051717-p1.jpg" museum="schack" objid="k2xnZJgxPd" invnr="11536">Arnold Böcklin: <i>Villa am Meer II</i>, 1865, olie på lærred. Sammlung Schack, München.</picture>
+        <picture src="matthison2019051717-p1.jpg" museum="schack" objid="k2xnZJgxPd" invnr="11536">Arnold Böcklin: <i>Villa am Meer II</i>, 1865, olie på lærred.</picture>
     </pictures>
     <quality>korrektur1,kilde,side</quality>
 </head>

--- a/fdirs/michaelis/1900.xml
+++ b/fdirs/michaelis/1900.xml
@@ -44,7 +44,7 @@ og naaet den sidste store Horisont.
     <firstline>Barsk er din Ynde. Din buede Læbe ej kender til Latter</firstline>
     <source pages="9-10"/>
     <pictures>
-        <picture src="michaelis201709151-p1.jpg" museum="bolognaarchaeological"><i>L'Athena Lemnia</i>, marmor, græsk, ca. 451-448 f.Kr., Museo civico archeologico, Bologna.</picture>
+        <picture src="michaelis201709151-p1.jpg" museum="bolognaarchaeological"><i>L'Athena Lemnia</i>, marmor, græsk, ca. 451-448 f.Kr.</picture>
     </pictures>
     <quality>korrektur1,korrektur2,kilde,side</quality>
 </head>
@@ -258,7 +258,7 @@ Det er Slaven, der retter sin trodsige Krop
     <firstline>Milde Kölner-Moder med din lille Mund</firstline>
     <source pages="18-19"/>
     <pictures>
-        <picture src="michaelis201709156-p1.jpg" museum="kolumba">Stefan Lochner (ca. 1410-1451): <i>Madonna med Violen</i>, før 1450, 121.5 × 102 cm. Kolumba Museum, Köln.</picture>
+        <picture src="michaelis201709156-p1.jpg" museum="kolumba">Stefan Lochner (ca. 1410-1451): <i>Madonna med Violen</i>, før 1450, 121.5 × 102 cm.</picture>
     </pictures>
     <quality>korrektur1,korrektur2,kilde,side</quality>
 </head>
@@ -2085,7 +2085,7 @@ i Øjets bundløse Sø.
     <source pages="93-94"/>
     <pictures>
         <picture src="michaelis2017091542-p1.jpg" wikidata="Q2252345" museum="rijksmuseum">
-          Rembrandt: <i>The anatomy lesson of Dr. Joan Deyman</i>, ca. 1666, olie på lærred, 100 × 134 cm. Rijksmuseum, Amsterdam.
+          Rembrandt: <i>The anatomy lesson of Dr. Joan Deyman</i>, ca. 1666, olie på lærred, 100 × 134 cm.
           <!-- metadata checked: 2026-07-16 -->
         </picture>
     </pictures>

--- a/fdirs/molbech/portraits.xml
+++ b/fdirs/molbech/portraits.xml
@@ -4,12 +4,12 @@
       Fra P. Hansen: <i>Illustreret Dansk Litteraturhistorie</i>, 2. udg, 1902.
   </picture>
   <picture src="p2.jpg" primary="true" square-src="p2-square.jpg" museum="kb" objid="465532">
-      Jens Petersen (fotograf): <i>Chr.K.F. Molbech</i>, ukendt år. Det Kongelige Bibliotek.
+      Jens Petersen (fotograf): <i>Chr.K.F. Molbech</i>, ukendt år.
   </picture>
   <picture src="p3.jpg" museum="kb" objid="465538">
-    Barthold Friedrich Brütt (fotograf): <i>Chr.K.F. Molbech</i>, ukendt år. Det Kongelige Bibliotek.
+    Barthold Friedrich Brütt (fotograf): <i>Chr.K.F. Molbech</i>, ukendt år.
   </picture>
   <picture src="p4.jpg" museum="kb" objid="443560">
-    <i>Chr.K.F. Molbech</i>, grafik. Det Kongelige Bibliotek.
+    <i>Chr.K.F. Molbech</i>, grafik.
   </picture>
 </pictures>

--- a/fdirs/moliere/portraits.xml
+++ b/fdirs/moliere/portraits.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <pictures>
   <picture src="p2-oval.jpg" primary="true" square-src="p2-square.jpg" museum="conde">
-    Pierre Mignard: <i>Molière</i>, ca. 1658. Musée Condé.
+    Pierre Mignard: <i>Molière</i>, ca. 1658.
   </picture>
 </pictures>

--- a/fdirs/musset/portraits.xml
+++ b/fdirs/musset/portraits.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <pictures>
   <picture src="p1-oval.jpg" primary="true" square-src="p1-square.jpg" museum="orsay">
-      Charles Landelle (1821-1908): <i>Portrait d'Alfred de Musset</i>, 1854, pastel, 53,5 × 46 cm. Musée d'Orsay.
+      Charles Landelle (1821-1908): <i>Portrait d'Alfred de Musset</i>, 1854, pastel, 53,5 × 46 cm.
       <!-- http://www.musee-orsay.fr/en/collections/index-of-works/notice.html?nnumid=018083 -->
   </picture>
 </pictures>

--- a/fdirs/nielsenlc/1905.xml
+++ b/fdirs/nielsenlc/1905.xml
@@ -170,7 +170,7 @@ med Roser vi smykkede vor Ransel!
    <firstline>Vi kommer syngende langvejs fra</firstline>
    <source pages="8-9"/>
    <pictures>
-       <picture src="nielsenlc2017100903-p1.jpg" museum="operaduomo">Luca della Robbia (1399/1400-1482): udsnit af <i>Cantoria di Luca della Robbia</i>, 1431-1438, bassorelief. Museo dell'Opera del Duomo, Firenze.</picture>
+       <picture src="nielsenlc2017100903-p1.jpg" museum="operaduomo">Luca della Robbia (1399/1400-1482): udsnit af <i>Cantoria di Luca della Robbia</i>, 1431-1438, bassorelief.</picture>
    </pictures>
    <!-- https://it.wikipedia.org/wiki/Cantoria_di_Luca_della_Robbia -->
    <quality>korrektur1,kilde,side</quality>

--- a/fdirs/nielsenz/portraits.xml
+++ b/fdirs/nielsenz/portraits.xml
@@ -1,4 +1,4 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <pictures>
-  <picture src="p1.jpg" primary="true" square-src="p1-square.jpg" museum="kb" objid="486143">Hansen &amp; Weller (fotografer): <i>Zakarias Nielsen</i>, ukendt år, fotografi. Det Kongelige Bibliotek.</picture>
+  <picture src="p1.jpg" primary="true" square-src="p1-square.jpg" museum="kb" objid="486143">Hansen &amp; Weller (fotografer): <i>Zakarias Nielsen</i>, ukendt år, fotografi.</picture>
 </pictures>

--- a/fdirs/novalis/portraits.xml
+++ b/fdirs/novalis/portraits.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <pictures>
   <picture src="p1.jpg" primary="true" square-src="p1-square.jpg" museum="novalis">
-    Franz Gareis (1775–1803): <i>Novalis</i>, ca. 1799. Forschungsstätte für Frühromantik und Novalis-Museum, Schloss Oberwiederstedt.
+    Franz Gareis (1775–1803): <i>Novalis</i>, ca. 1799.
   </picture>
 </pictures>

--- a/fdirs/oehlenschlaeger/1860-20.xml
+++ b/fdirs/oehlenschlaeger/1860-20.xml
@@ -973,7 +973,7 @@ Og den gode Sag.
        <note>Ove Malling (1747-1829); der alluderes til hans bog, <i>Store og gode Handlinger af Danske, Norske og Holstenere,</i> 1777.</note>
    </notes>
    <pictures>
-       <picture src="oehlen2002011501-p1.jpg" museum="smk" invnr="KKSgb11583">J.F. Clemens (kobberstikker) efter forlæg af C.G. Kratzenstein Stub: <i>Ove Malling</i>, 242 × 174 mm, 1810. Den Kongelige Kobberstiksamling.</picture>
+       <picture src="oehlen2002011501-p1.jpg" museum="smk" invnr="KKSgb11583">J.F. Clemens (kobberstikker) efter forlæg af C.G. Kratzenstein Stub: <i>Ove Malling</i>, 242 × 174 mm, 1810.</picture>
    </pictures>
    <source pages="26"/>
    <quality>korrektur1,korrektur2,kilde,side</quality>

--- a/fdirs/oehlenschlaeger/1860-22.xml
+++ b/fdirs/oehlenschlaeger/1860-22.xml
@@ -10068,7 +10068,7 @@ Gud skienker Fremtid Grøde.
     <firstline>Skiøn er den Fest, som Ætten fryder</firstline>
     <pictures>
         <picture src="oehlenschlaeger20190218124-p1.jpg" year="1840-1843" museum="smk" invnr="KMS493">
-            Sophus Schack: <i>Christian VIII og Caroline Amalies salving i Frederiksborg Slotskirke den 28. juni 1840</i>, 1840-1943, olie på lærred, 295 × 222 cm. Statens Museem for Kunst.
+            Sophus Schack: <i>Christian VIII og Caroline Amalies salving i Frederiksborg Slotskirke den 28. juni 1840</i>, 1840-1943, olie på lærred, 295 × 222 cm.
         </picture>
     </pictures>
     <source pages="267-277"/>

--- a/fdirs/overbeck/portraits.xml
+++ b/fdirs/overbeck/portraits.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <pictures>
   <picture src="p1.jpg" primary="true" square-src="p1-square.jpg" museum="behnhaus">
-      Rudolph Suhrlandt (1781–1862): <i>Christian Adolph Overbeck</i>, 1818, olie på lærred, 84 × 67,5 cm. Museum Behnhaus Drägerhaus, Lübeck.
+      Rudolph Suhrlandt (1781–1862): <i>Christian Adolph Overbeck</i>, 1818, olie på lærred, 84 × 67,5 cm.
   </picture>
 </pictures>

--- a/fdirs/plough/1861.xml
+++ b/fdirs/plough/1861.xml
@@ -3171,7 +3171,7 @@ For Folkets friske, sunde Liv i Norden.
     <subtitle>(8de August 1859)</subtitle>
     <firstline>Nu aabnes Riddarholmens Kongebolig</firstline>
    <pictures>
-       <picture src="plough2018031458-p1.jpg" museum="natmus.se" objid="80941">Fredric Westin: <i>Oskar I, 1799-1859, kung av Sverige och Norge</i>, 1825, olie på lærred, 80,5×64,5cm. Nationalmuseet, Stockholm.</picture>
+       <picture src="plough2018031458-p1.jpg" museum="natmus.se" objid="80941">Fredric Westin: <i>Oskar I, 1799-1859, kung av Sverige och Norge</i>, 1825, olie på lærred, 80,5×64,5cm.</picture>
    </pictures>
    <source pages="106-113"/>
     <quality>korrektur1,korrektur2,kilde,side</quality>

--- a/fdirs/pram/1782.xml
+++ b/fdirs/pram/1782.xml
@@ -74,7 +74,7 @@ Nordens Digtere bebrejdes deres Taushed. Vore afdöde Skialde Tullin, Stenersen,
     <pictures>
         <picture artwork="juel/emilie-kilde-1784" />
         <picture src="pram2018071803-p1.jpg" museum="hamburgerkunsthalle">
-            Caspar David Friedrich: <i>Emilias Kilde, 5. Mai 1797</i>, fjer, akvarel, 21,8 × 16,7 cm. Hamburger Kunsthalle, Kupferstichkabinett.
+            Caspar David Friedrich: <i>Emilias Kilde, 5. Mai 1797</i>, fjer, akvarel, 21,8 × 16,7 cm., Kupferstichkabinett.
         </picture>
         <picture artwork="jensenca/schimmelmann-1827">
             Den 80-årige Schimmelmann lod sig i 1827 male af C.A. Jensen.

--- a/fdirs/ramsay/portraits.xml
+++ b/fdirs/ramsay/portraits.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <pictures>
   <picture src="p1.jpg" primary="true" square-src="p1-square.jpg" museum="scotnpg">
-    William Aikman: <i>Allan Ramsay</i>, 1722, olie på lærred, 75,7 × 64 cm. Scottish National Portrait Gallery.
+    William Aikman: <i>Allan Ramsay</i>, 1722, olie på lærred, 75,7 × 64 cm.
   </picture>
 </pictures>

--- a/fdirs/reboul/portraits.xml
+++ b/fdirs/reboul/portraits.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <pictures>
   <picture src="p1.jpg" primary="true" square-src="p1-square.jpg" year="1857" museum="orsay">
-    Antoine Crespon: <i>Jean Reboul</i>, albuminpapir på karton, Musée d'Orsay, Paris.
+    Antoine Crespon: <i>Jean Reboul</i>, albuminpapir på karton.
     <!-- https://www.musee-orsay.fr/fr/oeuvres/jean-reboul-ne-nimes-en-1796-mort-en-1864-poete-dit-le-boulanger-nimois-auteur-de-lange-et-lenfant-64668 -->
   </picture>
 </pictures>

--- a/fdirs/rimbaud/portraits.xml
+++ b/fdirs/rimbaud/portraits.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <pictures>
   <picture src="p1.jpg" primary="true" square-src="p1-square.jpg" museum="orsay">
-    Henri Fantin-Latour: <i>Un coin du table</i>, 1872, oliemaleri. Musée d'Orsay, Paris. Rimbaud er siddende nummer to fra venstre.
+    Henri Fantin-Latour: <i>Un coin du table</i>, 1872, oliemaleri. Rimbaud er siddende nummer to fra venstre.
   </picture>
   <picture src="p2.jpg">
     Cazal: <i>Arthur Rimbaud</i>, 1872, skitse.

--- a/fdirs/rodeh/portraits.xml
+++ b/fdirs/rodeh/portraits.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <pictures>
   <picture src="p1.jpg" primary="true" square-src="p1-square.jpg" year="1908" museum="moderna">
-      Edvard Munch: <i>Portræt af den danske forfatter Helge Rode</i>, 1908, olie på lærred, 198 × 96 cm, Moderna Museet, Stockholm.
+      Edvard Munch: <i>Portræt af den danske forfatter Helge Rode</i>, 1908, olie på lærred, 198 × 96 cm.
   </picture>
   <picture src="p2.jpg">
       Ebbe Rode: <i>Helge Rode</i>, ukendt år, tegning. Det Kongelige Bibliotek. ,,Skuespilleren Ebbe Rodes (1910-1998) tegning af sin far.''

--- a/fdirs/roemer/portraits.xml
+++ b/fdirs/roemer/portraits.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <pictures>
   <picture src="p1.jpg" primary="true" square-src="p1-square.jpg" museum="fnm">
-      Jacob Koninck den yngre: <i>Ole Rømer</i>, ca. 1700. Frederiksborg Nationalhistorisk Museum.
+      Jacob Koninck den yngre: <i>Ole Rømer</i>, ca. 1700.
   </picture>
 </pictures>

--- a/fdirs/rossettic/portraits.xml
+++ b/fdirs/rossettic/portraits.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <pictures>
   <picture src="p1.jpg" primary="true" square-src="p1-square.jpg" museum="britishmuseum">
-    Dante Gabriel Rossetti: <i>Christina Rossetti</i>, kultegning med hvidt, 1848. British Museum.
+    Dante Gabriel Rossetti: <i>Christina Rossetti</i>, kultegning med hvidt, 1848.
   </picture>
 </pictures>

--- a/fdirs/scarron/portraits.xml
+++ b/fdirs/scarron/portraits.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <pictures>
   <picture src="p1.jpg" primary="true" square-src="p1-square.jpg" museum="tesse">
-      Ukendt maler: <i>Paul Scarron</i>, 17. årh. Musée de Tessé, Le Mans, Frankrig.
+      Ukendt maler: <i>Paul Scarron</i>, 17. årh.
   </picture>
 </pictures>

--- a/fdirs/schiller/portraits.xml
+++ b/fdirs/schiller/portraits.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <pictures>
   <picture src="p3.jpg" year="1791" museum="skd">
-      Anton Graff: <i>Portrait Friedrich Schiller</i>, begyndt 1786, færdiggjort 1791, olie på lærred, 71 × 57 cm. Städtische Galerie Dresden.
+      Anton Graff: <i>Portrait Friedrich Schiller</i>, begyndt 1786, færdiggjort 1791, olie på lærred, 71 × 57 cm.
   </picture>
   <picture src="p1.jpg" primary="true" square-src="p1-square.jpg" year="1793">
     Ludovike Simanowiz (1759-1827): <i>Friedrich Schiller</i>, mellem 1793 og 1794.

--- a/fdirs/scott/portraits.xml
+++ b/fdirs/scott/portraits.xml
@@ -5,6 +5,6 @@
   <picture src="p2.jpg">
   </picture>
   <picture src="p3.jpg" primary="true" square-src="p3-square.jpg" museum="scotnpg">
-    Sir Henry Raeburn: <i>Portrait of Walter Scott</i>, 1822, olie på lærred. Scottish National Portrait Gallery, Edinburgh.
+    Sir Henry Raeburn: <i>Portrait of Walter Scott</i>, 1822, olie på lærred.
   </picture>
 </pictures>

--- a/fdirs/sprague/portraits.xml
+++ b/fdirs/sprague/portraits.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <pictures>
   <picture src="p1.jpg" primary="true" square-src="p1-square.jpg" museum="met">
-      Southworth &amp; Hawes: <i>Charles Sprague</i>, daguerreotypi, ca. 1850. The Metropolitan Museum of Art.
+      Southworth &amp; Hawes: <i>Charles Sprague</i>, daguerreotypi, ca. 1850.
   </picture>
 </pictures>

--- a/fdirs/tennyson/1842.xml
+++ b/fdirs/tennyson/1842.xml
@@ -14,9 +14,9 @@
    <indextitle>The Lady of Shallot</indextitle>
    <firstline>On either side the river lie</firstline>
    <pictures>
-      <picture src="tennyson1999041201-p1.jpg" museum="leeds">John William Waterhouse (<year>1849</year>-<year>1917</year>): »The Lady of Shalott (looking at Lancelot)« (<year>1894</year>), oliemaleri, 142 × 86 cm, City Art Gallery, Leeds.</picture>
+      <picture src="tennyson1999041201-p1.jpg" museum="leeds">John William Waterhouse (<year>1849</year>-<year>1917</year>): »The Lady of Shalott (looking at Lancelot)« (<year>1894</year>), oliemaleri, 142 × 86 cm.</picture>
       <picture src="tennyson1999041201-p2.jpg" wikidata="Q2445726" museum="tate" invnr="N01543">John William Waterhouse (<year>1849</year>-<year>1917</year>): »The Lady of Shalott (on boat)« (<year>1888</year>), oliemaleri, 153 × 200 cm.</picture>
-      <picture src="tennyson1999041201-p3.jpg" museum="ago">John William Waterhouse (<year>1849</year>-<year>1917</year>): »"I am half sick of shadows," said the Lady of Shalott« (<year>1916</year>), oliemaleri, 100 × 74 cm, Art Gallery of Ontario, Toronto.</picture>
+      <picture src="tennyson1999041201-p3.jpg" museum="ago">John William Waterhouse (<year>1849</year>-<year>1917</year>): »"I am half sick of shadows," said the Lady of Shalott« (<year>1916</year>), oliemaleri, 100 × 74 cm.</picture>
    </pictures>
    <quality>korrektur1</quality>
 </head>

--- a/fdirs/topelius/portraits.xml
+++ b/fdirs/topelius/portraits.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <pictures>
   <picture src="p1.jpg" primary="true" square-src="p1-square.jpg" museum="helsinkiuni">
-    Albert Edelfelt (1854-1905): <i>Zacharias Topelius</i>, 1889. Helsingin yliopistomuseo (Helsinki University Museum).
+    Albert Edelfelt (1854-1905): <i>Zacharias Topelius</i>, 1889.
   </picture>
 </pictures>

--- a/fdirs/welhaven/portraits.xml
+++ b/fdirs/welhaven/portraits.xml
@@ -2,7 +2,7 @@
 <pictures>
     <picture artwork="gertner/1843-welhaven" />
     <picture src="p2.jpg" primary="true" square-src="p2-square.jpg" museum="oslo">
-        Carl Peter Lehmann: <i>Johan Sebastian Welhaven</i>, 1842. Oslo Museum.
+        Carl Peter Lehmann: <i>Johan Sebastian Welhaven</i>, 1842.
     </picture>
     <picture src="p3.jpg">
         Jacob Calmeyer: <i>Dikteren Johan Sebastian Welhaven</i>, 1827. Nasjonalmuseet, Oslo.

--- a/fdirs/whitman/portraits.xml
+++ b/fdirs/whitman/portraits.xml
@@ -3,7 +3,7 @@
   <picture src="p1.jpg" primary="true" square-src="p1-square.jpg">
   </picture>
   <picture src="p2.jpg" museum="smithsoniannpg">
-    Mathew Brady Studio: <i>Walt Whitman</i>, ca. 1870. National Portrait Gallery, Smithsonian Institution, Washington DC.
+    Mathew Brady Studio: <i>Walt Whitman</i>, ca. 1870.
   </picture>
   <picture src="p3.jpg">
   </picture>

--- a/fdirs/wordsworth/portraits.xml
+++ b/fdirs/wordsworth/portraits.xml
@@ -5,7 +5,7 @@
   <picture src="p2.jpg">
   </picture>
   <picture src="p3.jpg" year="1798" museum="cornell">
-    William Shuter: <i>William Wordsworth</i>, 1798, Cornell's Wordsworth Collection.
+    William Shuter: <i>William Wordsworth</i>, 1798.
   </picture>
   <picture src="p4.jpg" year="1831">
     <i>William Wordsworth</i>, stik fra 1831 af et portræt af Benjamin Robert Haydon.


### PR DESCRIPTION
## Ændringer

- fjerner 101 redundante museumsnavne fra billedbeskrivelser
- lader fortsat `museum`-id'et levere det kanoniske, linkede navn
- bevarer særskilte kreditlinjer og oplysninger om andre institutioner, fx
  Samuel H. Kress Collection
- tilføjer en test, som opdager kanoniske museumsnavne i beskrivelser med samme
  `museum`-id

## Baggrund

`FigCaption` renderer først billedbeskrivelsen og tilføjer derefter museets navn
fra `content/museums.xml` som et internt link. Når navnet også stod i
beskrivelsen, blev det vist to gange.

PR'en er lagt oven på fase 2 i #1353. Den tilsvarende oprydning af fase
1-posterne føjes direkte til #1351, så faseopdelingen bevares.

Fixes #1354

## Validering

- `npm test -- --runInBand`: 54 testsuiter og 2.385 tests består
- `npm run build-static`: XML-, artwork-, museums- og sidegenerering består;
  kommandoen stopper efterfølgende ved miljøets utilgængelige
  Elasticsearch-forbindelse (`EPERM`)
- `git diff --check` består
