### PR TITLE
Fuldfør museumslinks med objekt-id’er

### DIFF
--- a/content/museums.xml
+++ b/content/museums.xml
@@ -142,6 +142,7 @@
   </museum>
   <museum id="orsay">
     <name>Musée d'Orsay</name>
+    <deep-link>https://www.musee-orsay.fr/fr/oeuvres/${objId}</deep-link>
   </museum>
   <museum id="norton">
     <name>Norton Museum of Art</name>
@@ -151,12 +152,14 @@
   </museum>
   <museum id="ngv">
     <name>National Gallery of Victoria</name>
+    <deep-link>https://www.ngv.vic.gov.au/explore/collection/work/${objId}/</deep-link>
   </museum>
   <museum id="ashmolean">
     <name>Ashmolean Museum</name>
   </museum>
   <museum id="prado">
     <name>Museo Nacional del Prado</name>
+    <deep-link>https://www.museodelprado.es/en/the-collection/art-work/${objId}</deep-link>
   </museum>
   <museum id="scotnpg">
     <name>Scottish National Portrait Gallery</name>
@@ -241,6 +244,7 @@
   </museum>
   <museum id="britishmuseum">
     <name>The British Museum</name>
+    <deep-link>https://www.britishmuseum.org/collection/object/${objId}</deep-link>
   </museum>
   <museum id="tesse">
     <name>Musée de Tessé</name>
@@ -250,6 +254,7 @@
   </museum>
   <museum id="met">
     <name>The Metropolitan Museum of Art</name>
+    <deep-link>https://www.metmuseum.org/art/collection/search/${objId}</deep-link>
   </museum>
   <museum id="leeds">
     <name>Leeds Art Gallery</name>

--- a/fdirs/baudelaire/portraits.xml
+++ b/fdirs/baudelaire/portraits.xml
@@ -3,7 +3,7 @@
   <picture src="p1.jpg" primary="true" square-src="p1-square.jpg">
     Étienne Carjat (fotograf): <i>Charles Baudelaire</i>, ca. 1862, kulfotografi.
   </picture>
-  <picture src="p2.jpg" museum="orsay">
+  <picture src="p2.jpg" museum="orsay" objid="charles-baudelaire-au-fauteuil-50501" invnr="PHO 1991 2 1">
     Félix Nadar: <i>Charles Baudelaire au fauteuil</i>, 1855, fotografi, Musée d'Orsay, Paris.
   </picture>
   <picture src="p3.jpg" museum="norton">

--- a/fdirs/blake/artwork.xml
+++ b/fdirs/blake/artwork.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <pictures>
-  <picture id="1824-tree-beasts" year="1824-1-01" museum="ngv">
+  <picture id="1824-tree-beasts" year="1824-1-01" museum="ngv" objid="26892" invnr="988-3">
       <i>Dante Running from the Three Beasts</i>, 1824-27, blyant, blæk og vandfarve på papir, 370×528 mm. National Gallery of Victoria, Melbourne, Australia.
       <!-- http://www.blakearchive.org/copy/but812.1?descId=but812.1.wc.01 -->
       <!-- Canto I  -->

--- a/fdirs/boennelycke/1921.xml
+++ b/fdirs/boennelycke/1921.xml
@@ -93,7 +93,7 @@ er din unge Kærlighed. -
     <firstline>Berust af Kyssenes Aande</firstline>
     <source pages="12-14"/>
     <pictures>
-        <picture src="boennelycke2024091702-p1.jpg" museum="prado">Paolo Veronese: <i>Venus og Adonis</i>, olie på lærred, 163 × 192 cm, Museo del Prado</picture>
+        <picture src="boennelycke2024091702-p1.jpg" museum="prado" objid="venus-and-adonis/692667da-d0f5-4765-ba03-30fdce3513d1" invnr="P000482">Paolo Veronese: <i>Venus og Adonis</i>, olie på lærred, 163 × 192 cm, Museo del Prado</picture>
         <!-- https://en.wikipedia.org/wiki/File:Venus_y_Adonis_(Veronese).jpg -->
     </pictures>
     <quality>korrektur1,kilde,side</quality>

--- a/fdirs/dante/commedia.xml
+++ b/fdirs/dante/commedia.xml
@@ -1090,7 +1090,7 @@ con li occhi vòlti a chi del fango ingozza.
          Eugène Delacroix: <i>La Barque de Dante</i>, 1822, olie på lærred, 189×246 cm.
          <!-- metadata checked: 2026-07-16 -->
        </picture>
-       <picture src="dante2005050108-p2.jpg" wikidata="Q2665048" museum="orsay">
+       <picture src="dante2005050108-p2.jpg" wikidata="Q2665048" museum="orsay" objid="dante-et-virgile-153692">
          William-Adolphe Bouguereau: <i>Dante et Virgile</i>, 1850, olie på lærred, 280.5×225.3 cm. Musée d'Orsay.
          <!-- metadata checked: 2026-07-16 -->
        </picture>

--- a/fdirs/mallarme/portraits.xml
+++ b/fdirs/mallarme/portraits.xml
@@ -6,7 +6,7 @@
   <picture src="p2.jpg">
     Paul Nadar (fotograf): <i>Stéphane Mallarmé</i>, 1896.
   </picture>
-  <picture src="p3.jpg" museum="orsay">
+  <picture src="p3.jpg" museum="orsay" objid="stephane-mallarme-1133" invnr="RF 2661">
     Édouard Manet (1832–1883): <i>Stéphane Mallarmé</i>, 1876, olie på lærred. Musée d'Orsay.
   </picture>
 </pictures>

--- a/fdirs/musset/portraits.xml
+++ b/fdirs/musset/portraits.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <pictures>
-  <picture src="p1-oval.jpg" primary="true" square-src="p1-square.jpg" museum="orsay">
+  <picture src="p1-oval.jpg" primary="true" square-src="p1-square.jpg" museum="orsay" objid="portrait-dalfred-de-musset-18083" invnr="RF 5219">
       Charles Landelle (1821-1908): <i>Portrait d'Alfred de Musset</i>, 1854, pastel, 53,5 × 46 cm. Musée d'Orsay.
       <!-- http://www.musee-orsay.fr/en/collections/index-of-works/notice.html?nnumid=018083 -->
   </picture>

--- a/fdirs/reboul/portraits.xml
+++ b/fdirs/reboul/portraits.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <pictures>
-  <picture src="p1.jpg" primary="true" square-src="p1-square.jpg" year="1857" museum="orsay">
+  <picture src="p1.jpg" primary="true" square-src="p1-square.jpg" year="1857" museum="orsay" objid="jean-reboul-ne-nimes-en-1796-mort-en-1864-poete-dit-le-boulanger-nimois-auteur-de-lange-et-lenfant-64668">
     Antoine Crespon: <i>Jean Reboul</i>, albuminpapir på karton, Musée d'Orsay, Paris.
     <!-- https://www.musee-orsay.fr/fr/oeuvres/jean-reboul-ne-nimes-en-1796-mort-en-1864-poete-dit-le-boulanger-nimois-auteur-de-lange-et-lenfant-64668 -->
   </picture>

--- a/fdirs/rimbaud/portraits.xml
+++ b/fdirs/rimbaud/portraits.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <pictures>
-  <picture src="p1.jpg" primary="true" square-src="p1-square.jpg" museum="orsay">
+  <picture src="p1.jpg" primary="true" square-src="p1-square.jpg" museum="orsay" objid="coin-de-table-211" invnr="RF 1959">
     Henri Fantin-Latour: <i>Un coin du table</i>, 1872, oliemaleri. Musée d'Orsay, Paris. Rimbaud er siddende nummer to fra venstre.
   </picture>
   <picture src="p2.jpg">

--- a/fdirs/rossettic/portraits.xml
+++ b/fdirs/rossettic/portraits.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <pictures>
-  <picture src="p1.jpg" primary="true" square-src="p1-square.jpg" museum="britishmuseum">
+  <picture src="p1.jpg" primary="true" square-src="p1-square.jpg" museum="britishmuseum" objid="P_1937-0508-31" invnr="1937,0508.31">
     Dante Gabriel Rossetti: <i>Christina Rossetti</i>, kultegning med hvidt, 1848. British Museum.
   </picture>
 </pictures>

--- a/fdirs/sprague/portraits.xml
+++ b/fdirs/sprague/portraits.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <pictures>
-  <picture src="p1.jpg" primary="true" square-src="p1-square.jpg" museum="met">
+  <picture src="p1.jpg" primary="true" square-src="p1-square.jpg" museum="met" objid="268351" invnr="37.14.50">
       Southworth &amp; Hawes: <i>Charles Sprague</i>, daguerreotypi, ca. 1850. The Metropolitan Museum of Art.
   </picture>
 </pictures>


### PR DESCRIPTION
## Ændringer

- tilføjer deeplink-mønstre for Musée d'Orsay, The British Museum, National Gallery of Victoria, Museo Nacional del Prado og The Metropolitan Museum of Art
- registrerer verificerede objekt-id'er og inventarnumre for de syv værker fra issue #1356
- supplerer med tre yderligere verificerede Musée d'Orsay-poster for Alfred de Musset, Stéphane Mallarmé og Jean Reboul
- gør de ti billeder klikbare til museernes konkrete katalogposter

## Validering

- `npm test -- --runInBand`: 53 testsuiter og 2.384 tests består
- de ændrede værkfiler validerer mod `schemas/kalliopework.rng`
- alle ændrede XML-filer er velformede
- `git diff --check` består
- katalogposterne er kontrolleret mod museernes officielle sider

Fixes #1356
