### PR TITLE
Ret defekte deep-links til Uffizi

### DIFF
--- a/__tests__/museums.test.js
+++ b/__tests__/museums.test.js
@@ -1,0 +1,31 @@
+import { DOMParser } from '@xmldom/xmldom';
+
+import { build_museum_url } from '../tools/build-static/museums.js';
+
+const picture = attributes =>
+  new DOMParser().parseFromString(`<picture ${attributes}/>`, 'text/xml')
+    .documentElement;
+
+const collected = deepLink => ({
+  museums: new Map([['museum', { deepLink }]]),
+});
+
+describe('museum links', () => {
+  it('builds links from the identifier required by the template', () => {
+    expect(
+      build_museum_url(
+        picture('museum="museum" objid="work-slug" invnr="123"'),
+        collected('https://example.com/works/${objId}'),
+      ),
+    ).toBe('https://example.com/works/work-slug');
+  });
+
+  it('omits links when the identifier required by the template is missing', () => {
+    expect(
+      build_museum_url(
+        picture('museum="museum" invnr="123"'),
+        collected('https://example.com/works/${objId}'),
+      ),
+    ).toBeNull();
+  });
+});

--- a/content/museums.xml
+++ b/content/museums.xml
@@ -99,7 +99,7 @@
   <museum id="uffizi">
     <name>Galleria degli Uffizi</name>
     <link>https://www.uffizi.it/</link>
-    <deep-link>https://fotoinventari.uffizi.it/it/ricerca-opere?isPostBack=1&amp;numero_opera=${invNr}</deep-link>
+    <deep-link>https://www.uffizi.it/opere/${objId}</deep-link>
   </museum>
   <museum id="tate">
     <name>Tate</name>

--- a/fdirs/staffeldt/andre.xml
+++ b/fdirs/staffeldt/andre.xml
@@ -51,7 +51,7 @@ Gierne jeg for Kiephest og for Dukke
       <note>Trykt i Poulsens <i>Nytaarsgave</i> for 1802.</note>
    </notes>
    <pictures>
-      <picture src="staffeldt1999030406.jpg" wikidata="Q727875" museum="uffizi" invnr="1437">Vecellio Tiziano (1490-1576): »Venere di Urbino« (1538), oliemaleri, 119 × 165 cm.</picture>
+      <picture src="staffeldt1999030406.jpg" wikidata="Q727875" museum="uffizi" invnr="1437" objid="venere-urbino-tiziano">Vecellio Tiziano (1490-1576): »Venere di Urbino« (1538), oliemaleri, 119 × 165 cm.</picture>
    </pictures>
    <quality>korrektur1</quality>
    <keywords>sonnet</keywords>

--- a/tools/build-static/museums.js
+++ b/tools/build-static/museums.js
@@ -59,6 +59,12 @@ const build_museum_url = (picture, collected) => {
   if (museumId != null && (invNr != null || objId != null)) {
     const museum = collected.museums.get(museumId);
     if (museum != null && museum.deepLink != null) {
+      if (
+        (museum.deepLink.includes('${invNr}') && invNr == null) ||
+        (museum.deepLink.includes('${objId}') && objId == null)
+      ) {
+        return null;
+      }
       return museum.deepLink
         .replace('${invNr}', invNr)
         .replace('${objId}', objId);


### PR DESCRIPTION
## Ændringer

- erstatter Uffizis ustabile inventarsøgning med officielle værkssider baseret på `objid`
- tilføjer den verificerede værksslug `venere-urbino-tiziano` til Tizians *Venere di Urbino*
- undlader at generere et link til Raffaels Leo X, fordi posten kun har et inventarnummer og ingen dokumenteret værksside
- gør museum-URL-builderen robust over for manglende id'er
- tilføjer regressionstests af URL-builderen

## Baggrund

Den tidligere URL-skabelon brugte kun inventarnummeret. Uffizis arkiv kræver også den konkrete inventarsamling, og portalen svarer ikke stabilt. Det kunne derfor både give tvetydige og defekte links.

Uffizis officielle værkssider anvender redaktionelle slugs. Hvor en verificeret slug findes, gemmes den som `objid`. Poster uden en dokumenteret slug viser fortsat museums- og inventarmetadata, men får ikke et eksternt værkslink.

## Validering

- `npm test -- --runInBand`: 54 testsuiter og 2.386 tests bestået
- `npm run build-static-force-reload`: bestået
- `git diff --check`: bestået
- det genererede Uffizi-link til *Venere di Urbino* er kontrolleret mod den officielle værksside
- Leo X genererer `remoteUrl: null`

Fixes #1352
