### PR TITLE
Ret incremental opdatering af henvisninger

### DIFF
--- a/__tests__/mentions.test.js
+++ b/__tests__/mentions.test.js
@@ -1,7 +1,7 @@
 jest.mock('../tools/libs/caching.js', () => ({
-  isFileModified: () => false,
-  loadCachedJSON: () => null,
-  writeCachedJSON: () => {},
+  isFileModified: jest.fn(() => false),
+  loadCachedJSON: jest.fn(() => null),
+  writeCachedJSON: jest.fn(),
   force_reload: false,
 }));
 
@@ -31,6 +31,11 @@ import {
   writeJSON,
 } from '../tools/libs/helpers.js';
 import {
+  loadCachedJSON,
+  writeCachedJSON,
+} from '../tools/libs/caching.js';
+import {
+  build_person_or_keyword_refs,
   build_mentions_data,
   build_mentions_json,
   collectPersonOrKeywordRefs,
@@ -62,6 +67,9 @@ describe('mentions data', () => {
     fileExists.mockReturnValue(false);
     removeFile.mockClear();
     writeJSON.mockClear();
+    loadCachedJSON.mockReset();
+    loadCachedJSON.mockReturnValue(null);
+    writeCachedJSON.mockClear();
   });
 
   const buildCollected = () => {
@@ -146,6 +154,35 @@ describe('mentions data', () => {
     );
 
     expect(refs.has('bango')).toBe(false);
+  });
+
+  it('indsamler refs fra et nyt værk, selv om filen er uændret', () => {
+    loadCachedJSON.mockImplementation((key) => {
+      if (key === 'collected.person_or_keyword_refs') {
+        return [];
+      }
+      if (key === 'collected.person_or_keyword_refs_by_file') {
+        return [['fdirs/aarestrup/1863.xml', []]];
+      }
+      return null;
+    });
+    fileExists.mockReturnValue(true);
+    const collected = {
+      workids: new Map([
+        ['aarestrup', ['1863', 'ny-samling']],
+      ]),
+      texts: new Map(),
+      unlistedWorkFiles: [],
+    };
+
+    build_person_or_keyword_refs(collected);
+
+    expect(writeCachedJSON).toHaveBeenCalledWith(
+      'collected.person_or_keyword_refs_by_file',
+      expect.arrayContaining([
+        ['fdirs/aarestrup/ny-samling.xml', []],
+      ])
+    );
   });
 
   it('viser oversættelser fra den primære variant', () => {

--- a/tools/build-static/mentions.js
+++ b/tools/build-static/mentions.js
@@ -116,7 +116,11 @@ const build_person_or_keyword_refs = (collected) => {
         return;
       }
       knownFiles.add(filename);
-      if (!forced_reload && !isFileModified(filename)) {
+      if (
+        !forced_reload &&
+        refsByFile.has(filename) &&
+        !isFileModified(filename)
+      ) {
         return;
       } else {
         found_changes = true;


### PR DESCRIPTION
## Ændringer

- Indsaml henvisninger fra nyregistrerede værkfiler, selv når filens checksum allerede er kendt af buildet.
- Tilføj en regressionstest for et nyt værk, der endnu ikke findes i henvisningscachen.

## Årsag

Det inkrementelle build kunne springe en ny værkfil over, hvis et tidligere buildtrin allerede havde registreret filen som uændret. Dermed blev omvendte henvisninger, blandt andet oversættelser på forfattersiden, ikke opdateret.

## Effekt

Nye værker kommer nu med i henvisningsindekset ved det almindelige inkrementelle build.

## Validering

- `npm test -- --runInBand __tests__/mentions.test.js`
- `git diff --check`
