### PR TITLE
Stop build ved manglende museumsland

### DIFF
--- a/__tests__/museums.test.js
+++ b/__tests__/museums.test.js
@@ -1,7 +1,10 @@
 import { DOMParser } from '@xmldom/xmldom';
 
 import { museumsByCountry } from '../pages/museums.js';
-import { build_museum_url } from '../tools/build-static/museums.js';
+import {
+  build_museum_url,
+  validateMuseum,
+} from '../tools/build-static/museums.js';
 import {
   getElementsByTagName,
   loadXMLDoc,
@@ -51,6 +54,12 @@ describe('museum groups', () => {
     museums.forEach((museum) => {
       expect(safeGetText(museum, 'country')).not.toBeNull();
     });
+  });
+
+  it('stops the static build when country metadata is missing', () => {
+    expect(() =>
+      validateMuseum({ id: 'museum', country: null }),
+    ).toThrow('content/museums.xml: museum museum mangler <country>.');
   });
 });
 

--- a/tools/build-static/museums.js
+++ b/tools/build-static/museums.js
@@ -12,6 +12,14 @@ import {
   loadXMLDoc,
 } from './xml.js';
 
+const validateMuseum = (museum, xmlFilename = 'content/museums.xml') => {
+  if (museum.country == null || museum.country.trim() === '') {
+    throw new Error(
+      `${xmlFilename}: museum ${museum.id ?? '(uden id)'} mangler <country>.`,
+    );
+  }
+};
+
 // Read content/museums.xml and produce collected.museums to be used later.
 const build_museums = () => {
   const xmlFilename = `content/museums.xml`;
@@ -21,6 +29,7 @@ const build_museums = () => {
     !force_reload &&
     cached_museums.size !== 0
   ) {
+    cached_museums.forEach(museum => validateMuseum(museum, xmlFilename));
     return cached_museums;
   }
 
@@ -40,6 +49,7 @@ const build_museums = () => {
       country,
       deepLink,
     };
+    validateMuseum(data, xmlFilename);
     collected_museums.set(id, data);
   });
   writeCachedJSON('collected.museums', Array.from(collected_museums));
@@ -132,4 +142,5 @@ export {
   build_museum_url,
   build_museums,
   build_museum_pages,
+  validateMuseum,
 };


### PR DESCRIPTION
## Ændringer

- Valider, at alle museer har en ikke-tom `<country>`-værdi under `build_museums`.
- Kør valideringen både for frisk XML og for indlæste cachedata.
- Vis museums-id og kildefil i fejlmeddelelsen.
- Tilføj en regressionstest for manglende landekode.

## Årsag

`build-static` accepterede tidligere museumsdata uden landekode. Fejlen blev først opdaget af den separate Jest-test i CI, efter at static-buildet allerede havde gennemført museumsindlæsningen.

## Effekt

Et museum uden landekode stopper nu static-buildet straks med en konkret fejl, fx `content/museums.xml: museum mrbab mangler <country>.`.

## Validering

- `npm test -- --runInBand __tests__/museums.test.js` — 6 tests består
- `npm run test-ci` — 54 testsuites og 2391 tests består
- `git diff --check`
