### PR TITLE
Korrekturlæs Sidste Digte

### DIFF
--- a/fdirs/boedtcher/1875.xml
+++ b/fdirs/boedtcher/1875.xml
@@ -24,7 +24,7 @@
 <prose>
 Det er nu et Aar, siden <w>Ludvig Bødtcher</w> endte sit stille, ensomme Liv, og det tilfaldt da mig som en af hans nærmeste Slægtninge at gjennemgaa og ordne hans efterladte Papirer.
     Da jeg havde endt dette Arbejde, fik jeg den Tanke at udgive nærværende Samling, og for dennes Indhold skal jeg her med et Par Ord nærmere gjøre Rede.
-    Jeg har kaldt Bogen: «Ludvig Bødtchers sidste Digte» for at antyde, dels at der — i alt Fald saa vidt mig bekjendt — ikke existerer flere Digte af ham, der bør bringes frem for Offentligheden, dels at man i den vil finde de Digte, som han har produceret i sine sidste Aar. Samlingen indeholder nemlig de Digte, som i Tidsrummet, mellem den sidste Digtsamlings Udgivelse (1870) og Digterens Død have været trykte i forskjellige Tidsskrifter, og enkelte hidtil utrykte. — Med Hensyn til disse sidste havde jeg kun en indirecte Udtalelse fra Digteren selv om, hvad der maatte tages med, idet der paa ét af hans Arbejder fandtes følgende Paategning: «<w>Jeg ønsker ikke</w>, at dette Fragment indlemmes i, hvad jeg ellers har skrevet». (Dette Arbejde er en ufuldendt Operatext, »Camachos Bryllup«, af hvilken en enkelt Scene før har været trykt og vil findes i denne Samling under samme Titel.) Jeg var altsaa henvist til mit eget Skjøn, som jeg da har brugt efter bedste Evne, idet jeg dels har henvendt mig til Mænd, der baade have Hjerte for og Forstand paa Digtekonsten, dels holdt mig for Øje, at Digterens eget Princip var «at vælge kræsent blandt sin Børneflok»; og jeg vil haabe, at det nogenlunde er lykkedes mig at have faaet det og kun det med, der burde tages med.
+    Jeg har kaldt Bogen: «Ludvig Bødtchers sidste Digte» for at antyde, dels at der — i alt Fald saa vidt mig bekjendt — ikke existerer flere Digte af ham, der bør bringes frem for Offentligheden, dels at man i den vil finde de Digte, som han har produceret i sine sidste Aar. Samlingen indeholder nemlig de Digte, som i Tidsrummet mellem den sidste Digtsamlings Udgivelse (1870) og Digterens Død have været trykte i forskjellige Tidsskrifter, og enkelte hidtil utrykte. — Med Hensyn til disse sidste havde jeg kun en indirecte Udtalelse fra Digteren selv om, hvad der maatte tages med, idet der paa ét af hans Arbejder fandtes følgende Paategning: «<w>Jeg ønsker ikke</w>, at dette Fragment indlemmes i, hvad jeg ellers har skrevet». (Dette Arbejde er en ufuldendt Operatext, »Camachos Bryllup«, af hvilken en enkelt Scene før har været trykt og vil findes i denne Samling under samme Titel.) Jeg var altsaa henvist til mit eget Skjøn, som jeg da har brugt efter bedste Evne, idet jeg dels har henvendt mig til Mænd, der baade have Hjerte for og Forstand paa Digtekonsten, dels holdt mig for Øje, at Digterens eget Princip var «at vælge kræsent blandt sin Børneflok»; og jeg vil haabe, at det nogenlunde er lykkedes mig at have faaet det og kun det med, der burde tages med.
     En Angivelse af, fra hvilken Tid de enkelte Digte skrive sig, har jeg anset for unødvendig, og jeg skal i saa Henseende indskrænke mig til at bemærke, at, medens der iøvrigt ikke er fulgt nogen bestemt Plan med Hensyn til de enkelte Digtes Plads i Samlingen, vil dog Størstedelen af de ældste og hidtil utrykte Digte findes i Slutningen af Bogen, og at den ender med Ludvig Bødtchers sidste Digt.
     I det jeg endnu kun skal bringe min Tak til enhver, der velvillig har ydet mig sin Bistand, og navnlig for den imødekommende og værdifulde Hjælp, som jeg har modtaget af Hr. Etatsraad H. P. Holst, udtaler jeg det Haab, at denne lille Samling maa nyde samme gode Modtagelse, som hidtil er bleven Digterens Arbejder til Del.
 
@@ -65,14 +65,14 @@ Som før i Nattens blege Flamme!
 <head>
    <title>Til en gammel Ven!</title>
    <toctitle>Til en gammel Ven</toctitle>
-   <firstline>Nu voxe Aftenskyggerne, du Kjære!</firstline>
+   <firstline>Nu voxe Aftenskyggerne, Du Kjære!</firstline>
    <source pages="2-4"/>
    <keywords>rahbek</keywords>
    <quality>korrektur1,korrektur2,kilde,side</quality>
 </head>
 <body>
 <poetry>
-Nu voxe Aftenskyggerne, du Kjære! -
+Nu voxe Aftenskyggerne, Du Kjære! -
 Magnetisk hæmmes Skridtet af vor Fod,
 Og Ilden svales i det trætte Blod
 Ved Luftning fra en anden Atmosfære.
@@ -107,7 +107,7 @@ Hin Klang, der jevned Bølgen af et Had,
 Som skilte trende Brødres Hjerter ad,
 Der skabtes til hverandres Værn og Glæde.
 
-Selv svundne Somre gjemmer Hjertets Minde -
+Selv svundne Somre gjemme Hjertets Minde -
 Det var, som Solens Straale dengang gled
 Med mere varm og trofast Kjærlighed
 Hen over Skovens Bøgetræer og Linde.
@@ -232,7 +232,7 @@ Vi saae den svinde, den dunkle Sky,
 Og Friheds dejlige Morgengry
     Bredte sin Arm
     Kraftig og varm
-Henover gamle Danmarks Rige!
+Henover Danmarks gamle Rige!
 
 Det var som Luften gav Styrke ind,
 Just nu, da Øjeblikket gjeldte,
@@ -270,7 +270,7 @@ Du bringer atter Nordens Stamme!
 <body>
 <poetry>
 Kan vel en Blind om Farver tale?
-Og tør en gammel ugift Svend,
+Og bør en gammel ugift Svend,
 Hvis hele Liv svandt ensomt hen
 Sig nærme Hymens Højtidssale?
 
@@ -278,11 +278,11 @@ Dog - den maa være aandig blind,
 Hvem Synet af det Skjønne, Ideale
 Ej rører dybt i Sjæl og Sind! -
 Det lysner stundom frem i Livet,
-Her i Forkrænk'lighedens Bo,
+Her, i Forkrænk'lighedens Bo,
 Og spreder da sin milde Ro
-Lig Aftnens Guld, selv over Støvet!
+Lig Aftnens Guld selv over Støvet!
 
-I gamle elskelige To!
+I gamle, elskelige To!
 Hvorhen idag I festligt trine,
 Har Eders Blik den sjeldne Dyd
 At plante Blomsten Tusindfryd
@@ -292,20 +292,20 @@ Med Smil idag og vennehuld,
 Berører Ringens ægte Guld,
 Det ægteste, som Livet kjender!
 
-Halvhundred Aar i Fryd og Vee
-Som i en dunkel dyb Allee
+Halvhundred Aar i Fryd og Vee,
+Som i en dunkel, dyb Allee
 I vandred ømt og trofast sammen;
 Og Ringens Aand gav Eder Mod,
 Og lyste klart for Eders Fod,
 Naar ikke ret I kunde see,
 Og vendte mangen Sorg til Gammen!
 
-Længst svandt hin faure Ungdomstid,
+Længst svandt hin faure Ungdomstid
 Og Lokken, ak! blev sølverhvid,
 Men Ringen blev den Samme -
 Den funkler nu med sælsom Glands,
 Og smelter til en gylden Krands
-I Kjærlighedens Flamme!
+Ved Kjærlighedens Flamme!
 </poetry>
 </body>
 </text>
@@ -470,7 +470,7 @@ Slikkede sig om sin Mund,
 Saa selv Maanen maatte smile;
 
 Og som flink Matros i Rangen
-Fired den sig ned af Stangen,
+Fired den sig ned ad Stangen,
 Da den havde nydt sin Drik -
 Og forsvandt, den lille Strik!
 Og blev ikke dengang fangen.
@@ -540,13 +540,13 @@ Men - Kammas Aand er ej forsvunden.
 <text id="boedtcher2018100909" variant="boedtcher2001082601">
 <head>
    <title>April</title>
-   <firstline>Mit Hjerte hilser Dig April!</firstline>
+   <firstline>Mit Hjerte hilser Dig, April!</firstline>
    <source pages="22-23"/>
    <quality>korrektur1,korrektur2,kilde,side</quality>
 </head>
 <body>
 <poetry>
-Mit Hjerte hilser Dig April! -
+Mit Hjerte hilser Dig, April! -
 Jeg kjender godt dit Vexelsmil
 Og Taaren i dit Øje;
 Du vil ej ret for Alvor tro,
@@ -609,7 +609,7 @@ Siig, standser noget Savn det ædle Værk?
 See, Kjøkkenkniven tørstig blinker,
 Og Fisk i Sø, og Fugl i Dal
 Forlade, naar Camacho vinker,
-For evigt-Livets Kval!
+For evigt Livets Kval!
 Hvert Dyr, som tænksomt ned vi sender,
 Fra Grydens Dyb tilbagevender
 Kogt eller stegt, som Ideal!
@@ -675,13 +675,13 @@ Druens Rosenblod.
 <text id="boedtcher2018100911" variant="boedtcher2003010316">
 <head>
    <title>Til min egen Dreng</title>
-   <firstline>I din Haand du Lille! blinker</firstline>
+   <firstline>I din Haand, du Lille! blinker</firstline>
    <source pages="27-28"/>
    <quality>korrektur1,korrektur2,kilde,side</quality>
 </head>
 <body>
 <poetry>
-I din Haand du Lille! blinker
+I din Haand, du Lille! blinker
 Nøglen til Alverdens Skat:
 Naar din Fantasi kun vinker,
 Faaer du hvert et Ønske fat:
@@ -1519,7 +1519,7 @@ Som dufter, og som flammer;
 Knap aabner Blomsten sig paaklem,
 Før Bien fyrig iler frem
 Som til et Elskovsmøde -
-Den lister ned til Blomstens Bund,
+Den stirrer ned i Blomstens Bund,
 Og med sin lille Honningmund
 Den suger bort det Søde.
 
@@ -1564,7 +1564,7 @@ Hvor Glæden vinker, naar Du kalder:
 
 Og fremad jublende Du gaaer,
 Og med en Gartner ved din Side,
-Som fletter Blomster i dit Haar,
+Som fletter Roser i dit Haar,
 Og vogter Foden, som vil glide. -
 
 Men altid <w>frem!</w> Snart Vejen naaer
@@ -1713,7 +1713,7 @@ Hvisker kjærlig og blid med blussende Mund
 <head>
    <title>Bryllupsdigt</title>
    <!--<subtitle>Den 21. November 1872</subtitle>-->
-   <firstline>Riig var vor Glæde, let paa Skjæbnens Bølge</firstline>
+   <firstline>Rig var vor Glæde, let paa Skjæbnens Bølge</firstline>
    <dates>
        <event>1872-11-21</event>
    </dates>
@@ -1724,7 +1724,7 @@ Hvisker kjærlig og blid med blussende Mund
 <poetry>
 Rig var vor Glæde, let paa Skjæbnens Bølge
 Vugged vi trøstigt, selv hvor Skjær sig dølge,
-Holdt vi kun helligt Livets gyldne Smykke,
+Holdt vi kun helligt Livets bedste Smykke,
         Kjærligheds Lykke!
 
 Tusind af Blomster pryde Jordens Have,
@@ -1755,7 +1755,7 @@ Aldrig formørkes, smile med en Flamme,
 <body>
 <poetry>
 Til ingen Dødelig den Magt blev givet
-Som løser hver en Dissonants i Livet; -
+At løse hver en Dissonants i Livet; -
 ,,Fremtids Musik'' Du tidt vil faa at høre,
 Just ikke saare lifligt for dit Øre:
 Brug da din Kraft, forsøg, om Du kan magt'en
@@ -1921,9 +1921,9 @@ Til alle Hjerters Lyst!
 
 <text id="boedtcher2018100930" variant="boedtcher2002122524">
 <head>
-   <title>Til en Confirmandinde</title>
+   <title>Til en Confirmantinde</title>
    <subtitle>med en Blomsterbuket</subtitle>
-   <toctitle>Til en Confirmandinde, med en Blomsterbuket</toctitle>
+   <toctitle>Til en Confirmantinde, med en Blomsterbuket</toctitle>
    <firstline>Du selv, en Blomst fra Jordens Have</firstline>
    <source pages="80-81"/>
    <quality>korrektur1,korrektur2,kilde,side</quality>
@@ -1940,7 +1940,7 @@ Hvor jordisk Blomsterskjønhed brænder
 Og Sundhed boer i Stilkens Saft.
 Dog, selv i dine rene Hænder
 Vil Farvepragten slukkes ud,
-Og Alt hvad timeligt kun blænder
+Og Alt, hvad timeligt kun blænder
 Hjemfalder ogsaa Tidens Bud. -
 Kun hvad om Himlen kan erindre
 Skal aldrig falme, aldrig døe,
@@ -1968,7 +1968,7 @@ En yndig duftende Buket.
 Ak! hvad er vel min svage Sang
 Og Harpen, som Du knap kan høre,
 Mod Kirkens Røst og Orglets Klang,
-Som endnu toner i Dit Øre!
+Som endnu toner i dit Øre!
 
 Og hvad er al Veltalenhed,
 Som Jordens Kløgt vor Tunge lærte,
@@ -1976,7 +1976,7 @@ Imod dit Løfte og din Ed,
 Som kom fra et uskyldigt Hjerte!
 
 Snart viser Verden Dig sin Fryd,
-Og Glæden krandse vil Din Pande:
+Og Glæden krandse vil din Pande:
 Gid da i Alt en sagte Lyd
 Af Paaskeklokken sig maa blande!
 
@@ -2004,11 +2004,11 @@ Og Himlen selv vil Dig beskjærme!
 <poetry>
 Der er en Tid, da frisk Begejstring kalder,
 Og Hjertet boer i Glædens muntre Hal, -
-Et Gjenskin af hin tabte gyldne Alder,
+Et Gjenskin af hin tabte, gyldne Alder,
 Da Guldet selv var ubekjendt Metal:
 Det er den Tid, da Ungdomsdrømme maler
 Poetisk lys en Fremtid for vort Syn,
-Det er den Stund da Kjærlighed neddaler
+Det er den Stund, da Kjærlighed neddaler
 Og tænder Hjertet med sit første Lyn.
 
 Men Liv er Kamp, og mangen Drøm forsvinder,
@@ -2026,7 +2026,7 @@ See, tyve Aar og fem er lagt tilbage,
 Som med Velsignelse fra Dig udgik;
 Du bringer Livets bedste Sølversmykke:
 En kraftfuld Mand, en glad og elsket Viv,
-Og ømme Børn og stille huslig Lykke,
+Og ømme Børn og stille huslig Lykke
 Og i en skjøn Natur et virksomt Liv!
 </poetry>
 </body>
@@ -2257,8 +2257,8 @@ Bliver jeg vel til en Krølle!
 <nonum><center>2.</center></nonum>
 
 Jeg stakkels lille Strikkebrev!
-Min Fader raabte næppe ,,lev''!
-Før Du fik fat paa hvad han skrev
+Min Fader raabte næppe: ,,lev!''
+Før Du fik fat paa, hvad han skrev
 Og bort fra Dagens Lys mig rev.
 
 Du har en Maade vist som Faa
@@ -2267,14 +2267,14 @@ Du snør dem ind fra Top til Taa -
 Er det at handle med de Smaa?
 
 Jeg laa i Dage, laa i tre,
-Nysgjerrig hvad der vilde ske,
+Nysgjerrig, hvad der vilde ske,
 Men aldrig fik jeg Dig at see, -
 Imellem hørte jeg Dig le.
 
 Jeg hørte Sange fra din Mund,
 Du gav et Ryk fra Stund til Stund,
 Jeg vidste ikke ret din Grund:
-Ah, tænkte jeg, nu vugger hun.
+Ah! tænkte jeg, nu vugger hun.
 
 Men nu kom Ryk hvert Øjeblik -
 Mig Syn og Hørelse forgik;
@@ -2287,7 +2287,7 @@ Hvordan Du mig i Haanden fik.
 <text id="boedtcher2018100938" variant="boedtcher2003010349">
 <head>
    <title>Sangfuglen</title>
-   <firstline>Jeg hviled under Bøgens Skjul</firstline>
+   <firstline>Jeg hvilte under Bøgens Skjul</firstline>
    <source pages="99-100"/>
    <quality>korrektur1,korrektur2,kilde,side</quality>
 </head>
@@ -2296,13 +2296,13 @@ Hvordan Du mig i Haanden fik.
 Jeg hvilte under Bøgens Skjul
 En Sommeraften mild,
 Højt over mig der sad en Fugl,
-Smaanynned af og til.
+Som nynned af og til.
 Hvad Fuglen sang saa tyst i Løn,
 Ej fatted ret min Hu,
-Men Skoven aldrig var saa grøn
-Og duftende som nu!
+Men aldrig Skoven var saa grøn,
+Saa duftende som nu!
 
-Et Blink brød frem bag Løvets Hang
+Et Glimt kom frem bag Løvets Hang
 Af Øresundets Blaa,
 Da kunde klart, hvad Fuglen sang,
 Mit Hjerte nok forstaa.
@@ -2312,11 +2312,11 @@ Og af og til et lille Nyn
 Af Tak og Glæde kom.
 
 Da Solen sank, en sagte Vind
-Gik gjennem Skov og Krat,
-En Hvisken lød i Bøg og Lind
+Gik gjennem Skov og Krat;
+Der hvisket blev i Bøg og Lind
 Et blideligt Godnat!
-Min lille Fugl nu tav paa stand,
-Den fandt til Reden Vej,
+Min lille Fugl nu tav paa Stand
+Og fandt til Reden Vej,
 Og drømte om et yndigt Land -
 Det Samme drømte jeg.
 </poetry>

--- a/fdirs/boedtcher/1875.xml
+++ b/fdirs/boedtcher/1875.xml
@@ -300,7 +300,7 @@ Og lyste klart for Eders Fod,
 Naar ikke ret I kunde see,
 Og vendte mangen Sorg til Gammen!
 
-Længst svandt hin faure Ungdomstid
+Længst svandt hin fagre Ungdomstid,
 Og Lokken, ak! blev sølverhvid,
 Men Ringen blev den Samme -
 Den funkler nu med sælsom Glands,


### PR DESCRIPTION
## Ændring

Korrekturlæser transskriptionen af Ludvig Bødtchers *Sidste Digte* (1875) mod det tilknyttede facsimile.

Retter 45 dokumenterede afvigelser i tegnsætning, historisk stavning, kapitalisering og ordlyd i `fdirs/boedtcher/1875.xml`. Ingen metadata, kildeopsætning eller tekst-id'er er ændret.

## Validering

- `xmllint --noout fdirs/boedtcher/1875.xml`
- `npm test -- --runInBand` — 54 suites, 2391 tests
- `npm run build`
- `git diff --check`
