### PR TITLE
Korrekturlæs Samlede Digte

### DIFF
--- a/fdirs/boedtcher/1940.xml
+++ b/fdirs/boedtcher/1940.xml
@@ -1393,7 +1393,7 @@ Stod Barnet i sin Ham paa hendes Skjød:
 Og Haanden afstrøg lempelig og blød
 Den lille Papagenos Fjedertrøje.
 
-Og medens Hjertet håndled lyst som Dagen,
+Og medens Hjertet handled lyst som Dagen,
 Sig modned Tankens Frugt paa skjulte Rod, -
 Thi klog den gamle Anna var som god,
 Og Frugten bar af Begge altid Smagen.
@@ -5361,7 +5361,7 @@ Hvor nys han saae et Rosenflor, -
 Og Nattens svundne Kogleri
 Gik atter fælt hans Syn forbi.
 Han stormede med Rædsel: ,,Fort!''
-Som måned han et Gjenfærd bort,
+Som maned han et Gjenfærd bort,
 Og Inger tyded Ordet grandt,
 Hun vendte hurtig Ryg - forsvandt
 Og løb som uden Vid og Sands
@@ -7426,7 +7426,7 @@ Hvisker kjærlig og blid med blussende Mund
 
 <text id="boedtcher2002122524">
 <head>
-   <title>Til en Confirmandinde</title>
+   <title>Til en Confirmantinde</title>
    <subtitle>(Med en Blomsterbouket)</subtitle>
    <firstline>Du selv, en Blomst fra Jordens Have</firstline>
    <notes>


### PR DESCRIPTION
## Ændring

Korrekturlæser Ludvig Bødtchers *Samlede Digte* (1940) mod det tilknyttede facsimile.

Retter tre dokumenterede transskriptionsfejl i `fdirs/boedtcher/1940.xml`: *håndled* → *handled*, *måned* → *maned* og *Confirmandinde* → *Confirmantinde*.

## Validering

- `xmllint --noout fdirs/boedtcher/1940.xml`
- `npm test -- --runInBand` — 54 suites, 2391 tests
- `npm run build`
- `git diff --check`
