### PR TITLE
Ret tekstfejl i Boedtcher 1870

### DIFF
--- a/fdirs/boedtcher/1870.xml
+++ b/fdirs/boedtcher/1870.xml
@@ -1317,7 +1317,7 @@ Stod Barnet i sin Ham paa hendes Skjød:
 Og Haanden afstrøg lempelig og blød
 Den lille Papagenos Fjedertrøje.
 
-Og medens Hjertet håndled lyst som Dagen,
+Og medens Hjertet handled lyst som Dagen,
 Sig modned Tankens Frugt paa skjulte Rod, -
 Thi klog den gamle Anna var som god,
 Og Frugten bar af Begge altid Smagen.
@@ -5212,7 +5212,7 @@ Hvor nys han saae et Rosenflor, -
 Og Nattens svundne Kogleri
 Gik atter fælt hans Syn forbi.
 Han stormede med Rædsel: «Fort!»
-Som måned han et Gjenfærd bort,
+Som maned han et Gjenfærd bort,
 Og Inger tyded Ordet grandt,
 Hun vendte hurtig Ryg - forsvandt
 Og løb som uden Vid og Sands


### PR DESCRIPTION
## Ændring

Retter to åbenlyse tekstfejl i *Digtninger* (1870): `håndled` til `handled` og `måned` til `maned`.

## Validering

- `npm test -- --runInBand __tests__/kalliopework-relaxng.test.js`
