### PR TITLE
Korrekturlæs Morgenstjernen

### DIFF
--- a/fdirs/ahlmann/1924.xml
+++ b/fdirs/ahlmann/1924.xml
@@ -27,7 +27,7 @@
     <firstline>Det frøs fornylig, og Sneen føg</firstline>
     <source pages="11-12"/>
     <keywords>bellman,froeding</keywords>
-    <quality>korrektur1,kilde,side</quality>
+    <quality>korrektur1,korrektur2,kilde,side</quality>
 </head>
 <body>
 <poetry>
@@ -88,7 +88,7 @@ Velkommen igen ad Aare.
     <firstline>Klokker har kimet, tonende og travle</firstline>
     <source pages="13-14"/>
     <keywords>thorvaldsen</keywords>
-    <quality>korrektur1,kilde,side</quality>
+    <quality>korrektur1,korrektur2,kilde,side</quality>
 </head>
 <body>
 <poetry>
@@ -146,7 +146,7 @@ løft den for Haabet om det gyldne Skrud,
     <firstline>Hastigt løber Tiden</firstline>
     <source pages="15-16"/>
     <keywords>thorvaldsen</keywords>
-    <quality>korrektur1,kilde,side</quality>
+    <quality>korrektur1,korrektur2,kilde,side</quality>
 </head>
 <body>
 <poetry>
@@ -186,7 +186,7 @@ som den blonde Knægt
 og bliv Eventyret
 for den danske Slægt.
 
-<nonum><small>(1920)</small></nonum>
+<nonum><small>(1921)</small></nonum>
 </poetry>
 </body>
 </text>
@@ -210,7 +210,7 @@ for den danske Slægt.
     <subtitle>Morgen i Rom</subtitle>
     <firstline>Op med Skodderne - ah, det var godt</firstline>
     <source pages="19-21"/>
-    <quality>korrektur1,kilde,side</quality>
+    <quality>korrektur1,korrektur2,kilde,side</quality>
 </head>
 <body>
 <poetry>
@@ -290,7 +290,7 @@ saa længe det Spil bliver ved.
     <title>Frokosten</title>
     <firstline>Det var en Varme! Støvet, vandringstræt</firstline>
     <source pages="22-23"/>
-    <quality>korrektur1,kilde,side</quality>
+    <quality>korrektur1,korrektur2,kilde,side</quality>
 </head>
 <body>
 <poetry>
@@ -332,7 +332,7 @@ og ganske kort er nu den længste Vej.
     <title>Villa Aldobrandinis Have</title>
     <firstline>Hvorfor gaa hjem nu - Platanerne suser jo</firstline>
     <source pages="24"/>
-    <quality>korrektur1,kilde,side</quality>
+    <quality>korrektur1,korrektur2,kilde,side</quality>
 </head>
 <body>
 <poetry>
@@ -359,7 +359,7 @@ nærmer sig, nærmer sig. Slumren er sød.
     <title>Middelhavet</title>
     <firstline>Det er Morgen med Sol over Skrænt</firstline>
     <source pages="25-26"/>
-    <quality>korrektur1,kilde,side</quality>
+    <quality>korrektur1,korrektur2,kilde,side</quality>
 </head>
 <body>
 <poetry>
@@ -399,7 +399,7 @@ og noget kom i Leje igen.
     <title>Stornello</title>
     <firstline>Bjærget er fuldt af Violer</firstline>
     <source pages="27-28"/>
-    <quality>korrektur1,kilde,side</quality>
+    <quality>korrektur1,korrektur2,kilde,side</quality>
 </head>
 <body>
 <poetry>
@@ -441,7 +441,7 @@ jeg bringer hjem fra min Vandring.
     <title>Italiensk Højslette</title>
     <firstline>Skridt for Skridt, men sejgt og støt</firstline>
     <source pages="29-31"/>
-    <quality>korrektur1,kilde,side</quality>
+    <quality>korrektur1,korrektur2,kilde,side</quality>
 </head>
 <body>
 <poetry>
@@ -508,7 +508,7 @@ i Drømmen om Moderlandet.
     <title>Bøn i Bjergene</title>
     <firstline>O Liv, hvad vil du med mig</firstline>
     <source pages="32-33"/>
-    <quality>korrektur1,kilde,side</quality>
+    <quality>korrektur1,korrektur2,kilde,side</quality>
 </head>
 <body>
 <poetry>
@@ -544,7 +544,7 @@ en Hyrde i dine Bjerge.
     <title>Morgenstjernen</title>
     <firstline>Morgenstjernen blegned</firstline>
     <source pages="34-35"/>
-    <quality>korrektur1,kilde,side</quality>
+    <quality>korrektur1,korrektur2,kilde,side</quality>
 </head>
 <body>
 <poetry>
@@ -612,7 +612,7 @@ Siden - er i Dag
     <source pages="39-41"/>
     <!-- TODO: Find citatet -->
     <keywords>holstein</keywords>
-    <quality>korrektur1,kilde,side</quality>
+    <quality>korrektur1,korrektur2,kilde,side</quality>
 </head>
 <body>
 <poetry>
@@ -689,7 +689,7 @@ gaar over Gravens Grus.
     <title>Eremitagesletten</title>
     <firstline>Den store grønne Slette</firstline>
     <source pages="42-43"/>
-    <quality>korrektur1,kilde,side</quality>
+    <quality>korrektur1,korrektur2,kilde,side</quality>
 </head>
 <body>
 <poetry>
@@ -751,7 +751,7 @@ som hele Verden toner.
     <subtitle>En Bryllupssang</subtitle>
     <firstline>Vinden vifter, Birken slaar</firstline>
     <source pages="44-45"/>
-    <quality>korrektur1,kilde,side</quality>
+    <quality>korrektur1,korrektur2,kilde,side</quality>
 </head>
 <body>
 <poetry>
@@ -799,7 +799,7 @@ Foraarsnattens første Stjerne.
     <title>Det femte Lys</title>
     <firstline>Det var Sankt Hans</firstline>
     <source pages="46-47"/>
-    <quality>korrektur1,kilde,side</quality>
+    <quality>korrektur1,korrektur2,kilde,side</quality>
 </head>
 <body>
 <poetry>
@@ -843,7 +843,7 @@ og søgte det forliste.
     <subtitle>Til P. E. Tange-Müller paa Sophienberg.</subtitle>
     <firstline>Skyen sejled i Himlens Blaa</firstline>
     <source pages="48-49"/>
-    <quality>korrektur1,kilde,side</quality>
+    <quality>korrektur1,korrektur2,kilde,side</quality>
 </head>
 <body>
 <poetry>
@@ -897,7 +897,7 @@ og lod den opstaa ved Vintertid.
     <title>Til den Genkomne</title>
     <firstline>Det var de urolige Dage</firstline>
     <source pages="50"/>
-    <quality>korrektur1,kilde,side</quality>
+    <quality>korrektur1,korrektur2,kilde,side</quality>
 </head>
 <body>
 <poetry>
@@ -924,7 +924,7 @@ tre rødmende Roser.
     <title>Augustaften</title>
     <firstline>Barnet, som nylig løb og leged her</firstline>
     <source pages="51"/>
-    <quality>korrektur1,kilde,side</quality>
+    <quality>korrektur1,korrektur2,kilde,side</quality>
 </head>
 <body>
 <poetry>
@@ -951,7 +951,7 @@ Jeg er et Træ med Rod og Løv paa Kviste.
     <title>En Stjerne for en Tagsten -</title>
     <firstline>Alting forfalder, alting gaar tilsidst</firstline>
     <source pages="52"/>
-    <quality>korrektur1,kilde,side</quality>
+    <quality>korrektur1,korrektur2,kilde,side</quality>
 </head>
 <body>
 <poetry>
@@ -978,7 +978,7 @@ Ved Himlens Porte lér en jordisk Stodder.
     <title>Gæstekammeret</title>
     <firstline>Han lytted længe til Husets Lyde</firstline>
     <source pages="53-54"/>
-    <quality>korrektur1,kilde,side</quality>
+    <quality>korrektur1,korrektur2,kilde,side</quality>
 </head>
 <body>
 <poetry>
@@ -1029,7 +1029,7 @@ og Døden standser et Sted og lytter.
         <note>Ellen Rindom (1877-1922), dansk skuespillerinde.</note>
     </notes>
     <source pages="55-56"/>
-    <quality>korrektur1,kilde,side</quality>
+    <quality>korrektur1,korrektur2,kilde,side</quality>
 </head>
 <body>
 <poetry>
@@ -1086,7 +1086,7 @@ under Sol og Stjerne.
         <note>Hjalmar Söderberg (1869-1941), svensk forfatter.</note>
     </notes>
     <source pages="57-59"/>
-    <quality>korrektur1,kilde,side</quality>
+    <quality>korrektur1,korrektur2,kilde,side</quality>
 </head>
 <body>
 <poetry>
@@ -1170,7 +1170,7 @@ i et køligt Smil.
     <title>En Moders Sang</title>
     <firstline>Aftnen mørkner den grønne Eng</firstline>
     <source pages="60-61"/>
-    <quality>korrektur1,kilde,side</quality>
+    <quality>korrektur1,korrektur2,kilde,side</quality>
 </head>
 <body>
 <poetry>
@@ -1222,7 +1222,7 @@ og du er Blomsten, han sendte.
         <note>Ella Ungermann (1891-1921), danske skuespillerinde.</note>
     </notes>
     <source pages="65"/>
-    <quality>korrektur1,kilde,side</quality>
+    <quality>korrektur1,korrektur2,kilde,side</quality>
 </head>
 <body>
 <poetry>
@@ -1249,7 +1249,7 @@ og du, som styrted med brustne Øjne.
     <title>Høstsang</title>
     <firstline>Imellem de lave Diger</firstline>
     <source pages="66-67"/>
-    <quality>korrektur1,kilde,side</quality>
+    <quality>korrektur1,korrektur2,kilde,side</quality>
 </head>
 <body>
 <poetry>
@@ -1307,7 +1307,7 @@ og af den velsignede Sol.
     <title><num>I.</num>Den unge Digter</title>
     <firstline>Det spilled i strømmende Vande</firstline>
     <source pages="68-69"/>
-    <quality>korrektur1,kilde,side</quality>
+    <quality>korrektur1,korrektur2,kilde,side</quality>
 </head>
 <body>
 <poetry>
@@ -1351,7 +1351,7 @@ naar Høsten skal slette den ud.
     <title><num>II.</num>Den gamle Digter</title>
     <firstline>Hvad hjælper det, Vaaren vil komme</firstline>
     <source pages="69-72"/>
-    <quality>korrektur1,kilde,side</quality>
+    <quality>korrektur1,korrektur2,kilde,side</quality>
 </head>
 <body>
 <poetry>
@@ -1431,7 +1431,7 @@ naar Vaaren kommer igen.
     <subtitle>Til en Digter.</subtitle>
     <firstline>Det grønne Vinløv udenfor mit Kammer</firstline>
     <source pages="73-74"/>
-    <quality>korrektur1,kilde,side</quality>
+    <quality>korrektur1,korrektur2,kilde,side</quality>
 </head>
 <body>
 <poetry>
@@ -1481,7 +1481,7 @@ læg ham Løv, Vinløv om hans Pande.
     <subtitle>Til Studenterne i »Forum«.</subtitle>
     <firstline>Dagen blev kort</firstline>
     <source pages="75-76"/>
-    <quality>korrektur1,kilde,side</quality>
+    <quality>korrektur1,korrektur2,kilde,side</quality>
 </head>
 <body>
 <poetry>
@@ -1538,7 +1538,7 @@ den, som ej tager sin Vinter,
     <title>Septembersang</title>
     <firstline>Somre kommer og Somre gaar</firstline>
     <source pages="77-79"/>
-    <quality>korrektur1,kilde,side</quality>
+    <quality>korrektur1,korrektur2,kilde,side</quality>
 </head>
 <body>
 <poetry>
@@ -1608,7 +1608,7 @@ Bliv, hvor du er,
     <title>Vinternats Præludium</title>
     <firstline>Fodtrin holdt op med at vandre</firstline>
     <source pages="83-84"/>
-    <quality>korrektur1,kilde,side</quality>
+    <quality>korrektur1,korrektur2,kilde,side</quality>
 </head>
 <body>
 <poetry>
@@ -1648,7 +1648,7 @@ gennem det skælvende Hjerte.
     <toctitle>Slædefarten I-V</toctitle>
     <firstline>Hun havde lovet, hun vilde komme</firstline>
     <source pages="85-96"/>
-    <quality>korrektur1,kilde,side</quality>
+    <quality>korrektur1,korrektur2,kilde,side</quality>
 </head>
 <body>
 <poetry>
@@ -1877,7 +1877,7 @@ en Genfærdsfryd, en forsvunden Leg).
     <title>November</title>
     <firstline>Igennem Træerne de sorte nøgne</firstline>
     <source pages="99-100"/>
-    <quality>korrektur1,kilde,side</quality>
+    <quality>korrektur1,korrektur2,kilde,side</quality>
 </head>
 <body>
 <poetry>
@@ -1908,7 +1908,7 @@ indtil al Pragt og Lyst i dig er daanet,
     <subtitle>Til en Digter.</subtitle>
     <firstline>Dagen helded et Efteraar</firstline>
     <source pages="101-103"/>
-    <quality>korrektur1,kilde,side</quality>
+    <quality>korrektur1,korrektur2,kilde,side</quality>
 </head>
 <body>
 <poetry>
@@ -1976,7 +1976,7 @@ spejled Evighedens Dug,
     <title>Skibene</title>
     <firstline>Lette og luftgraa Maager</firstline>
     <source pages="104"/>
-    <quality>korrektur1,kilde,side</quality>
+    <quality>korrektur1,korrektur2,kilde,side</quality>
 </head>
 <body>
 <poetry>
@@ -2009,7 +2009,7 @@ her i den venstre Side.
     <title>Sent Efteraar</title>
     <firstline>Et Fuglepip i Vejens Hegn</firstline>
     <source pages="105-116"/>
-    <quality>korrektur1,kilde,side</quality>
+    <quality>korrektur1,korrektur2,kilde,side</quality>
 </head>
 <body>
 <poetry>
@@ -2327,7 +2327,7 @@ Bag Stjernerne er jeg.
     <title>Gaarden</title>
     <firstline>Ingen Sol, der vaager</firstline>
     <source pages="117-119"/>
-    <quality>korrektur1,kilde,side</quality>
+    <quality>korrektur1,korrektur2,kilde,side</quality>
 </head>
 <body>
 <poetry>
@@ -2402,7 +2402,7 @@ mod hinanden vendt.
     <title>I Julens Gaard</title>
     <firstline>Det grønne Foraar gik saa brat</firstline>
     <source pages="120-123"/>
-    <quality>korrektur1,kilde,side</quality>
+    <quality>korrektur1,korrektur2,kilde,side</quality>
 </head>
 <body>
 <poetry>
@@ -2489,7 +2489,7 @@ i Julens Navn, med Julens Sind,
     <title>Juleaften</title>
     <firstline>Aftnen kom - og Timen kom!</firstline>
     <source pages="124-125"/>
-    <quality>korrektur1,kilde,side</quality>
+    <quality>korrektur1,korrektur2,kilde,side</quality>
 </head>
 <body>
 <poetry>
@@ -2531,7 +2531,7 @@ er Julen atter slukket.
     <title>Dostojewskij</title>
     <firstline>Snestormen pisker paa Ruder</firstline>
     <source pages="126"/>
-    <quality>korrektur1,kilde,side</quality>
+    <quality>korrektur1,korrektur2,kilde,side</quality>
 </head>
 <body>
 <poetry>
@@ -2563,7 +2563,7 @@ begynder en Fugl at synge.
     <title>Det sner -</title>
     <firstline>Det hvirvler af Sne over Tag og Top</firstline>
     <source pages="127-128"/>
-    <quality>korrektur1,kilde,side</quality>
+    <quality>korrektur1,korrektur2,kilde,side</quality>
 </head>
 <body>
 <poetry>
@@ -2600,7 +2600,7 @@ og hilser, med Haanden mod Hjertet.
     <title>Drivhuset</title>
     <firstline>Mens udenfor alt er i Dvale</firstline>
     <source pages="129-130"/>
-    <quality>korrektur1,kilde,side</quality>
+    <quality>korrektur1,korrektur2,kilde,side</quality>
 </head>
 <body>
 <poetry>
@@ -2639,7 +2639,7 @@ din egen velsignede Sommer.
     <title>Det sner endnu</title>
     <firstline>Der var et Ur, der vækked mig</firstline>
     <source pages="131-132"/>
-    <quality>korrektur1,kilde,side</quality>
+    <quality>korrektur1,korrektur2,kilde,side</quality>
 </head>
 <body>
 <poetry>
@@ -2681,7 +2681,7 @@ at grønnes med den nøgne Gren.
     <title>Til en ung Mand</title>
     <firstline>Din Lyst skal brydes af Suk og Strid</firstline>
     <source pages="133"/>
-    <quality>korrektur1,kilde,side</quality>
+    <quality>korrektur1,korrektur2,kilde,side</quality>
 </head>
 <body>
 <poetry>
@@ -2714,7 +2714,7 @@ naar Vinteren gaar dig i Møde.
     <title>Domkirken</title>
     <firstline>Der stod den, iført en kostbar Dragt</firstline>
     <source pages="134-137"/>
-    <quality>korrektur1,kilde,side</quality>
+    <quality>korrektur1,korrektur2,kilde,side</quality>
 </head>
 <body>
 <poetry>
@@ -2807,7 +2807,7 @@ se Sejlene hejses, det mørkner om lidt
     <title>Første Foraar</title>
     <firstline>Vinterkulde steg af Mulde,</firstline>
     <source pages="138-139"/>
-    <quality>korrektur1,kilde,side</quality>
+    <quality>korrektur1,korrektur2,kilde,side</quality>
 </head>
 <body>
 <poetry>
@@ -2849,7 +2849,7 @@ Lyst og mørkt gaar Vævens Traade.
     <firstline>I Landet Vé, som af Havet steg</firstline>
     <keywords>jensenjv</keywords>
     <source pages="140-142"/>
-    <quality>korrektur1,kilde,side</quality>
+    <quality>korrektur1,korrektur2,kilde,side</quality>
 </head>
 <body>
 <quote margin-left="30%" font-size="small">

--- a/fdirs/ahlmann/1924.xml
+++ b/fdirs/ahlmann/1924.xml
@@ -186,7 +186,7 @@ som den blonde Knægt
 og bliv Eventyret
 for den danske Slægt.
 
-<nonum><small>(1921)</small></nonum>
+<nonum><small>(1920)</small></nonum>
 </poetry>
 </body>
 </text>


### PR DESCRIPTION
## Ændringer

- Retter årstallet efter »Svenske Digtere i det danske Foraar« fra 1920 til 1921.
- Markerer alle 47 tekstposter i *Morgenstjernen* som korrekturlæst to gange.

## Baggrund

Korrekturen er sammenholdt med bogens faksimile. Årstallet var afveget fra originaltrykket.

## Validering

- `npm run build-static`
