### PR TITLE
Ret links til Staatliche Museen zu Berlin

### DIFF
--- a/content/museums.xml
+++ b/content/museums.xml
@@ -52,7 +52,7 @@
     <name>Staatliche Museen zu Berlin</name>
     <country>de</country>
     <link>https://www.smb.museum/home/</link>
-    <deep-link>http://www.smb-digital.de/eMuseumPlus?objectId=${objId}</deep-link>
+    <deep-link>https://search.smb.museum/object/obj-${objId}</deep-link>
   </museum>
   <museum id="md">
     <country>de</country>


### PR DESCRIPTION
## Ændring

- erstatter den udfasede `smb-digital.de`-skabelon med Staatliche Museen zu Berlins aktuelle objektsider på `search.smb.museum`
- bevarer de eksisterende objekt-id’er og indsætter dem i formatet `obj-${objId}`

## Hvorfor

De gamle links omdirigerer til den nye samlingsdatabase. Direkte links undgår den udfasede HTTP-adresse og fører brugeren direkte til den aktuelle objektvisning.

## Virkning

De seks billeder med registrerede SMB-objekt-id’er får direkte HTTPS-links til deres poster i museets nuværende samlingsdatabase. Schiller-portrættet uden verificeret objekt-id ændres ikke.

## Validering

- alle seks kendte SMB-objektlinks returnerer HTTP 200
- `xmllint --noout content/museums.xml`
- `git diff --check`
- `npm test -- --runInBand` — 2.390 tests består
- `npm run build-static` består
