### PR TITLE
Markér Andersen-digte som varianter

### DIFF
--- a/fdirs/andersen/1830.xml
+++ b/fdirs/andersen/1830.xml
@@ -17,7 +17,7 @@
 </workhead>
 <workbody>
 
-<text id="andersen2017110701">
+<text id="andersen2017110701" variant="andersen2003013101">
 <head>
     <title>Rime-Djævelen</title>
     <subtitle>”Mὴ  ἐισενεγκης ἡμᾶς ἐις πειρασμον.”</subtitle>
@@ -214,7 +214,7 @@ De rysted paa Haanden af Smerte,
 </body>
 </text>
 
-<text id="andersen2017110703">
+<text id="andersen2017110703" variant="andersen2002121702">
 <head>
     <title>Den rædselsfulde Time</title>
     <firstline>Kom ei Rundetaarn for nær, er det Midnatstide</firstline>
@@ -1488,7 +1488,7 @@ Men Duggen staaer som Taare paa Møens hvide Barm.
 </body>
 </text>
 
-<text id="andersen2017110720">
+<text id="andersen2017110720" variant="andersen2002122206">
 <head>
     <title>Hjerte-Suk til Maanen</title>
     <firstline>Hulde Maane, stiig fra Skyen frem!</firstline>
@@ -2369,7 +2369,7 @@ Med nøgne Pusselanker i Bjergets Sale gaae.
 </text>
 
 
-<text id="andersenandrea11">
+<text id="andersenandrea11" variant="andersen2002121701">
 <head>
    <title>Aftenen</title>
    <subtitle>
@@ -2870,7 +2870,7 @@ Brødkonen staaer og fryser, en bleg, en nordisk Mø.
 </body>
 </text>
 
-<text id="andersen2017110746">
+<text id="andersen2017110746" variant="andersen2002122205">
 <head>
     <title>Tanker ved en ituslagen Jydepotte</title>
     <firstline>Du er ei meer!</firstline>

--- a/fdirs/andersen/1831.xml
+++ b/fdirs/andersen/1831.xml
@@ -1670,7 +1670,7 @@ Og Alt, hvad han kun saae i Drømme.
 </body>
 </text>
 
-<text id="andersen2002110809">
+<text id="andersen2002110809" variant="andersen1831a0">
 <head>
    <title>Phantasie ved Vesterhavet</title>
    <toctitle>Phantasie ved Vesterhavet</toctitle>

--- a/fdirs/andersen/1831.xml
+++ b/fdirs/andersen/1831.xml
@@ -1677,7 +1677,7 @@ Og Alt, hvad han kun saae i Drømme.
    <indextitle>Phantasie ved Vesterhavet</indextitle>
    <firstline>Er disse høie, sorte Masser Fjelde?</firstline>
    <notes>
-      <note>Et originalmanuskript til dette digt er bevaret, med otte ekstra linjer som altså ikke kom med i den endelige udgave, se <xref poem="andersen1831a0"/>.</note>
+      <note>Et originalmanuskript til dette digt er bevaret med otte ekstra linjer, som ikke kom med i den endelige udgave.</note>
    </notes>
    <source pages="77-78"/>
    <keywords>ingemann</keywords>

--- a/fdirs/andersen/1854.xml
+++ b/fdirs/andersen/1854.xml
@@ -20,7 +20,7 @@
 </head>
 <content>
 
-<text id="andersen2002122201">
+<text id="andersen2002122201" variant="andersen2002121801">
 <head>
    <title>Poesien</title>
    <toctitle>Poesien</toctitle>

--- a/fdirs/andersen/1854.xml
+++ b/fdirs/andersen/1854.xml
@@ -28,7 +28,7 @@
    <firstline>Der er et herligt Land</firstline>
    <notes>
       <note>Teksten følger <i>Samlede Skrifter</i>, bind XV (1854), side 1-2.</note>
-      <note>Digtet blev offentliggjort første gang i lejlighedstrykket <i>Festen for Adam Oehlenschlæger</i> (1849), se <xref poem="andersen2002121801"/>, hvor digtet er direkte henvendt til Adam Oehlenschläger og i fjerde strofe skriver ,,Dig'' (dvs. Oehlenschläger), hvor der i nærværende version læses det ubestemte ,,Den'' og ,,ham''.</note>
+      <note>Digtet blev offentliggjort første gang i lejlighedstrykket <i>Festen for Adam Oehlenschlæger</i> (1849), hvor det er direkte henvendt til Adam Oehlenschläger og i fjerde strofe skriver ,,Dig'' (dvs. Oehlenschläger), hvor der i nærværende version læses det ubestemte ,,Den'' og ,,ham''.</note>
    </notes>
    <keywords>oehlenschlaeger</keywords>
    <quality>korrektur1,kilde,side</quality>

--- a/fdirs/andersen/andre.xml
+++ b/fdirs/andersen/andre.xml
@@ -534,12 +534,13 @@ Jeg haaber, ingen spiser Fisk, som dette Carmen læser. -
 <text id="andersen2003013101">
 <head>
    <title>Rime-Djævelen</title>
+   <subtitle>”μὴ εἰσενέγκῃς ἡμᾶς εἰς πειρασμόν.”</subtitle>
    <toctitle>Rime-Djævelen</toctitle>
    <indextitle>Rime-Djævelen</indextitle>
    <firstline>Før jeg med Blæk Papiret vil bemale</firstline>
    <notes>
        <note>Teksten følger førstetrykket i <i>Kjøbenhavns flyvende Post</i> Nr. 85, ,,Fredagen den 24<sup>de</sup> October'' (1828). Digtet blev siden <a poem="andersen2017110701">medtaget</a> i <i>Digte</i> (1830).</note>
-      <note>Digtet har et motto på oldgræsk, se faksimilen.</note>
+      <note>Mottoet er den græske udgave af Fadervors ,,Led os ikke i fristelse.'' <xref bibel="bibelmatt06,13"/>.</note>
    </notes>
    <pictures>
       <picture src="andersen2003013101-p1.jpg">Faksimile af digtet, side 1/2.</picture>
@@ -3036,7 +3037,7 @@ at tidt den Hjertet sprænger.
 </body>
 </text>
 
-<text id="andersen2005050101">
+<text id="andersen2005050101" variant="andersen1999041411">
 <head>
    <firstline>Barn Jesus i en Krybbe laae</firstline>
    <quality>korrektur1,korrektur2</quality>

--- a/fdirs/andersen/andre.xml
+++ b/fdirs/andersen/andre.xml
@@ -14,7 +14,7 @@
    <indextitle>Aftenen</indextitle>
    <firstline>En Aften deilig, som i en Roman!</firstline>
    <notes>
-       <note>Teksten følger førstetrykket i <i>Kjøbenhavns flyvende Post</i> Nr. 66, ,,Fredagen den 17<sup>de</sup> August'' (1827). Digtet blev siden <a poem="andersenandrea11">medtaget</a> i <i>Digte</i> (1830).</note>
+       <note>Teksten følger førstetrykket i <i>Kjøbenhavns flyvende Post</i> Nr. 66, ,,Fredagen den 17<sup>de</sup> August'' (1827). Digtet blev siden medtaget i <i>Digte</i> (1830).</note>
    </notes>
    <pictures>
       <picture src="andersen2002121701.jpg">Faksimile af digtet.</picture>
@@ -173,7 +173,7 @@ Læser, gid Du vaagne maa, dersom Du har sovet!
    <firstline>Du er ei meer!</firstline>
    <notes>
       <note>* Maa gjerne optages i <i>Gravblomsterne</i>.</note>
-      <note>Teksten følger førstetrykket i <i>Kjøbenhavns flyvende Post</i> Nr. 82, ,,Fredagen den 12<sup>te</sup> October'' (1827). Digtet blev siden <a poem="andersen2017110746">medtaget</a> i <i>Digte</i> (1830).</note>
+      <note>Teksten følger førstetrykket i <i>Kjøbenhavns flyvende Post</i> Nr. 82, ,,Fredagen den 12<sup>te</sup> October'' (1827). Digtet blev siden medtaget i <i>Digte</i> (1830).</note>
    </notes>
    <pictures>
       <picture src="andersen2002122205-p1.jpg">Faksimile af digtet.</picture>
@@ -252,7 +252,7 @@ Snart hvile ogsaa vore trætte Bene.
    <indextitle>Hjerte-Suk til Maanen</indextitle>
    <firstline>Hulde Maane, stiig fra Skyen frem!</firstline>
    <notes>
-       <note>Teksten følger førstetrykket i <i>Kjøbenhavns flyvende Post</i> Nr. 86, ,,Fredagen den 26<sup>de</sup> October'' (1827). Digtet blev siden <a poem="andersen2017110720">medtaget</a> i <i>Digte</i> (1830).</note>
+       <note>Teksten følger førstetrykket i <i>Kjøbenhavns flyvende Post</i> Nr. 86, ,,Fredagen den 26<sup>de</sup> October'' (1827). Digtet blev siden medtaget i <i>Digte</i> (1830).</note>
        <note>Mottoet stammer fra Wielands <xref poem="wieland2018042301,383-384"/>.</note>
    </notes>
    <pictures>
@@ -539,7 +539,7 @@ Jeg haaber, ingen spiser Fisk, som dette Carmen læser. -
    <indextitle>Rime-Djævelen</indextitle>
    <firstline>Før jeg med Blæk Papiret vil bemale</firstline>
    <notes>
-       <note>Teksten følger førstetrykket i <i>Kjøbenhavns flyvende Post</i> Nr. 85, ,,Fredagen den 24<sup>de</sup> October'' (1828). Digtet blev siden <a poem="andersen2017110701">medtaget</a> i <i>Digte</i> (1830).</note>
+       <note>Teksten følger førstetrykket i <i>Kjøbenhavns flyvende Post</i> Nr. 85, ,,Fredagen den 24<sup>de</sup> October'' (1828). Digtet blev siden medtaget i <i>Digte</i> (1830).</note>
       <note>Mottoet er den græske udgave af Fadervors ,,Led os ikke i fristelse.'' <xref bibel="bibelmatt06,13"/>.</note>
    </notes>
    <pictures>
@@ -1774,7 +1774,7 @@ Det som vi elsked, boer hos Lysets Hære.
    <indextitle>Phantasie ved Vesterhavet</indextitle>
    <firstline>Er disse høie, sorte Masser Fjelde?</firstline>
    <notes>
-      <note>Teksten følger delvist en transskription på <a href="http://www.andersen.sdu.dk/vaerk/vesterhavet/trans.html">H.C. Andersen-Centrets hjemmeside</a>, delvist en faksimile af slutningen af digtet på samme side. Linje 37-44 er skåret væk i digtets endelige version i <i>Phantasier og Skizzer</i> (1831), se <xref poem="andersen2002110809"/> - de øvrige afvigelser er ubetydelige.</note>
+      <note>Teksten følger delvist en transskription på <a href="http://www.andersen.sdu.dk/vaerk/vesterhavet/trans.html">H.C. Andersen-Centrets hjemmeside</a>, delvist en faksimile af slutningen af digtet på samme side. Linje 37-44 er skåret væk i digtets endelige version i <i>Phantasier og Skizzer</i> (1831); de øvrige afvigelser er ubetydelige.</note>
    </notes>
    <quality>korrektur1</quality>
 </head>


### PR DESCRIPTION
## Ændringer

- forbinder otte par af H.C. Andersens tekstforekomster som varianter
- dækker førstetryk og senere bogudgaver, manuskript og trykt udgave samt en næsten identisk genudgivelse
- tilføjer det græske motto til førstetrykket af »Rime-Djævelen« og erstatter faksimilehenvisningen med en forklarende note og bibelhenvisning

Variantforbindelserne betyder, at de beslægtede tekstforekomster vises samlet, i stedet for at de fremstår som uafhængige dubletter i titelindekset.

## Validering

- `npm test -- --runInBand __tests__/variants.test.js`
- `KALLIOPE_SKIP_ELASTICSEARCH=1 npm run build-static-force-reload`
- `git diff --check`
