### PR TITLE
Tilføj afstand under nøgleord på digtvisninger

### DIFF
--- a/pages/text.js
+++ b/pages/text.js
@@ -433,7 +433,9 @@ const TextPage = (props) => {
     const list = text.keywords.map((k) => {
       return <KeywordLink keyword={k} lang={lang} key={k.id} />;
     });
-    renderedKeywords = <div style={{ marginTop: '30px' }}>{list}</div>;
+    renderedKeywords = (
+      <div style={{ marginTop: '30px', marginBottom: '30px' }}>{list}</div>
+    );
   }
 
   const noteCount = notes.length + (text.footnotes_count || 0);


### PR DESCRIPTION
## Ændring

Tilføjer 30 px afstand under nøgleordene i digtvisningens sidebar.

## Baggrund

Keyword-wrapperen havde kun afstand over nøgleordene. Når et faksimilebillede fulgte direkte efter, stødte keyword-tagget derfor op til billedet uden luft imellem.

## Effekt

Nøgleord har nu samme afstand under som over, så de adskilles visuelt fra efterfølgende billeder.

## Validering

- `git diff --check`
- `npm test -- --runInBand` — 54 testsuiter og 2.392 tests bestået

Fixes #1379
