### PR TITLE
Del minioverskrifter i sidebars

### DIFF
--- a/components/external-identifier-links.js
+++ b/components/external-identifier-links.js
@@ -2,6 +2,7 @@ import { buildExternalIdentifierLinks } from '../common/external-identifiers.js'
 import _ from '../common/translations.js';
 import Tooltip from './tooltip.js';
 import TwoColumns from './twocolumns.js';
+import SidebarMiniHeading from './sidebarminiheading.js';
 
 const ExternalIdentifierLinks = ({
   identifiers,
@@ -57,7 +58,7 @@ const ExternalIdentifierLinks = ({
     <section
       className="external-identifiers"
       aria-label={heading}>
-      <div className="heading">{heading}</div>
+      <SidebarMiniHeading>{heading}</SidebarMiniHeading>
       <div className="links">
         {links.map((link) => (
           <Tooltip text={link.label} key={link.id}>
@@ -73,12 +74,6 @@ const ExternalIdentifierLinks = ({
       <style jsx>{`
         .external-identifiers {
           margin-top: 28px;
-        }
-        .heading {
-          margin-bottom: 8px;
-          color: #666;
-          font-size: 0.8em;
-          font-weight: bold;
         }
         .links {
           display: flex;

--- a/components/sidebarminiheading.js
+++ b/components/sidebarminiheading.js
@@ -1,0 +1,20 @@
+const SidebarMiniHeading = ({ children }) => {
+  return (
+    <div className="sidebar-mini-heading">
+      {children}
+      <style jsx>{`
+        .sidebar-mini-heading {
+          margin: 0 0 7px;
+          color: #777;
+          font-size: 0.75em;
+          font-weight: 600;
+          letter-spacing: 0.06em;
+          line-height: 1.2;
+          text-transform: uppercase;
+        }
+      `}</style>
+    </div>
+  );
+};
+
+export default SidebarMiniHeading;

--- a/pages/bio.js
+++ b/pages/bio.js
@@ -15,6 +15,7 @@ import Page from '../components/page.js';
 import Picture from '../components/picture.js';
 import { poetNameString } from '../components/poetname-helpers.js';
 import PoetName from '../components/poetname.js';
+import SidebarMiniHeading from '../components/sidebarminiheading.js';
 import SidebarSplit from '../components/sidebarsplit.js';
 import SplitWhenSmall from '../components/split-when-small.js';
 import TextContent from '../components/textcontent.js';
@@ -47,17 +48,13 @@ const PersonMetaLine = ({ label, value }) => {
     return null;
   }
   const styles = {
-    key: {
-      fontWeight: 'bold',
-      fontSize: '0.8em',
-    },
     item: {
-      marginBottom: '10px',
+      marginBottom: '22px',
     },
   };
   return (
     <div style={styles.item}>
-      <div style={styles.key}>{label}</div>
+      <SidebarMiniHeading>{label}</SidebarMiniHeading>
       <div>{value}</div>
     </div>
   );

--- a/pages/text.js
+++ b/pages/text.js
@@ -433,7 +433,9 @@ const TextPage = (props) => {
     const list = text.keywords.map((k) => {
       return <KeywordLink keyword={k} lang={lang} key={k.id} />;
     });
-    renderedKeywords = <div style={{ marginTop: '30px' }}>{list}</div>;
+    renderedKeywords = (
+      <div style={{ marginTop: '30px', marginBottom: '30px' }}>{list}</div>
+    );
   }
 
   const noteCount = notes.length + (text.footnotes_count || 0);

--- a/pages/text.js
+++ b/pages/text.js
@@ -12,6 +12,7 @@ import HelpKalliope from '../components/helpkalliope.js';
 import * as Links from '../components/links.js';
 import { poetMenu } from '../components/menu.js';
 import Note from '../components/note.js';
+import SidebarMiniHeading from '../components/sidebarminiheading.js';
 import Page from '../components/page.js';
 import { poetNameString } from '../components/poetname-helpers.js';
 import PoetName from '../components/poetname.js';
@@ -131,7 +132,7 @@ const MetadataGroup = ({ title, children, printHidden = false }) => {
   const className = `metadata-group${printHidden ? ' print-hidden' : ''}`;
   return (
     <section className={className}>
-      <h4>{title}</h4>
+      <SidebarMiniHeading>{title}</SidebarMiniHeading>
       {children}
       <style jsx>{`
         .metadata-group {
@@ -139,15 +140,6 @@ const MetadataGroup = ({ title, children, printHidden = false }) => {
         }
         .metadata-group:last-child {
           margin-bottom: 0;
-        }
-        .metadata-group :global(h4) {
-          margin: 0 0 7px;
-          color: #777;
-          font-size: 0.75em;
-          font-weight: 600;
-          letter-spacing: 0.06em;
-          line-height: 1.2;
-          text-transform: uppercase;
         }
         .metadata-group :global(a) {
           hyphens: none;


### PR DESCRIPTION
## Ændring
Fastsætter en fælles komponent til minioverskrifter i sidebaren og bruger den på biografisider og digtsider.

Det giver konsistent typografi for labels i sidebaren (fx `Navn`, `Født`, `Noter`, `Kilde` osv.).

## Ændrede filer
- `components/sidebarminiheading.js` (ny komponent)
- `pages/text.js`
- `pages/bio.js`
- `components/external-identifier-links.js`

## Validering
- Manuelle visuelle ændringer gennemgået for at sikre, at stilen nu er fælles på relevante sider.
- `about` og `keyword` blev udeladt efter ønske og bruger deres tidligere udtryk.
