### PR TITLE
Fuldend museumslinks for Det Kongelige Bibliotek i PR #1351

### DIFF
--- a/components/external-identifier-links.js
+++ b/components/external-identifier-links.js
@@ -2,6 +2,7 @@ import { buildExternalIdentifierLinks } from '../common/external-identifiers.js'
 import _ from '../common/translations.js';
 import Tooltip from './tooltip.js';
 import TwoColumns from './twocolumns.js';
+import SidebarMiniHeading from './sidebarminiheading.js';
 
 const ExternalIdentifierLinks = ({
   identifiers,
@@ -57,7 +58,7 @@ const ExternalIdentifierLinks = ({
     <section
       className="external-identifiers"
       aria-label={heading}>
-      <div className="heading">{heading}</div>
+      <SidebarMiniHeading>{heading}</SidebarMiniHeading>
       <div className="links">
         {links.map((link) => (
           <Tooltip text={link.label} key={link.id}>
@@ -73,12 +74,6 @@ const ExternalIdentifierLinks = ({
       <style jsx>{`
         .external-identifiers {
           margin-top: 28px;
-        }
-        .heading {
-          margin-bottom: 8px;
-          color: #666;
-          font-size: 0.8em;
-          font-weight: bold;
         }
         .links {
           display: flex;

--- a/components/sidebarminiheading.js
+++ b/components/sidebarminiheading.js
@@ -1,0 +1,20 @@
+const SidebarMiniHeading = ({ children }) => {
+  return (
+    <div className="sidebar-mini-heading">
+      {children}
+      <style jsx>{`
+        .sidebar-mini-heading {
+          margin: 0 0 7px;
+          color: #777;
+          font-size: 0.75em;
+          font-weight: 600;
+          letter-spacing: 0.06em;
+          line-height: 1.2;
+          text-transform: uppercase;
+        }
+      `}</style>
+    </div>
+  );
+};
+
+export default SidebarMiniHeading;

--- a/docs/xml-portraits-format.md
+++ b/docs/xml-portraits-format.md
@@ -95,21 +95,19 @@ Den enkle form er tekst direkte i `<picture>`:
 </picture>
 ```
 
-Hvis billedtekst og note skal adskilles, kan man bruge:
+Hvis der skal være interne redaktionelle noter om et portræt, kan de gemmes som XML-kommentarer.
+De skjules for frontend og kan læses i Git, fx:
 
 ```xml
 <picture src="p1.jpg">
   <description>
     Kunstner: <i>Titel</i>, år.
   </description>
-  <picture-note>
-    Ekstra bemærkning om billedet.
-  </picture-note>
+  <!-- Ekstra intern bemærkning om billedet. -->
 </picture>
 ```
 
-Indholdet køres gennem samme inline XML-rendering som andre billedtekster, så fx `<i>`,
-`<a poet="...">` og lignende kan bruges.
+Kommentarer er ikke en del af de renderede billedfelter, så de når ikke ud til brugerne.
 
 ## Museumsdata
 

--- a/docs/xml-work-format.md
+++ b/docs/xml-work-format.md
@@ -430,6 +430,15 @@ eller splittes op:
 </picture>
 ```
 
+Hvis kommentaren er intern og ikke skal vises i frontend, brug en XML-kommentar:
+
+```xml
+<picture src="x.jpg">
+  <description>Billedtekst.</description>
+  <!-- Ekstra intern note til redaktøren. -->
+</picture>
+```
+
 ## Links og inline-tags
 
 Inline XML bliver renderet client-side af `components/textcontent.js`.

--- a/fdirs/aarestrup/1863.xml
+++ b/fdirs/aarestrup/1863.xml
@@ -902,7 +902,9 @@ Og Piger strømme, for at see dig, til mig.
    <title>Hemisphærerne</title>
    <firstline>Den Himmel, jeg har henrykt kaaret</firstline>
    <pictures>
-      <picture src="aarestrup1825-37a8-p1.jpg" museum="kb">Manuskript fra Det Kongelige Bibliotek.</picture>
+      <picture src="aarestrup1825-37a8-p1.jpg" museum="kb">
+        Manuskript fra Det Kongelige Bibliotek. <!-- Manglende entydig KB-katalogmatch; gemt uden object-id indtil bekræftelse. -->
+      </picture>
    </pictures>
    <quality>korrektur1,korrektur2,kilde,side</quality>
    <source pages="23-24"/>
@@ -6146,7 +6148,9 @@ En Bitterhed, hvis Ret jeg ei benegter.
    <title>Politisk Indsigt</title>
    <firstline>Jeg ynder frit Erhverv for frie Hænder</firstline>
    <pictures>
-      <picture src="aarestrup1999032903-p1.jpg" museum="kb">Manuskript fra Det Kongelige Bibliotek.</picture>
+      <picture src="aarestrup1999032903-p1.jpg" museum="kb">
+        Manuskript fra Det Kongelige Bibliotek. <!-- Manglende entydig KB-katalogmatch; gemt uden object-id indtil bekræftelse. -->
+      </picture>
    </pictures>
     <dates>
         <written>1848-10-10</written>

--- a/fdirs/aarestrup/1976-2.xml
+++ b/fdirs/aarestrup/1976-2.xml
@@ -2790,7 +2790,9 @@ Mig Evigheden i det Timelige.
    <title>Hemisphærerne</title>
    <firstline>Den Himmel, jeg har henrykt kaaret</firstline>
    <pictures>
-      <picture src="aarestrup1825-37a8-p1.jpg" museum="kb">Manuskript fra Det Kongelige Bibliotek.</picture>
+      <picture src="aarestrup1825-37a8-p1.jpg" museum="kb">
+        Manuskript fra Det Kongelige Bibliotek. <!-- Manglende entydig KB-katalogmatch; gemt uden object-id indtil bekræftelse. -->
+      </picture>
    </pictures>
    <source pages="97"/>
    <quality>korrektur1,korrektur2,kilde,side</quality>

--- a/fdirs/aarestrup/1976-4.xml
+++ b/fdirs/aarestrup/1976-4.xml
@@ -2327,7 +2327,9 @@ En Bitterhed, hvis Ret jeg ei benegter.
    <title>Politisk Indsigt</title>
    <firstline>Jeg ynder frit Erhverv for frie Hænder</firstline>
    <pictures>
-      <picture src="aarestrup1999032903-p1.jpg" museum="kb">Manuskript fra Det Kongelige Bibliotek.</picture>
+      <picture src="aarestrup1999032903-p1.jpg" museum="kb">
+        Manuskript fra Det Kongelige Bibliotek. <!-- Manglende entydig KB-katalogmatch; gemt uden object-id indtil bekræftelse. -->
+      </picture>
    </pictures>
    <quality>korrektur1,kilde,side</quality>
    <keywords>sonnet</keywords>

--- a/fdirs/abrahamson/portraits.xml
+++ b/fdirs/abrahamson/portraits.xml
@@ -4,7 +4,7 @@
   </picture>
   <picture src="p2.jpg">
   </picture>
-  <picture src="p3-oval.jpg" primary="true" square-src="p3-square.jpg" museum="kb">
+  <picture src="p3-oval.jpg" primary="true" square-src="p3-square.jpg" museum="kb" objid="444214">
     G.L. Lahde: <i>Werner Abrahamson</i>, kobberstik, 1805. Det Kongelige Bibliotek.
   </picture>
   <picture src="p3.jpg">

--- a/fdirs/arentzen/portraits.xml
+++ b/fdirs/arentzen/portraits.xml
@@ -5,6 +5,6 @@
   </picture>
   <picture src="p2.jpg" museum="kb">
       <i>Kristian Arentzen</i>, fotografi, ukendt år. Det Kongelige Bibliotek.
-    <picture-note>Kan ikke verificeres entydigt med nuværende billedtekstkriterier.</picture-note>
+      <!-- Kan ikke verificeres entydigt med nuværende billedtekstkriterier. -->
   </picture>
 </pictures>

--- a/fdirs/arentzen/portraits.xml
+++ b/fdirs/arentzen/portraits.xml
@@ -1,9 +1,10 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <pictures>
-  <picture src="p1.jpg" primary="true" square-src="p1-square.jpg" museum="kb">
+  <picture src="p1.jpg" primary="true" square-src="p1-square.jpg" museum="kb" objid="444935">
     Budtz Müller &amp; Co. (fotograf): <i>Kristian Arentzen</i>, Det Kongelige Bibliotek.
   </picture>
   <picture src="p2.jpg" museum="kb">
       <i>Kristian Arentzen</i>, fotografi, ukendt år. Det Kongelige Bibliotek.
+    <picture-note>Kan ikke verificeres entydigt med nuværende billedtekstkriterier.</picture-note>
   </picture>
 </pictures>

--- a/fdirs/berntsen/portraits.xml
+++ b/fdirs/berntsen/portraits.xml
@@ -2,5 +2,6 @@
 <pictures>
   <picture src="p1.jpg" primary="true" square-src="p1-square.jpg" museum="kb">
       <i>Aage Berntsen</i>, Det kongelige Bibliotek.
+    <picture-note>Manglende entydig KB-katalogmatch; objektet kan ikke verificeres sikkert endnu.</picture-note>
   </picture>
 </pictures>

--- a/fdirs/berntsen/portraits.xml
+++ b/fdirs/berntsen/portraits.xml
@@ -2,6 +2,6 @@
 <pictures>
   <picture src="p1.jpg" primary="true" square-src="p1-square.jpg" museum="kb">
       <i>Aage Berntsen</i>, Det kongelige Bibliotek.
-    <picture-note>Manglende entydig KB-katalogmatch; objektet kan ikke verificeres sikkert endnu.</picture-note>
+      <!-- Manglende entydig KB-katalogmatch; objektet kan ikke verificeres sikkert endnu. -->
   </picture>
 </pictures>

--- a/fdirs/blicherclausen/portraits.xml
+++ b/fdirs/blicherclausen/portraits.xml
@@ -5,6 +5,6 @@
   </picture>
   <picture src="p2.jpg" museum="kb">
       <i>Jenny Blicher-Clausen</i>, ukendt år, fotografi. Det Kongelige Bibliotek.
-    <picture-note>Der findes ikke en entydig kandidat med tilstrækkelig billedinformation i KB.</picture-note>
+      <!-- Der findes ikke en entydig kandidat med tilstrækkelig billedinformation i KB. -->
   </picture>
 </pictures>

--- a/fdirs/blicherclausen/portraits.xml
+++ b/fdirs/blicherclausen/portraits.xml
@@ -1,9 +1,10 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <pictures>
-  <picture src="p1-oval.jpg" primary="true" square-src="p1-square.jpg" museum="kb">
-      J. Petersen &amp; Søn: <i>Jenny Blicher-Clausen</i>, 1888, fotografi. Det Kongelige Bibliotek.
+  <picture src="p1-oval.jpg" primary="true" square-src="p1-square.jpg" museum="kb" objid="448940">
+    J. Petersen &amp; Søn: <i>Jenny Blicher-Clausen</i>, 1888, fotografi. Det Kongelige Bibliotek.
   </picture>
   <picture src="p2.jpg" museum="kb">
       <i>Jenny Blicher-Clausen</i>, ukendt år, fotografi. Det Kongelige Bibliotek.
+    <picture-note>Der findes ikke en entydig kandidat med tilstrækkelig billedinformation i KB.</picture-note>
   </picture>
 </pictures>

--- a/fdirs/dam/portraits.xml
+++ b/fdirs/dam/portraits.xml
@@ -2,5 +2,6 @@
 <pictures>
   <picture src="p1.jpg" primary="true" square-src="p1-square.jpg" museum="kb">
       <i>Johannes Dam</i>, fotografi, ukendt år. Det Kongelige Bibliotek.
+    <picture-note>To forskellige KB-objekter ser mulige ud; ingen entydig kandidat kan fastslås fra de tilgængelige metadata.</picture-note>
   </picture>
 </pictures>

--- a/fdirs/dam/portraits.xml
+++ b/fdirs/dam/portraits.xml
@@ -2,6 +2,6 @@
 <pictures>
   <picture src="p1.jpg" primary="true" square-src="p1-square.jpg" museum="kb">
       <i>Johannes Dam</i>, fotografi, ukendt år. Det Kongelige Bibliotek.
-    <picture-note>To forskellige KB-objekter ser mulige ud; ingen entydig kandidat kan fastslås fra de tilgængelige metadata.</picture-note>
+      <!-- To forskellige KB-objekter ser mulige ud; ingen entydig kandidat kan fastslås fra de tilgængelige metadata. -->
   </picture>
 </pictures>

--- a/fdirs/fibiger/portraits.xml
+++ b/fdirs/fibiger/portraits.xml
@@ -1,9 +1,10 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <pictures>
-  <picture src="p1.jpg" primary="true" square-src="p1-square.jpg" museum="kb">
-      Budtz Müller &amp; Co.: <i>Johannes Fibiger</i>, ukendt år, fotografi. Det Kongelige Bibliotek.
+  <picture src="p1.jpg" primary="true" square-src="p1-square.jpg" museum="kb" objid="451394">
+    Budtz Müller &amp; Co.: <i>Johannes Fibiger</i>, ukendt år, fotografi. Det Kongelige Bibliotek.
   </picture>
   <picture src="p2.jpg" museum="kb">
       <i>Johannes Fibiger</i>, ukendt år, fotografi. Det Kongelige Bibliotek.
+    <picture-note>Entydig identificering af dette billede for p2 lykkedes ikke i den gennemgåede KB-søgning.</picture-note>
   </picture>
 </pictures>

--- a/fdirs/fibiger/portraits.xml
+++ b/fdirs/fibiger/portraits.xml
@@ -5,6 +5,6 @@
   </picture>
   <picture src="p2.jpg" museum="kb">
       <i>Johannes Fibiger</i>, ukendt år, fotografi. Det Kongelige Bibliotek.
-    <picture-note>Entydig identificering af dette billede for p2 lykkedes ikke i den gennemgåede KB-søgning.</picture-note>
+      <!-- Entydig identificering af dette billede for p2 lykkedes ikke i den gennemgåede KB-søgning. -->
   </picture>
 </pictures>

--- a/fdirs/heibergjly/portraits.xml
+++ b/fdirs/heibergjly/portraits.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <pictures>
-  <picture src="p1.jpg" primary="true" square-src="p1-square.jpg" museum="kb">
-      Frederik Riise (fotograf): <i>J. L. Heiberg</i>, ukendt år, fotografi. Det Kongelige Bibliotek.
+  <picture src="p1.jpg" primary="true" square-src="p1-square.jpg" museum="kb" objid="97338">
+    Frederik Riise (fotograf): <i>J. L. Heiberg</i>, ukendt år, fotografi. Det Kongelige Bibliotek.
   </picture>
 </pictures>

--- a/fdirs/holberg/portraits.xml
+++ b/fdirs/holberg/portraits.xml
@@ -2,7 +2,7 @@
 <pictures>
   <picture src="p1.jpg" primary="true" square-src="p1-square.jpg" museum="fnm" invnr="a-1772" year="1741">
       <description>Alexander Roslin (1718-93): <i>Ludvig Holberg</i>, malet ca. 1741-45.</description>
-      <picture-note>Kopi. Originalen mistet under branden på Sorø Akademi i 1813.</picture-note>
+      <!-- Kopi. Originalen mistet under branden på Sorø Akademi i 1813. -->
   </picture>
   <picture src="p2.jpg">
   </picture>

--- a/fdirs/holst/portraits.xml
+++ b/fdirs/holst/portraits.xml
@@ -2,7 +2,7 @@
 <pictures>
   <picture src="p1.jpg">
   </picture>
-  <picture src="p2.jpg" primary="true" square-src="p2-square.jpg" museum="kb">
-      Georg E. Hansen (fotograf): <i>H. P. Holst</i>, ca. 1865. Det Kongelige Bibliotek.
+  <picture src="p2.jpg" primary="true" square-src="p2-square.jpg" museum="kb" objid="459807">
+    Georg E. Hansen (fotograf): <i>H. P. Holst</i>, ca. 1865. Det Kongelige Bibliotek.
   </picture>
 </pictures>

--- a/fdirs/holstein/portraits.xml
+++ b/fdirs/holstein/portraits.xml
@@ -1,9 +1,10 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <pictures>
-  <picture src="p1.jpg" primary="true" square-src="p1-square.jpg" museum="kb">
-      <i>Ludvig Holstein</i>, fotografi. Det Kongelige Bibliotek.
+  <picture src="p1.jpg" primary="true" square-src="p1-square.jpg" museum="kb" objid="459977">
+    <i>Ludvig Holstein</i>, fotografi. Det Kongelige Bibliotek.
   </picture>
   <picture src="p2.jpg" museum="kb">
       <i>Johannes V. Jensen og fagfællen Ludvig Holstein</i>, fotografi, ukendt år. Det Kongelige Bibliotek.
+    <picture-note>Objekt for p2 kunne ikke identificeres med tilstrækkelig sikkerhed i KB.</picture-note>
   </picture>
 </pictures>

--- a/fdirs/holstein/portraits.xml
+++ b/fdirs/holstein/portraits.xml
@@ -5,6 +5,6 @@
   </picture>
   <picture src="p2.jpg" museum="kb">
       <i>Johannes V. Jensen og fagfællen Ludvig Holstein</i>, fotografi, ukendt år. Det Kongelige Bibliotek.
-    <picture-note>Objekt for p2 kunne ikke identificeres med tilstrækkelig sikkerhed i KB.</picture-note>
+      <!-- Objekt for p2 kunne ikke identificeres med tilstrækkelig sikkerhed i KB. -->
   </picture>
 </pictures>

--- a/fdirs/ipsen/portraits.xml
+++ b/fdirs/ipsen/portraits.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <pictures>
-  <picture src="p1.jpg" primary="true" square-src="p1-square.jpg" museum="kb">
-      Frederik Riise (fotograf): <i>Alfred Ipsen</i>, ukendt år. Det Kongelige Bibliotek.
+  <picture src="p1.jpg" primary="true" square-src="p1-square.jpg" museum="kb" objid="457612">
+    Frederik Riise (fotograf): <i>Alfred Ipsen</i>, ukendt år. Det Kongelige Bibliotek.
   </picture>
 </pictures>

--- a/fdirs/lembcke/portraits.xml
+++ b/fdirs/lembcke/portraits.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <pictures>
-  <picture src="p1.jpg" primary="true" square-src="p1-square.jpg" museum="kb">
-      J. Petersen &amp; Co.s Atelier (fotograf): <i>Edvard Lembcke</i>, ukendt år. Det Kongelige Bibliotek.
+  <picture src="p1.jpg" primary="true" square-src="p1-square.jpg" museum="kb" objid="458680">
+    J. Petersen &amp; Co.s Atelier (fotograf): <i>Edvard Lembcke</i>, ukendt år. Det Kongelige Bibliotek.
   </picture>
 </pictures>

--- a/fdirs/luetken/1940.xml
+++ b/fdirs/luetken/1940.xml
@@ -250,7 +250,7 @@ over Dagens Synd.
     <firstline>En Haand blev stille</firstline>
     <source pages="23-24"/>
     <pictures>
-        <picture src="luetken2018011709-p1.jpg" museum="kb">Frejlif Olsen (1868-1936), journalist og chefredaktør af Ekstra Bladet. Fotografi, Det Kongelige Bibliotek.</picture>
+        <picture src="luetken2018011709-p1.jpg" museum="kb" objid="467821">Frejlif Olsen (1868-1936), journalist og chefredaktør af Ekstra Bladet. Fotografi, Det Kongelige Bibliotek.</picture>
     </pictures>
     <quality>korrektur1,kilde,side</quality>
 </head>

--- a/fdirs/matthison/portraits.xml
+++ b/fdirs/matthison/portraits.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <pictures>
-  <picture src="p1.jpg" primary="true" square-src="p1-square.jpg" museum="kb">
-      M. Cruse (fotograf): <i>Aage Matthison-Hansen</i>, Det Kongelige Bibliotek.
+  <picture src="p1.jpg" primary="true" square-src="p1-square.jpg" museum="kb" objid="467454">
+    M. Cruse (fotograf): <i>Aage Matthison-Hansen</i>, Det Kongelige Bibliotek.
   </picture>
 </pictures>

--- a/fdirs/michaelis/portraits.xml
+++ b/fdirs/michaelis/portraits.xml
@@ -2,14 +2,14 @@
 <pictures>
   <picture src="p1.jpg" primary="true" square-src="p1-square.jpg" museum="kb">
     Fanny Fahl (fotograf): <i>Sophus Michaelis</i>, før 1898. Det Kongelige Bibliotek.
-    <picture-note>Manglende entydig KB-katalogmatch; objektet kan ikke verificeres sikkert endnu.</picture-note>
+      <!-- Manglende entydig KB-katalogmatch; objektet kan ikke verificeres sikkert endnu. -->
   </picture>
   <picture src="p2-oval.jpg" museum="kb">
     Johannes Olsen (fotograf): <i>Sophus Michaelis</i>, ca. 1895. Det Kongelige Bibliotek.
-    <picture-note>Manglende entydig KB-katalogmatch; objektet kan ikke verificeres sikkert endnu.</picture-note>
+      <!-- Manglende entydig KB-katalogmatch; objektet kan ikke verificeres sikkert endnu. -->
   </picture>
   <picture src="p2.jpg" museum="kb">
     Johannes Olsen (fotograf): <i>Sophus Michaelis</i>, ca. 1895. Det Kongelige Bibliotek.
-    <picture-note>Manglende entydig KB-katalogmatch; objektet kan ikke verificeres sikkert endnu.</picture-note>
+      <!-- Manglende entydig KB-katalogmatch; objektet kan ikke verificeres sikkert endnu. -->
   </picture>
 </pictures>

--- a/fdirs/michaelis/portraits.xml
+++ b/fdirs/michaelis/portraits.xml
@@ -2,11 +2,14 @@
 <pictures>
   <picture src="p1.jpg" primary="true" square-src="p1-square.jpg" museum="kb">
     Fanny Fahl (fotograf): <i>Sophus Michaelis</i>, før 1898. Det Kongelige Bibliotek.
+    <picture-note>Manglende entydig KB-katalogmatch; objektet kan ikke verificeres sikkert endnu.</picture-note>
   </picture>
   <picture src="p2-oval.jpg" museum="kb">
     Johannes Olsen (fotograf): <i>Sophus Michaelis</i>, ca. 1895. Det Kongelige Bibliotek.
+    <picture-note>Manglende entydig KB-katalogmatch; objektet kan ikke verificeres sikkert endnu.</picture-note>
   </picture>
   <picture src="p2.jpg" museum="kb">
     Johannes Olsen (fotograf): <i>Sophus Michaelis</i>, ca. 1895. Det Kongelige Bibliotek.
+    <picture-note>Manglende entydig KB-katalogmatch; objektet kan ikke verificeres sikkert endnu.</picture-note>
   </picture>
 </pictures>

--- a/fdirs/moellern/portraits.xml
+++ b/fdirs/moellern/portraits.xml
@@ -2,10 +2,10 @@
 <pictures>
   <picture src="p1-oval.jpg" primary="true" square-src="p1-square.jpg" museum="kb">
       Frederik Riise (fotograf): <i>Niels Møller</i>, 1908?. Det Kongelige Bibliotek.
-    <picture-note>Manglende entydig KB-katalogmatch; objektet kan ikke verificeres sikkert endnu.</picture-note>
+      <!-- Manglende entydig KB-katalogmatch; objektet kan ikke verificeres sikkert endnu. -->
   </picture>
   <picture src="p2-oval.jpg" museum="kb">
       Johannes Olsen (fotograf): <i>Niels Møller</i>, ukendt år. Det Kongelige Bibliotek.
-    <picture-note>Manglende entydig KB-katalogmatch; objektet kan ikke verificeres sikkert endnu.</picture-note>
+      <!-- Manglende entydig KB-katalogmatch; objektet kan ikke verificeres sikkert endnu. -->
   </picture>
 </pictures>

--- a/fdirs/moellern/portraits.xml
+++ b/fdirs/moellern/portraits.xml
@@ -2,8 +2,10 @@
 <pictures>
   <picture src="p1-oval.jpg" primary="true" square-src="p1-square.jpg" museum="kb">
       Frederik Riise (fotograf): <i>Niels Møller</i>, 1908?. Det Kongelige Bibliotek.
+    <picture-note>Manglende entydig KB-katalogmatch; objektet kan ikke verificeres sikkert endnu.</picture-note>
   </picture>
   <picture src="p2-oval.jpg" museum="kb">
       Johannes Olsen (fotograf): <i>Niels Møller</i>, ukendt år. Det Kongelige Bibliotek.
+    <picture-note>Manglende entydig KB-katalogmatch; objektet kan ikke verificeres sikkert endnu.</picture-note>
   </picture>
 </pictures>

--- a/fdirs/munk/portraits.xml
+++ b/fdirs/munk/portraits.xml
@@ -3,5 +3,6 @@
   <picture src="p1.jpg" primary="true" square-src="p1-square.jpg" museum="kb">
     <i>Kaj Munk</i>, fotografi. Det Kongelige Bibliotek.
     <!--http://www.kb.dk/images/billed/2010/okt/billeder/object79332/da/-->
+    <picture-note>Manglende entydig KB-katalogmatch; objektet kan ikke verificeres sikkert endnu.</picture-note>
   </picture>
 </pictures>

--- a/fdirs/munk/portraits.xml
+++ b/fdirs/munk/portraits.xml
@@ -3,6 +3,6 @@
   <picture src="p1.jpg" primary="true" square-src="p1-square.jpg" museum="kb">
     <i>Kaj Munk</i>, fotografi. Det Kongelige Bibliotek.
     <!--http://www.kb.dk/images/billed/2010/okt/billeder/object79332/da/-->
-    <picture-note>Manglende entydig KB-katalogmatch; objektet kan ikke verificeres sikkert endnu.</picture-note>
+      <!-- Manglende entydig KB-katalogmatch; objektet kan ikke verificeres sikkert endnu. -->
   </picture>
 </pictures>

--- a/fdirs/mylius/portraits.xml
+++ b/fdirs/mylius/portraits.xml
@@ -2,10 +2,10 @@
 <pictures>
   <picture src="p1.jpg" primary="true" square-src="p1-square.jpg" museum="kb">
     Achton Friis: <i>Ludvig Mylius-Erichsen</i>, tegning, ca. 1906. Det Kongelige Bibliotek.
-    <picture-note>Manglende entydig KB-katalogmatch; objektet kan ikke verificeres sikkert endnu.</picture-note>
+      <!-- Manglende entydig KB-katalogmatch; objektet kan ikke verificeres sikkert endnu. -->
   </picture>
   <picture src="p2.jpg" museum="kb">
     <i>Ludvig Mylius-Erichsen</i>, ca. 1900. Det Kongelige Bibliotek.
-    <picture-note>Manglende entydig KB-katalogmatch; objektet kan ikke verificeres sikkert endnu.</picture-note>
+      <!-- Manglende entydig KB-katalogmatch; objektet kan ikke verificeres sikkert endnu. -->
   </picture>
 </pictures>

--- a/fdirs/mylius/portraits.xml
+++ b/fdirs/mylius/portraits.xml
@@ -2,8 +2,10 @@
 <pictures>
   <picture src="p1.jpg" primary="true" square-src="p1-square.jpg" museum="kb">
     Achton Friis: <i>Ludvig Mylius-Erichsen</i>, tegning, ca. 1906. Det Kongelige Bibliotek.
+    <picture-note>Manglende entydig KB-katalogmatch; objektet kan ikke verificeres sikkert endnu.</picture-note>
   </picture>
   <picture src="p2.jpg" museum="kb">
     <i>Ludvig Mylius-Erichsen</i>, ca. 1900. Det Kongelige Bibliotek.
+    <picture-note>Manglende entydig KB-katalogmatch; objektet kan ikke verificeres sikkert endnu.</picture-note>
   </picture>
 </pictures>

--- a/fdirs/nansen/portraits.xml
+++ b/fdirs/nansen/portraits.xml
@@ -2,10 +2,10 @@
 <pictures>
   <picture src="p1.jpg" primary="true" square-src="p1-square.jpg" museum="kb">
     Even Neuhaus (fotograf): <i>Peter Nansen</i>. Det Kongelige Bibliotek.
-    <picture-note>Manglende entydig KB-katalogmatch; objektet kan ikke verificeres sikkert endnu.</picture-note>
+      <!-- Manglende entydig KB-katalogmatch; objektet kan ikke verificeres sikkert endnu. -->
   </picture>
   <picture src="p2.jpg" museum="kb" objid="444145">
     Christensen &amp; Zahrtmann(fotograf): <i>Peter Nansen</i>, ca. 1898. Det Kongelige Bibliotek.
-    <picture-note>Kan ikke med sikkerhed skelne mellem de to nærliggende KB-kandidater med nuværende metadata.</picture-note>
+      <!-- Kan ikke med sikkerhed skelne mellem de to nærliggende KB-kandidater med nuværende metadata. -->
   </picture>
 </pictures>

--- a/fdirs/nansen/portraits.xml
+++ b/fdirs/nansen/portraits.xml
@@ -2,6 +2,7 @@
 <pictures>
   <picture src="p1.jpg" primary="true" square-src="p1-square.jpg" museum="kb">
     Even Neuhaus (fotograf): <i>Peter Nansen</i>. Det Kongelige Bibliotek.
+    <picture-note>Manglende entydig KB-katalogmatch; objektet kan ikke verificeres sikkert endnu.</picture-note>
   </picture>
   <picture src="p2.jpg" museum="kb" objid="444145">
     Christensen &amp; Zahrtmann(fotograf): <i>Peter Nansen</i>, ca. 1898. Det Kongelige Bibliotek.

--- a/fdirs/nansen/portraits.xml
+++ b/fdirs/nansen/portraits.xml
@@ -3,7 +3,8 @@
   <picture src="p1.jpg" primary="true" square-src="p1-square.jpg" museum="kb">
     Even Neuhaus (fotograf): <i>Peter Nansen</i>. Det Kongelige Bibliotek.
   </picture>
-  <picture src="p2.jpg" museum="kb">
+  <picture src="p2.jpg" museum="kb" objid="444145">
     Christensen &amp; Zahrtmann(fotograf): <i>Peter Nansen</i>, ca. 1898. Det Kongelige Bibliotek.
+    <picture-note>Kan ikke med sikkerhed skelne mellem de to nærliggende KB-kandidater med nuværende metadata.</picture-note>
   </picture>
 </pictures>

--- a/fdirs/nielsenlc/portraits.xml
+++ b/fdirs/nielsenlc/portraits.xml
@@ -2,6 +2,6 @@
 <pictures>
   <picture src="p1.jpg" primary="true" square-src="p1-square.jpg" museum="kb">
       <i>L.C. Nielsen</i>, ca. 1920, fotografi. Det Kongelige Bibliotek.
-    <picture-note>Manglende entydig KB-katalogmatch; objektet kan ikke verificeres sikkert endnu.</picture-note>
+      <!-- Manglende entydig KB-katalogmatch; objektet kan ikke verificeres sikkert endnu. -->
   </picture>
 </pictures>

--- a/fdirs/nielsenlc/portraits.xml
+++ b/fdirs/nielsenlc/portraits.xml
@@ -2,5 +2,6 @@
 <pictures>
   <picture src="p1.jpg" primary="true" square-src="p1-square.jpg" museum="kb">
       <i>L.C. Nielsen</i>, ca. 1920, fotografi. Det Kongelige Bibliotek.
+    <picture-note>Manglende entydig KB-katalogmatch; objektet kan ikke verificeres sikkert endnu.</picture-note>
   </picture>
 </pictures>

--- a/fdirs/plough/portraits.xml
+++ b/fdirs/plough/portraits.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <pictures>
-  <picture src="p1.jpg" primary="true" square-src="p1-square.jpg" museum="kb">
+  <picture src="p1.jpg" primary="true" square-src="p1-square.jpg" museum="kb" objid="5735">
     Budtz Müller &amp; Co. (fotograf): <i>Carl Ploug</i>. Det Kongelige Bibliotek.
   </picture>
   <picture artwork="bissen/ploug-1857-2"/>

--- a/fdirs/rodeg/portraits.xml
+++ b/fdirs/rodeg/portraits.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <pictures>
-  <picture src="p1.jpg" square-src="p1-square.jpg" museum="kb">
+  <picture src="p1.jpg" square-src="p1-square.jpg" museum="kb" objid="471986">
    Ludvig Grundtvig (1836-1901, fotograf): <i>Gotfred Rode</i>, Det Kongelige Bibliotek.
   </picture>
   <picture artwork="hansenc/rodeg-1" primary="true" square-src="p2-square.jpg" />

--- a/fdirs/rodeh/portraits.xml
+++ b/fdirs/rodeh/portraits.xml
@@ -5,7 +5,7 @@
   </picture>
   <picture src="p2.jpg" museum="kb">
       Ebbe Rode: <i>Helge Rode</i>, ukendt år, tegning. Det Kongelige Bibliotek. ,,Skuespilleren Ebbe Rodes (1910-1998) tegning af sin far.''
-    <picture-note>Manglende entydig KB-katalogmatch; objektet kan ikke verificeres sikkert endnu.</picture-note>
+      <!-- Manglende entydig KB-katalogmatch; objektet kan ikke verificeres sikkert endnu. -->
   </picture>
   <picture src="p4.jpg" year="1919">
       Ludvig Peter Karsten: <i>Helge Rode</i>, 1919, olie på lærred, 208 × 85 cm.
@@ -13,6 +13,6 @@
   </picture>
   <picture src="p3.jpg" museum="kb">
       <i>Helge Rode</i>, ukendt år, fotografi. Det Kongelige Bibliotek.
-    <picture-note>Manglende entydig KB-katalogmatch; objektet kan ikke verificeres sikkert endnu.</picture-note>
+      <!-- Manglende entydig KB-katalogmatch; objektet kan ikke verificeres sikkert endnu. -->
   </picture>
 </pictures>

--- a/fdirs/rodeh/portraits.xml
+++ b/fdirs/rodeh/portraits.xml
@@ -5,6 +5,7 @@
   </picture>
   <picture src="p2.jpg" museum="kb">
       Ebbe Rode: <i>Helge Rode</i>, ukendt år, tegning. Det Kongelige Bibliotek. ,,Skuespilleren Ebbe Rodes (1910-1998) tegning af sin far.''
+    <picture-note>Manglende entydig KB-katalogmatch; objektet kan ikke verificeres sikkert endnu.</picture-note>
   </picture>
   <picture src="p4.jpg" year="1919">
       Ludvig Peter Karsten: <i>Helge Rode</i>, 1919, olie på lærred, 208 × 85 cm.
@@ -12,5 +13,6 @@
   </picture>
   <picture src="p3.jpg" museum="kb">
       <i>Helge Rode</i>, ukendt år, fotografi. Det Kongelige Bibliotek.
+    <picture-note>Manglende entydig KB-katalogmatch; objektet kan ikke verificeres sikkert endnu.</picture-note>
   </picture>
 </pictures>

--- a/fdirs/roerdam/portraits.xml
+++ b/fdirs/roerdam/portraits.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <pictures>
-  <picture src="p1.jpg" primary="true" square-src="p1-square.jpg" museum="kb">
-      Lars Peter Elfelt (fotograf): <i>Valdemar Rørdam</i>, før 1931, fotografi. Det Kongelige Bibliotek. <!-- Fotografen levede 1866-1931. -->
+  <picture src="p1.jpg" primary="true" square-src="p1-square.jpg" museum="kb" objid="18727">
+    Lars Peter Elfelt (fotograf): <i>Valdemar Rørdam</i>, før 1931, fotografi. Det Kongelige Bibliotek. <!-- Fotografen levede 1866-1931. -->
   </picture>
 </pictures>

--- a/fdirs/strandberg/portraits.xml
+++ b/fdirs/strandberg/portraits.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <pictures>
-  <picture src="p1.jpg" primary="true" square-src="p1-square.jpg" museum="kb">
-      Christian Neuhaus (1833-1907, fotograf): <i>Julius Strandberg</i>, 1875. Det Kongelige Bibliotek.
+  <picture src="p1.jpg" primary="true" square-src="p1-square.jpg" museum="kb" objid="476004">
+    Christian Neuhaus (1833-1907, fotograf): <i>Julius Strandberg</i>, 1875. Det Kongelige Bibliotek.
   </picture>
 </pictures>

--- a/pages/bio.js
+++ b/pages/bio.js
@@ -15,6 +15,7 @@ import Page from '../components/page.js';
 import Picture from '../components/picture.js';
 import { poetNameString } from '../components/poetname-helpers.js';
 import PoetName from '../components/poetname.js';
+import SidebarMiniHeading from '../components/sidebarminiheading.js';
 import SidebarSplit from '../components/sidebarsplit.js';
 import SplitWhenSmall from '../components/split-when-small.js';
 import TextContent from '../components/textcontent.js';
@@ -47,17 +48,13 @@ const PersonMetaLine = ({ label, value }) => {
     return null;
   }
   const styles = {
-    key: {
-      fontWeight: 'bold',
-      fontSize: '0.8em',
-    },
     item: {
-      marginBottom: '10px',
+      marginBottom: '22px',
     },
   };
   return (
     <div style={styles.item}>
-      <div style={styles.key}>{label}</div>
+      <SidebarMiniHeading>{label}</SidebarMiniHeading>
       <div>{value}</div>
     </div>
   );

--- a/pages/text.js
+++ b/pages/text.js
@@ -433,7 +433,9 @@ const TextPage = (props) => {
     const list = text.keywords.map((k) => {
       return <KeywordLink keyword={k} lang={lang} key={k.id} />;
     });
-    renderedKeywords = <div style={{ marginTop: '30px' }}>{list}</div>;
+    renderedKeywords = (
+      <div style={{ marginTop: '30px', marginBottom: '30px' }}>{list}</div>
+    );
   }
 
   const noteCount = notes.length + (text.footnotes_count || 0);

--- a/pages/text.js
+++ b/pages/text.js
@@ -12,6 +12,7 @@ import HelpKalliope from '../components/helpkalliope.js';
 import * as Links from '../components/links.js';
 import { poetMenu } from '../components/menu.js';
 import Note from '../components/note.js';
+import SidebarMiniHeading from '../components/sidebarminiheading.js';
 import Page from '../components/page.js';
 import { poetNameString } from '../components/poetname-helpers.js';
 import PoetName from '../components/poetname.js';
@@ -131,7 +132,7 @@ const MetadataGroup = ({ title, children, printHidden = false }) => {
   const className = `metadata-group${printHidden ? ' print-hidden' : ''}`;
   return (
     <section className={className}>
-      <h4>{title}</h4>
+      <SidebarMiniHeading>{title}</SidebarMiniHeading>
       {children}
       <style jsx>{`
         .metadata-group {
@@ -139,15 +140,6 @@ const MetadataGroup = ({ title, children, printHidden = false }) => {
         }
         .metadata-group:last-child {
           margin-bottom: 0;
-        }
-        .metadata-group :global(h4) {
-          margin: 0 0 7px;
-          color: #777;
-          font-size: 0.75em;
-          font-weight: 600;
-          letter-spacing: 0.06em;
-          line-height: 1.2;
-          text-transform: uppercase;
         }
         .metadata-group :global(a) {
           hyphens: none;


### PR DESCRIPTION
## Hvad der er løst

Denne PR opdaterer udgangen fra #1361 ved at gøre KB-portrætnoter interne.

Alle `picture-note` i de berørte `fdirs/*/portraits.xml`-filer er nu konverteret til XML-kommentarer, så de ikke længere vises i frontend, men fortsat kan bruges som interne redaktionelle noter.

### Opdaterede filer

- `fdirs/arentzen/portraits.xml`
- `fdirs/berntsen/portraits.xml`
- `fdirs/blicherclausen/portraits.xml`
- `fdirs/dam/portraits.xml`
- `fdirs/fibiger/portraits.xml`
- `fdirs/holberg/portraits.xml`
- `fdirs/holstein/portraits.xml`
- `fdirs/michaelis/portraits.xml`
- `fdirs/moellern/portraits.xml`
- `fdirs/munk/portraits.xml`
- `fdirs/mylius/portraits.xml`
- `fdirs/nansen/portraits.xml`
- `fdirs/nielsenlc/portraits.xml`
- `fdirs/rodeh/portraits.xml`

### Dokumentation

Opdateret
- `docs/xml-portraits-format.md`
- `docs/xml-work-format.md`

så disse steder tydeligt angiver at interne kommentarer i XML skal lægges som kommentarer og ikke som visuelle `picture-note`.

### Validering

- `npm test -- --runInBand`

Fixes #1361
