### PR TITLE
Digitaliseringskilder: strukturer href på source

### DIFF
--- a/__tests__/build-static-source.test.js
+++ b/__tests__/build-static-source.test.js
@@ -1,0 +1,62 @@
+import { DOMParser } from '@xmldom/xmldom';
+import {
+  collectSourceDigitalUrl,
+  resolveSourceDigitalUrl,
+  resolveSourceDigitalUrlForText,
+} from '../tools/build-static/source.js';
+
+describe('source digital URL helpers', () => {
+  const parseSource = (sourceXml) => {
+    const doc = new DOMParser().parseFromString(`<root>${sourceXml}</root>`, 'text/xml');
+    return doc.getElementsByTagName('source')[0];
+  };
+
+  it('reads explicit href from source node', () => {
+    const sourceNode = parseSource('<source href="https://example.com">Kilde</source>');
+
+    expect(collectSourceDigitalUrl(sourceNode)).toBe('https://example.com');
+    expect(resolveSourceDigitalUrl({ sourceNode, inheritedDigitalUrl: 'https://inherited.com' })).toBe(
+      'https://example.com'
+    );
+  });
+
+  it('uses inherited source-url when source node lacks explicit href', () => {
+    const sourceNode = parseSource('<source>Kilde</source>');
+
+    expect(resolveSourceDigitalUrlForText({
+      sourceNode,
+      sourceForText: { digitalUrl: 'https://inherited.com' },
+    })).toBe('https://inherited.com');
+  });
+
+  it('does not override explicit source-url even when inherited has a better URL', () => {
+    const sourceNode = parseSource(
+      '<source href="https://example.org/facsimile.pdf">Kilde</source>'
+    );
+
+    expect(
+      resolveSourceDigitalUrlForText({
+        sourceNode,
+        sourceForText: { digitalUrl: 'https://www.rexlibris.kb.dk/ma/123' },
+      })
+    ).toBe('https://example.org/facsimile.pdf');
+  });
+
+  it('prefers a REX URL over a direct PDF fallback', () => {
+    expect(
+      resolveSourceDigitalUrl({
+        sourceNode: null,
+        inheritedDigitalUrl: [
+          'https://example.org/facsimile.pdf',
+          'https://www.rexlibris.kb.dk/ma/123',
+        ],
+      })
+    ).toBe('https://www.rexlibris.kb.dk/ma/123');
+  });
+
+  it('returns null when no url is available', () => {
+    const sourceNode = parseSource('<source>Kilde</source>');
+
+    expect(resolveSourceDigitalUrlForText({ sourceNode })).toBeNull();
+  });
+});

--- a/docs/xml-work-format.md
+++ b/docs/xml-work-format.md
@@ -80,12 +80,23 @@ En kilde paa vaerkniveau kan bruges som default for tekster i samme vaerk:
 </source>
 ```
 
+En stabil digitalisering kan tilføjes på kilde-niveau:
+
+```xml
+<source href="https://www.kb.dk/en/..." facsimile="115308051039_color"
+        facsimile-pages-num="66"
+        facsimile-pages-offset="8">
+  Erica: <i>Lyngblomster</i>, 1856.
+</source>
+```
+
 Attributter:
 
 - `id`: valgfri kilde-id. Uden `id` bliver kilden `default`.
 - `facsimile`: mappe/id for faksimile. `.pdf` fjernes automatisk, hvis det er angivet.
 - `facsimile-pages-num`: antal sider i faksimilen. Paakraeves naar `facsimile` bruges.
 - `facsimile-pages-offset`: tal der laegges til trykte sidetal for at finde faksimilesider.
+- `href`: valgfri URL til en stabil digital udgave af teksten.
 
 Flere kilder kan defineres ved at give dem hver deres `id`:
 
@@ -198,6 +209,10 @@ En tekstkilde kan bruge default-kilden fra `<workhead>`:
 <source pages="11-12"/>
 ```
 
+```xml
+<source href="https://archive.org/details/..." pages="11-12"/>
+```
+
 Eller en navngivet kilde:
 
 ```xml
@@ -208,8 +223,25 @@ Attributter:
 
 - `in`: kilde-id fra `<workhead><source id="...">`. Uden `in` bruges `default`.
 - `pages`: trykte sidetal.
+- `href`: valgfri URL til teksten eller den digitale udgave. Tilsidesætter evt. `href` på den arvede værkkilde.
 - `facsimile`: override af faksimile.
 - `facsimile-pages`: konkret faksimileside eller interval.
+
+Eksempel (text kilde med arv og override):
+
+```xml
+<source href="https://kb.dk/some-stable-record">...</source>
+<source in="bd2" href="https://kb.dk/manual-override">...</source>
+```
+
+Regler:
+
+- `<workhead><source href="...">` sættes på værkniveau og kan arves af tekster uden egen kilde-href.
+- Et tekstniveau `<source href="...">` erstatter URL'en fra den arvede værk-kilde.
+- `href`: valgfri URL til den digitale kilde for teksten/udgaven.
+
+`href` arves fra den valgte værkkilde, når teksten ikke selv angiver sin egen `href`.
+Hvis teksten angiver en `href`, tilsidesætter den arvet `href`.
 
 Hvis `facsimile-pages` mangler, men `pages` og `facsimile-pages-offset` findes,
 beregnes faksimilesiderne automatisk.
@@ -421,16 +453,7 @@ For lokale billeder kan billedteksten enten vaere direkte indhold:
 <picture src="x.jpg">Billedtekst.</picture>
 ```
 
-eller splittes op:
-
-```xml
-<picture src="x.jpg">
-  <description>Billedtekst.</description>
-  <picture-note>Ekstra note.</picture-note>
-</picture>
-```
-
-Hvis kommentaren er intern og ikke skal vises i frontend, brug en XML-kommentar:
+Eller splittes op:
 
 ```xml
 <picture src="x.jpg">
@@ -438,6 +461,9 @@ Hvis kommentaren er intern og ikke skal vises i frontend, brug en XML-kommentar:
   <!-- Ekstra intern note til redaktøren. -->
 </picture>
 ```
+
+Hvis billedteksten skal opdeles, bruges `description`; der er ikke brug for `<picture-note>`
+til interne redaktionelle kommentarer.
 
 ## Links og inline-tags
 

--- a/fdirs/barton/andre.xml
+++ b/fdirs/barton/andre.xml
@@ -74,9 +74,9 @@ And Patience wins the race.
 <head>
    <title>The Sea-Shell</title>
    <firstline>Hast thou heard of a shell on the margin of ocean</firstline>
+   <source href="https://books.google.com/books?id=f3cCAAAAQAAJ">Bernard Barton: <i>Hymns and Poems for Little Folks</i>, 1875.</source>
    <notes>
        <note>Bernard Barton: »The Sea-Shell«, i <i>Hymns and Poems for Little Folks</i>, 1875.</note>
-       <!-- Digitaliseret i https://books.google.com/books?id=f3cCAAAAQAAJ -->
    </notes>
    <quality>korrektur1,kilde</quality>
 </head>

--- a/fdirs/chaucer/canterbury.xml
+++ b/fdirs/chaucer/canterbury.xml
@@ -2,7 +2,7 @@
 <kalliopework id="canterbury" author="chaucer" status="incomplete" type="poetry">
 <workhead>
    <title>Canterbury Tales</title>
-   <source>Geoffrey Chaucer: <i>The Complete Works of Geoffrey Chaucer</i>, bd. 4, red. Walter W. Skeat, Clarendon Press, Oxford, 1894. Digitaliseret i <a href="https://archive.org/details/cu31924059935290">Internet Archive</a>.</source>
+   <source href="https://archive.org/details/cu31924059935290">Geoffrey Chaucer: <i>The Complete Works of Geoffrey Chaucer</i>, bd. 4, red. Walter W. Skeat, Clarendon Press, Oxford, 1894.</source>
 </workhead>
 <workbody>
 

--- a/fdirs/daumer/1846.xml
+++ b/fdirs/daumer/1846.xml
@@ -4,7 +4,7 @@
    <title>Hafis. Eine Sammlung persischer Gedichte</title>
    <subtitle>Nebst poetischen Zugaben aus verschiedenen Völkern und Ländern</subtitle>
    <year>1846</year>
-   <source>Georg Friedrich Daumer: <i>Hafis. Eine Sammlung persischer Gedichte, nebst poetischen Zugaben aus verschiedenen Völkern und Ländern</i>, Hoffmann und Campe, Hamburg, 1846<!-- Digitaliseret i <a href="https://hdl.handle.net/11858/00-1734-0000-0002-6F5A-D">TextGrid Repository</a>.--></source>
+   <source href="https://hdl.handle.net/11858/00-1734-0000-0002-6F5A-D">Georg Friedrich Daumer: <i>Hafis. Eine Sammlung persischer Gedichte, nebst poetischen Zugaben aus verschiedenen Völkern und Ländern</i>, Hoffmann und Campe, Hamburg, 1846</source>
 </workhead>
 <workbody>
 

--- a/fdirs/geibel/1841.xml
+++ b/fdirs/geibel/1841.xml
@@ -3,7 +3,7 @@
 <workhead>
    <title>Zeitstimmen</title>
    <year>1841</year>
-   <source>Emanuel Geibel: <i>Zeitstimmen. Zwölf Gedichte</i>, Friedrich Aschenfeldt, Lübeck, 1841. Digitaliseret i <a href="https://books.google.com/books?id=LuVXAAAAcAAJ">Google Books</a>.</source>
+   <source href="https://books.google.com/books?id=LuVXAAAAcAAJ">Emanuel Geibel: <i>Zeitstimmen. Zwölf Gedichte</i>, Friedrich Aschenfeldt, Lübeck, 1841.</source>
 </workhead>
 <workbody>
 

--- a/fdirs/gilm/andre.xml
+++ b/fdirs/gilm/andre.xml
@@ -2,7 +2,7 @@
 <kalliopework id="andre" author="gilm" status="incomplete" type="poetry">
 <workhead>
     <title>Andre digte</title>
-    <source>Hermann von Gilm: <i>Gedichte</i>, A. G. Liebeskind, Leipzig, 1894<!-- Digitaliseret i <a href="https://archive.org/details/gedichte00gilmuoft">Internet Archive</a>.--></source>
+    <source href="https://archive.org/details/gedichte00gilmuoft">Hermann von Gilm: <i>Gedichte</i>, A. G. Liebeskind, Leipzig, 1894</source>
 </workhead>
 <workbody>
 
@@ -59,7 +59,7 @@ Und trinkt die Thränen, die wir euch erpressen!“
 <head>
     <title>Niemand weiß</title>
     <firstline>Niemand weiß von meinem Hasse</firstline>
-    <source pages="187"/><!--<a href="https://books.google.com/books?id=bnegEcl8v0sC&amp;pg=PA187">Google Books</a>.-->
+    <source pages="187" href="https://books.google.com/books?id=bnegEcl8v0sC&amp;pg=PA187"/>
     <quality>korrektur1,kilde,side</quality>
 </head>
 <body>

--- a/fdirs/gotter/andre.xml
+++ b/fdirs/gotter/andre.xml
@@ -10,9 +10,9 @@
 <head>
    <title>Unbefangen</title>
    <firstline>Ich bin ein Mädchen, fein und jung</firstline>
+   <source href="https://de.wikisource.org/wiki/Die_zehnte_Muse"/>
    <notes>
        <note>Teksten følger <i>Die zehnte Muse, Dichtung vom Brettl und fürs Brettl</i>, Maximilian Bern (red.), Verlag Otto Elsner, Berlin, 1904, p. 100.</note>
-       <!-- https://de.wikisource.org/wiki/Die_zehnte_Muse -->
    </notes>
    <quality>korrektur1</quality>
 </head>
@@ -170,7 +170,7 @@ Nicht Einen von euch wiedersehn?
 <head>
     <title>Die Tageszeiten der Seele</title>
     <firstline>Einst kannt’ ich nicht der Liebe Macht</firstline>
-    <!-- https://books.google.dk/books?id=jmIrNAoC63AC&hl=fr&pg=PA22#v=onepage&q&f=false -->
+    <source href="https://books.google.dk/books?id=jmIrNAoC63AC&amp;hl=fr&amp;pg=PA22"/>
 </head>
 <body>
 <poetry>

--- a/fdirs/helvig/1812.xml
+++ b/fdirs/helvig/1812.xml
@@ -3,7 +3,7 @@
 <workhead>
     <title>Taschenbuch der Sagen und Legenden</title>
     <year>1812</year>
-    <source>Amalie von Helwig og Friedrich de la Motte Fouqué (red.): <i>Taschenbuch der Sagen und Legenden</i>, Realschulbuchhandlung, Berlin, 1812<!-- Digitaliseret af <a href="https://nbn-resolving.de/urn:nbn:de:hbz:061:2-15">Universitäts- und Landesbibliothek Düsseldorf</a>.--></source>
+    <source href="https://nbn-resolving.de/urn:nbn:de:hbz:061:2-15">Amalie von Helwig og Friedrich de la Motte Fouqué (red.): <i>Taschenbuch der Sagen und Legenden</i>, Realschulbuchhandlung, Berlin, 1812</source>
 </workhead>
 <workbody>
 

--- a/fdirs/pichler/1906.xml
+++ b/fdirs/pichler/1906.xml
@@ -3,7 +3,7 @@
 <workhead>
    <title>Marksteine</title>
    <year>1906</year>
-   <source>Adolf Pichler: <i>Marksteine. Gesammelte Dichtungen. Der Marksteine Band I/II</i>, 3. vermehrte Auflage, Georg Müller, München og Leipzig, 1906.<!-- https://books.google.com/books?id=FzkmAAAAMAAJ --></source> 
+   <source href="https://books.google.com/books?id=FzkmAAAAMAAJ">Adolf Pichler: <i>Marksteine. Gesammelte Dichtungen. Der Marksteine Band I/II</i>, 3. vermehrte Auflage, Georg Müller, München og Leipzig, 1906.</source>
 </workhead>
 <workbody>
 

--- a/fdirs/pichler/1907.xml
+++ b/fdirs/pichler/1907.xml
@@ -3,7 +3,7 @@
 <workhead>
    <title>Neue Marksteine</title>
    <year>1907</year>
-   <source>Adolf Pichler: <i>Neue Marksteine. Erzählende Dichtungen. Der Marksteine Band III</i>, 3. vermehrte Auflage, Georg Müller, München og Leipzig, 1907.<!-- https://archive.org/details/neuemarksteineer00pich --></source>
+   <source href="https://archive.org/details/neuemarksteineer00pich">Adolf Pichler: <i>Neue Marksteine. Erzählende Dichtungen. Der Marksteine Band III</i>, 3. vermehrte Auflage, Georg Müller, München og Leipzig, 1907.</source>
 </workhead>
 <workbody>
 

--- a/fdirs/rossettid/1870.xml
+++ b/fdirs/rossettid/1870.xml
@@ -3,7 +3,7 @@
 <workhead>
    <title>Poems</title>
    <year>1870</year>
-   <source>Dante Gabriel Rossetti: <i>Poems</i>, F. S. Ellis, London, 1870. Digitaliseret i <a href="https://rossettiarchive.iath.virginia.edu/docs/1-1870.1stedn.rad.html">The Rossetti Archive</a>.</source>
+   <source href="https://rossettiarchive.iath.virginia.edu/docs/1-1870.1stedn.rad.html">Dante Gabriel Rossetti: <i>Poems</i>, F. S. Ellis, London, 1870.</source>
 </workhead>
 <workbody>
 

--- a/fdirs/rueckert/1844.xml
+++ b/fdirs/rueckert/1844.xml
@@ -3,7 +3,7 @@
 <workhead>
    <title>Liebesfrühling</title>
    <year>1844</year>
-   <source>Friedrich Rückert: <i>Liebesfrühling</i>. Digitaliseret i <a href="https://projekt-gutenberg.org/authors/friedrich-rueckert/books/liebesfruehling/">Projekt Gutenberg-DE</a>.</source>
+   <source href="https://projekt-gutenberg.org/authors/friedrich-rueckert/books/liebesfruehling/">Friedrich Rückert: <i>Liebesfrühling</i>.</source>
 </workhead>
 <workbody>
 

--- a/fdirs/schandorph/1863.xml
+++ b/fdirs/schandorph/1863.xml
@@ -313,10 +313,10 @@ der skinner med Smil ad Rum og ad Tid,
     <title>Romance</title>
     <subtitle>(Efter Prosper Mérimée: Théatre de Clara Gazul: Les Espagnols en Danemarc Journée II, Sc. I.)</subtitle>
     <firstline>Ridder Alvar fra Zamora</firstline>
+    <source href="https://archive.org/details/thtredeclara00mruoft"/>
     <pictures>
         <picture src="schandorph2018092407-p1.jpg">Prosper Mérimée: <i>Théâtre de Clara Gazul, comédienne espagnole; suivi de La Jacquerie et de La famille Carvajal</i>,  Paris Charpentier, Paris, 1857, p. 37.</picture>
         <picture src="schandorph2018092407-p2.jpg">Ibid., p. 38.</picture>
-        <!-- Fra https://archive.org/details/thtredeclara00mruoft -->
     </pictures>
     <source pages="15-17"/>
     <quality>korrektur1,kilde,side</quality>

--- a/pages/text.js
+++ b/pages/text.js
@@ -145,6 +145,10 @@ const MetadataGroup = ({ title, children, printHidden = false }) => {
           hyphens: none;
           overflow-wrap: break-word;
         }
+        .metadata-group :global(p.digital-source) {
+          margin-top: 10px;
+          margin-bottom: 0;
+        }
         @media print {
           .metadata-group.print-hidden {
             display: none;
@@ -370,16 +374,32 @@ const TextPage = (props) => {
 
   let sourceText = '';
   let renderedSource = null;
+  let renderedDigitalSource = null;
   if (text.source != null) {
     const source = text.source;
-    sourceText = source.source.replace(/\.?$/, ', ');
-    sourceText += 's. ' + source.pages + '.';
-    renderedSource = (
-      <TextContent
-        contentHtml={[[sourceText, { html: true }]]}
-        contentLang="da"
-      />
-    );
+    if (source.source != null && source.source.length > 0) {
+      sourceText = source.source;
+      if (source.pages != null) {
+        sourceText = sourceText.replace(/\.?$/, ', ');
+        sourceText += 's. ' + source.pages + '.';
+      }
+      renderedSource = (
+        <TextContent
+          contentHtml={[[sourceText, { html: true }]]}
+          contentLang="da"
+        />
+      );
+    }
+    if (source.digitalUrl != null) {
+      renderedDigitalSource = (
+        <a
+          href={source.digitalUrl}
+          target="_blank"
+          rel="noopener noreferrer">
+          {_('Digital kilde', lang)}
+        </a>
+      );
+    }
   }
 
   let textPictures = [...text.pictures];
@@ -462,9 +482,12 @@ const TextPage = (props) => {
           {translationSourceNotes}
         </MetadataGroup>
       ) : null}
-      {renderedSource != null ? (
+      {renderedSource != null || renderedDigitalSource != null ? (
         <MetadataGroup title={_('Kilde', lang)}>
           {renderedSource}
+          {renderedDigitalSource != null ? (
+            <p className="digital-source">{renderedDigitalSource}</p>
+          ) : null}
         </MetadataGroup>
       ) : null}
       {text.variants.length > 0 ? (

--- a/schemas/kalliopework.rng
+++ b/schemas/kalliopework.rng
@@ -168,6 +168,7 @@
       <optional><attribute name="in"><text/></attribute></optional>
       <optional><attribute name="pages"><text/></attribute></optional>
       <optional><attribute name="facsimile"><text/></attribute></optional>
+      <optional><attribute name="href"><text/></attribute></optional>
       <optional><attribute name="facsimile-pages"><text/></attribute></optional>
       <optional><attribute name="facsimile-pages-num"><text/></attribute></optional>
       <optional><attribute name="facsimile-pages-offset"><text/></attribute></optional>

--- a/tools/build-static.js
+++ b/tools/build-static.js
@@ -88,6 +88,10 @@ import {
   b,
   print_benchmarking_results,
 } from './build-static/benchmarking.js';
+import {
+  collectSourceDigitalUrl,
+  resolveSourceDigitalUrlForText,
+} from './build-static/source.js';
 import { mapLimit } from './build-static/concurrency.js';
 import { createProgressReporter } from './build-static/progress.js';
 import { validateFirstlineMarkup } from './build-static/validation.js';
@@ -410,23 +414,33 @@ const handle_text = async (
   let source = null;
   let workSource = null;
   if (sourceNode != null) {
-    const sourceId = safeGetAttr(sourceNode, 'in') || 'default';
-    workSource = sourceWork.sources[sourceId];
-    if (workSource == null) {
+    const sourceReferenceId = safeGetAttr(sourceNode, 'in');
+    const sourceId = sourceReferenceId ?? 'default';
+    workSource = sourceWork.sources[sourceId] ?? null;
+    if (sourceReferenceId != null && workSource == null) {
       throw new Error(
         `fdirs/${sourcePoetId}/${sourceWorkId}.xml ${sourceTextId} references undefined source.`,
       );
     }
     let pages = null;
     const pagesAttr = safeGetAttr(sourceNode, 'pages');
-    let sourceBookRef = workSource ? workSource.source : null;
+    let sourceBookRef = workSource == null ? null : workSource.source;
     const sourceNodeInner = safeGetInnerXML(sourceNode);
     if (sourceNodeInner.length > 0) {
       sourceBookRef = sourceNodeInner;
     }
+    const digitalUrl = resolveSourceDigitalUrlForText({
+      sourceNode,
+      sourceForText: workSource,
+    });
+    if (sourceBookRef == null && digitalUrl == null) {
+      throw new Error(
+        `fdirs/${sourcePoetId}/${sourceWorkId}.xml ${sourceTextId} references undefined source.`,
+      );
+    }
     const facsimile =
-      safeGetAttr(sourceNode, 'facsimile') ||
-      (workSource ? workSource.facsimile : null);
+      safeGetAttr(sourceNode, 'facsimile') ??
+      (workSource == null ? null : workSource.facsimile);
     let facsimilePages = safeGetAttr(sourceNode, 'facsimile-pages');
     if (
       facsimilePages == null &&
@@ -461,7 +475,9 @@ const handle_text = async (
     source = {
       source: sourceBookRef,
       pages: pagesAttr,
-      facsimilePageCount: workSource.facsimilePageCount,
+      digitalUrl,
+      facsimilePageCount:
+        workSource == null ? null : workSource.facsimilePageCount,
       facsimile,
       facsimilePages,
       facsimilePoetId: sourcePoetId,
@@ -1219,8 +1235,8 @@ const works_second_pass = async (collected) => {
         filename,
       ]);
       const sourceTexts = textsBySourceWork.get(`${poetId}/${workId}`) || [];
-      sourceTexts.forEach(text => {
-        sourceFilesForText(text).forEach(sourceFile =>
+      sourceTexts.forEach((text) => {
+        sourceFilesForText(text).forEach((sourceFile) =>
           sourceFiles.add(sourceFile)
         );
       });
@@ -1236,45 +1252,46 @@ const works_second_pass = async (collected) => {
       const data = collected.works.get(`${poetId}/${workId}`);
       let sources = {};
       getChildrenByTagName(head, 'source').forEach((sourceNode) => {
-      let source = null;
-      const sourceInner = safeGetInnerXML(sourceNode);
-      if (sourceInner != null && sourceInner.length > 0) {
-        source = { source: sourceInner };
-      }
-      if (source == null || source.source == null) {
-        throw new Error(
-          `fdirs/${poetId}/${workId}.xml has source with no title.`
-        );
-      }
-      const sourceId = safeGetAttr(sourceNode, 'id') || 'default';
-      let facsimile = safeGetAttr(sourceNode, 'facsimile');
-      if (facsimile != null) {
-        facsimile = facsimile.replace(/.pdf$/, '');
-        let facsimilePagesOffset = safeGetAttr(
-          sourceNode,
-          'facsimile-pages-offset'
-        );
-        if (facsimilePagesOffset != null) {
-          facsimilePagesOffset = parseInt(facsimilePagesOffset, 10);
+        let source = null;
+        const sourceInner = safeGetInnerXML(sourceNode);
+        if (sourceInner != null && sourceInner.length > 0) {
+          source = { source: sourceInner };
         }
-
-        const facsimilePageCount = safeGetAttr(
-          sourceNode,
-          'facsimile-pages-num'
-        );
-        if (facsimilePageCount == null) {
+        if (source == null || source.source == null) {
           throw new Error(
-            `fdirs/${poetId}/${workId}.xml is missing facsimile-pages-num in source.`
+            `fdirs/${poetId}/${workId}.xml has source with no title.`
           );
         }
-        source = {
-          ...source,
-          facsimile,
-          facsimilePageCount: parseInt(facsimilePageCount, 10),
-          facsimilePagesOffset,
-        };
-      }
-      sources[sourceId] = source;
+        source.digitalUrl = collectSourceDigitalUrl(sourceNode);
+        const sourceId = safeGetAttr(sourceNode, 'id') || 'default';
+        let facsimile = safeGetAttr(sourceNode, 'facsimile');
+        if (facsimile != null) {
+          facsimile = facsimile.replace(/.pdf$/, '');
+          let facsimilePagesOffset = safeGetAttr(
+            sourceNode,
+            'facsimile-pages-offset'
+          );
+          if (facsimilePagesOffset != null) {
+            facsimilePagesOffset = parseInt(facsimilePagesOffset, 10);
+          }
+
+          const facsimilePageCount = safeGetAttr(
+            sourceNode,
+            'facsimile-pages-num'
+          );
+          if (facsimilePageCount == null) {
+            throw new Error(
+              `fdirs/${poetId}/${workId}.xml is missing facsimile-pages-num in source.`
+            );
+          }
+          source = {
+            ...source,
+            facsimile,
+            facsimilePageCount: parseInt(facsimilePageCount, 10),
+            facsimilePagesOffset,
+          };
+        }
+        sources[sourceId] = source;
       });
       data.sources = sources;
       collected_works.set(poetId + '-' + workId, data);

--- a/tools/build-static/source.js
+++ b/tools/build-static/source.js
@@ -1,0 +1,89 @@
+import { safeGetAttr } from './xml.js';
+
+const normalizeUrl = (url) => (url == null ? null : url.trim());
+
+const isRexUrl = (url) => {
+  if (url == null || url.length === 0) {
+    return false;
+  }
+  try {
+    const parsedUrl = new URL(url);
+    return (
+      parsedUrl.hostname.includes('rexlibris.kb.dk') ||
+      parsedUrl.pathname.includes('/search/eng') ||
+      parsedUrl.pathname.includes('/work/')
+    );
+  } catch {
+    return /rexlibris\.kb\.dk/i.test(url);
+  }
+};
+
+const isDirectPdfUrl = (url) => {
+  if (url == null || url.length === 0) {
+    return false;
+  }
+  try {
+    const parsedUrl = new URL(url);
+    return parsedUrl.pathname.toLowerCase().endsWith('.pdf');
+  } catch {
+    return /\.pdf(?:[?#]|$)/i.test(url);
+  }
+};
+
+const scoreDigitalUrl = (url) => {
+  if (isRexUrl(url)) {
+    return 3;
+  }
+  if (isDirectPdfUrl(url)) {
+    return 1;
+  }
+  return 2;
+};
+
+const preferPreferredDigitalUrl = (urls) => {
+  if (!Array.isArray(urls)) {
+    const normalizedUrl = normalizeUrl(urls);
+    return normalizedUrl == null || normalizedUrl.length === 0 ? null : normalizedUrl;
+  }
+  let digitalUrl = null;
+  let bestScore = -1;
+  for (const candidate of urls) {
+    const candidateUrl = normalizeUrl(candidate);
+    if (candidateUrl == null || candidateUrl.length === 0) {
+      continue;
+    }
+    const score = scoreDigitalUrl(candidateUrl);
+    if (score > bestScore) {
+      digitalUrl = candidateUrl;
+      bestScore = score;
+    }
+  }
+  return digitalUrl;
+};
+
+export const resolveSourceDigitalUrl = ({
+  sourceNode,
+  inheritedDigitalUrl,
+}) => {
+  const explicitDigitalUrl =
+    sourceNode == null ? null : safeGetAttr(sourceNode, 'href');
+  if (explicitDigitalUrl != null && explicitDigitalUrl.length > 0) {
+    return explicitDigitalUrl.trim();
+  }
+  return preferPreferredDigitalUrl(inheritedDigitalUrl);
+};
+
+export const collectSourceDigitalUrl = (sourceNode) =>
+  sourceNode == null ? null : normalizeUrl(safeGetAttr(sourceNode, 'href'));
+
+export const resolveSourceDigitalUrlForText = ({
+  sourceNode,
+  sourceForText,
+}) => {
+  const inheritedDigitalUrl =
+    sourceForText == null ? null : sourceForText.digitalUrl;
+  return resolveSourceDigitalUrl({
+    sourceNode,
+    inheritedDigitalUrl,
+  });
+};


### PR DESCRIPTION
## Løsning af #1388

Denne PR implementerer understøttelse for digitale kilde-links som `href` på `<source>`-niveau og visning som intern link i teksten.

Nøglepunkter:

- Udvidet schema (`schemas/kalliopework.rng`) med valgfrit `href` på source-elementer.
- Opdateret build-logik i `tools/build-static.js` til at:
  - parse `source[href]` på værk- og tekstanivå
  - arve værk-`href` til tekstniveau, men lade tekstens egen `href` overstyre
  - udsende `digitalUrl` i tekstens source-data
- Flyttet eksisterende digitaliserings-links ud af fritekstkommentarer og ind som `href` i relevante `fdirs/...xml`.
- Frontend: viser linket under Kilde-sektionen som separat “Digital kilde”.
- Opdateret dokumentation i `docs/xml-work-format.md` inkl. regler om arve/override af `href`.
- Tilføjet/opdateret tests for kildelink-håndtering (`__tests__/build-static-source.test.js`).
- Rettet dokumentationsafsnit om billedtekst/picture-note ifølge ønske om at bruge `description`/noter i stedet.

For at undgå at eksponere interne kommentarer i frontend er digitaliseringslinkene nu struktureret som felter på kilderne i stedet for fritekstkommentarer.

Fixes #1388

Verificeret:
- `npm test -- __tests__/build-static-source.test.js`
- `npm test -- __tests__/links.test.js __tests__/build-static-source.test.js`
- `npm test -- __tests__/kalliopework-relaxng.test.js`
- `npm test -- __tests__/translations.test.js`
- `KALLIOPE_SKIP_ELASTICSEARCH=1 npm run build-static`
