### PR TITLE
Undgå genstart af Elasticsearch ved statisk build

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -21,15 +21,15 @@ help:
 		'make status                    Vis status for Docker Compose-services'
 
 elasticsearch:
-	$(COMPOSE) up -d elasticsearch
+	$(COMPOSE) up -d --wait elasticsearch
 
 build-static: elasticsearch
 	$(COMPOSE) --profile build build static-builder
-	$(COMPOSE) --profile build run --rm static-builder
+	$(COMPOSE) --profile build run --rm --no-deps static-builder
 
 build-static-force-reload: elasticsearch
 	$(COMPOSE) --profile build build static-builder
-	$(COMPOSE) --profile build run --rm static-builder npm run build-static-force-reload
+	$(COMPOSE) --profile build run --rm --no-deps static-builder npm run build-static-force-reload
 
 build-facsimiles:
 	$(COMPOSE) --profile facsimiles run --rm --build facsimile-builder npm run build-facsimiles -- all


### PR DESCRIPTION
## Hvad er ændret?

- venter på, at Elasticsearch er sund, før statiske builds fortsætter
- starter `static-builder` med `--no-deps`, så Compose bruger den eksisterende Elasticsearch-container
- anvender samme adfærd ved både normale builds og force-reload

## Hvorfor?

`make build-static` startede først Elasticsearch og lod derefter `docker compose run` håndtere afhængigheden igen. På produktionsserveren kunne Compose derfor forsøge at genskabe Elasticsearch-containeren, mens host-port 9200 stadig var optaget, og buildet fejlede med `port is already allocated`.

Fixet bevarer den dokumenterede adgang via `localhost:9200`, men forhindrer builder-kørslen i at genstarte eller genskabe afhængigheden.

## Validering

- `docker compose config --quiet`
- verificeret understøttelse af `docker compose up --wait`
- verificeret understøttelse af `docker compose run --no-deps`
- `make -n build-static`
- `make -n build-static-force-reload`
- `git diff --check`
