### PR TITLE
Fastlås Compose-projektnavnet

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,3 +1,5 @@
+name: kalliope
+
 services:
   elasticsearch:
     image: docker.elastic.co/elasticsearch/elasticsearch:7.17.20


### PR DESCRIPTION
## Hvad er ændret?

Compose-projektnavnet fastlåses til `kalliope` i `docker-compose.yml`.

## Hvorfor?

Compose udleder ellers projektnavnet af checkout-mappens navn. Efter en flytning fra `kalliope-docker` til `kalliope` blev den gamle container `kalliope-docker-app-1` derfor stående som en separat stack og beholdt host-port 3001. Den nye `kalliope-app-1` kunne ikke starte og fejlede med `port is already allocated`.

Et eksplicit projektnavn sikrer, at fremtidige flytninger eller omdøbninger af checkoutet fortsat administrerer samme Compose-stack.

Den eksisterende gamle stack skal ryddes op én gang med `docker compose -p kalliope-docker down`; kommandoen bruger ikke `-v`, så volumenerne bevares.

## Validering

- `docker compose config --quiet`
- `docker compose config --format json` rapporterer projektnavnet `kalliope`
- `git diff --check`
