### PR TITLE
Korrekturlæs Vers (1887)

### DIFF
--- a/fdirs/joergensenj/1887.xml
+++ b/fdirs/joergensenj/1887.xml
@@ -25,7 +25,7 @@
     <title>Foraarsminder.</title>
     <firstline>Det var en Foraarsdag, sidst i April</firstline>
     <source pages="3-5"/>
-    <quality>korrektur1,kilde,side</quality>
+    <quality>korrektur1,korrektur2,kilde,side</quality>
 </head>
 <body>
 <poetry>
@@ -50,7 +50,7 @@ mumled en Bæk forbi.
 Jeg laa der saa fjærnt, saa stille i Gem,
 et Sted, hvor ingen mig kendte -
 der dæmred dog vagt den Tanke frem:
-jeg laa der for èn at vente;
+jeg laa der for én at vente;
 jeg spejdede spændt ad Stien hen;
 lød der ej Fodtrin i Støvet?
 stirred det ikke bag Løvet
@@ -92,10 +92,10 @@ til Mindernes laasede Land.
 
 <text id="joergensenj2024052302">
 <head>
-    <title>Avgustnat</title>
+    <title>Avgustnat.</title>
     <firstline>Tung og fugtig er Løvets Duft</firstline>
     <source pages="6"/>
-    <quality>korrektur1,kilde,side</quality>
+    <quality>korrektur1,korrektur2,kilde,side</quality>
 </head>
 <body>
 <poetry>
@@ -122,10 +122,10 @@ her var det, vi mødtes en Gang.
 
 <text id="joergensenj2024052303">
 <head>
-    <title>Gengangere</title>
+    <title>Gengangere.</title>
     <firstline>Jeg standsede og stirred</firstline>
     <source pages="7-8"/>
-    <quality>korrektur1,kilde,side</quality>
+    <quality>korrektur1,korrektur2,kilde,side</quality>
 </head>
 <body>
 <poetry>
@@ -164,10 +164,10 @@ ak! disse Barnedrømme
 
 <text id="joergensenj2024052304">
 <head>
-    <title>Elverleg</title>
+    <title>Elverleg.</title>
     <firstline>Den hvide, koglende Maaneglans</firstline>
     <source pages="8-9"/>
-    <quality>korrektur1,kilde,side</quality>
+    <quality>korrektur1,korrektur2,kilde,side</quality>
 </head>
 <body>
 <poetry>
@@ -202,10 +202,10 @@ skal Gangen derover jeg vove?
 
 <text id="joergensenj2024052305">
 <head>
-    <title>Solnedgang</title>
+    <title>Solnedgang.</title>
     <firstline>Bag den fjærne Kyst</firstline>
     <source pages="10-11"/>
-    <quality>korrektur1,kilde,side</quality>
+    <quality>korrektur1,korrektur2,kilde,side</quality>
 </head>
 <body>
 <poetry>
@@ -255,7 +255,7 @@ for evig.
     <title>Jeg vilde mane -</title>
     <firstline>Jeg vilde mane de sollyse Minder</firstline>
     <source pages="12"/>
-    <quality>korrektur1,kilde,side</quality>
+    <quality>korrektur1,korrektur2,kilde,side</quality>
 </head>
 <body>
 <poetry>
@@ -280,10 +280,10 @@ for Klangen fra mine Drømmes Hjem.
 
 <text id="joergensenj2024052307">
 <head>
-    <title>Tordenluft</title>
+    <title>Tordenluft.</title>
     <firstline>Fra løvtætte, slumrende Haver</firstline>
     <source pages="13-14"/>
-    <quality>korrektur1,kilde,side</quality>
+    <quality>korrektur1,korrektur2,kilde,side</quality>
 </head>
 <body>
 <poetry>
@@ -323,10 +323,10 @@ der er Torden deroppe i Luften.
 
 <text id="joergensenj2024052308">
 <head>
-    <title>En forladt Park</title>
+    <title>En forladt Park.</title>
     <firstline>En stille Kirkegaard foruden døde</firstline>
     <source pages="14-15"/>
-    <quality>korrektur1,kilde,side</quality>
+    <quality>korrektur1,korrektur2,kilde,side</quality>
 </head>
 <body>
 <poetry>
@@ -362,10 +362,10 @@ ad Tidens lødløs dunkelblanke Flod.
 
 <text id="joergensenj2024052309">
 <head>
-    <title>Bøn</title>
+    <title>Bøn.</title>
     <firstline>Jeg kommer til dig, o evige Moder, trættet paa Sjæl og paa Sind</firstline>
     <source pages="16-18"/>
-    <quality>korrektur1,kilde,side</quality>
+    <quality>korrektur1,korrektur2,kilde,side</quality>
 </head>
 <body>
 <poetry>
@@ -377,18 +377,18 @@ og ydmyg kommer jeg nu til din Kirkes Hvælv
 at bede, hvor Stormen er Orgel, og Himlen er Taget.
 
 Mine Tanker svømme i vidløse Stimer om
-og søge forgæves et Tegn paa, hvorvidt de kom,
+og søge forgæves et Tegn paa, hvor vidt de kom,
 et eneste Fyrtaarnsglimt blot ud over Havet -
 forgæves jeg spejder med Loddet mit Væsens Dyb;
 er det Klipper, det rører? Eller blot sovende Kryb?
 - I miledyb Tavshed nede er Svaret begravet.
 
-Jeg ved blot et: jeg er træt af at se mig se!v,
+Jeg ved blot et: jeg er træt af at se mig selv,
 af at lytte til egen Higens savnfødte Elv,
 der bruser ustandselig, skumhvid i Sjælens Mørke.
 Jeg ønsker hver Attraas Død og hver Længselsflods Fald
 og Sjælen døv for de dragende Drømmes Kald
-og en stille Novemberregn forbrændende Tørke.
+og en stille Novemberregn for brændende Tørke.
 
 Jeg ønsker at slænge mig ned, for hver Livslænke fri,
 og lytte til Granernes susende Melodi
@@ -409,21 +409,21 @@ og vidt fra det fjærne en rullende Vogn kan jeg høre.
 
 O Moder, du higer som jeg! Der er Storm i dit Sind!
 Dine Sukke bærer den hedeaandende Vind,
-som over de endeløst nikkende Marker suser-
+som over de endeløst nikkende Marker suser -
 en Gravhvælving lig er Himlen over dig spændt -
 din Sol en Lampe, som for den døde er tændt -
 og Liget selv; den Lykke, du længer ej huser.
-<nonum><small><right><i>Juli 85</i></right></small></nonum>
+<nonum><small><right><i>Juli 85.</i></right></small></nonum>
 </poetry>
 </body>
 </text>
 
 <text id="joergensenj2024052310">
 <head>
-    <title>Eftersommer</title>
+    <title>Eftersommer.</title>
     <firstline>Det ligger dødt og dræbt, jeg higed mod</firstline>
     <source pages="18-19"/>
-    <quality>korrektur1,kilde,side</quality>
+    <quality>korrektur1,korrektur2,kilde,side</quality>
 </head>
 <body>
 <poetry>
@@ -455,10 +455,10 @@ paa hver et elsket Navn: et Haab, der døde.
 
 <text id="joergensenj2024052311">
 <head>
-    <title>Ene</title>
+    <title>Ene.</title>
     <firstline>Jeg ligger ved Havet</firstline>
     <source pages="20-21"/>
-    <quality>korrektur1,kilde,side</quality>
+    <quality>korrektur1,korrektur2,kilde,side</quality>
 </head>
 <body>
 <poetry>
@@ -497,10 +497,10 @@ men slænger mit Blyant i Havet og tier.
 
 <text id="joergensenj2024052312">
 <head>
-    <title>Portræt</title>
+    <title>Portræt.</title>
     <firstline>Dagen er død og forsvunden</firstline>
     <source pages="22-25"/>
-    <quality>korrektur1,kilde,side</quality>
+    <quality>korrektur1,korrektur2,kilde,side</quality>
 </head>
 <body>
 <poetry>
@@ -582,10 +582,10 @@ og hobes til Dage og Aar.
 
 <text id="joergensenj2024052313">
 <head>
-    <title>Bladefald</title>
+    <title>Bladefald.</title>
     <firstline>Nu bærer Livets Floder Lig paa Lig</firstline>
     <source pages="26-27"/>
-    <quality>korrektur1,kilde,side</quality>
+    <quality>korrektur1,korrektur2,kilde,side</quality>
 </head>
 <body>
 <poetry>
@@ -618,10 +618,10 @@ for Somrens Scene - Festen er forbi.
 
 <text id="joergensenj2024052314">
 <head>
-    <title>Nu ringer alle Klokker</title>
+    <title>Nu ringer alle Klokker -</title>
     <firstline>Nu ringer alle Klokker Natten ind</firstline>
     <source pages="27-29"/>
-    <quality>korrektur1,kilde,side</quality>
+    <quality>korrektur1,korrektur2,kilde,side</quality>
 </head>
 <body>
 <poetry>
@@ -680,10 +680,10 @@ mens alle Klokker ringe Mørket ind.
 
 <text id="joergensenj2024052315">
 <head>
-    <title>Længsel</title>
+    <title>Længsel.</title>
     <firstline>I Snekorallers Skove gad jeg gaa</firstline>
-    <source pages="30"/>
-    <quality>korrektur1,kilde,side</quality>
+    <source pages="30-31"/>
+    <quality>korrektur1,korrektur2,kilde,side</quality>
 </head>
 <body>
 <poetry>
@@ -717,10 +717,10 @@ med Dvaledrik fra Dødens Lethe-dybe Vande.
 
 <text id="joergensenj2024052316">
 <head>
-    <title>Julesalme</title>
+    <title>Julesalme.</title>
     <firstline>Du stille Vinter, der mit Liv har født</firstline>
     <source pages="31-32"/>
-    <quality>korrektur1,kilde,side</quality>
+    <quality>korrektur1,korrektur2,kilde,side</quality>
 </head>
 <body>
 <poetry>
@@ -771,10 +771,10 @@ det Liv af Savn jeg evned ej
 
 <text id="joergensenj2024052317">
 <head>
-    <title>Vinterlandskab</title>
+    <title>Vinterlandskab.</title>
     <firstline>Nu ebber Dagen. Timernes Flod</firstline>
     <source pages="33-34"/>
-    <quality>korrektur1,kilde,side</quality>
+    <quality>korrektur1,korrektur2,kilde,side</quality>
 </head>
 <body>
 <poetry>
@@ -817,10 +817,10 @@ Sindet, der smægter i Ørkentørke.
 
 <text id="joergensenj2024052318">
 <head>
-    <title>Søvnløs</title>
+    <title>Søvnløs.</title>
     <firstline>Sortgraa, dybe Fløjelsskygger som et Krypthvælv staa omkring mig</firstline>
     <source pages="35-36"/>
-    <quality>korrektur1,kilde,side</quality>
+    <quality>korrektur1,korrektur2,kilde,side</quality>
 </head>
 <body>
 <poetry>
@@ -832,7 +832,7 @@ deres trætte Blik fortælle, hvor de lider, hvor de længes.
 Intet Glimt i Nattens Øje, ingen Lyd paa Nattens Læber,
 Blodets Susen blot i Øret, naar det trykkes tæt mod Puden,
 ingen dagfødt Flyver gennem Mørkets store Øde stræber,
-Hjmlens liggraa, brustne Bikke stirre ind igennem Ruden.
+Himlens liggraa, brustne Blikke stirre ind igennem Ruden.
 
 Nattens sorte Sandskorn rinde lydløst ned igennem Rummet,
 alle Døre har de spærret, alle Stier har de lukket,
@@ -844,11 +844,11 @@ dræbt og død er hver en Længsel - Haab er Sagn - og Sol er slukket . . . . .
 
 <text id="joergensenj2024052319">
 <head>
-    <title>Faust til Foraaret</title>
+    <title>Faust til Foraaret.</title>
     <firstline>De har prist dig i svulmende Sange og løjet af Lykke dig fuld</firstline>
     <source pages="37-40"/>
     <!-- TODO: Smid mottoet til højre -->
-    <quality>korrektur1,kilde,side</quality>
+    <quality>korrektur1,korrektur2,kilde,side</quality>
 </head>
 <body>
 <poetry>
@@ -865,7 +865,7 @@ forbandet din Solstænksvrimmel i Vandenes vindknuste Spejl,
 forbandet hver Knop i Grøde, hvert Græs og hvert brydende Blad,
 hvert Liv, der staar op fra de døde - forbandet af alt mit Had.
 
-Forbandet din Fløjeisnats Kaabe, der luner om Drømmenes Væxt,
+Forbandet din Fløjelsnats Kaabe, der luner om Drømmenes Væxt,
 hvorunder en atter tør haabe trods Dagens stenskrevne Text,
 hvor Læber i Elskov modes, hvor Legemer favnes tæt,
 hvor rodløse Længsler fødes og spindes til hildende Næt.
@@ -906,16 +906,16 @@ alt Morgenens Guld om din Pande, din dugstænkte Dronningedragt
 
 <text id="joergensenj2024052320">
 <head>
-    <title>Solrødt</title>
+    <title>Solrødt.</title>
     <firstline>Nu brænder Dagens Skibe paa Baal i Vesterled</firstline>
     <source pages="41"/>
-    <quality>korrektur1,kilde,side</quality>
+    <quality>korrektur1,korrektur2,kilde,side</quality>
 </head>
 <body>
 <poetry>
 Nu brænder Dagens Skibe paa Baal i Vesterled,
 og Purpurgnister op mod Himlen sprænges,
-der driver gyldne Sky vrag, hvor Solenden gik ned,
+der driver gyldne Skyvrag, hvor Solen den gik ned,
 og røde Slør for Aftnens Guldport hænges.
 
 Igennem Skyfjældskløfter der Flammefloder gaa,
@@ -925,7 +925,7 @@ og Skoven staar med fnuggefine Kroner.
 
 Der synker Mulm fra oven mod Himlens hvide Bræm,
 og Livets Lyd af tusind Tunger ebber,
-der spire blanke Stjærner af Aftnensjordsmonfrem,
+der spire blanke Stjærner af Aftnens Jordsmon frem,
 som røde Vagtblus over Himlens Stepper.
 
 Og Natten lander stille i Maanens hvide Baad,
@@ -939,10 +939,10 @@ ved Dagens Dødsseng grædes der ingen savnfødt Graad
 
 <text id="joergensenj2024052321">
 <head>
-    <title>Sommernat</title>
+    <title>Sommernat.</title>
     <firstline>Stort og stille ligger Landet, dæmringslyst, med grøngraa Flader</firstline>
     <source pages="42-43"/>
-    <quality>korrektur1,kilde,side</quality>
+    <quality>korrektur1,korrektur2,kilde,side</quality>
 </head>
 <body>
 <poetry>
@@ -967,10 +967,10 @@ og langt ude i det fjærne hører jeg en Hund slaa an.
 
 <text id="joergensenj2024052322">
 <head>
-    <title>Maaneskin</title>
+    <title>Maaneskin.</title>
     <firstline>Solen er død. Mod matgylden Luft</firstline>
     <source pages="44-45"/>
-    <quality>korrektur1,kilde,side</quality>
+    <quality>korrektur1,korrektur2,kilde,side</quality>
 </head>
 <body>
 <poetry>
@@ -992,7 +992,7 @@ og gnistrer i Duggen med Glimt af Staal
 - dissvøbt og søvnfangen drikker Jorden
 Drømme af Nathimlens blegblaa Skaal.
 
-Natten er halvlys - med randiøse, vage
+Natten er halvlys - med randløse, vage
 Skygger og Skær, der i Dæmring forsvinder,
 Fjorden er graa, med en Maaneskinsflage,
 der sitrer som stimende Fiskefinner -
@@ -1016,10 +1016,10 @@ et længselsfyldt Digt om en Stjærne, der døde,
 
 <text id="joergensenj2024052323">
 <head>
-    <title>Skovdrømme</title>
+    <title>Skovdrømme.</title>
     <firstline>Jeg gik og drømte i Skoven</firstline>
     <source pages="46-48"/>
-    <quality>korrektur1,kilde,side</quality>
+    <quality>korrektur1,korrektur2,kilde,side</quality>
 </head>
 <body>
 <poetry>
@@ -1077,10 +1077,10 @@ før Markerne hvidne mod Høst.
 
 <text id="joergensenj2024052324">
 <head>
-    <title>Høsttid</title>
+    <title>Høsttid.</title>
     <firstline>Jeg standser og vender mig om i Høstens Dør</firstline>
     <source pages="49"/>
-    <quality>korrektur1,kilde,side</quality>
+    <quality>korrektur1,korrektur2,kilde,side</quality>
 </head>
 <body>
 <poetry>
@@ -1100,7 +1100,7 @@ der stiger et rædselsfødt Raab fra Savnenes Stimmel,
 som Høstens soltomme Afgrund gaber i Møde.
 
 Jeg vandrer ene og fattig til Høsten ind
-med Hj ærtet tynget af Tvivl og sygt af Drømme -
+med Hjærtet tynget af Tvivl og sygt af Drømme -
 men hen over Markerne stryger en havfødt Vind.
 De høster dernede i Sollysets fulde Strømme.
 <nonum><small><right><i>Aug. 86.</i></right></small></nonum>
@@ -1110,10 +1110,10 @@ De høster dernede i Sollysets fulde Strømme.
 
 <text id="joergensenj2024052325">
 <head>
-    <title>Nocturne</title>
+    <title>Nocturne.</title>
     <firstline>Jeg hilser dig, du store Maanenat</firstline>
     <source pages="50"/>
-    <quality>korrektur1,kilde,side</quality>
+    <quality>korrektur1,korrektur2,kilde,side</quality>
 </head>
 <body>
 <poetry>
@@ -1142,10 +1142,10 @@ og giv mig stenstøt Mod og Had af Staal.
 
 <text id="joergensenj2024052326">
 <head>
-    <title>Afsked</title>
+    <title>Afsked.</title>
     <firstline>Saa er det alt forbi, jeg længtes mod</firstline>
     <source pages="51"/>
-    <quality>korrektur1,kilde,side</quality>
+    <quality>korrektur1,korrektur2,kilde,side</quality>
 </head>
 <body>
 <poetry>
@@ -1174,10 +1174,10 @@ og samler sig Drømmevrag til Vinterbrænde.
 
 <text id="joergensenj2024052327">
 <head>
-    <title>Ved Havet</title>
+    <title>Ved Havet.</title>
     <firstline>Jeg gik en graavejrsmørk Dag, tæt op imod Høst</firstline>
     <source pages="52"/>
-    <quality>korrektur1,kilde,side</quality>
+    <quality>korrektur1,korrektur2,kilde,side</quality>
 </head>
 <body>
 <poetry>
@@ -1193,7 +1193,7 @@ og Fodens Knasen i Singels og Stumper af Vrag.
 
 Jeg strakte de tryglende Hænder mod dig, o Hav,
 som en Bønnebeder i Knæ for en savnskabt Gud
-og bad dig slette af Livets T. avler ud
+og bad dig slette af Livets Tavler ud
 Landet, du løfted af Urtidsvandenes Grav,
 
 at skylle bort de ældede Tankers Vægt,
@@ -1207,10 +1207,10 @@ og rydde paa Jorden Rum for en nyskabt Slægt.
 
 <text id="joergensenj2024052328">
 <head>
-    <title>Oktober</title>
+    <title>Oktober.</title>
     <firstline>Nu sprænger Aaret Somrens grønne Ham</firstline>
     <source pages="53"/>
-    <quality>korrektur1,kilde,side</quality>
+    <quality>korrektur1,korrektur2,kilde,side</quality>
 </head>
 <body>
 <poetry>
@@ -1234,10 +1234,10 @@ paa Taagedrypfaldets snigende Morderfødder.
 
 <text id="joergensenj2024052329">
 <head>
-    <title>Tusmørke</title>
+    <title>Tusmørke.</title>
     <firstline>Det led mod Solrøsttide - blaalig Em</firstline>
-    <source pages="54"/>
-    <quality>korrektur1,kilde,side</quality>
+    <source pages="54-55"/>
+    <quality>korrektur1,korrektur2,kilde,side</quality>
 </head>
 <body>
 <poetry>
@@ -1275,10 +1275,10 @@ jeg gaar, sjælsbitter, viljeveg og tankedøv.
 
 <text id="joergensenj2024052330">
 <head>
-    <title>Snefald</title>
+    <title>Snefald.</title>
     <firstline>Der falder Sne i Nat - det første hvide</firstline>
     <source pages="55-56"/>
-    <quality>korrektur1,kilde,side</quality>
+    <quality>korrektur1,korrektur2,kilde,side</quality>
 </head>
 <body>
 <poetry>
@@ -1308,10 +1308,10 @@ gaar gennem Skovens Træer af Koral.
 
 <text id="joergensenj2024052331">
 <head>
-    <title>Døden</title>
+    <title>Døden.</title>
     <firstline>Jeg drømmer om Døden, naar Morgnen spænder</firstline>
     <source pages="57-59"/>
-    <quality>korrektur1,kilde,side</quality>
+    <quality>korrektur1,korrektur2,kilde,side</quality>
 </head>
 <body>
 <poetry>
@@ -1365,10 +1365,10 @@ min Hjærneblomsts tankefostrende Blade.
 
 <text id="joergensenj2024052332">
 <head>
-    <title>Solvejg</title>
+    <title>Solvejg.</title>
     <firstline>Decembernattens klamme Maaneblaa</firstline>
     <source pages="59-60"/>
-    <quality>korrektur1,kilde,side</quality>
+    <quality>korrektur1,korrektur2,kilde,side</quality>
 </head>
 <body>
 <poetry>
@@ -1425,10 +1425,10 @@ en Mindelse om Solvejgs bløde Sange.
 
 <text id="joergensenj2024052333">
 <head>
-    <title>Januar</title>
+    <title>Januar.</title>
     <firstline>Der ligger hvidgraa Taager over Landet</firstline>
     <source pages="61-62"/>
-    <quality>korrektur1,kilde,side</quality>
+    <quality>korrektur1,korrektur2,kilde,side</quality>
 </head>
 <body>
 <poetry>
@@ -1467,10 +1467,10 @@ dør bort i dette store Nattestille.
 
 <text id="joergensenj2024052334">
 <head>
-    <title>Tøvejr</title>
+    <title>Tøvejr.</title>
     <firstline>Jeg vaagned op og hørte Fugle synge</firstline>
     <source pages="63-64"/>
-    <quality>korrektur1,kilde,side</quality>
+    <quality>korrektur1,korrektur2,kilde,side</quality>
 </head>
 <body>
 <poetry>
@@ -1509,10 +1509,10 @@ vemodigt klang der Foraarsminder gennem Luften.
 
 <text id="joergensenj2024052335">
 <head>
-    <title>Marts</title>
+    <title>Marts.</title>
     <firstline>Jeg længes ikke mer mod grønne Blade</firstline>
     <source pages="65"/>
-    <quality>korrektur1,kilde,side</quality>
+    <quality>korrektur1,korrektur2,kilde,side</quality>
 </head>
 <body>
 <poetry>
@@ -1541,10 +1541,10 @@ et Forspil blot til Vintrens triste Sange.
 
 <text id="joergensenj2024052336">
 <head>
-    <title>Et Farvel</title>
+    <title>Et Farvel.</title>
     <firstline>Jeg flakker ene om ad mørke Veje</firstline>
     <source pages="66-67"/>
-    <quality>korrektur1,kilde,side</quality>
+    <quality>korrektur1,korrektur2,kilde,side</quality>
 </head>
 <body>
 <poetry>
@@ -1594,10 +1594,10 @@ det er vort sidste, hulkende Farvel.
 
 <text id="joergensenj2024052337">
 <head>
-    <title>Paaske</title>
+    <title>Paaske.</title>
     <firstline>Jeg kørte hjem. Der mylred Folk paa Vejen</firstline>
     <source pages="68-69"/>
-    <quality>korrektur1,kilde,side</quality>
+    <quality>korrektur1,korrektur2,kilde,side</quality>
 </head>
 <body>
 <poetry>
@@ -1631,17 +1631,17 @@ og Nakken mod Vaggonens haarde Bræt.
 
 <text id="joergensenj2024052338">
 <head>
-    <title>Havblik</title>
+    <title>Havblik.</title>
     <firstline>Hvad vil du mig midt i en blæstkold Vaar</firstline>
     <source pages="69-72"/>
-    <quality>korrektur1,kilde,side</quality>
+    <quality>korrektur1,korrektur2,kilde,side</quality>
 </head>
 <body>
 <poetry>
 Hvad vil du mig midt i en blæstkold Vaar,
 du Minde om en solsvøbt Sommerdag,
-halvt glemselsslørt - som Land bag Varmedis
-Hvi vifter du din middagsiune Bris
+halvt glemselsslørt - som Land bag Varmedis:
+Hvi vifter du din middagslune Bris
 ind under denne Himmels Graavejrs-Tag
 og drager mig tilbage gennem Skyr
 af lange Tide-Vejes støvende Timer -
@@ -1653,7 +1653,7 @@ udover store Skoves Fjældmarksflader?
 
 Jeg kaldte ej. Du faldt som Foraarsregn,
 der drysser stille fra en hvidgraa Himmel
-ned over grønnende Marker og kneppede Hegn
+ned over grønnende Marker og knoppede Hegn
 igennem disblød, grødesvanger Luft,
 saa Sjælen svulmer, vemodsveg og svimmel
 af vædet Vejstøvs sommermindende Duft.
@@ -1669,7 +1669,7 @@ hvor mørke Master og skinnende lyse Sejl
 livløse staa, og knap en Sky sig flytter.
 
 Der sitrer Billedstriber over Havet
-af Skyer og Skibe - tjærne, disblaa Strande,
+af Skyer og Skibe - fjærne, disblaa Strande,
 der laa bag Bølgebrusets Hegn begravet,
 staa nu, luftbaarne, over de blanke Vande,
 - de sidste, flade Bølgers spæde Stemmer
@@ -1680,7 +1680,7 @@ jeg Lyd som fjærne Kirkeklokkers Ringen.
 Jeg glider ud paa Havet i min Baad,
 - al Lyd er død, undtagen Vandets Klukken
 om Boug og Bug med Klang som halvkvalt Graad;
-øg bag mig ligger Kølvandsstrimen, trukken
+og bag mig ligger Kølvandsstrimen, trukken
 med Lød af grønt igennem Havets graa,
 staalblanke Glas. De fjærne Landes blaa,
 langlige Strimer - hvide Sejl - en Strimmel
@@ -1688,15 +1688,15 @@ Røg fra en Damper dobbelttegnede staa
 udover vindløst Hav mod disgraa Himmel.
 
 Saa hælder Dagen. Glans af Guld og Blod
-gaar over Hav i Vest, og miletjserne,
+gaar over Hav i Vest, og milefjærne,
 solrøde Sejl som store Bavner brænder;
 paa Ør langt borte sig en Rude tænder
 i Glød af Solfaldshimlens Flammeflod
 med gylden Blinken som en jordfødt Stjærne.
 
 Det lufter op, og Havet bliver vækket
-og dønner dorsk med lange, blanke Bølger
-en Skude gaar for Sejl - en anden følger
+og dønner dorsk med lange, blanke Bølger -
+en Skude gaar for Sejl - en anden følger -
 jeg hører fjærne Raab og Trin paa Dækket,
 - den klingre Luft er fyldt af Støj og Stemmer -
 et Anker rasler ned - en Jagt forbi
@@ -1715,12 +1715,12 @@ en Hund - og Viben skriger over Heden.
 </body>
 </text>
 
-<text id="joergensenj2024052339">
+<text id="joergensenj2024052339" ignore-tests="internal-uppercase">
 <head>
-    <title>Nat</title>
+    <title>Nat.</title>
     <firstline>Med tusind grønne Rovdyr-Øjne stirrer</firstline>
     <source pages="73-76"/>
-    <quality>korrektur1,kilde,side</quality>
+    <quality>korrektur1,korrektur2,kilde,side</quality>
 </head>
 <body>
 <poetry>
@@ -1748,7 +1748,7 @@ Jeg sidder tavs, med Hjærtet tungt af Lede
 og Sorg, men rolig vugger sig Dit Bryst,
 og handskedækt imellem mine hede
 og nøgne Fingre ligger klam din Haand.
-- Jeg har jo mærket længst, hvordan vi giede
+- Jeg har jo mærket længst, hvordan vi glede
 som Baade, baarne blødt af Dage-Bølger,
 bort fra hinanden - jeg imod det brede
 isgraa og ørkengolde Havbliks-Øde -
@@ -1775,7 +1775,7 @@ i foraarsgrønne Skove - og et Minde,
 hvis Vingers Lyd er savnsyg Melodi,
 vil bære bort i stærke Gribbeklør
 min Fryd. Aar efter Aar vil langsomt rinde
-som Høstregns klamme Drys - men længselsog
+som Høstregns klamme Drys - men længsels-ør
 hjærtetung af Graad vil tit jeg hige
 med Sjælen syg og saar af havdybt Savn
 mod vore Elskovsdages Lykke Rige.
@@ -1811,10 +1811,10 @@ det er, som spøger i de stille Stunder.
 
 <text id="joergensenj2024052340">
 <head>
-    <title>Efterspil</title>
+    <title>Efterspil.</title>
     <firstline>Jeg havde bladet mine egne Vers</firstline>
     <source pages="77-78"/>
-    <quality>korrektur1,kilde,side</quality>
+    <quality>korrektur1,korrektur2,kilde,side</quality>
 </head>
 <body>
 <poetry>

--- a/fdirs/joergensenj/1887.xml
+++ b/fdirs/joergensenj/1887.xml
@@ -22,7 +22,7 @@
 
 <text id="joergensenj2024052301">
 <head>
-    <title>Foraarsminder.</title>
+    <title>Foraarsminder</title>
     <firstline>Det var en Foraarsdag, sidst i April</firstline>
     <source pages="3-5"/>
     <quality>korrektur1,korrektur2,kilde,side</quality>
@@ -50,7 +50,7 @@ mumled en Bæk forbi.
 Jeg laa der saa fjærnt, saa stille i Gem,
 et Sted, hvor ingen mig kendte -
 der dæmred dog vagt den Tanke frem:
-jeg laa der for én at vente;
+jeg laa der for èn at vente;
 jeg spejdede spændt ad Stien hen;
 lød der ej Fodtrin i Støvet?
 stirred det ikke bag Løvet
@@ -92,7 +92,7 @@ til Mindernes laasede Land.
 
 <text id="joergensenj2024052302">
 <head>
-    <title>Avgustnat.</title>
+    <title>Avgustnat</title>
     <firstline>Tung og fugtig er Løvets Duft</firstline>
     <source pages="6"/>
     <quality>korrektur1,korrektur2,kilde,side</quality>
@@ -122,7 +122,7 @@ her var det, vi mødtes en Gang.
 
 <text id="joergensenj2024052303">
 <head>
-    <title>Gengangere.</title>
+    <title>Gengangere</title>
     <firstline>Jeg standsede og stirred</firstline>
     <source pages="7-8"/>
     <quality>korrektur1,korrektur2,kilde,side</quality>
@@ -164,7 +164,7 @@ ak! disse Barnedrømme
 
 <text id="joergensenj2024052304">
 <head>
-    <title>Elverleg.</title>
+    <title>Elverleg</title>
     <firstline>Den hvide, koglende Maaneglans</firstline>
     <source pages="8-9"/>
     <quality>korrektur1,korrektur2,kilde,side</quality>
@@ -202,7 +202,7 @@ skal Gangen derover jeg vove?
 
 <text id="joergensenj2024052305">
 <head>
-    <title>Solnedgang.</title>
+    <title>Solnedgang</title>
     <firstline>Bag den fjærne Kyst</firstline>
     <source pages="10-11"/>
     <quality>korrektur1,korrektur2,kilde,side</quality>
@@ -280,7 +280,7 @@ for Klangen fra mine Drømmes Hjem.
 
 <text id="joergensenj2024052307">
 <head>
-    <title>Tordenluft.</title>
+    <title>Tordenluft</title>
     <firstline>Fra løvtætte, slumrende Haver</firstline>
     <source pages="13-14"/>
     <quality>korrektur1,korrektur2,kilde,side</quality>
@@ -323,7 +323,7 @@ der er Torden deroppe i Luften.
 
 <text id="joergensenj2024052308">
 <head>
-    <title>En forladt Park.</title>
+    <title>En forladt Park</title>
     <firstline>En stille Kirkegaard foruden døde</firstline>
     <source pages="14-15"/>
     <quality>korrektur1,korrektur2,kilde,side</quality>
@@ -362,7 +362,7 @@ ad Tidens lødløs dunkelblanke Flod.
 
 <text id="joergensenj2024052309">
 <head>
-    <title>Bøn.</title>
+    <title>Bøn</title>
     <firstline>Jeg kommer til dig, o evige Moder, trættet paa Sjæl og paa Sind</firstline>
     <source pages="16-18"/>
     <quality>korrektur1,korrektur2,kilde,side</quality>
@@ -420,7 +420,7 @@ og Liget selv; den Lykke, du længer ej huser.
 
 <text id="joergensenj2024052310">
 <head>
-    <title>Eftersommer.</title>
+    <title>Eftersommer</title>
     <firstline>Det ligger dødt og dræbt, jeg higed mod</firstline>
     <source pages="18-19"/>
     <quality>korrektur1,korrektur2,kilde,side</quality>
@@ -455,7 +455,7 @@ paa hver et elsket Navn: et Haab, der døde.
 
 <text id="joergensenj2024052311">
 <head>
-    <title>Ene.</title>
+    <title>Ene</title>
     <firstline>Jeg ligger ved Havet</firstline>
     <source pages="20-21"/>
     <quality>korrektur1,korrektur2,kilde,side</quality>
@@ -497,7 +497,7 @@ men slænger mit Blyant i Havet og tier.
 
 <text id="joergensenj2024052312">
 <head>
-    <title>Portræt.</title>
+    <title>Portræt</title>
     <firstline>Dagen er død og forsvunden</firstline>
     <source pages="22-25"/>
     <quality>korrektur1,korrektur2,kilde,side</quality>
@@ -582,7 +582,7 @@ og hobes til Dage og Aar.
 
 <text id="joergensenj2024052313">
 <head>
-    <title>Bladefald.</title>
+    <title>Bladefald</title>
     <firstline>Nu bærer Livets Floder Lig paa Lig</firstline>
     <source pages="26-27"/>
     <quality>korrektur1,korrektur2,kilde,side</quality>
@@ -680,7 +680,7 @@ mens alle Klokker ringe Mørket ind.
 
 <text id="joergensenj2024052315">
 <head>
-    <title>Længsel.</title>
+    <title>Længsel</title>
     <firstline>I Snekorallers Skove gad jeg gaa</firstline>
     <source pages="30-31"/>
     <quality>korrektur1,korrektur2,kilde,side</quality>
@@ -717,7 +717,7 @@ med Dvaledrik fra Dødens Lethe-dybe Vande.
 
 <text id="joergensenj2024052316">
 <head>
-    <title>Julesalme.</title>
+    <title>Julesalme</title>
     <firstline>Du stille Vinter, der mit Liv har født</firstline>
     <source pages="31-32"/>
     <quality>korrektur1,korrektur2,kilde,side</quality>
@@ -771,7 +771,7 @@ det Liv af Savn jeg evned ej
 
 <text id="joergensenj2024052317">
 <head>
-    <title>Vinterlandskab.</title>
+    <title>Vinterlandskab</title>
     <firstline>Nu ebber Dagen. Timernes Flod</firstline>
     <source pages="33-34"/>
     <quality>korrektur1,korrektur2,kilde,side</quality>
@@ -817,7 +817,7 @@ Sindet, der smægter i Ørkentørke.
 
 <text id="joergensenj2024052318">
 <head>
-    <title>Søvnløs.</title>
+    <title>Søvnløs</title>
     <firstline>Sortgraa, dybe Fløjelsskygger som et Krypthvælv staa omkring mig</firstline>
     <source pages="35-36"/>
     <quality>korrektur1,korrektur2,kilde,side</quality>
@@ -844,7 +844,7 @@ dræbt og død er hver en Længsel - Haab er Sagn - og Sol er slukket . . . . .
 
 <text id="joergensenj2024052319">
 <head>
-    <title>Faust til Foraaret.</title>
+    <title>Faust til Foraaret</title>
     <firstline>De har prist dig i svulmende Sange og løjet af Lykke dig fuld</firstline>
     <source pages="37-40"/>
     <!-- TODO: Smid mottoet til højre -->
@@ -906,7 +906,7 @@ alt Morgenens Guld om din Pande, din dugstænkte Dronningedragt
 
 <text id="joergensenj2024052320">
 <head>
-    <title>Solrødt.</title>
+    <title>Solrødt</title>
     <firstline>Nu brænder Dagens Skibe paa Baal i Vesterled</firstline>
     <source pages="41"/>
     <quality>korrektur1,korrektur2,kilde,side</quality>
@@ -939,7 +939,7 @@ ved Dagens Dødsseng grædes der ingen savnfødt Graad
 
 <text id="joergensenj2024052321">
 <head>
-    <title>Sommernat.</title>
+    <title>Sommernat</title>
     <firstline>Stort og stille ligger Landet, dæmringslyst, med grøngraa Flader</firstline>
     <source pages="42-43"/>
     <quality>korrektur1,korrektur2,kilde,side</quality>
@@ -967,7 +967,7 @@ og langt ude i det fjærne hører jeg en Hund slaa an.
 
 <text id="joergensenj2024052322">
 <head>
-    <title>Maaneskin.</title>
+    <title>Maaneskin</title>
     <firstline>Solen er død. Mod matgylden Luft</firstline>
     <source pages="44-45"/>
     <quality>korrektur1,korrektur2,kilde,side</quality>
@@ -1016,7 +1016,7 @@ et længselsfyldt Digt om en Stjærne, der døde,
 
 <text id="joergensenj2024052323">
 <head>
-    <title>Skovdrømme.</title>
+    <title>Skovdrømme</title>
     <firstline>Jeg gik og drømte i Skoven</firstline>
     <source pages="46-48"/>
     <quality>korrektur1,korrektur2,kilde,side</quality>
@@ -1077,7 +1077,7 @@ før Markerne hvidne mod Høst.
 
 <text id="joergensenj2024052324">
 <head>
-    <title>Høsttid.</title>
+    <title>Høsttid</title>
     <firstline>Jeg standser og vender mig om i Høstens Dør</firstline>
     <source pages="49"/>
     <quality>korrektur1,korrektur2,kilde,side</quality>
@@ -1110,7 +1110,7 @@ De høster dernede i Sollysets fulde Strømme.
 
 <text id="joergensenj2024052325">
 <head>
-    <title>Nocturne.</title>
+    <title>Nocturne</title>
     <firstline>Jeg hilser dig, du store Maanenat</firstline>
     <source pages="50"/>
     <quality>korrektur1,korrektur2,kilde,side</quality>
@@ -1142,7 +1142,7 @@ og giv mig stenstøt Mod og Had af Staal.
 
 <text id="joergensenj2024052326">
 <head>
-    <title>Afsked.</title>
+    <title>Afsked</title>
     <firstline>Saa er det alt forbi, jeg længtes mod</firstline>
     <source pages="51"/>
     <quality>korrektur1,korrektur2,kilde,side</quality>
@@ -1174,7 +1174,7 @@ og samler sig Drømmevrag til Vinterbrænde.
 
 <text id="joergensenj2024052327">
 <head>
-    <title>Ved Havet.</title>
+    <title>Ved Havet</title>
     <firstline>Jeg gik en graavejrsmørk Dag, tæt op imod Høst</firstline>
     <source pages="52"/>
     <quality>korrektur1,korrektur2,kilde,side</quality>
@@ -1207,7 +1207,7 @@ og rydde paa Jorden Rum for en nyskabt Slægt.
 
 <text id="joergensenj2024052328">
 <head>
-    <title>Oktober.</title>
+    <title>Oktober</title>
     <firstline>Nu sprænger Aaret Somrens grønne Ham</firstline>
     <source pages="53"/>
     <quality>korrektur1,korrektur2,kilde,side</quality>
@@ -1234,7 +1234,7 @@ paa Taagedrypfaldets snigende Morderfødder.
 
 <text id="joergensenj2024052329">
 <head>
-    <title>Tusmørke.</title>
+    <title>Tusmørke</title>
     <firstline>Det led mod Solrøsttide - blaalig Em</firstline>
     <source pages="54-55"/>
     <quality>korrektur1,korrektur2,kilde,side</quality>
@@ -1275,7 +1275,7 @@ jeg gaar, sjælsbitter, viljeveg og tankedøv.
 
 <text id="joergensenj2024052330">
 <head>
-    <title>Snefald.</title>
+    <title>Snefald</title>
     <firstline>Der falder Sne i Nat - det første hvide</firstline>
     <source pages="55-56"/>
     <quality>korrektur1,korrektur2,kilde,side</quality>
@@ -1308,7 +1308,7 @@ gaar gennem Skovens Træer af Koral.
 
 <text id="joergensenj2024052331">
 <head>
-    <title>Døden.</title>
+    <title>Døden</title>
     <firstline>Jeg drømmer om Døden, naar Morgnen spænder</firstline>
     <source pages="57-59"/>
     <quality>korrektur1,korrektur2,kilde,side</quality>
@@ -1365,7 +1365,7 @@ min Hjærneblomsts tankefostrende Blade.
 
 <text id="joergensenj2024052332">
 <head>
-    <title>Solvejg.</title>
+    <title>Solvejg</title>
     <firstline>Decembernattens klamme Maaneblaa</firstline>
     <source pages="59-60"/>
     <quality>korrektur1,korrektur2,kilde,side</quality>
@@ -1425,7 +1425,7 @@ en Mindelse om Solvejgs bløde Sange.
 
 <text id="joergensenj2024052333">
 <head>
-    <title>Januar.</title>
+    <title>Januar</title>
     <firstline>Der ligger hvidgraa Taager over Landet</firstline>
     <source pages="61-62"/>
     <quality>korrektur1,korrektur2,kilde,side</quality>
@@ -1467,7 +1467,7 @@ dør bort i dette store Nattestille.
 
 <text id="joergensenj2024052334">
 <head>
-    <title>Tøvejr.</title>
+    <title>Tøvejr</title>
     <firstline>Jeg vaagned op og hørte Fugle synge</firstline>
     <source pages="63-64"/>
     <quality>korrektur1,korrektur2,kilde,side</quality>
@@ -1509,7 +1509,7 @@ vemodigt klang der Foraarsminder gennem Luften.
 
 <text id="joergensenj2024052335">
 <head>
-    <title>Marts.</title>
+    <title>Marts</title>
     <firstline>Jeg længes ikke mer mod grønne Blade</firstline>
     <source pages="65"/>
     <quality>korrektur1,korrektur2,kilde,side</quality>
@@ -1541,7 +1541,7 @@ et Forspil blot til Vintrens triste Sange.
 
 <text id="joergensenj2024052336">
 <head>
-    <title>Et Farvel.</title>
+    <title>Et Farvel</title>
     <firstline>Jeg flakker ene om ad mørke Veje</firstline>
     <source pages="66-67"/>
     <quality>korrektur1,korrektur2,kilde,side</quality>
@@ -1594,7 +1594,7 @@ det er vort sidste, hulkende Farvel.
 
 <text id="joergensenj2024052337">
 <head>
-    <title>Paaske.</title>
+    <title>Paaske</title>
     <firstline>Jeg kørte hjem. Der mylred Folk paa Vejen</firstline>
     <source pages="68-69"/>
     <quality>korrektur1,korrektur2,kilde,side</quality>
@@ -1631,7 +1631,7 @@ og Nakken mod Vaggonens haarde Bræt.
 
 <text id="joergensenj2024052338">
 <head>
-    <title>Havblik.</title>
+    <title>Havblik</title>
     <firstline>Hvad vil du mig midt i en blæstkold Vaar</firstline>
     <source pages="69-72"/>
     <quality>korrektur1,korrektur2,kilde,side</quality>
@@ -1717,7 +1717,7 @@ en Hund - og Viben skriger over Heden.
 
 <text id="joergensenj2024052339" ignore-tests="internal-uppercase">
 <head>
-    <title>Nat.</title>
+    <title>Nat</title>
     <firstline>Med tusind grønne Rovdyr-Øjne stirrer</firstline>
     <source pages="73-76"/>
     <quality>korrektur1,korrektur2,kilde,side</quality>
@@ -1811,7 +1811,7 @@ det er, som spøger i de stille Stunder.
 
 <text id="joergensenj2024052340">
 <head>
-    <title>Efterspil.</title>
+    <title>Efterspil</title>
     <firstline>Jeg havde bladet mine egne Vers</firstline>
     <source pages="77-78"/>
     <quality>korrektur1,korrektur2,kilde,side</quality>


### PR DESCRIPTION
## Hvad er ændret?

Alle 40 tekster i Johannes Jørgensens *Vers* (1887) er sammenholdt med facsimilet. Dokumenterede OCR-, titel-, tegnsætnings- og sidefejl er rettet, og posterne er mærket `korrektur2`.

## Hvorfor?

Ændringerne gør transskriptionen kildetro og bevarer samtidig historisk ortografi, linjedeling og trykkets dokumenterede særformer.

## Kontrol

- XML og Relax NG validerer
- OCR-kandidatrapport: 0 uløste fund
- `git diff --check` består
- Hele Jest-suiten: 54 suiter / 2.405 tests består

PR’en er isoleret til `fdirs/joergensenj/1887.xml`.
