### PR TITLE
Korrekturlæs Stemninger (1892)

### DIFF
--- a/fdirs/joergensenj/1892.xml
+++ b/fdirs/joergensenj/1892.xml
@@ -944,7 +944,7 @@ men Deres Skæbne i en andens tvunden -
 og følte, der var runden lange Aar,
 og at min egen Ungdoms Tid var runden.
 
-Og saa Dem vandre bort ad nye Veje.
+Og saà Dem vandre bort ad nye Veje.
 mod Fjælde, der langs Himmelranden tegner
 de stærke Rygge, mens i Mindedis
 Forriderbakkerne langt borte blegner.
@@ -1033,7 +1033,7 @@ Jeg ser, hvor Bækkens Vande gaa
 glat over Grusets mørke Bund
 og under Brombærrankers Spind af Blade,
 men furet for hver Sten, den støder paa,
-- saa fure Tanker i en Hjærnes Flade.
+- saà fure Tanker i en Hjærnes Flade.
 Jeg ser den gaa i Sol og gaa i Skygge,
 - brun, hvor den er klar, grønt spejlende Skovens Lød,
 og okkerrød langs Breddens Kiselsten -

--- a/fdirs/joergensenj/1892.xml
+++ b/fdirs/joergensenj/1892.xml
@@ -28,7 +28,7 @@
     <title>Vignet</title>
     <firstline>Jeg vandrer over brede Marker frem</firstline>
     <source pages="3-4"/>
-    <quality>korrektur1,kilde,side</quality>
+    <quality>korrektur1,korrektur2,kilde,side</quality>
 </head>
 <body>
 <poetry>
@@ -62,7 +62,7 @@ i Sommernattens stille Gyldenrøde.
 <head>
     <title>Vildgæssene</title>
     <source pages="5-6"/>
-    <quality>korrektur1,kilde,side</quality>
+    <quality>korrektur1,korrektur2,kilde,side</quality>
 </head>
 <body>
 <prose>
@@ -84,7 +84,7 @@ i Sommernattens stille Gyldenrøde.
     <title>Juninat</title>
     <firstline>Nu slumrer Parken ind, og mørketæt</firstline>
     <source pages="7-8"/>
-    <quality>korrektur1,kilde,side</quality>
+    <quality>korrektur1,korrektur2,kilde,side</quality>
 </head>
 <body>
 <poetry>
@@ -108,7 +108,7 @@ Hvad vil mig denne grønligklare, fade
 Nat med sin blege Duft af Hæg og Poppel -
 sin sagte Hvisken af nylig fødte Blade
 og sine Nattergales Jagthunds-Kobbel,
-hvis glammende Trille r hidse sovende Minder
+hvis glammende Triller hidse sovende Minder
 og blundende Savn af deres Leje frem?
 
 Giv mig en sortblaa Nat, som aldrig svinder -
@@ -124,7 +124,7 @@ for denne Vaarnats staalkolde, vandblege Lød.
 <head>
     <title>Sommernatsregn</title>
     <source pages="9"/>
-    <quality>korrektur1,kilde,side</quality>
+    <quality>korrektur1,korrektur2,kilde,side</quality>
 </head>
 <body>
 <prose>
@@ -144,7 +144,7 @@ for denne Vaarnats staalkolde, vandblege Lød.
     <firstline>Jeg sad en Sommeraften i en Have</firstline>
     <source pages="10-11"/>
     <!-- TODO: Citatet er fra en Rubinstein. -->
-    <quality>korrektur1,kilde,side</quality>
+    <quality>korrektur1,korrektur2,kilde,side</quality>
 </head>
 <body>
 <poetry>
@@ -164,7 +164,7 @@ men længe efter fra Havestuen naade
 mig nu og da en svag Guitarakkord
 
 og smeltende Kvindestemmers bløde Sange
-og glade Raab. Tilsidst blev Lyset slukket -
+og glade Raab. Til sidst blev Lyset slukket -
 jeg hørte Trin i Gaarden - et sidste »Godnat« -
 og Lyd af Vindver, som med Smæld blev lukket.
 
@@ -196,7 +196,7 @@ ach! ohne Liebeslust und ohne Freud’.«
     <title>Sommernatssang</title>
     <firstline>Saa slænger jeg Dagens Harpe af Guld</firstline>
     <source pages="12"/>
-    <quality>korrektur1,kilde,side</quality>
+    <quality>korrektur1,korrektur2,kilde,side</quality>
 </head>
 <body>
 <poetry>
@@ -213,7 +213,7 @@ og skimte bag Løvet Fakkelglimt over Masker.
 Med Silkehuen i Nakken sat -
 under Kappen en Strængeleg klingrer -
 standser jeg saa i den lune Nat
-og i listende Greb over Tonetraadene  fingrer.
+og i listende Greb over Tonetraadene fingrer.
 
 Saa klirrer et Vindu - det lyser af Lin -
 jeg bryder mine Strænge i Brynde -
@@ -227,7 +227,7 @@ det er saligt og sødt under Sommerens sølvhvide Nætter at synde.
 <head>
     <title>Venus</title>
     <source pages="13"/>
-    <quality>korrektur1,kilde,side</quality>
+    <quality>korrektur1,korrektur2,kilde,side</quality>
 </head>
 <body>
 <prose>
@@ -244,7 +244,7 @@ det er saligt og sødt under Sommerens sølvhvide Nætter at synde.
     <title>Til -</title>
     <firstline>Mine Dage er bundne i drømmesart Spind</firstline>
     <source pages="14"/>
-    <quality>korrektur1,kilde,side</quality>
+    <quality>korrektur1,korrektur2,kilde,side</quality>
 </head>
 <body>
 <poetry>
@@ -276,7 +276,7 @@ i et varligt Kys paa en blysom Kind.
     <title>Julinat</title>
     <firstline>En Julinat. Jeg sidder paa en Spange</firstline>
     <source pages="15-16"/>
-    <quality>korrektur1,kilde,side</quality>
+    <quality>korrektur1,korrektur2,kilde,side</quality>
 </head>
 <body>
 <poetry>
@@ -321,7 +321,7 @@ som tusind Alfelæbers Elskovsmøde.
 <head>
     <title>Sommernat</title>
     <source pages="18-20"/>
-    <quality>korrektur1,kilde,side</quality>
+    <quality>korrektur1,korrektur2,kilde,side</quality>
 </head>
 <body>
 <prose>
@@ -348,7 +348,7 @@ som tusind Alfelæbers Elskovsmøde.
     <title>Mørke</title>
     <firstline>Gennem Julinattens Stille</firstline>
     <source pages="21"/>
-    <quality>korrektur1,kilde,side</quality>
+    <quality>korrektur1,korrektur2,kilde,side</quality>
 </head>
 <body>
 <poetry>
@@ -380,7 +380,7 @@ Ahasverus gaar forbi.
     <title>Ahasverus</title>
     <firstline>Stille lider Sommernatten</firstline>
     <source pages="22-23"/>
-    <quality>korrektur1,kilde,side</quality>
+    <quality>korrektur1,korrektur2,kilde,side</quality>
 </head>
 <body>
 <poetry>
@@ -421,7 +421,7 @@ i en bleggrøn Rømers Bund.
 <head>
     <title>Paradiset</title>
     <source pages="24-25"/>
-    <quality>korrektur1,kilde,side</quality>
+    <quality>korrektur1,korrektur2,kilde,side</quality>
 </head>
 <body>
 <prose>
@@ -438,7 +438,7 @@ i en bleggrøn Rømers Bund.
 <head>
     <title>Anadyomene</title>
     <source pages="26"/>
-    <quality>korrektur1,kilde,side</quality>
+    <quality>korrektur1,korrektur2,kilde,side</quality>
 </head>
 <body>
 <prose>
@@ -456,7 +456,7 @@ i en bleggrøn Rømers Bund.
     <title>Augustnætter</title>
     <firstline>Maanedis og Mosetaager</firstline>
     <source pages="27-33"/>
-    <quality>korrektur1,kilde,side</quality>
+    <quality>korrektur1,korrektur2,kilde,side</quality>
 </head>
 <body>
 <poetry>
@@ -603,8 +603,8 @@ sig tegner som en sort og stiv Cypres.
 <text id="joergensenj2024060316">
 <head>
     <title>Skumring</title>
-    <source pages="34"/>
-    <quality>korrektur1,kilde,side</quality>
+    <source pages="34-35"/>
+    <quality>korrektur1,korrektur2,kilde,side</quality>
 </head>
 <body>
 <prose>
@@ -625,7 +625,7 @@ sig tegner som en sort og stiv Cypres.
     <title>Høstaften</title>
     <firstline>Høstaftnen dises af Mørkedunst</firstline>
     <source pages="36-37"/>
-    <quality>korrektur1,kilde,side</quality>
+    <quality>korrektur1,korrektur2,kilde,side</quality>
 </head>
 <body>
 <poetry>
@@ -662,7 +662,7 @@ som Maanen i Skyerne svømmer.
     <title>Oktobernat</title>
     <firstline>Jeg vandrer hjemad, medens Maanen skinner</firstline>
     <source pages="38"/>
-    <quality>korrektur1,kilde,side</quality>
+    <quality>korrektur1,korrektur2,kilde,side</quality>
 </head>
 <body>
 <poetry>
@@ -694,7 +694,7 @@ som Poplens Kviste sig med Vinden bøje.
 <head>
     <title>Novembernat</title>
     <source pages="39-40"/>
-    <quality>korrektur1,kilde,side</quality>
+    <quality>korrektur1,korrektur2,kilde,side</quality>
 </head>
 <body>
 <prose>
@@ -722,7 +722,7 @@ som Poplens Kviste sig med Vinden bøje.
     <title>Vaarvers</title>
     <firstline>Nu drager Gærdets Graapil</firstline>
     <source pages="43-45"/>
-    <quality>korrektur1,kilde,side</quality>
+    <quality>korrektur1,korrektur2,kilde,side</quality>
 </head>
 <body>
 <poetry>
@@ -799,7 +799,7 @@ de Drømmes Elver-Tærner.
     <title>Taarnfalke</title>
     <firstline>Der staar en Stimmel i den snævre Gade</firstline>
     <source pages="46"/>
-    <quality>korrektur1,kilde,side</quality>
+    <quality>korrektur1,korrektur2,kilde,side</quality>
 </head>
 <body>
 <poetry>
@@ -831,7 +831,7 @@ to røde Falke deres Bytte flaa.
     <title>Et Møde</title>
     <firstline>Der brændte Sommersol paa Torvets Stene</firstline>
     <source pages="47"/>
-    <quality>korrektur1,kilde,side</quality>
+    <quality>korrektur1,korrektur2,kilde,side</quality>
 </head>
 <body>
 <poetry>
@@ -863,7 +863,7 @@ Du vender dig at se, om ej jeg kommer
     <title>Dagning</title>
     <firstline>Nu rider det unge Gry over Land</firstline>
     <source pages="48-49"/>
-    <quality>korrektur1,kilde,side</quality>
+    <quality>korrektur1,korrektur2,kilde,side</quality>
 </head>
 <body>
 <poetry>
@@ -895,7 +895,7 @@ at høste, hvor Regnen saade.
     <title>Sommerdag</title>
     <firstline>Jeg gaar den lange Sommerdag alene</firstline>
     <source pages="50-51"/>
-    <quality>korrektur1,kilde,side</quality>
+    <quality>korrektur1,korrektur2,kilde,side</quality>
 </head>
 <body>
 <poetry>
@@ -944,7 +944,7 @@ men Deres Skæbne i en andens tvunden -
 og følte, der var runden lange Aar,
 og at min egen Ungdoms Tid var runden.
 
-Og saà Dem vandre bort ad nye Veje.
+Og saa Dem vandre bort ad nye Veje.
 mod Fjælde, der langs Himmelranden tegner
 de stærke Rygge, mens i Mindedis
 Forriderbakkerne langt borte blegner.
@@ -956,7 +956,7 @@ Forriderbakkerne langt borte blegner.
 <head>
     <title>Vestenvind</title>
     <source pages="52"/>
-    <quality>korrektur1,kilde,side</quality>
+    <quality>korrektur1,korrektur2,kilde,side</quality>
 </head>
 <body>
 <prose>
@@ -974,7 +974,7 @@ Forriderbakkerne langt borte blegner.
     <title>Solbrand</title>
     <firstline>Jeg længes mod dig i den middagshede</firstline>
     <source pages="53-54"/>
-    <quality>korrektur1,kilde,side</quality>
+    <quality>korrektur1,korrektur2,kilde,side</quality>
 </head>
 <body>
 <poetry>
@@ -1013,7 +1013,7 @@ jeg véd saa godt, du kender mig ej længer.
     <title>Bækken</title>
     <firstline>Her løfter Jorden sig, og Skoven slipper</firstline>
     <source pages="55-57"/>
-    <quality>korrektur1,kilde,side</quality>
+    <quality>korrektur1,korrektur2,kilde,side</quality>
 </head>
 <body>
 <poetry>
@@ -1033,7 +1033,7 @@ Jeg ser, hvor Bækkens Vande gaa
 glat over Grusets mørke Bund
 og under Brombærrankers Spind af Blade,
 men furet for hver Sten, den støder paa,
-- saà fure Tanker i en Hjærnes Flade.
+- saa fure Tanker i en Hjærnes Flade.
 Jeg ser den gaa i Sol og gaa i Skygge,
 - brun, hvor den er klar, grønt spejlende Skovens Lød,
 og okkerrød langs Breddens Kiselsten -
@@ -1091,7 +1091,7 @@ den Kilde, hvoraf alle Kilder rinde,
     <title>Marine</title>
     <firstline>Hav i Flager mod Stranden</firstline>
     <source pages="58-59"/>
-    <quality>korrektur1,kilde,side</quality>
+    <quality>korrektur1,korrektur2,kilde,side</quality>
 </head>
 <body>
 <poetry>
@@ -1124,7 +1124,7 @@ og en Sol, der gaar ned.
     <title>Høsttid</title>
     <firstline>Saa ridses paa mit Øjes Nerve-Tavl</firstline>
     <source pages="60-63"/>
-    <quality>korrektur1,kilde,side</quality>
+    <quality>korrektur1,korrektur2,kilde,side</quality>
 </head>
 <body>
 <poetry>
@@ -1228,7 +1228,7 @@ og gyder det alt i din Ligfærds løvfaldsluende Baal.
         <note>Se Byrons <xref poem="byron1999040902,1409"/>.</note>
     </notes>
     <source pages="64-65"/>
-    <quality>korrektur1,kilde,side</quality>
+    <quality>korrektur1,korrektur2,kilde,side</quality>
 </head>
 <body>
 <poetry>
@@ -1276,7 +1276,7 @@ en ensom Kyst lig den, hvor Juan vandred med Haidee.
 <head>
     <title>Vinter</title>
     <source pages="66"/>
-    <quality>korrektur1,kilde,side</quality>
+    <quality>korrektur1,korrektur2,kilde,side</quality>
 </head>
 <body>
 <prose>
@@ -1299,7 +1299,7 @@ en ensom Kyst lig den, hvor Juan vandred med Haidee.
 <head>
     <title>Foraarsepistel</title>
     <source pages="69-72"/>
-    <quality>korrektur1,kilde,side</quality>
+    <quality>korrektur1,korrektur2,kilde,side</quality>
 </head>
 <body>
 <prose>
@@ -1328,7 +1328,7 @@ en ensom Kyst lig den, hvor Juan vandred med Haidee.
 <head>
     <title>Pinsemorgen</title>
     <source pages="73-76"/>
-    <quality>korrektur1,kilde,side</quality>
+    <quality>korrektur1,korrektur2,kilde,side</quality>
 </head>
 <body>
 <prose>
@@ -1371,7 +1371,7 @@ den kom frem, den Gang du ikke saae paa den . . .
 <head>
     <title>Fredriksberghave</title>
     <source pages="77-79"/>
-    <quality>korrektur1,kilde,side</quality>
+    <quality>korrektur1,korrektur2,kilde,side</quality>
 </head>
 <body>
 <prose>
@@ -1396,7 +1396,7 @@ sig under En, lige ude ved Vandkanten.
 <head>
     <title>Sankt Hans</title>
     <source pages="80-82"/>
-    <quality>korrektur1,kilde,side</quality>
+    <quality>korrektur1,korrektur2,kilde,side</quality>
 </head>
 <body>
 <prose>
@@ -1423,7 +1423,7 @@ sig under En, lige ude ved Vandkanten.
 <head>
     <title>Søndermarken</title>
     <source pages="83-88"/>
-    <quality>korrektur1,kilde,side</quality>
+    <quality>korrektur1,korrektur2,kilde,side</quality>
 </head>
 <body>
 <prose>
@@ -1440,7 +1440,7 @@ sig under En, lige ude ved Vandkanten.
     - - Saa var det Aar derefter - en Sommeraften hen i Avgust. Det begyndte at skumre, og Søndermarken var næsten tom. Kun paa en af de store Plæner saa jeg et Par unge Piger ifærd med at spille Ring. Den ene slank og lysklædt, den anden mindre, plumpere og i Mørkt.  Der var noget ved den slanke Lysklædte, som mindede mig om hint unge Barn, der den Junidag for Aar tilbage laa paa Knæ i Plænegræsset og plukkede sit Forklæde fuldt af Bellis . . .
     Uvilkaarligt gjorde jeg et Skridt ind i det duggede Græs. Et Øjeblik efter kom en forvildet Ring farende hen imod mig - jeg greb den, bar den tilbage - og udbad mig med det samme Tilladelse til at deltage i Spillet.
     Med en lille Latter gav den slanke Lyse mig Lov at være med. Jeg fik en Ring og en Pind og blev stillet op - og saa spillede vi, under mange Fejlgreb og megen Latter, indtil de gyldne Avguststjærner stod tændte over de mørke Trætoppe, og Havens Klokke ringede os ud.
-    Paa Vejen hjemad blev den lille plumpe Mørktklædte borte for os. Blød og ung og slank gik den Lysklædte ved min Side med Ringspilredskaberne i den lille, halvbehandskede Haand. . .
+    Paa Vejen hjemad blev den lille plumpe Mørktklædte borte for os. Blød og ung og slank gik den Lysklædte ved min Side med Ringspilredskaberne i den lille, halvbehandskede Haand . . .
     Jeg har aldrig sét hende siden den Nat.
     Men mangen silde Skumringsstund i den varme Sommer er det, naar jeg vandrer hin Ringspil-Plæne forbi, som skimtede jeg en ung og slank Skikkelse tegne sig lyst mod Aftenens Mørke derinde . . .
     - - Saa var det endelig for en Uges Tid siden, jeg en tidlig Formiddag kom gennem en af de Gange, som løber langs Søndermarkens yderste, mest skovlignende Rand - den, der vender ud imod Landet, og hvorfra man har Udsigt over Marker og Hegn og grønne Bankers Kamme og Spir af Kirker, som ligger gemt bag Horisonten.
@@ -1460,7 +1460,7 @@ sig under En, lige ude ved Vandkanten.
 <head>
     <title>Sommerbreve</title>
     <source pages="89-97"/>
-    <quality>korrektur1,kilde,side</quality>
+    <quality>korrektur1,korrektur2,kilde,side</quality>
 </head>
 <body>
 <prose>
@@ -1474,14 +1474,14 @@ sig under En, lige ude ved Vandkanten.
     Og nu sad jeg paa Bænken i Skovbrynet og var sørgmodig som En, der skal forlade sit Hjem - det Hjem, der ejer alle hans kæreste Minder, og hvor han gad blive for bestandig . . .
     Jeg tog min Lommebog frem og skrev:
     »Jeg er syg af at se de store Skove, syg af at aande Granernes Duft, syg af Længsel og syg af Hjemve. Droslen fløjter og lokker og kalder, Fluerne summer en gammel Sang - Sangen, der bar min Ungdoms Somre.«
-    »Vidt gik min Vej fra de store Skove, ind mellem Huse og Menneskers Mylr ...«
+    »Vidt gik min Vej fra de store Skove, ind mellem Huse og Menneskers Mylr . . .«
 
 <nonum><center>* * *</center></nonum>
 
     I det samme opdagede jeg, at Klokken var bleven mange, og jeg maatte hurtigst tilbage til Silkeborg. Paa mit Digt fik jeg aldrig nogen Slutning, men tre Uger efter, at det var skrevet, førte Jærnbane og Damper mig hjem til de store Skove, under hvis Skygge jeg er født . . .
     . . . Det er besynderligt at se et saadant Land igen, hvorfra man for ti Aar siden drog bort - ud i den vide Verden. Dets Skovlinjer forekommer En lavere, end man havde tænkt sig - dets Udsigter mindre vidtstrakte - dets Banker stænger for det horisontsøgende Blik. Gamle Huse er revne ned, og nye Bygninger bryder med deres grelle Rødt og Gult den dæmpede Harmoni mellem det grønne Land og den graa By. Hvor for ti Aar siden en Sti drog sig op over Græsbanker under blomstrende Hvidtjørn, der er Marken nu tavlet med Køkkenhaver, som Kommunen har anlagt og lejer ud til Smaakaarsfolk - og hvor før en Bæk vandt sig under hængende Pile, breder sig nu et Andels-Svineslagteri, som bruger Bækkens Vand til at føde sine Dampkedler med.
     Paany at knytte Forholdet til et Landskab eller et Menneske, med hvem man en Gang har været fortrolig, er som at prøve en Ring igen, man længe ikke har baaren.  Ringfingeren har i Mellemtiden forandret sig, er enten bleven for fed eller for mager, passer ikke mere . . .
-    Men en Morgen vaagner man tidligt og sér Solskinnet falde stærkt ind gennem de hvide Gardiner, der er trukne hen for Vinduet, og skimter bag deres Flor de røde Tage udenfor i stærk Sol og en varm, blaa Himmel med hvide Sommerskyer. . . Og med ét føler man det, som om Rum i Ens Sjæl, der længe har staaet ubeboede hen, lukkes op, og man træder derind og kender, at her var det, Ens Ungdom fejrede sine Fester. Og man er lykkelig som den, der efter lange Rejser har naaet sit Hjem.
+    Men en Morgen vaagner man tidligt og sér Solskinnet falde stærkt ind gennem de hvide Gardiner, der er trukne hen for Vinduet, og skimter bag deres Flor de røde Tage udenfor i stærk Sol og en varm, blaa Himmel med hvide Sommerskyer . . . Og med ét føler man det, som om Rum i Ens Sjæl, der længe har staaet ubeboede hen, lukkes op, og man træder derind og kender, at her var det, Ens Ungdom fejrede sine Fester. Og man er lykkelig som den, der efter lange Rejser har naaet sit Hjem.
 
 
 <nonum><center>II.</center></nonum>
@@ -1519,7 +1519,7 @@ sig under En, lige ude ved Vandkanten.
 <head>
     <title>Efteraar</title>
     <source pages="98-102"/>
-    <quality>korrektur1,kilde,side</quality>
+    <quality>korrektur1,korrektur2,kilde,side</quality>
 </head>
 <body>
 <prose>
@@ -1527,7 +1527,7 @@ sig under En, lige ude ved Vandkanten.
     En saadan Dag, eller rettere en Morgen som den igaar, driver uvilkaarligt Blodet i lettere Løb gennem Aarerne.  Det er, som om hvert Aarstidsskifte frembragte en vis Forventning, et vist Haab hos En. Man føler ved Indgangen til den nye Aarstid den samme vage Spænding, som naar man begiver sig ud i en ny Dag. Og falder da disse to Indtryk sammen, opstaar først ret Fornemmelsen af, at der er noget, som venter En i det fjærne.
     Der er noget paa en Gang overdaadigt og nøgternt ved Høsten. Haverne bugner i Fylde, alle Slags store Frugter plukkes ned fra Træerne eller samles ind fra de jordede Bede, en Duft af Korn og moden Frugt hænger ved Maanederne Avgust, September og Oktober. Og gylden som Frugterne staar Skoven, moden til Løvfald. Men over al Glans og al Rigdom løfter Himlen sig kold og bleg i sin Blaanen, og om Natten tindrer Stjærnerne stærkt, som var der Frostluft om dem.
     Høsten er de lange Vandringers Tid. Man skyder en let Genvej over Stubmarkerne, og der er ingen Solhede, som hindrer En i at gaa til. Landevejene ere haarde af Regn og støver ikke. Og langs Markstierne vokser Brombær over Gærder og Grøfter, store, sorte, saftige Bær, modnede i Septembers Sol og vaskede i dens Regn, duftkrydrede som solhed Gran at lugte til.
-    Og er man træt efter al den megen Fodtur, saa tager man ind i en Kro og beder. I den store Krohave ligger Kastanjernes faldne Blade paa den sorte Jord som store Guldvifter, indlagte med Grønt langs Ribberne. Og ved et gammelt Træbord, hvor den sidste Regns Væde endnu staar som Fugt under det nedfaldne Løv og klistrer det fast til Bordpladen, nyder man, med Hatten liggende paa Bænken ved Siden af sig, et frugalt og idyllisk Maaltid - Spejlæg og blødt Landbrød med godt Smør og et Krus gammelt 01. Det er hen paa Eftermiddagen - Solen stryger gylden over Havens Græsplæner og kaster lange Skygger af Ølkrus og Peberbøsse hen over Bordet - en Solsort synger endnu et kort Fløjt i Linden, hvorunder man sidder - og mellem de gule Lindeblade sér man højt oppe en blaa ren Luft med fjærne hvide Skyer . . .
+    Og er man træt efter al den megen Fodtur, saa tager man ind i en Kro og beder. I den store Krohave ligger Kastanjernes faldne Blade paa den sorte Jord som store Guldvifter, indlagte med Grønt langs Ribberne. Og ved et gammelt Træbord, hvor den sidste Regns Væde endnu staar som Fugt under det nedfaldne Løv og klistrer det fast til Bordpladen, nyder man, med Hatten liggende paa Bænken ved Siden af sig, et frugalt og idyllisk Maaltid - Spejlæg og blødt Landbrød med godt Smør og et Krus gammelt Øl. Det er hen paa Eftermiddagen - Solen stryger gylden over Havens Græsplæner og kaster lange Skygger af Ølkrus og Peberbøsse hen over Bordet - en Solsort synger endnu et kort Fløjt i Linden, hvorunder man sidder - og mellem de gule Lindeblade sér man højt oppe en blaa ren Luft med fjærne hvide Skyer . . .
     Eller man tager længere bort fra Byen - med Jærnbane, helt op i Nordsjælland.
     Den lille vaklende Gribskovbane fører En op gennem Skove af kobberrød Bøg - som Banker af Malmslakker løfter de sig til begge Sider - gennem Skove af sort Gran, med takkede Grene som Vikingehuses udskaarne Bjælker - gennem Skove af hvidstammet Birk i halvfaldent Flor af gyldne Blade som hvide Nymfer i løse Guldmorsslør.
     Saa sættes man af ved den lave, lange Plankebro, der er Station ved Grib Sø. Og springer ned i det høje, gulnede Græs, hvis Tuer i Bunden endnu er vaade af Morgenduggen, og baner sig Vej mellem et Krat af rødløvet Risbøg ned til Søen, der blank og stille ligger i sin Ramme af sorte Graner med spredte gyldne Birke - Ibenholt med Forsiringer af Guld.
@@ -1537,7 +1537,7 @@ sig under En, lige ude ved Vandkanten.
     . . . Saa aftnes det. Belæsset med mærkværdige Svampe og smukt Mos, med Buketter af visne Bregner og Risbøges røde Løv, drager man nedad mod Stationen ved Grib Sø. Paa en Vej under høje, mørke Graner kommer et Par Brændehuggere En imøde, høje Folk med Økser og Hakker over Skuldrene, ranke og alvorlige som Granerne, de fælder.
     - God Aften, hilser de . . . Og man forstaar i denne Skov, ene, mod Mørkning, hvad det betød, naar Folk i gamle Dage bød hinanden »Guds Fred« paa Vejene. De Brændehuggere har stærke Lemmer, og deres Hakker er frygtelige at se til med de blanke Jærnnæb . . .
     Saa naaer man Stationen. Der er endnu tyve Minuter, inden Toget kommer. Og medens Duggen falder paa Perronens Planker, og Himlen staar solrød over Grib Søs blanke Spejl, som ingen Dis slører, sidder man og venter.
-    Da rejser der sig langt borte i de store Skove et sagte Sus. Et Sus, der stiger og nærmer sig som en Flugt af mange Vinger, vokser til en brusende Brænding af Grantoppe, gaar hen over Ens Hoved med et koldt pludseligt Pust af Nattevind, fortsætter sig hinsides Banelinjen og drager videre ind gennem Skoven, ind over de Tusender Træer. . .
+    Da rejser der sig langt borte i de store Skove et sagte Sus. Et Sus, der stiger og nærmer sig som en Flugt af mange Vinger, vokser til en brusende Brænding af Grantoppe, gaar hen over Ens Hoved med et koldt pludseligt Pust af Nattevind, fortsætter sig hinsides Banelinjen og drager videre ind gennem Skoven, ind over de Tusender Træer . . .
     I det samme piber Toget langt borte . . .
     Men Aaringer efter kan det hænde, at man en Dag gennem Vinduet paa sit Kontor ser Løvet gulne paa den fattige Kastanie, som staar derude i den asfaltlagte Gaard - og saa mindes man med ét hin Aften saa langt tilbage, hin ensomme melankolske Aften i de vilde Skove . . .
 </prose>
@@ -1548,7 +1548,7 @@ sig under En, lige ude ved Vandkanten.
 <head>
     <title>Christianshavn</title>
     <source pages="103-107"/>
-    <quality>korrektur1,kilde,side</quality>
+    <quality>korrektur1,korrektur2,kilde,side</quality>
 </head>
 <body>
 <prose>
@@ -1581,7 +1581,7 @@ sig under En, lige ude ved Vandkanten.
 <head>
     <title>Lykke</title>
     <source pages="108-112"/>
-    <quality>korrektur1,kilde,side</quality>
+    <quality>korrektur1,korrektur2,kilde,side</quality>
 </head>
 <body>
 <prose>
@@ -1594,8 +1594,8 @@ sig under En, lige ude ved Vandkanten.
     Og bag Gardinet lød en Kvinderøst, der ogsaa raabte:
     - . . . morgen Papa!
     Jeg gik langsomt videre. Lidt henne vendte jeg mig og saae, at Gardinet nu var skudt mere til Side, og at et ungt Kvindehoved viste sig over Barnets - et Kvindehoved af en fin og sjælfuld Skønhed. Haaret gyldenblondt som Lindenes gule Blade i Høstens stærke Sol - Øjnene dunkelviolette som en Skumringshimmel - Kinderne rundede fint og langt som de ovale Blade af Aakandens hvide Blomst. .
-    - Hvilket Motiv for en tysk Maler, tænkte jeg, til et Billede, betitlet »Lykke« . . . Solskinnetover den vedbendgroede Villa, over Vinduets hvide Musselin, det blonde Barn og den unge Kvinde . . . og nedenfor den unge Mand, den lykkelige Ægtefælle, den glade Fader . . . Hvor det vilde gøre Lykke . . . hvor man vilde blive plaget med Fotografier efter det i alle Boghandlervinduer . . . hvor godt dets »Yndighed« vilde passe ind i Borgerskabets Kunstforstand, som kun har de tre Strænge - den religiøse, den sentimentale og den dekolleterede . . .
-    Og saa er der dog ingen Grund til at tro, at denne Mand skulde være lykkelig . . . Det er ganske sandt, at Solen skinner smukt over Vejen og Vinduet og de to glade Ansigter deroppe - at Luften er frisk af Nattekulden og Natteduggen - at Alleen staar højtidelig som en Basilika med sine ranke Stammesøjler og sit blaa Himmeltag, der er indlagt med fine, hvide Striber af fjærne, fjærne Skyer. .. Men sér han det, saaledes at han nyder det? .. .  Er det mere for ham end hvilken som helst anden Morgen med godt Vejr?
+    - Hvilket Motiv for en tysk Maler, tænkte jeg, til et Billede, betitlet »Lykke« . . . Solskinnet over den vedbendgroede Villa, over Vinduets hvide Musselin, det blonde Barn og den unge Kvinde . . . og nedenfor den unge Mand, den lykkelige Ægtefælle, den glade Fader . . . Hvor det vilde gøre Lykke . . . hvor man vilde blive plaget med Fotografier efter det i alle Boghandlervinduer . . . hvor godt dets »Yndighed« vilde passe ind i Borgerskabets Kunstforstand, som kun har de tre Strænge - den religiøse, den sentimentale og den dekolleterede . . .
+    Og saa er der dog ingen Grund til at tro, at denne Mand skulde være lykkelig . . . Det er ganske sandt, at Solen skinner smukt over Vejen og Vinduet og de to glade Ansigter deroppe - at Luften er frisk af Nattekulden og Natteduggen - at Alleen staar højtidelig som en Basilika med sine ranke Stammesøjler og sit blaa Himmeltag, der er indlagt med fine, hvide Striber af fjærne, fjærne Skyer . . . Men sér han det, saaledes at han nyder det? . . . Er det mere for ham end hvilken som helst anden Morgen med godt Vejr?
     Maaske er hele denne Hjemlykke, denne Familieglæde, som i Oktobermorgenens Solskin straaler mig i Møde, kun en skuffende Dekoration . . . Maaske er han et forpint Menneske, af hvis en Gang fine og rige Hjærne Huslighedens stikkende Myggesværm af smaa Bekymringer, fattige Sorger og intetsigende Tvistemaal har uddrevet de skønne og dybe Stemninger, som kun Eneboeren kan tillade sig at nyde, og bortjaget de fine Tanker, de udpenslede Billeder, som kun bliver til under den frie Ensomheds Klima, i den ubundne Lediggang, hvis Drivhusluft alene modner Aandens ædle Frugter.
     Maaske er denne unge Mands Længsler ganske andre end dem, som denne Oktobermorgens Solskin tilfredsstiller.  Det kan være, at han i Steden for dette Lys, denne kølige Friskhed, denne rene Morgenhimmel, begærer Skumring, Høstafteners Skygge, vaade Gader, hvis Søle skinner som grønligt Sølv i Lyset fra en rund Maanes højthængende Lampe, og langt borte i den skumrende Luft, under det gule Lys af en fjærn Fortovslygte, det vage Omrids af en slank Kvinde, som langsomt vandrer ind i Natten, der falder paa . . .
     Og maaske er hin unge, blonde Kvinde under det løftede Musselinsforhæng slet ikke det fine og sjælfulde Væsen, det blide og fine Barn, som hendes violdunkle Øjne synes at forjætte . . . Maaske længes ogsaa hun bort og ud - til en stærkere, mere lidenskabelig Mandighed, til en mere solbrændt Elskov, en mere moden Lyst, end den lyshaarede Yngling, som er hendes Barns Fader, kan skænke . . . Maaske er denne Morgen et af de faa Øjeblikke i hendes Liv, hvor hun tror at elske denne Mand, fordi Solskinnet og den kolde Luft, der er krydret af Høsthavernes stærke og brogede Vellugt, fylder hendes Sjæl med en Ømhed, som udvælder i Smil og Fingerkys over ham dernede, blot fordi der ingen anden er, paa hvis Hoved hun kan ødsle sin Kærligheds duftende Salve . . .
@@ -1609,7 +1609,7 @@ sig under En, lige ude ved Vandkanten.
 <head>
     <title>Trædemøllen</title>
     <source pages="113-115"/>
-    <quality>korrektur1,kilde,side</quality>
+    <quality>korrektur1,korrektur2,kilde,side</quality>
 </head>
 <body>
 <prose>
@@ -1623,7 +1623,7 @@ sig under En, lige ude ved Vandkanten.
     Jeg blev staaende lige foran et af Tremmeburene, fuld af Væmmelse ved dette gule Fedt, der klistrede sig til mine Fødder og Hænder.
     Da saae jeg, at der foran et af de andre Bure i min Nærhed stod et Menneske ligesom jeg og stirrede ind i Buret, hvis Tromle drejede sig langsommere og langsommere.  Det store, sorte Væsen inden i blev mere og mere tydeligt - et Ansigt viste sig, blegt og udtæret - - et Menneskes Ansigt!
     Forfærdet vendte jeg Blikket mod det Bur, ved hvis Dør jeg selv stod - ogsaa dér begyndte Tromlen at dreje sig langsommere - ogsaa dér saae jeg et Menneske.
-    Og jeg begreb med ét, at jeg stod her som Afløser for ham derinde, og at naar han ikke kunde mere, saa vilde Døren blive aabnet - og det vilde være min Tur at krybe ind og træde Møllen for aldrig mere at komme ud. . .
+    Og jeg begreb med ét, at jeg stod her som Afløser for ham derinde, og at naar han ikke kunde mere, saa vilde Døren blive aabnet - og det vilde være min Tur at krybe ind og træde Møllen for aldrig mere at komme ud . . .
     I Rædsel søgte jeg at rive mig løs og flygte - ud til den tidlige Foraarsdags sølvgraa Himmel og den frie Luft og det fjærne Skimt over Havet af min Barndomslykkes Land . . .
     Men mine Fødder var klæbede fast i det gule Støv, saa jeg ikke mægtede at rokke dem af Stedet.
     Og jeg vilde vaagne - men kunde ikke . . .
@@ -1635,7 +1635,7 @@ sig under En, lige ude ved Vandkanten.
 <head>
     <title>Refugium</title>
     <source pages="116-120"/>
-    <quality>korrektur1,kilde,side</quality>
+    <quality>korrektur1,korrektur2,kilde,side</quality>
 </head>
 <body>
 <prose>
@@ -1662,7 +1662,7 @@ sig under En, lige ude ved Vandkanten.
 <head>
     <title>Vinterbrev</title>
     <source pages="121-124"/>
-    <quality>korrektur1,kilde,side</quality>
+    <quality>korrektur1,korrektur2,kilde,side</quality>
 </head>
 <body>
 <prose>
@@ -1688,7 +1688,7 @@ sig under En, lige ude ved Vandkanten.
 <head>
     <title>En Drøm</title>
     <source pages="125-127"/>
-    <quality>korrektur1,kilde,side</quality>
+    <quality>korrektur1,korrektur2,kilde,side</quality>
 </head>
 <body>
 <prose>
@@ -1702,7 +1702,7 @@ sig under En, lige ude ved Vandkanten.
     - Saa er det vel Fugle, foreslog jeg - og blev i det samme greben af Rædsel.
     - De sér altfor store ud . . . saa langt borte . . .  indvendte han. Ogsaa i hans Ansigt var der Rædsel.
     . . . Med ét var vi komne over Rækværket og kravlede ned ad Skrænten bag det. Nede ved Randen af Havet, som laa ganske dødt og mørkt, var samlet Mængder af Mennesker, som i Tavshed og Angst stirrede ud over Havet - ud mod de hvide Pletter, der med uhyggelig Hast nærmede sig . . .
-    Og med ét stod der i Havstokken en kæmpestor, skinnende hvid Fugl - med lange Hejreben og et Næb som en Tukan - og skinnende hvid over det Hele med en uhyggelig, ligbleg Glans. . .
+    Og med ét stod der i Havstokken en kæmpestor, skinnende hvid Fugl - med lange Hejreben og et Næb som en Tukan - og skinnende hvid over det Hele med en uhyggelig, ligbleg Glans . . .
     Og bag den stod i det samme andre hvide Fugle, kæmpestore, sært forvredne af Krop og paa Næb . . . Og de skred frem mod os i Række bag Række . . . og med ét flygtede alle vi, som stod paa Strandbredden, klatrede op ad den høje Skrænt, snublede, rejste os, krøb og løb i Angst . . . og bag os rykkede de hvide Fugle frem i skinnende Hærskarer, genfærdsstive, spøgelseuhyggelige . . .
     Jeg vendte mig . . . bag mig var der endnu Mennesker, men til begge Sider for mig rykkede Fuglene frem, og Skræntens Fod og Havets mørke Mark var helt dækket af de hvide Fugle.
     Og i Rædsel raabtes der foran mig: den yderste Dag, den yderste Dag!
@@ -1725,7 +1725,7 @@ sig under En, lige ude ved Vandkanten.
     <title>Tatere</title>
     <firstline>Saa ligger Søen for ham, stor og blaa</firstline>
     <source pages="131-147"/>
-    <quality>korrektur1,kilde,side</quality>
+    <quality>korrektur1,korrektur2,kilde,side</quality>
 </head>
 <body>
 <poetry>
@@ -2160,7 +2160,7 @@ Men ud fra Skoven jubler Dansetakten:
     <title>Ellen</title>
     <firstline>Under Sommersolen lysner</firstline>
     <source pages="148-158"/>
-    <quality>korrektur1,kilde,side</quality>
+    <quality>korrektur1,korrektur2,kilde,side</quality>
 </head>
 <body>
 <poetry>
@@ -2432,7 +2432,7 @@ bær mig, mit Liv, mit eget og min Kæres!
     <title>Sommer</title>
     <firstline>Saa er jeg i dit Hus paany, o Sommer</firstline>
     <source pages="159-166"/>
-    <quality>korrektur1,kilde,side</quality>
+    <quality>korrektur1,korrektur2,kilde,side</quality>
 </head>
 <body>
 <poetry>
@@ -2471,7 +2471,7 @@ og Graners Grenenæt staar lysforgyldt;
 det rasler sagte over Bladebunden -
 som vandred tavs, med Fingeren for Munden,
 en Gud usynligt ad den brune Sti . . .
-En Angst mig sitrer gennem Hjærte- Grunden
+En Angst mig sitrer gennem Hjærte-Grunden
 - er det den gamle Pan, som gaar forbi,
 at skræmme med sin Stav mig fra mit Blade-Hi?
 
@@ -2585,7 +2585,7 @@ rør ved mit Hjærte med din Læge-Rod,
 lad over mig dit Sundhedsvæld udgydes -
 min Tanke bøjes alt - ve, skal den sønderbrydes?
 
-. .. Det bliver stille om mig. Dagen hælder.
+. . . Det bliver stille om mig. Dagen hælder.
 Kun svagt det pipper fra en Fuglemund,
 og dulgt og dæmpet Kildens Vande vælder
 med lønlig Lyd i Lundens grønne Grund -


### PR DESCRIPTION
## Hvad er ændret?

Alle 47 tekster i Johannes Jørgensens *Stemninger* (1892) er sammenholdt med facsimilet. Sikre tekst-, ellipse-, mellemrum- og sidehenvisningsfejl er rettet, og posterne er mærket `korrektur2`.

## Hvorfor?

Ændringerne fjerner OCR-forvanskninger uden at modernisere kildens historiske sprog eller repositoryets tegnkonventioner.

## Kontrol

- XML og Relax NG validerer
- OCR-kandidatrapport: 0 fund
- UTF-8/encoding-kontrol og `git diff --check` består
- Hele Jest-suiten: 54 suiter / 2.405 tests består

PR’en er isoleret til `fdirs/joergensenj/1892.xml`.
