### PR TITLE
Korrekturlæs Lyrik (1904)

### DIFF
--- a/fdirs/joergensenj/1904.xml
+++ b/fdirs/joergensenj/1904.xml
@@ -19,7 +19,7 @@
     <title>Bøn</title>
     <firstline>Jeg kommer til dig, o evige Moder, trættet paa Sjæl og paa Sind</firstline>
     <source pages="11-13"/>
-    <quality>korrektur1,kilde,side</quality>
+    <quality>korrektur1,korrektur2,kilde,side</quality>
 </head>
 <body>
 <poetry>
@@ -75,7 +75,7 @@ og Liget selv: den Lykke, du længer ej huser.
     <title>Længsel</title>
     <firstline>I Snekorallers Skove gad jeg gaa</firstline>
     <source pages="14"/>
-    <quality>korrektur1,kilde,side</quality>
+    <quality>korrektur1,korrektur2,kilde,side</quality>
 </head>
 <body>
 <poetry>
@@ -114,7 +114,7 @@ med Dvaledrik fra Dødens Lethe-dybe Vande.
     <title>Søvnløs</title>
     <firstline>Sortgraa, dybe Fløjelsskygger som et Krypthvælv staa omkring mig</firstline>
     <source pages="15"/>
-    <quality>korrektur1,kilde,side</quality>
+    <quality>korrektur1,korrektur2,kilde,side</quality>
 </head>
 <body>
 <poetry>
@@ -143,7 +143,7 @@ dræbt og død er hver en Længsel — Haab er Sagn — og Sol er slukket .....
     <title>Solrødt</title>
     <firstline>Nu brænder Dagens Skibe paa Baal i Vesterled</firstline>
     <source pages="16"/>
-    <quality>korrektur1,kilde,side</quality>
+    <quality>korrektur1,korrektur2,kilde,side</quality>
 </head>
 <body>
 <poetry>
@@ -177,7 +177,7 @@ de syge Sanser blot mod Mørket længes.
     <title>Sommernat</title>
     <firstline>Stort og stille ligger Landet, dæmringslyst, med grøngraa Flader</firstline>
     <source pages="17"/>
-    <quality>korrektur1,kilde,side</quality>
+    <quality>korrektur1,korrektur2,kilde,side</quality>
 </head>
 <body>
 <poetry>
@@ -206,7 +206,7 @@ og langt ude i det fjærne hører jeg en Hund slaa an.
     <title>Maaneskin</title>
     <firstline>Solen er død. Mod matgylden Luft</firstline>
     <source pages="18-19"/>
-    <quality>korrektur1,kilde,side</quality>
+    <quality>korrektur1,korrektur2,kilde,side</quality>
 </head>
 <body>
 <poetry>
@@ -256,7 +256,7 @@ et Sagn om en støvstyrtet Marmorgudinde.
     <title>Solvejg</title>
     <firstline>Decembernattens klamme Maaneblaa</firstline>
     <source pages="20-21"/>
-    <quality>korrektur1,kilde,side</quality>
+    <quality>korrektur1,korrektur2,kilde,side</quality>
 </head>
 <body>
 <poetry>
@@ -308,7 +308,7 @@ en Mindelse om Solvejgs bløde Sange.
     <title>Januar</title>
     <firstline>Der ligger hvidgraa Taager over Landet</firstline>
     <source pages="22-23"/>
-    <quality>korrektur1,kilde,side</quality>
+    <quality>korrektur1,korrektur2,kilde,side</quality>
 </head>
 <body>
 <poetry>
@@ -349,7 +349,7 @@ dør bort i dette store Nattestille.
     <title>Tøvejr</title>
     <firstline>Jeg vaagned op og hørte Fugle synge</firstline>
     <source pages="24-25"/>
-    <quality>korrektur1,kilde,side</quality>
+    <quality>korrektur1,korrektur2,kilde,side</quality>
 </head>
 <body>
 <poetry>
@@ -393,7 +393,7 @@ vemodigt klang der Foraarsminder gennem Luften.
     <title>Vaarvers</title>
     <firstline>Nu drager Gærdets Graapil</firstline>
     <source pages="26-28"/>
-    <quality>korrektur1,kilde,side</quality>
+    <quality>korrektur1,korrektur2,kilde,side</quality>
 </head>
 <body>
 <poetry>
@@ -464,7 +464,7 @@ Drømmenes Elver-Tærner.
     <title>Dagning</title>
     <firstline>Nu rider det unge Gry over Land</firstline>
     <source pages="29"/>
-    <quality>korrektur1,kilde,side</quality>
+    <quality>korrektur1,korrektur2,kilde,side</quality>
 </head>
 <body>
 <poetry>
@@ -496,7 +496,7 @@ at høste, hvor Regnen saaede.
     <title>Folkevise</title>
     <firstline>Unge Kvinder vandre forbi —</firstline>
     <source pages="30"/>
-    <quality>korrektur1,kilde,side</quality>
+    <quality>korrektur1,korrektur2,kilde,side</quality>
 </head>
 <body>
 <poetry>
@@ -533,7 +533,7 @@ Det dufter af Løv og lyser af Blomster klare.
     <title>Walpurgisnat</title>
     <firstline>Walpurgisnat. Walpurgisnat</firstline>
     <source pages="31-32"/>
-    <quality>korrektur1,kilde,side</quality>
+    <quality>korrektur1,korrektur2,kilde,side</quality>
 </head>
 <body>
 <poetry>
@@ -573,7 +573,7 @@ O fjærne, bløde Hænder...
     <title>Marine</title>
     <firstline>Hav i Flager mod Stranden</firstline>
     <source pages="33"/>
-    <quality>korrektur1,kilde,side</quality>
+    <quality>korrektur1,korrektur2,kilde,side</quality>
 </head>
 <body>
 <poetry>
@@ -604,7 +604,7 @@ og en Sol, der gaar ned.
     <title>Mørke</title>
     <firstline>Gennem Julinattens Stilhed</firstline>
     <source pages="34"/>
-    <quality>korrektur1,kilde,side</quality>
+    <quality>korrektur1,korrektur2,kilde,side</quality>
 </head>
 <body>
 <poetry>
@@ -636,7 +636,7 @@ Ahasverus gaar forbi . . .
     <title>Ahasverus</title>
     <firstline>Stille lider Sommernatten</firstline>
     <source pages="35-36"/>
-    <quality>korrektur1,kilde,side</quality>
+    <quality>korrektur1,korrektur2,kilde,side</quality>
 </head>
 <body>
 <poetry>
@@ -678,7 +678,7 @@ i en bleggrøn Rømers Bund.
     <title>Augustnætter</title>
     <firstline>Maanedis og Mosetaager</firstline>
     <source pages="37-39"/>
-    <quality>korrektur1,kilde,side</quality>
+    <quality>korrektur1,korrektur2,kilde,side</quality>
 </head>
 <body>
 <poetry>
@@ -749,7 +749,7 @@ rinder ud i øde Himmel.
     <title>Manon</title>
     <firstline>Under Sommersolen lysner</firstline>
     <source pages="40-48"/>
-    <quality>korrektur1,kilde,side</quality>
+    <quality>korrektur1,korrektur2,kilde,side</quality>
 </head>
 <body>
 <poetry>
@@ -962,7 +962,7 @@ skønne Manon!
     <title>Høstdrøm</title>
     <firstline>Jeg drømte i Nat om øde</firstline>
     <source pages="49"/>
-    <quality>korrektur1,kilde,side</quality>
+    <quality>korrektur1,korrektur2,kilde,side</quality>
 </head>
 <body>
 <poetry>
@@ -999,7 +999,7 @@ de røde Risbøges Hegn.
     <title>Oktobernat</title>
     <firstline>Jeg vandrer hjemad, medens Maanen skinner</firstline>
     <source pages="50"/>
-    <quality>korrektur1,kilde,side</quality>
+    <quality>korrektur1,korrektur2,kilde,side</quality>
 </head>
 <body>
 <poetry>
@@ -1033,7 +1033,7 @@ som Poplens Kviste sig med Vinden bøje.
     <title>Vinterskumring</title>
     <firstline>Jeg ser, hvor Himlen blaaner bag min Rude</firstline>
     <source pages="51"/>
-    <quality>korrektur1,kilde,side</quality>
+    <quality>korrektur1,korrektur2,kilde,side</quality>
 </head>
 <body>
 <poetry>
@@ -1065,7 +1065,7 @@ som Blod af tvende vaandefulde Vunder.
     <title>Februar</title>
     <firstline>Idag er den omme, den graa og onde Vinter</firstline>
     <source pages="52"/>
-    <quality>korrektur1,kilde,side</quality>
+    <quality>korrektur1,korrektur2,kilde,side</quality>
 </head>
 <body>
 <poetry>
@@ -1099,7 +1099,7 @@ et Dalstrøg imod Sønden, som blaaner af Violer.
     <title>Hjemvandring</title>
     <firstline>Jeg vandrer over brede Marker frem</firstline>
     <source pages="53"/>
-    <quality>korrektur1,kilde,side</quality>
+    <quality>korrektur1,korrektur2,kilde,side</quality>
 </head>
 <body>
 <poetry>
@@ -1134,7 +1134,7 @@ i Sommernattens stille Gyldenrøde.
     <title>Arkturus</title>
     <firstline>Der blinker en enlig Stjærne</firstline>
     <source pages="54"/>
-    <quality>korrektur1,kilde,side</quality>
+    <quality>korrektur1,korrektur2,kilde,side</quality>
 </head>
 <body>
 <poetry>
@@ -1161,7 +1161,7 @@ i Længlernes lyse Nat...
     <title>Aftenlyd</title>
     <firstline>Nu synger Drosler i den silde Aften</firstline>
     <source pages="55"/>
-    <quality>korrektur1,kilde,side</quality>
+    <quality>korrektur1,korrektur2,kilde,side</quality>
 </head>
 <body>
 <poetry>
@@ -1188,7 +1188,7 @@ de længselsfulde Fugles Fløjter lyder.
     <title>Nymfer</title>
     <firstline>Det suser tungt i store Træer</firstline>
     <source pages="56"/>
-    <quality>korrektur1,kilde,side</quality>
+    <quality>korrektur1,korrektur2,kilde,side</quality>
 </head>
 <body>
 <poetry>
@@ -1220,7 +1220,7 @@ i disse lyse Lunde.
     <title>Pan</title>
     <firstline>Jeg ser en Mark, et øde Vand</firstline>
     <source pages="57"/>
-    <quality>korrektur1,kilde,side</quality>
+    <quality>korrektur1,korrektur2,kilde,side</quality>
 </head>
 <body>
 <poetry>
@@ -1252,7 +1252,7 @@ fra Jordens dybe Hjærte.
     <title>Stjærnenat</title>
     <firstline>Jeg vandrer silde i den mørke Have</firstline>
     <source pages="58-59"/>
-    <quality>korrektur1,kilde,side</quality>
+    <quality>korrektur1,korrektur2,kilde,side</quality>
 </head>
 <body>
 <poetry>
@@ -1294,7 +1294,7 @@ O Gud, hvorfor, hvorfor? Hvorfor, o Gud?
     <title>Havet</title>
     <firstline>Det regned stille fra en Graavejrshimmel</firstline>
     <source pages="60-61"/>
-    <quality>korrektur1,kilde,side</quality>
+    <quality>korrektur1,korrektur2,kilde,side</quality>
 </head>
 <body>
 <poetry>
@@ -1336,7 +1336,7 @@ som Myggen favnes af et evigt Rav.
     <title>Høstvind</title>
     <firstline>Jeg vandrer hastigt i den køle Dag</firstline>
     <source pages="62-63"/>
-    <quality>korrektur1,kilde,side</quality>
+    <quality>korrektur1,korrektur2,kilde,side</quality>
 </head>
 <body>
 <poetry>
@@ -1388,7 +1388,7 @@ og flyve ensom over Jordens Børn.
     <title>Sommersang</title>
     <firstline>Søde Snerrers Sommerduft</firstline>
     <source pages="64"/>
-    <quality>korrektur1,kilde,side</quality>
+    <quality>korrektur1,korrektur2,kilde,side</quality>
 </head>
 <body>
 <poetry>
@@ -1415,7 +1415,7 @@ og min Sjæl er underfuld.
     <title>Aftenfred</title>
     <firstline>Fra Aftenhimlens gule Blomsterbræm —</firstline>
     <source pages="65"/>
-    <quality>korrektur1,kilde,side</quality>
+    <quality>korrektur1,korrektur2,kilde,side</quality>
 </head>
 <body>
 <poetry>
@@ -1442,7 +1442,7 @@ og som et sølvhvidt Vand den blege Egn.
     <title>Foraarssange</title>
     <firstline>Vandet risler med sagte Lyd</firstline>
     <source pages="66-74"/>
-    <quality>korrektur1,kilde,side</quality>
+    <quality>korrektur1,korrektur2,kilde,side</quality>
 </head>
 <body>
 <poetry>
@@ -1684,7 +1684,7 @@ af Evighed.
     <title>Angelusklokker</title>
     <firstline>Der rødmer Skyer langt ude</firstline>
     <source pages="75"/>
-    <quality>korrektur1,kilde,side</quality>
+    <quality>korrektur1,korrektur2,kilde,side</quality>
 </head>
 <body>
 <poetry>
@@ -1716,7 +1716,7 @@ min Sjæl er vendt.
     <title>Den evige Sne</title>
     <firstline>Den evige Sne, den evige Sne</firstline>
     <source pages="76"/>
-    <quality>korrektur1,kilde,side</quality>
+    <quality>korrektur1,korrektur2,kilde,side</quality>
 </head>
 <body>
 <poetry>
@@ -1743,7 +1743,7 @@ som Skumring og Aftensvale.
     <title>Gensyn</title>
     <firstline>Den store Skov, den store Skov</firstline>
     <source pages="77-78"/>
-    <quality>korrektur1,kilde,side</quality>
+    <quality>korrektur1,korrektur2,kilde,side</quality>
 </head>
 <body>
 <poetry>
@@ -1790,7 +1790,7 @@ jeg kan dig ikke glemme!
     <title>Øer i Havet</title>
     <firstline>De stride, staalblaa Strømme</firstline>
     <source pages="79-80"/>
-    <quality>korrektur1,kilde,side</quality>
+    <quality>korrektur1,korrektur2,kilde,side</quality>
 </head>
 <body>
 <poetry>
@@ -1837,7 +1837,7 @@ til mine Minders Genklang.
     <title>Gamle Sange</title>
     <firstline>En svunden Vaar imod mig slaar</firstline>
     <source pages="81"/>
-    <quality>korrektur1,kilde,side</quality>
+    <quality>korrektur1,korrektur2,kilde,side</quality>
 </head>
 <body>
 <poetry>
@@ -1864,7 +1864,7 @@ nu og for alle Tide!
     <title>Høstsuk</title>
     <firstline>Saa standser jeg ved Vejens Kant</firstline>
     <source pages="82"/>
-    <quality>korrektur1,kilde,side</quality>
+    <quality>korrektur1,korrektur2,kilde,side</quality>
 </head>
 <body>
 <poetry>
@@ -1898,7 +1898,7 @@ min Gud!
     <firstline>Vinterskumring, Taagefald</firstline>
     <source pages="83-87"/>
     <keywords>verlaine</keywords>
-    <quality>korrektur1,kilde,side</quality>
+    <quality>korrektur1,korrektur2,kilde,side</quality>
 </head>
 <body>
 <poetry>
@@ -2030,7 +2030,7 @@ Lad ham frelst dit Aasyn se!
     <title>Undergang</title>
     <firstline>Solen svinder, Skyer graane</firstline>
     <source pages="88"/>
-    <quality>korrektur1,kilde,side</quality>
+    <quality>korrektur1,korrektur2,kilde,side</quality>
 </head>
 <body>
 <poetry>
@@ -2062,7 +2062,7 @@ er den Drøm, vi har igen.
     <title>Stilleliv</title>
     <firstline>Det er saa blankt, det Græs, som groer</firstline>
     <source pages="89-90"/>
-    <quality>korrektur1,kilde,side</quality>
+    <quality>korrektur1,korrektur2,kilde,side</quality>
 </head>
 <body>
 <poetry>
@@ -2110,7 +2110,7 @@ vox ind i Livets Sommer.
     <firstline>En Himmel, tæt og blaa som Ametyst</firstline>
     <source pages="91"/>
     <keywords>sonnet</keywords>
-    <quality>korrektur1,kilde,side</quality>
+    <quality>korrektur1,korrektur2,kilde,side</quality>
 </head>
 <body>
 <poetry>
@@ -2140,7 +2140,7 @@ og flyver stille i Guds Himmel ind.
     <title>Media Vita</title>
     <firstline>Som en Flod med stærke, stride Vande</firstline>
     <source pages="92"/>
-    <quality>korrektur1,kilde,side</quality>
+    <quality>korrektur1,korrektur2,kilde,side</quality>
 </head>
 <body>
 <poetry>
@@ -2172,7 +2172,7 @@ giv os ej den bitre Død i Vold.
     <title>Allesjælesnat</title>
     <firstline>Store Stjærner staa deroppe</firstline>
     <source pages="93"/>
-    <quality>korrektur1,kilde,side</quality>
+    <quality>korrektur1,korrektur2,kilde,side</quality>
 </head>
 <body>
 <poetry>


### PR DESCRIPTION
## Hvad er ændret?

Alle 45 tekster i Johannes Jørgensens *Lyrik* (1904) er sammenholdt med facsimilet og mærket `korrektur2`. Brødtekst, titler, førstelinjer, strofer og sideintervaller viste sig allerede kildetro.

## Hvorfor?

PR’en dokumenterer den gennemførte anden korrektur og løfter kvalitetsstatus uden unødvendige tekstændringer.

## Kontrol

- XML og Relax NG validerer
- OCR-kandidatrapport: 0 uløste fund
- `git diff --check` består
- Hele Jest-suiten: 54 suiter / 2.405 tests består

PR’en er isoleret til `fdirs/joergensenj/1904.xml`.
