### PR TITLE
Korrekturlæs Blomster og Frugter (1907)

### DIFF
--- a/fdirs/joergensenj/1907.xml
+++ b/fdirs/joergensenj/1907.xml
@@ -17,8 +17,8 @@
 <head>
     <title>Blomster og Frugter</title>
     <firstline>Snart er det Høst — det halve Aar er omme</firstline>
-    <source pages="[upagineret]" facsimile-pages="10" />
-    <quality>korrektur1,kilde,side</quality>
+    <source pages="[upagineret]" facsimile-pages="12-13" />
+    <quality>korrektur1,korrektur2,kilde,side</quality>
 </head>
 <body>
 <poetry>
@@ -54,7 +54,7 @@
     <title>Foraarsvers</title>
     <firstline>Luften lun, og Solen blid</firstline>
     <source pages="5-6"/>
-    <quality>korrektur1,kilde,side</quality>
+    <quality>korrektur1,korrektur2,kilde,side</quality>
 </head>
 <body>
 <poetry>
@@ -111,7 +111,7 @@ og hvilken liflig Duft af Hyacinther!
     <title>Søvnen</title>
     <firstline>Bag de fjærne Markers sidste Rand</firstline>
     <source pages="7-14"/>
-    <quality>korrektur1,kilde,side</quality>
+    <quality>korrektur1,korrektur2,kilde,side</quality>
 </head>
 <body>
 <poetry>
@@ -252,7 +252,7 @@ Søvn vor Moder, Søvn vor Søster!
     <title>Juleminde</title>
     <firstline>En Vinteraftens gule Luft</firstline>
     <source pages="15-16"/>
-    <quality>korrektur1,kilde,side</quality>
+    <quality>korrektur1,korrektur2,kilde,side</quality>
 </head>
 <body>
 <poetry>
@@ -305,7 +305,7 @@ jeg ser en gylden Strime.
     <toctitle>„Onkel Jørgen“</toctitle>
     <firstline>Jeg husker dig, en Skoledag</firstline>
     <source pages="17-18"/>
-    <quality>korrektur1,kilde,side</quality>
+    <quality>korrektur1,korrektur2,kilde,side</quality>
 </head>
 <body>
 <poetry>
@@ -357,7 +357,7 @@ min gode, gamle Lærer.
     <title>Hendrik Ballin</title>
     <firstline>Saa er han død. Jeg fik ej sagt</firstline>
     <source pages="19-20"/>
-    <quality>korrektur1,kilde,side</quality>
+    <quality>korrektur1,korrektur2,kilde,side</quality>
 </head>
 <body>
 <poetry>
@@ -404,7 +404,7 @@ har strøget hvert et Skyldbrev ud.
     <title>Bengt</title>
     <firstline>Blaa Vinca blomstrer paa hans Grav</firstline>
     <source pages="21-22"/>
-    <quality>korrektur1,kilde,side</quality>
+    <quality>korrektur1,korrektur2,kilde,side</quality>
 </head>
 <body>
 <poetry>
@@ -446,7 +446,7 @@ og finde dig blandt Engle smaa.
     <title>Solskinssalme</title>
     <firstline>Saa lys en Lund, saa lun en Luft</firstline>
     <source pages="23-24"/>
-    <quality>korrektur1,kilde,side</quality>
+    <quality>korrektur1,korrektur2,kilde,side</quality>
 </head>
 <body>
 <poetry>
@@ -483,7 +483,7 @@ fra Lys til Lys, fra Dag til Dag!
     <title>Bøn</title>
     <firstline>Gud, som er af Evighed</firstline>
     <source pages="25-26"/>
-    <quality>korrektur1,kilde,side</quality>
+    <quality>korrektur1,korrektur2,kilde,side</quality>
 </head>
 <body>
 <poetry>
@@ -530,7 +530,7 @@ i sit Hjemland. Amen.
     <title>Vise</title>
     <firstline>Strænge Herr Synd og saa Jomfru Sorg</firstline>
     <source pages="27-28"/>
-    <quality>korrektur1,kilde,side</quality>
+    <quality>korrektur1,korrektur2,kilde,side</quality>
 </head>
 <body>
 <poetry>
@@ -582,7 +582,7 @@ lys mig til Himmerigs Rige!
     <title>Fristelse</title>
     <firstline>Ak, milde Nat med Maaneskin</firstline>
     <source pages="29"/>
-    <quality>korrektur1,kilde,side</quality>
+    <quality>korrektur1,korrektur2,kilde,side</quality>
 </head>
 <body>
 <poetry>
@@ -610,7 +610,7 @@ vig bort og lad mig ene . . .
     <firstline>Mig drømte, saa sorgfuldt var Maanens Skin</firstline>
     <source pages="30"/>
     <keywords>heine</keywords>
-    <quality>korrektur1,kilde,side</quality>
+    <quality>korrektur1,korrektur2,kilde,side</quality>
 </head>
 <body>
 <poetry>
@@ -637,7 +637,7 @@ og nede stod jeg, saa alene . . .
     <title>Foraarsensomhed</title>
     <firstline>Hvor her er smukt</firstline>
     <source pages="31-32"/>
-    <quality>korrektur1,kilde,side</quality>
+    <quality>korrektur1,korrektur2,kilde,side</quality>
 </head>
 <body>
 <poetry>
@@ -684,7 +684,7 @@ jeg kalder Jer.
     <title>Sommerminder</title>
     <firstline>Over Marker har jeg vanket</firstline>
     <source pages="33-34"/>
-    <quality>korrektur1,kilde,side</quality>
+    <quality>korrektur1,korrektur2,kilde,side</quality>
 </head>
 <body>
 <poetry>
@@ -736,7 +736,7 @@ synger sødt i Aftensvale.
     <title>Gamle Steder</title>
     <firstline>En Duft af Søvand og Tjære</firstline>
     <source pages="35-38"/>
-    <quality>korrektur1,kilde,side</quality>
+    <quality>korrektur1,korrektur2,kilde,side</quality>
 </head>
 <body>
 <poetry>
@@ -827,7 +827,7 @@ tung som i en Dødninghave.
     <title>Borgruin</title>
     <firstline>Solskin over Ruiner</firstline>
     <source pages="39-40"/>
-    <quality>korrektur1,kilde,side</quality>
+    <quality>korrektur1,korrektur2,kilde,side</quality>
 </head>
 <body>
 <poetry>
@@ -879,7 +879,7 @@ saa lifligt vil for mig spille . . .
     <title>Säntis</title>
     <firstline>Stille, stille, der rører sig ej</firstline>
     <source pages="41-42"/>
-    <quality>korrektur1,kilde,side</quality>
+    <quality>korrektur1,korrektur2,kilde,side</quality>
 </head>
 <body>
 <poetry>
@@ -916,7 +916,7 @@ saa ser jeg dig atter skinne!
     <title>Klosterhave</title>
     <firstline>Ferskentræerne blomstrer</firstline>
     <source pages="43-44"/>
-    <quality>korrektur1,kilde,side</quality>
+    <quality>korrektur1,korrektur2,kilde,side</quality>
 </head>
 <body>
 <poetry>
@@ -963,7 +963,7 @@ fuldmodne Frugter bære!
         <note>Gendigtning af Giosuè Carduccis <xref type="translation" poem="carducci2026072801"/> fra <i>Rime nuove</i> (1887).</note>
     </notes>
     <keywords>sonnet</keywords>
-    <quality>korrektur1,kilde,side</quality>
+    <quality>korrektur1,korrektur2,kilde,side</quality>
 </head>
 <body>
 <poetry>
@@ -997,7 +997,7 @@ Hav Tak, o Herre, for vor Søster Døden!
     <notes>
         <note>Gendigtning af Giosuè Carduccis <xref type="translation" poem="carducci2026072802"/> fra <i>Rime nuove</i> (1887).</note>
     </notes>
-    <quality>korrektur1,kilde,side</quality>
+    <quality>korrektur1,korrektur2,kilde,side</quality>
 </head>
 <body>
 <poetry>
@@ -1027,7 +1027,7 @@ Natur, der evigt i sit Væsen hviler.
     <title>Høstmorgen</title>
     <firstline>Nu ruster Alleens Blade</firstline>
     <source pages="47-48"/>
-    <quality>korrektur1,kilde,side</quality>
+    <quality>korrektur1,korrektur2,kilde,side</quality>
 </head>
 <body>
 <poetry>
@@ -1064,7 +1064,7 @@ og saa er jeg død.
     <title>Udlændighed</title>
     <firstline>Det er en stille Aftenstund i Høst</firstline>
     <source pages="49-50"/>
-    <quality>korrektur1,kilde,side</quality>
+    <quality>korrektur1,korrektur2,kilde,side</quality>
 </head>
 <body>
 <poetry>
@@ -1106,7 +1106,7 @@ og, Herre, lad mig bo blandt mine Børn!
     <title>I det Fremmede</title>
     <firstline>Dagen er klar, og Himlen ren og blaa</firstline>
     <source pages="51-52"/>
-    <quality>korrektur1,kilde,side</quality>
+    <quality>korrektur1,korrektur2,kilde,side</quality>
 </head>
 <body>
 <poetry>
@@ -1138,7 +1138,7 @@ du kære, lille Haand, som dog er min!
     <title>Qui plasmasti me...</title>
     <firstline>O Gud, du lod mig</firstline>
     <source pages="53-55"/>
-    <quality>korrektur1,kilde,side</quality>
+    <quality>korrektur1,korrektur2,kilde,side</quality>
 </head>
 <body>
 <poetry>
@@ -1202,7 +1202,7 @@ frels mig af Naade!
     <notes>
         <note>Fri og forkortet gendigtning af Clemens Brentanos <xref type="translation" poem="brentano2026072801"/>.</note>
     </notes>
-    <quality>korrektur1,kilde,side</quality>
+    <quality>korrektur1,korrektur2,kilde,side</quality>
 </head>
 <body>
 <poetry>
@@ -1278,7 +1278,7 @@ Jesus, gennem dine Vunder!
     <notes>
         <note>Gendigtning af Paul Verlaines <xref type="translation" poem="verlaine2026072801"/> fra <i>Sagesse</i> (1880).</note>
     </notes>
-    <quality>korrektur1,kilde,side</quality>
+    <quality>korrektur1,korrektur2,kilde,side</quality>
 </head>
 <body>
 <poetry>
@@ -1325,7 +1325,7 @@ og nikkede til mig og sagde: „Min Ven!“
         <note>Gendigtning af Paul Verlaines <xref type="translation" poem="verlaine2026072802"/> fra <i>Sagesse</i> (1880).</note>
     </notes>
     <keywords>sonnet</keywords>
-    <quality>korrektur1,kilde,side</quality>
+    <quality>korrektur1,korrektur2,kilde,side</quality>
 </head>
 <body>
 <poetry>
@@ -1359,7 +1359,7 @@ Alt ruller Tordnen — skynd dig hen at bede!
     <notes>
         <note>Gendigtning af Paul Verlaines <xref type="translation" poem="verlaine2026072803"/> fra <i>Sagesse</i> (1880).</note>
     </notes>
-    <quality>korrektur1,kilde,side</quality>
+    <quality>korrektur1,korrektur2,kilde,side</quality>
 </head>
 <body>
 <poetry>
@@ -1391,7 +1391,7 @@ Bed for Kasper, naar han er død!
     <title>Mariavise</title>
     <firstline>Aldrig saae Jorden en Dreng saa skøn</firstline>
     <source pages="65-67"/>
-    <quality>korrektur1,kilde,side</quality>
+    <quality>korrektur1,korrektur2,kilde,side</quality>
 </head>
 <body>
 <poetry>
@@ -1447,7 +1447,7 @@ De lukkede Graven med Kamp og Sten —
     <title>Naturen ved Korset</title>
     <firstline>Tunge Dage, triste Dage</firstline>
     <source pages="68-69"/>
-    <quality>korrektur1,kilde,side</quality>
+    <quality>korrektur1,korrektur2,kilde,side</quality>
 </head>
 <body>
 <poetry>
@@ -1499,7 +1499,7 @@ hilset af den frelste Jord.
     <title>Maria i Naturen</title>
     <firstline>Nu svulmer der Knopper, nu springer der Løv</firstline>
     <source pages="70-71"/>
-    <quality>korrektur1,kilde,side</quality>
+    <quality>korrektur1,korrektur2,kilde,side</quality>
 </head>
 <body>
 <poetry>
@@ -1543,7 +1543,7 @@ Maria i Hermelinskaaben, Maria i Sne!
     <pictures>
         <picture src="2026072832-p1.jpg" year="1903" museum="mrbab" objid="maurice-denis-la-vierge-a-l-ecole" invnr="3998">Maurice Denis (1870–1943): <i>La Vierge à l’école</i>, 1903, olie på lærred, 158 × 200 cm.</picture>
     </pictures>
-    <quality>korrektur1,kilde,side</quality>
+    <quality>korrektur1,korrektur2,kilde,side</quality>
 </head>
 <body>
 <poetry>
@@ -1603,7 +1603,7 @@ at med Maria evigt vi maa være.
     <title>Bethlehem</title>
     <firstline>O Bethlehem, du Julestad</firstline>
     <source pages="75-76"/>
-    <quality>korrektur1,kilde,side</quality>
+    <quality>korrektur1,korrektur2,kilde,side</quality>
 </head>
 <body>
 <poetry>
@@ -1655,7 +1655,7 @@ hos Dig og Sanct Marie.
     <title>Julestjærnen</title>
     <firstline>Stjærner, Stjærner over Jorden</firstline>
     <source pages="77-85"/>
-    <quality>korrektur1,kilde,side</quality>
+    <quality>korrektur1,korrektur2,kilde,side</quality>
 </head>
 <body>
 <poetry>
@@ -1817,7 +1817,7 @@ hjem fra det Fjærne.
     <title>De hellige tre Konger</title>
     <firstline>Klare Klokker kimer mod Sky —</firstline>
     <source pages="86-90"/>
-    <quality>korrektur1,kilde,side</quality>
+    <quality>korrektur1,korrektur2,kilde,side</quality>
 </head>
 <body>
 <poetry>


### PR DESCRIPTION
## Hvad er ændret?

Alle 35 tekster i Johannes Jørgensens *Blomster og Frugter* (1907) er gennemgået to gange mod facsimilet og mærket `korrektur2`. Åbningsdigtets facsimilehenvisning er rettet fra side 10 til side 12–13.

## Hvorfor?

Brødteksten var kildetro; rettelsen sikrer, at læserens facsimilelink åbner de rigtige sider.

## Kontrol

- XML og Relax NG validerer
- Alle sideintervaller kontrolleret mod PDF’en
- OCR-kandidatrapport: 0 fund
- `git diff --check` og hele Jest-suiten (2.405 tests) består

PR’en er isoleret til `fdirs/joergensenj/1907.xml`.
