### PR TITLE
Korrekturlæs Digte 1894–1898 (1916)

### DIFF
--- a/fdirs/joergensenj/1916.xml
+++ b/fdirs/joergensenj/1916.xml
@@ -1259,7 +1259,7 @@ paa din Port, o Evighed.
 <text id="joergensenj2026072225">
 <head>
     <title>Kopi efter en engelsk Digter</title>
-    <subtitle><i>To live Christ-lorn ...</i></subtitle>
+    <subtitle>To live Christ-lorn ...</subtitle>
     <firstline>At leve uden Christi Haand i min</firstline>
     <notes>
         <note>Gendigtning af W. H. Abbotts <xref type="translation" poem="abbott2026072201"/>.</note>

--- a/fdirs/joergensenj/1916.xml
+++ b/fdirs/joergensenj/1916.xml
@@ -18,7 +18,7 @@
     <title>Vision</title>
     <firstline>Det Land, jeg saa inat i mine Drømme</firstline>
     <source pages="9"/>
-    <quality>korrektur1,kilde,side</quality>
+    <quality>korrektur1,korrektur2,kilde,side</quality>
 </head>
 <body>
 <poetry>
@@ -51,7 +51,7 @@ og bad, landflygtig, for et fremmed Billed.
     <title>Gensyn</title>
     <firstline>Den store Skov, den store Skov</firstline>
     <source pages="10-11"/>
-    <quality>korrektur1,kilde,side</quality>
+    <quality>korrektur1,korrektur2,kilde,side</quality>
 </head>
 <body>
 <poetry>
@@ -103,7 +103,7 @@ Jeg kan dig ikke glemme!
     <title>Øer i Havet</title>
     <firstline>De stride, staalblaa Strømme</firstline>
     <source pages="12-13"/>
-    <quality>korrektur1,kilde,side</quality>
+    <quality>korrektur1,korrektur2,kilde,side</quality>
 </head>
 <body>
 <poetry>
@@ -150,7 +150,7 @@ til mine Minders Genklang.
     <title>Gamle Sange</title>
     <firstline>En svunden Vaar imod mig slaar</firstline>
     <source pages="14"/>
-    <quality>korrektur1,kilde,side</quality>
+    <quality>korrektur1,korrektur2,kilde,side</quality>
 </head>
 <body>
 <poetry>
@@ -183,7 +183,7 @@ nu og for alle Tide!
     <title><num>I.</num> Bjærgluft</title>
     <firstline>Jeg sidder i Fyrreskygger</firstline>
     <source pages="15-17"/>
-    <quality>korrektur1,kilde,side</quality>
+    <quality>korrektur1,korrektur2,kilde,side</quality>
 </head>
 <body>
 <poetry>
@@ -257,10 +257,10 @@ og Jordens liflige Luft.
 
 <text id="joergensenj2026072206">
 <head>
-    <title><num>II.</num>Angelusklokker</title>
+    <title><num>II.</num> Angelusklokker</title>
     <firstline>Der rødmer Skyer langt ude</firstline>
     <source pages="18"/>
-    <quality>korrektur1,kilde,side</quality>
+    <quality>korrektur1,korrektur2,kilde,side</quality>
 </head>
 <body>
 <poetry>
@@ -289,10 +289,10 @@ min Sjæl er vendt.
 
 <text id="joergensenj2026072207">
 <head>
-    <title><num>III.</num>St. Gotthard</title>
+    <title><num>III.</num> St. Gotthard</title>
     <firstline>Den evige Sne, den evige Sne</firstline>
     <source pages="19"/>
-    <quality>korrektur1,kilde,side</quality>
+    <quality>korrektur1,korrektur2,kilde,side</quality>
 </head>
 <body>
 <poetry>
@@ -316,10 +316,10 @@ som Skumring og Aftensvale.
 
 <text id="joergensenj2026072208">
 <head>
-    <title><num>IV.</num>Mørke</title>
+    <title><num>IV.</num> Mørke</title>
     <firstline>Det er i de sorte Nætter</firstline>
     <source pages="20-21"/>
-    <quality>korrektur1,kilde,side</quality>
+    <quality>korrektur1,korrektur2,kilde,side</quality>
 </head>
 <body>
 <poetry>
@@ -368,10 +368,10 @@ tier og lytter dertil.
 
 <text id="joergensenj2026072209">
 <head>
-    <title><num>V.</num>Uvejr</title>
+    <title><num>V.</num> Uvejr</title>
     <firstline>Paa Bjærgets Hæld et susende Hegn</firstline>
     <source pages="22-23"/>
-    <quality>korrektur1,kilde,side</quality>
+    <quality>korrektur1,korrektur2,kilde,side</quality>
 </head>
 <body>
 <poetry>
@@ -407,10 +407,10 @@ staar Bjærgenes Bræm som en Solskinsfest.
 
 <text id="joergensenj2026072210">
 <head>
-    <title><num>VI.</num>St. Laurentii Taarer</title>
+    <title><num>VI.</num> St. Laurentii Taarer</title>
     <firstline>Der falder mange Stjærneskud i Nat</firstline>
     <source pages="24-25"/>
-    <quality>korrektur1,kilde,side</quality>
+    <quality>korrektur1,korrektur2,kilde,side</quality>
 </head>
 <body>
 <poetry>
@@ -454,10 +454,10 @@ Og foran lyser intet Gensyns Kærte.
 
 <text id="joergensenj2026072211">
 <head>
-    <title><num>VII.</num>Anima anceps</title>
+    <title><num>VII.</num> Anima anceps</title>
     <firstline>Den hedenske Morgen, naar Sjælen hvælver</firstline>
     <source pages="26-27"/>
-    <quality>korrektur1,kilde,side</quality>
+    <quality>korrektur1,korrektur2,kilde,side</quality>
 </head>
 <body>
 <poetry>
@@ -502,7 +502,7 @@ en Stjærne mod Nat, og kun Gud er stor ...
     <title>Rejseminde</title>
     <firstline>Jeg griber et Bind i min Bogreol</firstline>
     <source pages="28-31"/>
-    <quality>korrektur1,kilde,side</quality>
+    <quality>korrektur1,korrektur2,kilde,side</quality>
 </head>
 <body>
 <poetry>
@@ -593,7 +593,7 @@ Sanminiatos Kirke.
         <note>Gendigtning af William Morris’ <xref type="translation" poem="morrisw2026072201"/>.</note>
     </notes>
     <source pages="32"/>
-    <quality>korrektur1,kilde,side</quality>
+    <quality>korrektur1,korrektur2,kilde,side</quality>
 </head>
 <body>
 <poetry>
@@ -626,7 +626,7 @@ hvad efter Død er os bered.
     <title>Frugttid</title>
     <firstline>Ak, al min Tro er bleven Muld og Støv</firstline>
     <source pages="33"/>
-    <quality>korrektur1,kilde,side</quality>
+    <quality>korrektur1,korrektur2,kilde,side</quality>
 </head>
 <body>
 <poetry>
@@ -656,7 +656,7 @@ og at jeg gærne vilde Verden vinde.
     <title>Høstsuk</title>
     <firstline>Saa standser jeg ved Vejens Kant</firstline>
     <source pages="34"/>
-    <quality>korrektur1,kilde,side</quality>
+    <quality>korrektur1,korrektur2,kilde,side</quality>
 </head>
 <body>
 <poetry>
@@ -688,7 +688,7 @@ min Gud!
     <title>Gylden Taage</title>
     <firstline>Har jeg min Fane sænket</firstline>
     <source pages="35-37"/>
-    <quality>korrektur1,kilde,side</quality>
+    <quality>korrektur1,korrektur2,kilde,side</quality>
 </head>
 <body>
 <poetry>
@@ -770,7 +770,7 @@ som lægger paa Ploven sin Haand.
     <title>Aftenbøn</title>
     <firstline>Dagen har været saa tung og haard</firstline>
     <source pages="38-40"/>
-    <quality>korrektur1,kilde,side</quality>
+    <quality>korrektur1,korrektur2,kilde,side</quality>
 </head>
 <body>
 <poetry>
@@ -839,7 +839,7 @@ i Evigheds Evighed. Amen.
     <firstline>Vinterskumring, Taagefald</firstline>
     <source pages="41-47"/>
     <keywords>verlaine</keywords>
-    <quality>korrektur1,kilde,side</quality>
+    <quality>korrektur1,korrektur2,kilde,side</quality>
 </head>
 <body>
 <poetry>
@@ -970,7 +970,7 @@ lad ham frelst Dit Aasyn se!
     <title>Livets Sang</title>
     <firstline>Det er en Julimorgenstund</firstline>
     <source pages="48-54"/>
-    <quality>korrektur1,kilde,side</quality>
+    <quality>korrektur1,korrektur2,kilde,side</quality>
 </head>
 <body>
 <poetry>
@@ -1102,7 +1102,7 @@ at vi hos Dig maa bygge!
     <title>Stilleliv</title>
     <firstline>Det er saa blankt, det Græs, som groer</firstline>
     <source pages="55-56"/>
-    <quality>korrektur1,kilde,side</quality>
+    <quality>korrektur1,korrektur2,kilde,side</quality>
 </head>
 <body>
 <poetry>
@@ -1149,7 +1149,7 @@ vox ind i Livets Sommer.
     <title>Sommeraften</title>
     <firstline>Saa stille, saa stille, nu Dagen er død</firstline>
     <source pages="57"/>
-    <quality>korrektur1,kilde,side</quality>
+    <quality>korrektur1,korrektur2,kilde,side</quality>
 </head>
 <body>
 <poetry>
@@ -1171,7 +1171,7 @@ af Sølv over Synsranden skyder.
     <title>Morgenandagt</title>
     <firstline>En Himmel, tæt og blaa som Amethyst</firstline>
     <source pages="58"/>
-    <quality>korrektur1,kilde,side</quality>
+    <quality>korrektur1,korrektur2,kilde,side</quality>
 </head>
 <body>
 <poetry>
@@ -1202,7 +1202,7 @@ og flyver stille i Guds Himmel ind.
     <subtitle>Parafrase af St. Notkers Hymne</subtitle>
     <firstline>Som en Flod med stærke, stride Vande</firstline>
     <source pages="59"/>
-    <quality>korrektur1,kilde,side</quality>
+    <quality>korrektur1,korrektur2,kilde,side</quality>
 </head>
 <body>
 <poetry>
@@ -1234,7 +1234,7 @@ giv os ej den bitre Død i Vold.
     <title>Allesjælesnat</title>
     <firstline>Store Stjærner staa deroppe</firstline>
     <source pages="60"/>
-    <quality>korrektur1,kilde,side</quality>
+    <quality>korrektur1,korrektur2,kilde,side</quality>
 </head>
 <body>
 <poetry>
@@ -1259,13 +1259,13 @@ paa din Port, o Evighed.
 <text id="joergensenj2026072225">
 <head>
     <title>Kopi efter en engelsk Digter</title>
-    <subtitle>To live Christ-lorn ...</subtitle>
+    <subtitle><i>To live Christ-lorn ...</i></subtitle>
     <firstline>At leve uden Christi Haand i min</firstline>
     <notes>
         <note>Gendigtning af W. H. Abbotts <xref type="translation" poem="abbott2026072201"/>.</note>
     </notes>
     <source pages="61"/>
-    <quality>korrektur1,kilde,side</quality>
+    <quality>korrektur1,korrektur2,kilde,side</quality>
 </head>
 <body>
 <poetry>
@@ -1299,7 +1299,7 @@ for Liv og Død — o Gud, om det var sandt!
         <note>Gendigtning af Dante Gabriel Rossettis <xref type="translation" poem="rossettid2026072201"/>.</note>
     </notes>
     <source pages="62-66"/>
-    <quality>korrektur1,kilde,side</quality>
+    <quality>korrektur1,korrektur2,kilde,side</quality>
 </head>
 <body>
 <poetry>
@@ -1406,7 +1406,7 @@ til Dig og Ham, som Du har fød.
     <subtitle>Julehymne fra det 4. Aarh. af Sedulius</subtitle>
     <firstline>Fra der, hvor Solen først gaar frem</firstline>
     <source pages="67-68"/>
-    <quality>korrektur1,kilde,side</quality>
+    <quality>korrektur1,korrektur2,kilde,side</quality>
 </head>
 <body>
 <poetry>
@@ -1453,10 +1453,10 @@ Amen.
 <text id="joergensenj2026072228">
 <head>
     <title>Victimae paschali laudes</title>
-    <subtitle>Paaskesekvens AF Herman Contractus</subtitle>
+    <subtitle>Paaskesekvens af Herman Contractus</subtitle>
     <firstline>Paaskelammet vi vor Lov frembære</firstline>
     <source pages="69"/>
-    <quality>korrektur1,kilde,side</quality>
+    <quality>korrektur1,korrektur2,kilde,side</quality>
 </head>
 <body>
 <poetry>
@@ -1487,7 +1487,7 @@ Vær os naadig, stærke Christ og blide!
     <subtitle>Pinsesekvens fra det 11. Aarh.</subtitle>
     <firstline>Kom, o Helligaand, herned</firstline>
     <source pages="70-71"/>
-    <quality>korrektur1,kilde,side</quality>
+    <quality>korrektur1,korrektur2,kilde,side</quality>
 </head>
 <body>
 <poetry>


### PR DESCRIPTION
## Hvad er ændret?

Alle 29 tekster i andenudgaven af Johannes Jørgensens *Digte 1894–1898* (1916) er sammenholdt med facsimilet og mærket `korrektur2`. Seks manglende mellemrum i nummererede titler, en kursiveret undertitel og en inkonsekvent titelkapitælisering er rettet.

## Hvorfor?

Ændringerne bringer titelmetadata og typografisk markup i overensstemmelse med kilden.

## Kontrol

- XML og Relax NG validerer
- OCR-kandidatrapport: 0 fund
- `git diff --check` består
- Hele Jest-suiten: 54 suiter / 2.405 tests består

PR’en er isoleret til `fdirs/joergensenj/1916.xml`.
