### PR TITLE
Korrekturlæs Der er en Brønd, som rinder (1920)

### DIFF
--- a/fdirs/joergensenj/1920.xml
+++ b/fdirs/joergensenj/1920.xml
@@ -4,12 +4,12 @@
     <title>Der er en Brønd, som rinder</title>
     <year>1920</year>
     <notes>
-        <note>Teksten følger Johannes Jørgensen: <i>Der er en Brønd, som rinder</i>, Gyldendalske Boghandel, Nordisk Forlag, Kjøbenhavn, 1920.</note>
+        <note>Teksten følger Johannes Jørgensen: <i>Der er en Brønd, som rinder</i>, Gyldendalske Boghandel, Nordisk Forlag, 2. oplag, Kjøbenhavn, 1920.</note>
     </notes>
     <pictures>
         <picture src="1920-p1.jpg">Titelbladet til <i>Der er en Brønd, som rinder</i> (1920) lyder ,,JOHANNES JØRGENSEN // DER ER EN BRØND, SOM RINDER // „Die Brunnen immer rauschen” / DES KNABEN WUNDERHORN // GYLDENDALSKE BOGHANDEL · NORDISK FORLAG // KJØBENHAVN · KRISTIANIA / BERLIN · LONDON / MCMXX''.</picture>
     </pictures>
-    <source facsimile="130019417736-color.pdf" facsimile-pages-num="97" facsimile-pages-offset="9">Johannes Jørgensen: <i>Der er en Brønd, som rinder</i>, Gyldendalske Boghandel, Nordisk Forlag, Kjøbenhavn, 1920.</source>
+    <source facsimile="130019417736-color.pdf" facsimile-pages-num="97" facsimile-pages-offset="9">Johannes Jørgensen: <i>Der er en Brønd, som rinder</i>, Gyldendalske Boghandel, Nordisk Forlag, 2. oplag, Kjøbenhavn, 1920.</source>
 </workhead>
 <workbody>
 
@@ -18,7 +18,7 @@
     <title>Hjem</title>
     <firstline>Den hellige Morgenarbejdsstund</firstline>
     <source pages="9-10"/>
-    <quality>korrektur1,kilde,side</quality>
+    <quality>korrektur1,korrektur2,kilde,side</quality>
 </head>
 <body>
 <poetry>
@@ -53,7 +53,7 @@ Assisi, April 1920.
     <title>Der er en Brønd, som rinder</title>
     <firstline>Der er en Brønd, som rinder</firstline>
     <source pages="11-13"/>
-    <quality>korrektur1,kilde,side</quality>
+    <quality>korrektur1,korrektur2,kilde,side</quality>
 </head>
 <body>
 <poetry>
@@ -101,7 +101,7 @@ for hvad ej mer er til.
     <title>Der staar tre Stjærner paa Himlen</title>
     <firstline>Der staar tre Stjærner paa Himlen</firstline>
     <source pages="14-15"/>
-    <quality>korrektur1,kilde,side</quality>
+    <quality>korrektur1,korrektur2,kilde,side</quality>
 </head>
 <body>
 <poetry>
@@ -128,7 +128,7 @@ den tredje er gammel og graa.
     <title>Du rækker mig en Bog</title>
     <firstline>Du rækker mig en Bog, min lille Søster —</firstline>
     <source pages="16-17"/>
-    <quality>korrektur1,kilde,side</quality>
+    <quality>korrektur1,korrektur2,kilde,side</quality>
 </head>
 <body>
 <poetry>
@@ -161,7 +161,7 @@ og blader end en Gang i Billedbogen.
     <title>Samtale</title>
     <firstline>Du drog til Hesperiens Strande —</firstline>
     <source pages="18-20"/>
-    <quality>korrektur1,kilde,side</quality>
+    <quality>korrektur1,korrektur2,kilde,side</quality>
 </head>
 <body>
 <poetry>
@@ -204,7 +204,7 @@ og blader end en Gang i Billedbogen.
     <firstline>Mosrosen strejfer mig i Nattens Mørke</firstline>
     <source pages="21-22"/>
     <keywords>sonnet</keywords>
-    <quality>korrektur1,kilde,side</quality>
+    <quality>korrektur1,korrektur2,kilde,side</quality>
 </head>
 <body>
 <poetry>
@@ -232,7 +232,7 @@ det er, som strøg mig sagte Moders Hænder.
     <title>Ak, de fjærne Skove</title>
     <firstline>Ak, de fjærne Skove er ej fjærne</firstline>
     <source pages="23-24"/>
-    <quality>korrektur1,kilde,side</quality>
+    <quality>korrektur1,korrektur2,kilde,side</quality>
 </head>
 <body>
 <poetry>
@@ -261,7 +261,7 @@ og de fjærne Skove er saa fjærne.
     <title>Her staar de grønne Stammer</title>
     <firstline>Her staar de grønne Stammer</firstline>
     <source pages="25-26"/>
-    <quality>korrektur1,kilde,side</quality>
+    <quality>korrektur1,korrektur2,kilde,side</quality>
 </head>
 <body>
 <poetry>
@@ -288,7 +288,7 @@ endnu en Gang.
     <title>Ja, det er Foraar</title>
     <firstline>Ja, det er Foraar nu</firstline>
     <source pages="27-28"/>
-    <quality>korrektur1,kilde,side</quality>
+    <quality>korrektur1,korrektur2,kilde,side</quality>
 </head>
 <body>
 <poetry>
@@ -319,7 +319,7 @@ der sletter mig og alt og alle ud . . .
     <title>I Løvet Natvinden suser</title>
     <firstline>I Løvet Natvinden suser</firstline>
     <source pages="29-31"/>
-    <quality>korrektur1,kilde,side</quality>
+    <quality>korrektur1,korrektur2,kilde,side</quality>
 </head>
 <body>
 <poetry>
@@ -371,7 +371,7 @@ og Ruderne maaneskinsblaa.
     <title>Ved Porten, hvor de grønne Linde staa</title>
     <firstline>Ved Porten, hvor de grønne Linde staa</firstline>
     <source pages="32-34"/>
-    <quality>korrektur1,kilde,side</quality>
+    <quality>korrektur1,korrektur2,kilde,side</quality>
 </head>
 <body>
 <poetry>
@@ -425,7 +425,7 @@ tager Du mine Hænder mellem Dine.
     <title>Gammel Vise</title>
     <firstline>I spillede Boldt i Lunden</firstline>
     <source pages="35-36"/>
-    <quality>korrektur1,kilde,side</quality>
+    <quality>korrektur1,korrektur2,kilde,side</quality>
 </head>
 <body>
 <poetry>
@@ -452,7 +452,7 @@ det blev hos Dig.
     <title>Gammel Sang ved Klaveret</title>
     <firstline>Kom mig ej nær, kom mig ej nær</firstline>
     <source pages="37-38"/>
-    <quality>korrektur1,kilde,side</quality>
+    <quality>korrektur1,korrektur2,kilde,side</quality>
 </head>
 <body>
 <poetry>
@@ -479,7 +479,7 @@ du Stjærne, fjærnt i Himlens Rand!
     <title>Der staar i Horisonten</title>
     <firstline>Der staar i Horisonten</firstline>
     <source pages="39-40"/>
-    <quality>korrektur1,kilde,side</quality>
+    <quality>korrektur1,korrektur2,kilde,side</quality>
 </head>
 <body>
 <poetry>
@@ -516,7 +516,7 @@ Farvel, du hvide Hus.
     <title>Bøgeskov</title>
     <firstline>Bøgeskoven suser stille</firstline>
     <source pages="41-45"/>
-    <quality>korrektur1,kilde,side</quality>
+    <quality>korrektur1,korrektur2,kilde,side</quality>
 </head>
 <body>
 <poetry>
@@ -585,7 +585,7 @@ uafladeligt og stille:
     <title>Ærenpris</title>
     <firstline>Ærenpris Du kære</firstline>
     <source pages="46-47"/>
-    <quality>korrektur1,kilde,side</quality>
+    <quality>korrektur1,korrektur2,kilde,side</quality>
 </head>
 <body>
 <poetry>
@@ -623,7 +623,7 @@ bliver Du Kærminde.
     <firstline>Stenen rager i Havet ud</firstline>
     <source pages="48-49"/>
     <!-- TODO: Hvorfor den tysk overskrift? Er det monstro noget oversat? -->
-    <quality>korrektur1,kilde,side</quality>
+    <quality>korrektur1,korrektur2,kilde,side</quality>
 </head>
 <body>
 <poetry>
@@ -650,7 +650,7 @@ og Havet skummer og strømmer.
     <title>Der staar skrevet hos Profeten Zacharias</title>
     <firstline>De har gennemboret mine Hænder</firstline>
     <source pages="50-51"/>
-    <quality>korrektur1,kilde,side</quality>
+    <quality>korrektur1,korrektur2,kilde,side</quality>
 </head>
 <body>
 <poetry>
@@ -677,7 +677,7 @@ mit eget Kød og Blod.
     <title>Schelden falder i Havet</title>
     <firstline>Schelden falder i Havet</firstline>
     <source pages="52-54"/>
-    <quality>korrektur1,kilde,side</quality>
+    <quality>korrektur1,korrektur2,kilde,side</quality>
 </head>
 <body>
 <poetry>
@@ -724,7 +724,7 @@ rinder ud i et sommerblaat Vand.
     <title>Park</title>
     <firstline>Den lune Luft laa stille, uden Vind</firstline>
     <source pages="55-56"/>
-    <quality>korrektur1,kilde,side</quality>
+    <quality>korrektur1,korrektur2,kilde,side</quality>
 </head>
 <body>
 <poetry>
@@ -756,7 +756,7 @@ Og saa begyndte stille det at regne.
     <title>Italiensk Motiv</title>
     <firstline>Jeg hørte Dig synge. Lykkelig? Hvem véd</firstline>
     <source pages="57"/>
-    <quality>korrektur1,kilde,side</quality>
+    <quality>korrektur1,korrektur2,kilde,side</quality>
 </head>
 <body>
 <poetry>
@@ -779,7 +779,7 @@ at kun et fattigt Minde er tilbage.
     <title>Er det endnu ikke nok?</title>
     <firstline>Er det endnu ikke nok med Marker og Haver</firstline>
     <source pages="58-59"/>
-    <quality>korrektur1,kilde,side</quality>
+    <quality>korrektur1,korrektur2,kilde,side</quality>
 </head>
 <body>
 <poetry>
@@ -801,7 +801,7 @@ der staar saa langt, langt borte — og som jeg aldrig naaer.
     <title>Lad kun —</title>
     <firstline>Lad kun de sidste Blade synke ned</firstline>
     <source pages="60"/>
-    <quality>korrektur1,kilde,side</quality>
+    <quality>korrektur1,korrektur2,kilde,side</quality>
 </head>
 <body>
 <poetry>
@@ -825,7 +825,7 @@ alt, hvad jeg leved langt fra Dig, min Gud!
     <title>Lovsang</title>
     <firstline>Velsignet være Du, vor Herre Gud</firstline>
     <source pages="61-63"/>
-    <quality>korrektur1,kilde,side</quality>
+    <quality>korrektur1,korrektur2,kilde,side</quality>
 </head>
 <body>
 <poetry>
@@ -867,7 +867,7 @@ Til hvem, o Herre, skal vi ellers gaa?
     <title>Frankrigs Liljer</title>
     <firstline>Frankrigs Liljer, rundne af det dybe</firstline>
     <source pages="64-65"/>
-    <quality>korrektur1,kilde,side</quality>
+    <quality>korrektur1,korrektur2,kilde,side</quality>
 </head>
 <body>
 <poetry>
@@ -895,7 +895,7 @@ renere, fordi den groer af Grave?
     <title>Flanderns Løve</title>
     <firstline>Den Gang Fjenden sejersstor drog ind i Gent —</firstline>
     <source pages="66-68"/>
-    <quality>korrektur1,kilde,side</quality>
+    <quality>korrektur1,korrektur2,kilde,side</quality>
 </head>
 <body>
 <poetry>
@@ -940,7 +940,7 @@ hilser Kongen, Albert Atterdag.
     <title>Det genvundne Land</title>
     <firstline>Det genvundne Land! Ja det er det</firstline>
     <source pages="69-73"/>
-    <quality>korrektur1,kilde,side</quality>
+    <quality>korrektur1,korrektur2,kilde,side</quality>
 </head>
 <body>
 <poetry>
@@ -984,7 +984,7 @@ Og vi rækker imod dem vor Haand, vi har ikke andet at gøre —
 det er som det glade Budskab — aabn kun Hjærte og Øre!
 
 Ræk Haanden ud og tag glad imod — og tak saa atter og atter
-for genfunden Ven og Broder, for genfunden Søster og Datter!
+for genvunden Ven og Broder, for genvunden Søster og Datter!
 </poetry>
 </body>
 </text>


### PR DESCRIPTION
## Hvad er ændret?

Alle 27 tekster i Johannes Jørgensens *Der er en Brønd, som rinder* (1920) er sammenholdt med facsimilet og mærket `korrektur2`. Udgaveangivelsen er præciseret til 2. oplag, og `genfunden` er rettet til kildens `genvunden`.

## Hvorfor?

Transskriptionen og bibliografien følger nu det konkrete facsimile.

## Kontrol

- XML og Relax NG validerer
- OCR-kandidatrapport: 0 fund
- UTF-8/encoding-kontrol og `git diff --check` består
- Hele Jest-suiten: 54 suiter / 2.405 tests består

PR’en er isoleret til `fdirs/joergensenj/1920.xml`.
