### PR TITLE
Korrekturlæs Aarestrups faksimiletekster

### DIFF
--- a/fdirs/aarestrup/1838.xml
+++ b/fdirs/aarestrup/1838.xml
@@ -37,7 +37,7 @@ Af en lønlig Drift, fast uden Villie.
 See da - som paa Lyngens brune Flade,
 Som paa Heire-Axet over Tilie,
 Som paa flygtigt Skum af en Najade,
-Som paa Mosbundens gule Lilie,
+Som paa Mosebundens gule Lilie,
 Som paa Kalkkorallens Svamp og Plade,
 Som paa Strandens spraglede Conchilie -
 Nogle Øieblik paa disse Blade,
@@ -249,7 +249,7 @@ Af Klippen, blodig saaret, han Frist for Livet fandt.
 
 Iiskolde Stænk fra Strømmen det hede Blod ham kjøle;
 Vildt stirrer han ned, og hører Slusen brøle.
-Det sorter for hans Blik - hjælp Gud! - hans Kraft forsager -
+Det sortner for hans Blik - hjælp Gud! - hans Kraft forsager -
 Da føler han sig løftet, en Haand ham opad drager.
 
 Med saaret Knæ og Skulder paa Klippens Blok han staaer,
@@ -495,7 +495,7 @@ Forbløder sig og døer -
 Halloh, Halloh, Halloh, Halloh!
 Hvor Hundekobblet gjøer -
 
-Der blomstrer opgsaa stille
+Der blomstrer ogsaa stille
 I Skyggen Blomster vilde,
 Og der er Græsset blødt;
 Og fløiter Nattergalen,
@@ -597,7 +597,7 @@ Mit: da capo! hidindtil.
 
 Men dog kjær, ei sandt, af Natten? -
 Ja; det Ord, at gjemt til den
-Egentligt er gjemt til Katten,
+Egentlig er gjemt til Katten,
 Er Bagtalelse, min Ven!
 
 Noget maa du Maanen unde? -
@@ -631,7 +631,7 @@ Og jeg venter, Ingen kommer,
 Trøster mig den smukke Sang.
 
 Ah, i Birkelundens Midte
-Jægerhuset? - Lag mig gaae!
+Jægerhuset? - Lad mig gaae!
 Veed du ikke, een kan fritte
 Meer end ti kan svare paa.
 </poetry>
@@ -729,7 +729,7 @@ Naar Faren er forbi, saa maa den være glemt.
 Han tog sin Viv paa Skjødet, trak Kufferten frem,
 Og viste, hvad fra Reisen han bragte med sig hjem.
 Af Silketøj og Linned saa lystelig en Skat;
-Et Tut med Sølverpenge den var i Krogen sat.
+En Tut med Sølverpenge den var i Krogen sat.
 
 Lysvaagen ud af Reden den lille Gut da sprang,
 Den stumped' Skjorte ham om Benene hang.
@@ -1531,7 +1531,7 @@ Ulykken rammer Alle!
 Men Greven stod bag Døren -
 Det Syn ham ei forlysted -
 Han stødte hende Dolken
-Til Hæften ind i Brystet.
+Til Hæftet ind i Brystet.
 
 Ulykken rammer Alle!
 
@@ -1935,7 +1935,7 @@ Og Qvinderne med Krandse.
 Men ungen Radbod mødte dem
 I Harnisk og med Landse.
 
-Og Bondes Blod i Strømme flød
+Og Bondens Blod i Strømme flød
 Alt paa hans egen Ager,
 Som Bierne i Kuben døe
 I egne Honningkager.
@@ -1984,7 +1984,7 @@ Til Dommedag dem vækker.
    <notes>
       <note>Lægen Aarestrup ledsagede i 1832 komtesse Amalie Raben fra Aalholm på en helbredsrejse gennem Tyskland til Böhmen og Østrig, hvor hun døde.</note>
    </notes>
-   <quality>korrektur1,korrektur2,korrektur2,kilde</quality>
+   <quality>korrektur1,korrektur2,kilde</quality>
    <keywords>romantismen</keywords>
 </head>
 <body>
@@ -2241,7 +2241,7 @@ Den Krands, den voxer og den bliver,
 Uvisnelig, en evig Fryd.
 
 Hvad Duggen er for Rosens Rødme,
-Er Viin for Læbers Rosenild,
+Er Viin for Læbens Rosenild,
 Lad derfor Sødt berøre Sødme,
 Løft Glassets skjønne Farvespil!
 
@@ -2357,7 +2357,7 @@ Flammen, der fra Ovnen lyser,
 Som en Busemand dig kyser.
 
 Tro ei, at din Storm fordriver
-Blomstringsmodet med dit Skryd -
+Blomstringsmodet med sit Skryd -
 Naar den unge Mø os bliver,
 Har vi Vaarens bedste Pryd;
 Du, med dine lange River,
@@ -2943,7 +2943,7 @@ En Skare Folk, som græde.
 
 Hvorhen, Signor Dottore?
 Med Hastværk han sig skyndte;
-Det hele Gade lugter
+Den hele Gade lugter
 Endnu af Pebermynte.
 
 Friseuren her jeg kjender -
@@ -3438,7 +3438,7 @@ Ved Tanken om din Galde blot, at zittre.
 9.
 Blomst af Pelargonien,
 Din fine Tegning fik mig til at tænke,
-Vi sad en Sommenqvæld i Catalonien.
+Vi sad en Sommerqvæld i Catalonien.
 
 10.
 Søde Narcisse,
@@ -4095,7 +4095,7 @@ Ved Hjelp af Øielaaget.
 
 Bag denne gamle Træstub
 Et Baand, et løsnet, bandt hun -
-Og hvor Markiser lufter
+Og hvor Markisen lufter
 Paa Hjørnet der, forsvandt hun.
 
 Jeg skimtede i Mørket
@@ -4306,7 +4306,7 @@ Af Himmelbuen blaaner,
 Hvem flygtigt et Par Stjerner
 Halv skamfuldt Øiet laaner;
 
-Hvori, hvor du blot vilde
+Hvori, hvis du blot vilde
 Ud over Randen kikke,
 Du saae, skjøndt lidt formørket,
 Dit Engleansigt nikke -
@@ -5724,14 +5724,14 @@ Den dræbende Forandring!
    <title>En Afsked</title>
    <toctitle>En Afsked</toctitle>
    <indextitle>En Afsked</indextitle>
-   <firstline>O, intet Under, de bevares</firstline>
+   <firstline>O, intet Under, du bevares</firstline>
    <source pages="264-265"/>
    <quality>korrektur1,korrektur2,korrektur3,kilde</quality>
    <keywords>romantismen</keywords>
 </head>
 <body>
 <poetry>
-O, intet Under, de bevares
+O, intet Under, du bevares
 Med Laas og Lukke, som en Skat,
 At En - jeg veed nok hvem - dig vogter
 Med Argusøine Dag og Nat.
@@ -5741,7 +5741,7 @@ Som Flagermuus omkring et Baal,
 Og at jeg selv beruset tumler
 Som Bremsen fra en Nektarskaal.
 
-Al Sommerblæstens vame Blødhed
+Al Sommerblæstens varme Blødhed
 Er i din melkehvide Arm,
 Al Blomsterskjønhed i Naturen
 Har fyldt og rundet denne Barm.

--- a/fdirs/aarestrup/1863.xml
+++ b/fdirs/aarestrup/1863.xml
@@ -1933,14 +1933,14 @@ Dit Bryst, din Arm, din Læbe.
 
 <text id="aarestrup2018110406">
 <head>
-    <title>Min Elskte! Orglet lyder</title>
-    <firstline>Min Elskte! Orglet lyder</firstline>
+    <title>Min Elskte! Orglet toner</title>
+    <firstline>Min Elskte! Orglet toner</firstline>
     <source pages="48-49"/>
     <quality>korrektur1,korrektur2,kilde,side</quality>
 </head>
 <body>
 <poetry>
-Min Elskte! Orglet lyder -
+Min Elskte! Orglet toner -
 O, den catholske Sang,
 Jeg kan den ei beskrive;
 Hørte du den engang!
@@ -13687,7 +13687,7 @@ Maanskinscabinettet samle.
 I de bløde Lænestole
 Damerne med Atlasslæbet,
 Blændende sig atter kaste,
-Munden smiler, rosenlæbet.
+Munden smiler rosenlæbet.
 
 Ridderne, som paa Tapetet
 Knapt om Dagen man kan mærke,

--- a/fdirs/aarestrup/1863.xml
+++ b/fdirs/aarestrup/1863.xml
@@ -9,7 +9,7 @@
    <pictures>
        <picture type="titlepage" src="1863-p1.jpg">Titelbladet til <i>Efterladte Digte</i> (1863) lyder ,,Efterladte Digte / af / Emil Aarestrup. // Udgivne / ved / Christian Winther og F. L. Liebenberg. // Kjøbenhavn. / Forlagt af Samfundet til den danske Literaturs Fremme. / Thieles Bogtrykkeri. / 1863.''</picture>
    </pictures>
-   <source facsimile="11530803779C" facsimile-pages-num="368" facsimile-pages-offset="18">Emil Aarestrup: <i>Efterladte Digte</i>, Christian Winther og F.L. Liebenberg (red.), Samfundet til den danske Literaturs Fremme, Kbh., 1863.</source>
+   <source facsimile="11530803779C" facsimile-pages-num="370" facsimile-pages-offset="18">Emil Aarestrup: <i>Efterladte Digte</i>, Christian Winther og F.L. Liebenberg (red.), Samfundet til den danske Literaturs Fremme, Kbh., 1863.</source>
 </workhead>
 <workbody>
 
@@ -81,7 +81,7 @@ Du skræmmer Ingen bort, du smiler, rækker Haanden,
 Med Guldsnor om sin Hat, fuldpaaklædt vandrer Aanden.
 Og vil man følge dig til Gravens stille Læ,
 Da gaaer du langsomt hen, hen til et Hyldetræ.
-Opklappet, pyntet nyt, den smalle Høi sig strækker,
+Opklappet, pyntet nys, den smalle Høi sig strækker,
 Og Arv har hegnet den med tætte Buxbomhækker.
 Did gaaer Pernille tidt, bevæget, sælsom rørt,
 Om Morgenen, med Sand og Blomster i sit Skjørt.
@@ -98,7 +98,7 @@ Det kjære Instrument, som var hans Holberg kjær.
 <head>
    <title>Ved Hoffmanns Død</title>
    <firstline>See, Naturen føler Smerte</firstline>
-   <quality>korrektur1,kilde,side</quality>
+   <quality>korrektur1,korrektur2,kilde,side</quality>
    <source pages="4-5"/>
 </head>
 <body>
@@ -409,7 +409,7 @@ Da voved Petrus ikke
 At hæve sine Blikke.
 Han græd, han skjalv som Sivet,
 Og sukked: ,,Jeg vil drage
-I Fængslets Død tilbage,
+I Fængslets Dyb tilbage,
 Min Gud! og vinde Livet.''
 
 Begfakler brændte, Hallen
@@ -659,7 +659,7 @@ Maa vige Sædet med sin Liliestengel.
 <body>
 <poetry>
 Jeg gik saa tidt til disse Klippestene
-Ned af hvis Muur de kolde Kilder skylle,
+Ned ad hvis Muur de kolde Kilder skylle,
 Hvis Krat og Ranker Vandreren indhylle -
 Der var en Ro, en Fred - jeg var alene.
 
@@ -727,7 +727,7 @@ Vent ham ei længer, du Danmarks friske, yndige Sommer,
 Vent ham ei længer med Blomster og Glæde; han kommer ei mere.
 Ei til Velkomst, Venner, bereder det duftende Bæger;
 Han, som vi rakte det helst, vor Fischer, kommer ei mere.
-Fjern, hvor Javaneren samler paa fugtige Marker sin Riisfrugt,
+Fjernt, hvor Javaneren samler paa fugtige Marker sin Riisfrugt,
 Standste hans Vei; der lagde han træt sig til Hvile, og Palmen
 Breder sit prægtige Blad høitidelig over hans Gravhøi.
 O, hvor længtes vi Alle, hvor speidende søgte ei Blikket
@@ -741,7 +741,7 @@ O bebreider ham Intet; han veg jo beskeden for eder,
 I, som foragte en Sjæl, der har barnligen offret sig Konsten,
 Eder han veg - han veg for den nordiske Kuld, og i Syden
 Favnte ham to Gange hedt, med begeistrende Skjønhed, Naturen,
-Ak! og tredie Gang i et Kys tilaaned ham Døden.
+Ak! og tredie Gang i et Kys tilaanded ham Døden.
 Men han var lykkelig, ja, Poesien belønner sin Dyrker;
 Nu i sin evige Fred forklaret han svæver omkring os,
 Venskab ham offrer og længe skal offre ham hædrende Veemod.
@@ -1160,7 +1160,7 @@ Hvis bruunlige Trængsel
 Din Tinding omflokker.
 
 Forgjæves! Min Tanke
-Kun vandrer og leder
+Kun aander og leder
 Om Lokkernes Ranke,
 Du fletter og breder.
 
@@ -1242,7 +1242,7 @@ Henslørende over
 Blegrøde Koraller;
 
 Paa mørke Aurikler,
-Paa dufende Klaser,
+Paa duftende Klaser,
 Hvis Tykning sig vikler
 Om blændende Vaser.
 
@@ -1704,7 +1704,7 @@ Som Duggens Diamanter;
 
 Og kunde ikke skjelnes,
 Skjøndt fra den bedske Kilde,
-Fra lune himmelfaldne,
+Fra hine himmelfaldne,
 Forfriskende og milde,
 
 Med alle Regnbufarver,
@@ -1801,7 +1801,7 @@ Som truer med at knække;
 Hun skyder Trillebøren,
 Som Hunden hjelper trække.
 
-Om sine brune Skuldre
+Om hendes brune Skuldre
 Har hun et fattigt Stykke
 Og paa den unge Pande
 Kun Svedens Perlesmykke.
@@ -1933,14 +1933,14 @@ Dit Bryst, din Arm, din Læbe.
 
 <text id="aarestrup2018110406">
 <head>
-    <title>Min Elskte! Orglet toner</title>
-    <firstline>Min Elskte! Orglet toner</firstline>
+    <title>Min Elskte! Orglet lyder</title>
+    <firstline>Min Elskte! Orglet lyder</firstline>
     <source pages="48-49"/>
     <quality>korrektur1,korrektur2,kilde,side</quality>
 </head>
 <body>
 <poetry>
-Min Elskte! Orglet toner -
+Min Elskte! Orglet lyder -
 O, den catholske Sang,
 Jeg kan den ei beskrive;
 Hørte du den engang!
@@ -2410,7 +2410,7 @@ Endnu en Kamp for Polen.
 
 Kom, giv mig Drengen, Amme!
 Tag Huen af ham, skynd dig.
-O, hvor hams lille Hoved
+O, hvor hans lille Hoved
 I Solen skinner yndig!
 
 See til din Søn, Sabinski!
@@ -3039,7 +3039,7 @@ At Madonnas Lampe brænder!
 
 Tag imod vor Mildhedsgave!
 Beed Andægtige, som knæle
-I Capellet, løste Bønnen
+I Capellet, løfte Bønnen
 For to elskovsfulde Sjæle:
 
 At den Kummer, som de føle,
@@ -3082,7 +3082,7 @@ Rosen fandt sin Sjæls Udkaarne i den grønne Semperviv;
 Trives denne i dens Nærhed, kan ei Rosen skrante hen.
 Mellem Planter, mellem Stene, mellem alle Verdens Dyr
 Virke Sympathiens Kræfter, selv mellem stolte Mænd
-Hvor er den, som ikke føler, at hans Liv mon plat forgaae,
+Hvor er den, som ikke føler, at hans Liv maa plat forgaae,
 Findes ei det Skjød, hvori han lægge kan sit Hoved hen?
 Hvor er den saa strenge Qvinde, at hun ikke sygner bleg,
 Naar hun, som en Ranke, rives fra den elskte Ungersvend?
@@ -3115,7 +3115,7 @@ At din Kamp, som for at værge Ungerne en Løves,
 Naar jeg lokket af din Skjønhed, som en Bi af Liliens,
 Sank imod dit Bryst og søgte søde Kys, behøves?
 Føler du ei, denne Modstand strider mod Naturen?
-Qvæler den ei Hjertets bedre Stemme, naar den øves?
+Qvæler du ei Hjertets bedre Stemme, naar den øves?
 Alt, hvormed en Viisdomshaand har Verden sammenslynget,
 Alle Baand, som sammenholde Livets Række, kløves;
 Alt, hvad Gud har foranstaltet til sin Skabnings Bedste,
@@ -3187,7 +3187,7 @@ Skilt fra mig ved et Rum, Sjælene ei kan forstaae.
 Tankerne vaagne om dem, de Venner, der nylig forlod os,
 For i den brogede Stad Vinterens Lede at flye.
 Tankerne vaagne om dig, Veninde, du Blide af Hjertet,
-Englen for mine Smaa, Husets fortrolige Gjæst.
+Englen for mine Smaa, Husets fortroligste Gjæst.
 Gjerne en Stund om den lysende Arne vi trykked os sammen,
 Vexled skjemtrige Ord, havde vi dig i vor Ring;
 Men paa Papir, med konstige Skrifttræk nøder mig Skjæbnen
@@ -3203,7 +3203,7 @@ Hilsen fra mine Børn, Hilsen og Kys fra min Viv.
 Jævnt gaaer Tiden her; man lever, skjøndt neppe det mærkes;
 Deri, troer jeg, bestaaer just det lyksalige Liv.
 Himlen er immermørk, indsvøbt i Skyerne, tragisk,
-Ikke en Rist, som er lys, ikke en Plet, som er blaa.
+Ikke en Rift, som er lys, ikke en Plet, som er blaa.
 Meer langmodig, veed jeg, Camelen ei drager i Ørken,
 End paa Bøndernes Vogn jeg den moradsige Vei;
 Ingen Bjørn i Hi paa Mos og visnede Blade
@@ -3254,7 +3254,7 @@ Men da Drømmen forsvandt,
 Siig os hvad vi fandt?
 Knap Mindet - ikke sandt?
 
-Nei, nu er du for slem!
+Nei, den Sats er for slem!
 Sagtens gives der dem,
 For hvilke Elskovs Sol ei oprandt;
 Som ei saae nogen Frugt,
@@ -3285,8 +3285,8 @@ Men Huset holdt han af.
 Derfor Slægtning og Ven
 Derfor Datter og Søn,
 En Skaal for Brudeparret, de To,
-Der i femogtyve Aar,
-Der i Høst som i Vaar,
+Der i Høst, som i Vaar,
+Som i Dage, i Aar,
 Var enige og troe!
   Rosen, de dannede
     Til Krands,
@@ -3441,7 +3441,7 @@ Hans Mening om Qvinderne til -
 Som lettelig lod sig formode -
 Var ogsaa dumdristig og vild
 Og efter hans krusede Ho'ede:
-,,Heel lukkelig Manden vel var,
+,,Heel lykkelig Manden vel var,
 Der fandt sig en elskelig Qvinde;
 Men bedre det var dog, et Par,
 En Snees endnu bedre at finde!''
@@ -3539,7 +3539,7 @@ Ei det Navn var mit.
 
 O, men du, Veninde,
 Klare Maane - o
-Dine blide Straaler
+Dine blege Straaler
 Gav mit Hjerte Ro!
 
 Du har seet min Taare,
@@ -3548,7 +3548,7 @@ Naar du stille lyste
 Over Bjerg og Dal.
 
 Du har hørt mig sukke
-Paa den høie Borg
+Paa din høie Borg
 Som dit Næ forsvinder,
 Svinde lad min Sorg!
 
@@ -3606,7 +3606,7 @@ Disse tause, døde Steder.
 <head>
     <title>Fremtiden</title>
     <firstline>Alting bagvendt og forkludret!</firstline>
-    <quality>korrektur1,korrektur2,korrektur2,kilde,side</quality>
+    <quality>korrektur1,korrektur2,kilde,side</quality>
     <dates>
         <written>1837-11-24</written>
     </dates>
@@ -4314,7 +4314,7 @@ Og det meest Straalende paa Høitidsdagen?
 Det var - hvortil man snart igjen see Magen! -
 Det Ideales Seier over Trangen,
 Det Ædles sikkre Høide over Rangen,
-Og en Forstummelse af Hverdagsklangen.
+Og en Forstummelse af Hverdagsklagen.
 
 Det var ei nogen Jublen hen i Taaget,
 Ei noget Skraal af sammenløbne Drenge,
@@ -5099,7 +5099,7 @@ Men da du kom til Lollands Bøgeskove,
 Hvor Fuglene i Rosenhækker sove:
 
 Der satte Amor Buret i det Grønne;
-Der blev dit Buur - og du skal der forskjønne
+Det blev dit Buur - og du skal der forskjønne
 Som Brud og Viv det skjønne Engestofte.
 </poetry>
 </body>
@@ -5421,7 +5421,7 @@ Da kunde mig hver Svanebarm benaue,
 Og alle Elskovshymner maatte Taarer til.
 
 Jeg fandt saa majestætisk eet og andet,
-Som Andre finde umaadeligt og smaat;
+Som Andre finde maadeligt og smaat;
 Jeg fandt, vort hele Liv var saare vandet,
 Og at kun Hippokrenes Kilde smagte godt.
 
@@ -5443,7 +5443,7 @@ Langt over det, at ingen Mangler see.
 Nu er mig Verden bleven fuld og fyldig,
 Nu Livet blomstrer mig med Fryd og Held;
 Og Hjemmel har jeg for min Dom, en gyldig:
-Dens Skaber selv, der fandt, at Alt var vel.
+Den Skabers selv, der fandt, at Alt var vel.
 </poetry>
 </body>
 </text>
@@ -5770,7 +5770,7 @@ Den Strid, som det Forkrænkelige kjæmper,
 Og det Udødelige kun bestaaer;
 Og sank han end i Knæ lidt efter lidt,
 Ei Utaalmodighedens Suk blev hørt,
-Et Bitterhedens Skrig; da Timen kom,
+Ei Bitterhedens Skrig; da Timen kom,
 Var han beredt - Et Smiil var hans Farvel.
 
     Og derfor bringe vi Dig <w>vort</w> Farvel,
@@ -5875,7 +5875,7 @@ Hvor Leda i sin Uskyld klapped Svanen.
 Paa denne Tid, da Kongevælde
 Tidt stævnes ind for Tidens Skranke,
 Vil jeg et Træk af den fortælle,
-Det falder mig just nu i Tanken.
+Der falder mig just nu i Tanken.
 
 Et tusind Aar og noget mere
 Efter at Jesus Christ fik Livet,
@@ -5948,7 +5948,7 @@ Kun mine egne Sønner prøved
 Paa Sligt - det fuldt og fast jeg troede.
 
 Og for at ei Barmhjertigheden
-Retfærdigen skulde krænke,
+Retfærdigheden skulde krænke,
 Saa slukked Lyset jeg i Vreden,
 Og Blodet - hvis det var - lod stænke.
 
@@ -6070,8 +6070,8 @@ Hvad greb du der? Ih, fy for en Ulykke!
 
 <text id="aarestrup1999032901">
 <head>
-    <title>Den stakkelse Blindebuk! Han gjør sit Bedste</title>
-    <firstline>Den stakkelse Blindebuk! Han gjør sit Bedste</firstline>
+    <title>Den stakkels Blindebuk! Han gjør sit Bedste</title>
+    <firstline>Den stakkels Blindebuk! Han gjør sit Bedste</firstline>
     <dates>
         <written>1848-09-01</written>
     </dates>
@@ -6081,7 +6081,7 @@ Hvad greb du der? Ih, fy for en Ulykke!
 </head>
 <body>
 <poetry>
-Den stakkelse Blindebuk! han gjør sit Bedste,
+Den stakkels Blindebuk! han gjør sit Bedste,
 Han lytter, standser, vender sig i Hast,
 Gjør lange Spring og atter korte Kast,
 Raadvild, hvor han skal sine Næver fæste.
@@ -6224,7 +6224,7 @@ En sagte Bøn, men som i Himlen høres.
     <title>Prolog</title>
     <firstline>Jeg seer i Deres spændte Miner</firstline>
     <source pages="152-155"/>
-    <quality>korrektur1,kilde,side</quality>
+    <quality>korrektur1,korrektur2,kilde,side</quality>
 </head>
 <body>
 <poetry>
@@ -6266,7 +6266,7 @@ Det sympathetisk skjønne Broderskab
 Af Godt og Venligt, Muntert og Uskyldigt -
 Paa gammel Dansk: det reent <w>Selskabelige</w>.
 Det søger man selv midt i Sommerglæden,
-Hvor Eensombeden dog kan yndigt bygge
+Hvor Eensomheden dog kan yndigt bygge
 I Rosers Mørke og i Skovens Skygge;
 Hvormeget meer maa man i Vinterkulden
 Tye til den Varme, venligt Samqvem bringer,
@@ -6371,7 +6371,7 @@ Og Legemet kun vaager.
     <title>Mortensaften</title>
     <firstline>Det Gamle vil vi ei forsmaae</firstline>
     <source pages="156-158"/>
-    <quality>korrektur1,kilde,side</quality>
+    <quality>korrektur1,korrektur2,kilde,side</quality>
 </head>
 <body>
 <poetry>
@@ -6408,7 +6408,7 @@ Jo mere tung og hvid den var,
 Jo større Daad blev ham tilregnet;
 Jo mere fed, jo mere drøi,
 Jo flere Kys, jo mere Støi;
-Om Halsen Viv og Børn bam fløi
+Om Halsen Viv og Børn ham fløi
 Til Priis og Tak for Mortensgaasen.
 
 Og denne Skik - som Odin selv
@@ -6435,7 +6435,7 @@ De gode gamle Skikke leve!
         <event>1850-07-08</event>
     </dates>
     <keywords>sonnet</keywords>
-    <quality>korrektur1,kilde,side</quality>
+    <quality>korrektur1,korrektur2,kilde,side</quality>
 </head>
 <body>
 <poetry>
@@ -6464,7 +6464,7 @@ Af Stjerner, skjønnere end selv de Glades.
 <head>
     <title>Impromptu</title>
     <subtitle>Den 14de Marts 1851</subtitle>
-    <firstline>Der er saa lyst udi Gispens Gaard</firstline>
+    <firstline>Der er saa lyst udi Bispens Gaard</firstline>
     <source pages="159-160"/>
     <dates>
         <event>1851-03-14</event>
@@ -6472,11 +6472,11 @@ Af Stjerner, skjønnere end selv de Glades.
     <notes>
         <note>Melodi som den norske folkevise <xref poem="folkeviserno2018080401"/>.</note>
     </notes>
-    <quality>korrektur1,kilde,side</quality>
+    <quality>korrektur1,korrektur2,kilde,side</quality>
 </head>
 <body>
 <poetry>
-Der er saa lyst udi Gispens Gaard,
+Der er saa lyst udi Bispens Gaard,
 Som hang en Sommersol foroven;
 Musikkens Toner mod Loftet slaaer,
 Som alle Fugle sang i Skoven.
@@ -6527,7 +6527,7 @@ Vor Vert og vor Vertinde leve!
     <dates>
         <written>1851-07-23</written>
     </dates>
-    <quality>korrektur1,kilde,side</quality>
+    <quality>korrektur1,korrektur2,kilde,side</quality>
 </head>
 <body>
 <poetry>
@@ -6556,7 +6556,7 @@ Sin Fødselsdag, i Vennekredsen her.
 Forynget Kraft i hendes Hjerte strømmer,
 Og Helbred straaler fra det glade Blik;
 Paa hendes Sundhed Bægeret sig tømmer,
-Og gode Dufter imod Himlen gik.
+Og gode Ønsker imod Himlen gik.
 
 O ædle Frue, som dit Hjem forskjønner
 Ved milde Dyder, from og vennehuld!
@@ -6618,7 +6618,7 @@ Dagen seer kun Støv og Skimmel.
 
 Saadan gaaer det ogsaa Venskabs
 Stille Tegn og Billedværker,
-De forsvundne Symphatiers
+De forsvundne Sympathiers
 Efterladte Mindesmærker.
 
 Glemsel, som et Møl, dem gnaver,
@@ -6688,7 +6688,7 @@ Hvordan du kan fortumle og fortrylle.
     <title>En Engel stod ved Leiet stille</title>
     <firstline>En Engel stod ved Leiet stille</firstline>
     <source pages="164-165"/>
-    <quality>korrektur1,kilde,side</quality>
+    <quality>korrektur1,korrektur2,kilde,side</quality>
 </head>
 <body>
 <poetry>
@@ -6784,7 +6784,7 @@ Som huldt I mindes Furresøens Kyst!
     <title>Aphorismer</title>
     <firstline>Mod Kjærlighed Forstanden har den Skik</firstline>
     <source pages="166-169"/>
-    <quality>korrektur1,kilde,side</quality>
+    <quality>korrektur1,korrektur2,kilde,side</quality>
 </head>
 <body>
 <poetry>
@@ -6906,7 +6906,7 @@ Og dig intet Slemt har truffet!
     <title>Ritorneller</title>
     <firstline>Blomst af Forglemmigeien!</firstline>
     <source pages="169-186"/>
-    <quality>korrektur1,kilde,side</quality>
+    <quality>korrektur1,korrektur2,kilde,side</quality>
 </head>
 <body>
 <poetry>
@@ -7491,7 +7491,7 @@ Men der var ikke en, som ligned Manden.
 <head>
     <title>Til Christian Winther</title>
     <source pages="189-191"/>
-    <quality>korrektur1,kilde,side</quality>
+    <quality>korrektur1,korrektur2,kilde,side</quality>
 </head>
 <body>
 <prose>
@@ -7515,7 +7515,7 @@ Digternes Prydelse, - de danske Hjerters Næring og bedste Nydelse, - Christian 
         <picture artwork="koebke/1835-grethe-petersen" />
     </pictures>
     <source pages="191-193"/>
-    <quality>korrektur1,kilde,side</quality>
+    <quality>korrektur1,korrektur2,kilde,side</quality>
 </head>
 <body>
 <prose>
@@ -7533,12 +7533,12 @@ Digternes Prydelse, - de danske Hjerters Næring og bedste Nydelse, - Christian 
 <head>
    <title>Til Isak Sidenius</title>
    <subtitle>Med Bogen ,,Digte af Emil Aarestrup''.</subtitle>
-   <quality>korrektur1,kilde,side</quality>
+   <quality>korrektur1,korrektur2,kilde,side</quality>
    <source pages="193-195"/>
 </head>
 <body>
 <prose>
-    Kjære værslevske Venner! - Tag af mine Hænder - det, som I kjender, - den lille Gnist af Digterild, som brænder - ihvordan jeg mig ender og vender, - hvordan i Aaget man ogsaa mig spænder, - hvor haard end Nødden er under mine Tænder, - modtag disse Blade, jeg sender; - de muddrede, - pluddrede, - forkluddrede - har I ingen Andeel i; men desmere i de hjertelige, - vellystsmertelige, - hyggelige, - ikke altfor vederstyggelige, - kortsagt heldige og lykkelige. - Lad disse Blade kalde tilbage, - Venner, de henrundne Dage, - da jeg drak i Eders Huus - af det gjæstfrie Kruus, - tog mig en Priis, Isak, af dit Snuus, - og da Din Thrine dækked mig Disken, - med Fuglen og Fisken, - med Kniv og Gaffel, - med Viin og Karaffel, - Syltetøi og Vaffel, - og Eders Vittighed lyste over det landlige Taffel. - Lad disse Blade kalde tilbage - de henrundne Dage, - da Munterhed og Skrantenhed, - Glæde og Vrantenhed, - Overgivenhed og Trøstighed, - Hengivenhed og Lystighed, - Gebursdagsl'homberen og Onsdagswisthen, - Jordbærret paa Ranken og Abrikosen paa Qvisten, - Paaskeæget og Julegrøden, - Maaneskinnet og Aftenrøden, - hvert Skud, hvori vi forgrenede, - hver Glut, som Gud os forlehnede, - os meer og meer forenede. - Lad disse Blade kalde tilbage - de henrundne Dage, - samle - det Gamle, - fæste - det Næste, - gjæste - det Nye og hvad endnu kan reste, - samt anbefale mig paa det Bedste - til alle nordsjællandske Præstekoner og Præste. - Vi leve her som I sagtens kan tænke, - som en Hund i sin Lænke, - en Fugl i sit Buur, - vor hele Opmuntring er den gamle Madam Suhr. - Det fyger - og ryger, - knærker - og værker, - hvæser - og blæser; - istedenfor at leve, jeg læser; - Brændet er vaadt, - Tørven lugter ikke godt, - Brødet raat, - Melkefadet blaat, - Børnenes Næser fulde af -; - Alle Blade ere faldne af Rosen; - Posekiggerne føle paa Posen; - Tiggerunger løbe omkring med Lasen - om Hasen; - vores Præst er ikke engang en Æsel, men et Asen, - og Byfogdens nye Seletøi hele Julestadsen. - Men Du, Gudværelovet, - er lykkelig med dit overgivne Thrine, - mere vant til Børn, end til Mavepine; - Din nye Frøken, - der, hvis du har glemt det, kan lære Dig Brøken; - Faster - i Sengens varme Plaster; - Hanne - med den kloge Pande; - Nicoline og Emilie - den ene en Conchilie - den anden en Lilie; - Rasmus og Mølle - en Prygl og en Kølle; - Jacobus, - der studerer paa sin Globus; - og endnu mange, - som ikke mine Riim kan lange. - Ja, Du er lykkelig, - det siger jeg udtrykkelig, - og Han, som gjorde Dig Marken grødende, - Svinet fødende, - Dit Hjerte elskeligt og glødende, - Han vogte og bevare, - med sine Engles Jule- og Nytaarsskare - Dig og Dine, - saavelsom mig og mine; - Han i det nye Aar os lette, - hvad vi skal bære, som han har gjort i dette; - Han knytte med sin Haand - uopløseligen vore Venskabsbaand, - og blæse paa os med sin Aand!
+    Kjære værslevske Venner! - Tag af mine Hænder - det, som I kjender, - den lille Gnist af Digterild, som brænder - ihvordan jeg mig ender og vender, - hvordan i Aaget man ogsaa mig spænder, - hvor haard end Nødden er under mine Tænder, - modtag disse Blade, jeg sender; - de muddrede, - pluddrede, - forkluddrede - har I ingen Andeel i; men desmere i de hjertelige, - lystigsmertelige, - hyggelige, - ikke altfor vederstyggelige, - kortsagt heldige og lykkelige. - Lad disse Blade kalde tilbage, - Venner, de henrundne Dage, - da jeg drak i Eders Huus - af det gjæstfrie Kruus, - tog mig en Priis, Isak, af dit Snuus, - og da Din Thrine dækked mig Disken, - med Fuglen og Fisken, - med Kniv og Gaffel, - med Viin og Karaffel, - Syltetøi og Vaffel, - og Eders Vittighed lyste over det landlige Taffel. - Lad disse Blade kalde tilbage - de henrundne Dage, - da Munterhed og Skrantenhed, - Glæde og Vrantenhed, - Overgivenhed og Trøstighed, - Hengivenhed og Lystighed, - Gebursdagsl'homberen og Onsdagswisthen, - Jordbærret paa Ranken og Abrikosen paa Qvisten, - Paaskeæget og Julegrøden, - Maaneskinnet og Aftenrøden, - hvert Skud, hvori vi forgrenede, - hver Glut, som Gud os forlehnede, - os meer og mere forenede. - Lad disse Blade kalde tilbage - de henrundne Dage, - samle - det Gamle, - fæste - det Næste, - gjæste - det Nye og hvad endnu kan reste, - samt anbefale mig paa det Bedste - til alle nordsjællandske Præstekoner og Præste. - Vi leve her som I sagtens kan tænke, - som en Hund i sin Lænke, - en Fugl i sit Buur, - vor hele Opmuntring er den gamle Madam Suhr. - Det fyger - og ryger, - knærker - og værker, - hvæser - og blæser; - istedenfor at leve, jeg læser; - Brændet er vaadt, - Tørven lugter ikke godt, - Brødet raat, - Melkefadet blaat, - Børnenes Næser fulde af -; - Alle Blade ere faldne af Rosen; - Posekiggerne føle paa Posen; - Tiggerunger løbe omkring med Lasen - om Hasen; - vores Præst er ikke engang en Æsel, men et Asen, - og Byfogdens nye Seletøi hele Julestadsen. - Men Du, Gudværelovet, - er lykkelig med dit overgivne Thrine, - mere vant til Børn, end til Mavepine; - Din nye Frøken, - der, hvis du har glemt det, kan lære Dig Brøken; - Faster - i Sengens varme Plaster; - Hanne - med den kloge Pande; - Nicoline og Emilie - den ene en Conchilie - den anden en Lilie; - Rasmus og Mølle - en Prygl og en Kølle; - Jacobus, - der studerer paa sin Globus; - og endnu mange, - som ikke mine Riim kan lange. - Ja, Du er lykkelig, - det siger jeg udtrykkelig, - og Han, som gjorde Dig Marken grødende, - Svinet fødende, - Dit Hjerte elskeligt og glødende, - Han vogte og bevare, - med sine Engles Jule- og Nytaarsskare - Dig og Dine, - saavelsom mig og mine; - Han i det nye Aar os lette, - hvad vi skal bære, som han har gjort i dette; - Han knytte med sin Haand - uopløseligen vore Venskabsbaand, - og blæse paa os med sin Aand!
 
 <center><small>Nysted, den 24de December 1837.</small></center>
 </prose>
@@ -7549,7 +7549,7 @@ Digternes Prydelse, - de danske Hjerters Næring og bedste Nydelse, - Christian 
 <head>
     <title>Til Isak Sidenius</title>
     <source pages="195-197"/>
-    <quality>korrektur1,kilde,side</quality>
+    <quality>korrektur1,korrektur2,kilde,side</quality>
 </head>
 <body>
 <prose>
@@ -7565,7 +7565,7 @@ Digternes Prydelse, - de danske Hjerters Næring og bedste Nydelse, - Christian 
 <head>
    <title>Til Baronesse Rosenørn-Lehn paa hendes Fødselsdag</title>
    <subtitle>Den 1ste Januar 1840.</subtitle>
-   <quality>korrektur1,kilde,side</quality>
+   <quality>korrektur1,korrektur2,kilde,side</quality>
    <dates>
        <event>1840-01-01</event>
    </dates>
@@ -7573,7 +7573,7 @@ Digternes Prydelse, - de danske Hjerters Næring og bedste Nydelse, - Christian 
 </head>
 <body>
 <prose>
-    Paa en Dag, der er bestemt Lykønskninger og Foræringer - til Kjærligheds og Hengivenheds følsomme Erklæringer - og skulde være fri for alle kolde Besværinger - for alle Livets destoværre bittre Belæringer - var det Bestemmelsen for dette Blad - naar man skidlte det ad - at det skulde indeholde noget, jeg veed nok hvad - noget moderne æsthetisk - og dog gammeldags ethisk - noget tiltrækkende magnetisk - egentlig poetisk - og om det var muligt virkelig prophetisk - noget, man ikke kunde læse uden at smile - noget, der ikke traf, som en Tordenkile - men hvori dog hørtes Klang af Apollos Pile - noget, der ikke mindede om kritiske File - men om varme Sommerbølger, der ile - og i en yndig Natur indbyde til Hvile. - Det skulde forsvare sin Plads - ved Siden af en Krands og et Blomsterglas - det skulde være tilpas - mellem de udsøgteste Sager - i et Skjønheds-Lager - uden at være anstrængende - paatrængende - eller overhængende - skulde det harmonere - for ikke at sige concurrere - med hvad de fineste Hænder brodere - med hvad taknemlige Hjerter - ved Nattens eensomme Kjerter - have udgrundet - og udfundet - omdisputeret - og udspeculeret - men hvad neppe Nogen før i Dag har udspioneret - det skulde, for at sige det Høieste - og angive Alt paa det Nøieste - paa en af Aarets faureste Feste - passe for den Bedste - det skulde, skjøndt gjennem en Pen, der hører til de strideste, - ikke uskyldighvideste, - tale til den Blideste, - det skulde, skjøndt kommen fra en af de Uregjerligste og Vildeste - ikke saare den Beskedneste og Stilleste - det skulde ønske Held og Lykke - over den, der fortjener alle Glæders Smykke - det skulde vise hen i Tiden - og pege paa Alt ved Siden, - der i skjønne Omflettelser - er fuldt af rige Forjettelser; - det skulde være Billedet af alle Gavers Rundhed - det skulde love Karskhed og Sundhed - det skulde være den sande Veltalenheds Eftertragtelse, - og udtrykke Følelser af Hengivenhed og Høiagtelse. - Det var Fornemmelsen - af hvad det skulde og burde, det var Bestemmelsen, - Maalet, som sattes. - Tilgiv, Fuldførelsen fattes!
+    Paa en Dag, der er bestemt Lykønskninger og Foræringer - til Kjærligheds og Hengivenheds følsomme Erklæringer - og skulde være fri for alle kolde Besværinger - for alle Livets destoværre bittre Belæringer - var det Bestemmelsen for dette Blad - naar man skilte det ad - at det skulde indeholde noget, jeg veed nok hvad - noget moderne æsthetisk - og dog gammeldags ethisk - noget tiltrækkende magnetisk - egentlig poetisk - og om det var muligt virkelig prophetisk - noget, man ikke kunde læse uden at smile - noget, der ikke traf, som en Tordenkile - men hvori dog hørtes Klang af Apollos Pile - noget, der ikke mindede om kritiske File - men om varme Sommerbølger, der ile - og i en yndig Natur indbyde til Hvile. - Det skulde forsvare sin Plads - ved Siden af en Krands og et Blomsterglas - det skulde være tilpas - mellem de udsøgteste Sager - i et Skjønheds-Lager - uden at være anstrængende - paatrængende - eller overhængende - skulde det harmonere - for ikke at sige concurrere - med hvad de fineste Hænder brodere - med hvad taknemlige Hjerter - ved Nattens eensomme Kjerter - have udgrundet - og udfundet - omdisputeret - og udspeculeret - men hvad neppe Nogen før i Dag har udspioneret - det skulde, for at sige det Høieste - og angive Alt paa det Nøieste - paa en af Aarets faureste Feste - passe for den Bedste - det skulde, skjøndt gjennem en Pen, der hører til de strideste, - ikke uskyldighvideste, - tale til den Blideste, - det skulde, skjøndt kommen fra en af de Uregjerligste og Vildeste - ikke saare den Beskedneste og Stilleste - det skulde ønske Held og Lykke - over den, der fortjener alle Glæders Smykke - det skulde vise hen i Tiden - og pege paa Alt ved Siden, - der i skjønne Omflettelser - er fuldt af rige Forjettelser; - det skulde være Billedet af alle Gavers Rundhed - det skulde love Karskhed og Sundhed - det skulde være den sande Veltalenheds Eftertragtelse, - og udtrykke Følelser af Hengivenhed og Høiagtelse. - Det var Fornemmelsen - af hvad det skulde og burde, det var Bestemmelsen, - Maalet, som sattes. - Tilgiv, Fuldførelsen fattes!
 </prose>
 </body>
 </text>
@@ -7597,7 +7597,7 @@ Digternes Prydelse, - de danske Hjerters Næring og bedste Nydelse, - Christian 
         <note>Gendigtning af Hans Aßmann Freiherr von Abschatz: <xref type="translation" poem="abschatz2019120702"/>.</note>
     </notes>
     <source pages="201-202"/>
-    <quality>korrektur1,kilde,side</quality>
+    <quality>korrektur1,korrektur2,kilde,side</quality>
 </head>
 <body>
 <poetry>
@@ -7646,7 +7646,7 @@ Fører et elendigt Liv.
         <note>Gendigtning af »Forget me not«, 1831.</note>
     </notes>
     <source pages="202-203"/>
-    <quality>korrektur1,kilde,side</quality>
+    <quality>korrektur1,korrektur2,kilde,side</quality>
 </head>
 <body>
 <poetry>
@@ -7718,7 +7718,7 @@ Ved et saa sødt Bedrag.
         <note>Gendigtning af Pierre-Jean de Béranger: <xref type="translation" poem="beranger2018110601"/>.</note>
     </notes>
     <source pages="204-205"/>
-    <quality>korrektur1,kilde,side</quality>
+    <quality>korrektur1,korrektur2,kilde,side</quality>
 </head>
 <body>
 <poetry>
@@ -7866,7 +7866,7 @@ Om det var titusind Miil.
         <note>Gendigtning af Lord Byron: <xref type="translation" poem="byron2018120801"/>.</note>
     </notes>
     <source pages="207-226"/>
-    <quality>korrektur1,kilde,side</quality>
+    <quality>korrektur1,korrektur2,kilde,side</quality>
 </head>
 <body>
 <poetry>
@@ -8494,7 +8494,7 @@ Og aldrig meer et Løv sig kruser.
         <note>Gendigtning af Lord Byron: <xref type="translation" poem="byron2018120802"/>.</note>
     </notes>
     <source pages="226-229"/>
-    <quality>korrektur1,kilde,side</quality>
+    <quality>korrektur1,korrektur2,kilde,side</quality>
 </head>
 <body>
 <poetry>
@@ -8648,7 +8648,7 @@ Drik og drukn i Glæde Verden!
         <note>Gendigtning af Allan Cunningham: <xref type="translation" poem="cunningham2019090802"/>.</note>
     </notes>
     <source pages="230-231"/>
-    <quality>korrektur1,kilde,side</quality>
+    <quality>korrektur1,korrektur2,kilde,side</quality>
 </head>
 <body>
 <poetry>
@@ -8701,7 +8701,7 @@ Den kan vort Elskovsblik forstaae.
         <note>Gendigtning af Allan Cunningham: <xref type="translation" poem="cunningham2019090804"/>.</note>
     </notes>
     <source pages="231-232"/>
-    <quality>korrektur1,kilde,side</quality>
+    <quality>korrektur1,korrektur2,kilde,side</quality>
 </head>
 <body>
 <poetry>
@@ -8761,7 +8761,7 @@ Den kjække Hak Humle.
     <toctitle>- Falck: Legende</toctitle>
     <firstline>I Bayerlandet, i Ingolstad</firstline>
     <source pages="233-234"/>
-    <quality>korrektur1,kilde,side</quality>
+    <quality>korrektur1,korrektur2,kilde,side</quality>
 </head>
 <body>
 <poetry>
@@ -8997,7 +8997,7 @@ Saalænge jeg har Lyst.''
       <note>Gendigtning af Goethes <xref type="translation" poem="goethe2018121101"/>.</note>
    </notes>
     <source pages="238-240"/>
-    <quality>korrektur1,kilde,side</quality>
+    <quality>korrektur1,korrektur2,kilde,side</quality>
 </head>
 <body>
 <poetry>
@@ -9084,7 +9084,7 @@ Mit stille Haab, min bange Tro!
     <toctitle>- -: Kirkeklokken</toctitle>
     <firstline>Syng Psalmerne, du liden Dreng!</firstline>
     <source pages="240-241"/>
-    <quality>korrektur1,kilde,side</quality>
+    <quality>korrektur1,korrektur2,kilde,side</quality>
 </head>
 <body>
 <poetry>
@@ -9402,7 +9402,7 @@ For, som Guderne, at sove.
    <notes>
       <note>Oversættelse af Heinrich Heine: <xref type="translation" poem="heine2000082605"/>.</note>
    </notes>
-   <quality>korrektur1,kilde,side</quality>
+   <quality>korrektur1,korrektur2,kilde,side</quality>
    <source pages="246-247"/>
 </head>
 <body>
@@ -9760,7 +9760,7 @@ Gud give, han skjød mig ihjel!
    <title>Vaarnattens Øine, stjerneblaa</title>
    <toctitle>- -: Vaarnattens Øine, stjerneblaa</toctitle>
    <firstline>Vaarnattens Øine, stjerneblaa</firstline>
-   <quality>korrektur1,kilde,side</quality>
+   <quality>korrektur1,korrektur2,kilde,side</quality>
    <notes>
       <note>Gendigtning af Heinrich Heines <xref type="translation" poem="heine2018120905"/>.</note>
    </notes>
@@ -9884,7 +9884,7 @@ Læse med Jubel Himmelordene:
         <note>Gendigtning af Heinrich Heines <xref type="translation" poem="heine2000010801"/>.</note>
     </notes>
     <source pages="255-257"/>
-    <quality>korrektur1,kilde,side</quality>
+    <quality>korrektur1,korrektur2,kilde,side</quality>
 </head>
 <body>
 <poetry>
@@ -9977,7 +9977,7 @@ Dreier sig hele den drukne Verden.
         <note>Gendigtning af Felicia Hemans' <xref type="translation" poem="hemans2019072001"/>.</note>
     </notes>
     <source pages="258"/>
-    <quality>korrektur1,kilde,side</quality>
+    <quality>korrektur1,korrektur2,kilde,side</quality>
 </head>
 <body>
 <poetry>
@@ -10015,7 +10015,7 @@ Hvor er det høie Hav?
         <note>Gendigtning af »Der Muck und die Flue verheirathen sich«.</note>
     </notes>
     <source pages="258-259"/>
-    <quality>korrektur1,kilde,side</quality>
+    <quality>korrektur1,korrektur2,kilde,side</quality>
 </head>
 <body>
 <poetry>
@@ -10058,7 +10058,7 @@ Og snapper dennem baade.
         <note>Gendigtning af Hugos <xref type="translation" poem="hugo20181109"/>.</note>
     </notes>
     <source pages="259-260"/>
-    <quality>korrektur1,kilde,side</quality>
+    <quality>korrektur1,korrektur2,kilde,side</quality>
 </head>
 <body>
 <poetry>
@@ -10102,7 +10102,7 @@ Strakt mod Hjemmet med min Mand?
         <note>Gendigtning af Victor Hugo: <xref type="translation" poem="hugo2018111001"/></note>
     </notes>
     <source pages="260-263"/>
-    <quality>korrektur1,kilde,side</quality>
+    <quality>korrektur1,korrektur2,kilde,side</quality>
 </head>
 <body>
 <poetry>
@@ -10207,13 +10207,13 @@ En Dolk det perlesmukte Skaft.
         <note>Gendigtning af Victor Hugo: <xref type="translation" poem="hugo2018111003"/>.</note>
     </notes>
     <source pages="263-265"/>
-    <quality>korrektur1,kilde,side</quality>
+    <quality>korrektur1,korrektur2,kilde,side</quality>
 </head>
 <body>
 <poetry>
 Jeg drømmer vaagen Dag og Nat, med Feberglød,
     Forgjæves stiger Sukket;
-Min Albaide bar alt længst i Gravens Skjød
+Min Albaide har alt længst i Gravens Skjød
     De brune Øine lukket.
 
 Hun var kun femten Aar, mig tro, mit Liv, min Lyst
@@ -10280,7 +10280,7 @@ Og kan ei samle meer de sønderhugne Led,
         <note>Gendigtning af Vicor Hugo: <xref type="translation" poem="hugo2018111002"/>.</note>
     </notes>
     <source pages="265-266"/>
-    <quality>korrektur1,kilde,side</quality>
+    <quality>korrektur1,korrektur2,kilde,side</quality>
 </head>
 <body>
 <poetry>
@@ -10376,7 +10376,7 @@ Een, een Haand til os af Graven.''
         <note>Gendigtning af Justinus Kerner: <xref type="translation" poem="kerner2018120902"/>.</note>
     </notes>
     <source pages="267-268"/>
-    <quality>korrektur1,kilde,side</quality>
+    <quality>korrektur1,korrektur2,kilde,side</quality>
 </head>
 <body>
 <poetry>
@@ -10427,7 +10427,7 @@ Der græsser Hesten i Maaneskin.
         <note>Gendigtning af Justinus Kerner: <xref type="translation" poem="kerner2018120903"/>.</note>
     </notes>
     <source pages="268-269"/>
-    <quality>korrektur1,kilde,side</quality>
+    <quality>korrektur1,korrektur2,kilde,side</quality>
 </head>
 <body>
 <poetry>
@@ -10682,7 +10682,7 @@ At jeg maa bede: stands dem ikke!
         <note>Gendigtning af Thomas Moore: <xref type="translation" poem="moore2018121001"/>.</note>
     </notes>
     <source pages="273"/>
-    <quality>korrektur1,kilde,side</quality>
+    <quality>korrektur1,korrektur2,kilde,side</quality>
 </head>
 <body>
 <poetry>
@@ -10715,7 +10715,7 @@ Undtagen dem af Himlens Vinde?
         <note>Gendigtning af Thomas Moore: <xref type="translation" poem="moore2018121002"/>.</note>
     </notes>
     <source pages="274"/>
-    <quality>korrektur1,kilde,side</quality>
+    <quality>korrektur1,korrektur2,kilde,side</quality>
 </head>
 <body>
 <poetry>
@@ -10751,7 +10751,7 @@ Saa sødt, som de har skuffet mig.
         <note>Gendigtning af Thomas Moore: <xref type="translation" poem="moore2018111204"/>.</note>
     </notes>
     <source pages="274-276"/>
-    <quality>korrektur1,kilde,side</quality>
+    <quality>korrektur1,korrektur2,kilde,side</quality>
 </head>
 <body>
 <poetry>
@@ -10819,7 +10819,7 @@ O, Cara! er der Tegn til Liv?
         <note>Gendigtning af Thomas Moore: <xref type="translation" poem="moore2018121003"/>.</note>
     </notes>
     <source pages="276"/>
-    <quality>korrektur1,kilde,side</quality>
+    <quality>korrektur1,korrektur2,kilde,side</quality>
 </head>
 <body>
 <poetry>
@@ -10855,7 +10855,7 @@ At være Sjælen, som ei skill's fra dig!''
         <note>Gendigtning af Thomas Moore: <xref type="translation" poem="moore2018111207"/>.</note>
     </notes>
     <source pages="277-278"/>
-    <quality>korrektur1,kilde,side</quality>
+    <quality>korrektur1,korrektur2,kilde,side</quality>
 </head>
 <body>
 <poetry>
@@ -10921,7 +10921,7 @@ Og roe deres hvide Kanoe.
         <note>Gendigtning af Thomas Moore: <xref type="translation" poem="moore2018111205"/>.</note>
     </notes>
     <source pages="278-279"/>
-    <quality>korrektur1,kilde,side</quality>
+    <quality>korrektur1,korrektur2,kilde,side</quality>
 </head>
 <body>
 <poetry>
@@ -11017,7 +11017,7 @@ Du har jo lært mig det i Mørke!''
         <note>Gendigtning af Thomas Moore: <xref type="translation" poem="moore2018121004"/>.</note>
     </notes>
     <source pages="280-281"/>
-    <quality>korrektur1,kilde,side</quality>
+    <quality>korrektur1,korrektur2,kilde,side</quality>
 </head>
 <body>
 <poetry>
@@ -11074,7 +11074,7 @@ Med eet: o Gud tilgive dig!
         <note>Gendigtning af Thomas Moore: <xref type="translation" poem="moore2018121005"/>.</note>
     </notes>
     <source pages="282-283"/>
-    <quality>korrektur1,kilde,side</quality>
+    <quality>korrektur1,korrektur2,kilde,side</quality>
 </head>
 <body>
 <poetry>
@@ -11127,7 +11127,7 @@ Saasnart han siger Sandhed til dig!
         <note>Gendigtning af Thomas Moore: <xref type="translation" poem="moore2018121015"/>.</note>
     </notes>
     <source pages="283"/>
-    <quality>korrektur1,kilde,side</quality>
+    <quality>korrektur1,korrektur2,kilde,side</quality>
 </head>
 <body>
 <poetry>
@@ -11165,7 +11165,7 @@ End duftende Roser og selv dine Kys!
         <note>Gendigtning af Thomas Moore: <xref type="translation" poem="moore2018111208"/>.</note>
     </notes>
     <source pages="284-285"/>
-    <quality>korrektur1,kilde,side</quality>
+    <quality>korrektur1,korrektur2,kilde,side</quality>
 </head>
 <body>
 <poetry>
@@ -11216,7 +11216,7 @@ Skulde just sige Nei til sin Beiler - o Fanny!
         <note>Gendigtning af Thomas Moore: <xref type="translation" poem="moore2018121006"/>.</note>
     </notes>
     <source pages="285-286"/>
-    <quality>korrektur1,kilde,side</quality>
+    <quality>korrektur1,korrektur2,kilde,side</quality>
 </head>
 <body>
 <poetry>
@@ -11260,7 +11260,7 @@ Men gjem blot Taarerne til mig!
         <note>Gendigtning af Thomas Moore: <xref type="translation" poem="moore2018121007"/>.</note>
     </notes>
     <source pages="286"/>
-    <quality>korrektur1,kilde,side</quality>
+    <quality>korrektur1,korrektur2,kilde,side</quality>
 </head>
 <body>
 <poetry>
@@ -11339,7 +11339,7 @@ Eet Himmellegeme mere, du!
         <note>Oversættelse af Thomas Moore: <xref type="translation" poem="moore2018121008"/>.</note>
     </notes>
     <source pages="287-288"/>
-    <quality>korrektur1,kilde,side</quality>
+    <quality>korrektur1,korrektur2,kilde,side</quality>
 </head>
 <body>
 <poetry>
@@ -11375,7 +11375,7 @@ Før jaged Ingen der.
         <note>Oversættelse af Thomas Moore: <xref type="translation" poem="moore2018121009"/>.</note>
     </notes>
     <source pages="288"/>
-    <quality>korrektur1,kilde,side</quality>
+    <quality>korrektur1,korrektur2,kilde,side</quality>
 </head>
 <body>
 <poetry>
@@ -11407,7 +11407,7 @@ Være hos dig! Hvis Forandring,
         <note>Oversættelse af Thomas Moore: <xref type="translation" poem="moore2018121010"/>.</note>
     </notes>
     <source pages="289"/>
-    <quality>korrektur1,kilde,side</quality>
+    <quality>korrektur1,korrektur2,kilde,side</quality>
 </head>
 <body>
 <poetry>
@@ -11443,7 +11443,7 @@ Hvem sukker for Gamle, naar Unge kan faaes?
         <note>Oversættelse af Thomas Moore: <xref type="translation" poem="moore2018121011"/>.</note>
     </notes>
     <source pages="289-290"/>
-    <quality>korrektur1,kilde,side</quality>
+    <quality>korrektur1,korrektur2,kilde,side</quality>
 </head>
 <body>
 <poetry>
@@ -11451,7 +11451,7 @@ O havde jeg bare Tid dertil,
 Fanny kjære! saa sukkede jeg,
 Og hvert et Smiil, al Øiets Ild
 Det blev til Graad for dig.
-Mcd Elskov, Slummer og Skjemt
+Med Elskov, Slummer og Skjemt
 Mit Liv er saa occupeert,
 At Timen, til Graaden bestemt,
 Har altid mit Hjerte geneert.
@@ -11487,7 +11487,7 @@ Regn gjør det mindre endnu.
         <note>Oversættelse af Thomas Moore: <xref type="translation" poem="moore2018121012"/>.</note>
     </notes>
     <source pages="290"/>
-    <quality>korrektur1,kilde,side</quality>
+    <quality>korrektur1,korrektur2,kilde,side</quality>
 </head>
 <body>
 <poetry>
@@ -11515,7 +11515,7 @@ Som Dag og Nat for Damernes, hvad var for Engle vi!
         <note>Oversættelse af Thomas Moore: <xref type="translation" poem="moore2018121101"/>.</note>
     </notes>
     <source pages="291"/>
-    <quality>korrektur1,kilde,side</quality>
+    <quality>korrektur1,korrektur2,kilde,side</quality>
 </head>
 <body>
 <poetry>
@@ -11559,7 +11559,7 @@ Naar det er sødest, døer det.
         <note>Oversættelse af Thomas Moore: <xref type="translation" poem="moore2018121102"/>.</note>
     </notes>
     <source pages="292"/>
-    <quality>korrektur1,kilde,side</quality>
+    <quality>korrektur1,korrektur2,kilde,side</quality>
 </head>
 <body>
 <poetry>
@@ -11608,7 +11608,7 @@ Langt mere end hans egen den klædte ham godt.
         <note>Oversættelse af Thomas Moore: <xref type="translation" poem="moore2018121103"/>.</note>
     </notes>
     <source pages="293"/>
-    <quality>korrektur1,kilde,side</quality>
+    <quality>korrektur1,korrektur2,kilde,side</quality>
 </head>
 <body>
 <poetry>
@@ -11651,7 +11651,7 @@ Og nød som sin hver Frugt.
    <notes>
       <note>Oversættelse af Thomas Moore: <xref type="translation" poem="moore2000082950"/>.</note>
    </notes>
-   <quality>korrektur1,kilde,side</quality>
+   <quality>korrektur1,korrektur2,kilde,side</quality>
    <source pages="294"/>
 </head>
 <body>
@@ -11660,7 +11660,7 @@ I Midnattens Time, ved Stjernegraad vil jeg gaae
 Til den Dal, vi elskte, hvis Løndom Dig lykkelig saae
 Og jeg troer, hvis Aander kan undfly, komme os nær
 Erindrende Stedet for Glæde, saa kommer du der
-At sige mig: Elskov er til, selv bah Himlens Blaa
+At sige mig: Elskov er til, selv bag Himlens Blaa
 
 Og jeg synger den Sang som henreev os, dengang
 Vore Stemmers forenede Røst som een Stemme klang
@@ -11681,7 +11681,7 @@ Istemmende svagt den eengang saa elskede Sang.
    <notes>
       <note>Oversættelse af Thomas Moore: <xref type="translation" poem="moore2000082956"/>.</note>
    </notes>
-   <quality>korrektur1,kilde,side</quality>
+   <quality>korrektur1,korrektur2,kilde,side</quality>
    <source pages="294-295"/>
 </head>
 <body>
@@ -11722,7 +11722,7 @@ Og som Natten vor Død nærmes hellig og mild.
         <note>Oversættelse af Thomas Moore: <xref type="translation" poem="moore2000082932"/>.</note>
     </notes>
     <source pages="295-296"/>
-    <quality>korrektur1,kilde,side</quality>
+    <quality>korrektur1,korrektur2,kilde,side</quality>
 </head>
 <body>
 <poetry>
@@ -11766,7 +11766,7 @@ Har at elske de Læber, som komme os nær!
    <notes>
       <note>Oversættelse af Thomas Moore: <xref type="translation" poem="moore2000082940"/>.</note>
    </notes>
-   <quality>korrektur1,kilde,side</quality>
+   <quality>korrektur1,korrektur2,kilde,side</quality>
    <source pages="296-297"/>
 </head>
 <body>
@@ -11789,7 +11789,7 @@ Lesbia klæder sig i Guld
 Men hendes Lemmer er forklemte
 Intet Fyld af Skjønheds Huld
 Synes at staae hvor Gud bestemte
-O min Noras Dragt et let
+O min Noras Dragt er let
 Den flagrer hen som Morgenduften
 Giver hver en Skjønhed Ret
 At synke, svulme frit i Luften
@@ -11827,7 +11827,7 @@ Som varmer dine Blik, o Nora Creina.
       <note>Oversættelse af Thomas Moore: <xref type="translation" poem="moore2018111301"/>.</note>
     </notes>
     <source pages="297-299"/>
-    <quality>korrektur1,kilde,side</quality>
+    <quality>korrektur1,korrektur2,kilde,side</quality>
 </head>
 <body>
 <poetry>
@@ -11899,7 +11899,7 @@ Til Bod er jeg svøbt i dit Haar.
         <note>Oversættelse af Thomas Moore: <xref type="translation" poem="moore2018121104"/>.</note>
     </notes>
     <source pages="299-300"/>
-    <quality>korrektur1,kilde,side</quality>
+    <quality>korrektur1,korrektur2,kilde,side</quality>
 </head>
 <body>
 <poetry>
@@ -12053,7 +12053,7 @@ End hører jeg det suse:
         <note>Gendigtning af Rückert: <xref type="translation" poem="rueckert2018111401"/> in: <i>Brahmanishe Erzählungen</i> (1839).</note>
     </notes>
     <source pages="302-303"/>
-    <quality>korrektur1,kilde,side</quality>
+    <quality>korrektur1,korrektur2,kilde,side</quality>
 </head>
 <body>
 <poetry>
@@ -12116,7 +12116,7 @@ Naar, om ei Mennesker, saa Dyrene dog klage.
         <note>Gendigtning af Rückert: <xref type="translation" poem="rueckert2018121101"/> in: <i>Brahmanishe Erzählungen</i> (1839).</note>
     </notes>
     <source pages="304-305"/>
-    <quality>korrektur1,kilde,side</quality>
+    <quality>korrektur1,korrektur2,kilde,side</quality>
 </head>
 <body>
 <poetry>
@@ -12170,7 +12170,7 @@ Og gift med En, der føder mig en saadan Glut.''
         <note>Gendigtning af Rückert: <xref type="translation" poem="rueckert2018121102"/>.</note>
     </notes>
     <source pages="305-306"/>
-    <quality>korrektur1,kilde,side</quality>
+    <quality>korrektur1,korrektur2,kilde,side</quality>
 </head>
 <body>
 <poetry>
@@ -12351,7 +12351,7 @@ Seer den fra sin Sky.
         <note>Gendigtning af Rückert: <xref type="translation" poem="rueckert2018121104"/>.</note>
     </notes>
     <source pages="309-311"/>
-    <quality>korrektur1,kilde,side</quality>
+    <quality>korrektur1,korrektur2,kilde,side</quality>
 </head>
 <body>
 <poetry>
@@ -12439,7 +12439,7 @@ Glad ved Livet, uden Frygt.''''
         <note>Gendigtning af Rückert: <xref type="translation" poem="rueckert2018121105"/>.</note>
     </notes>
     <source pages="311-312"/>
-    <quality>korrektur1,kilde,side</quality>
+    <quality>korrektur1,korrektur2,kilde,side</quality>
 </head>
 <body>
 <poetry>
@@ -12517,7 +12517,7 @@ Hvis ikke, bliv ude!
         <note>Gendigtning af Friedrich von Sallet: <xref type="translation" poem="sallet2019090801"/>.</note>
     </notes>
     <source pages="313"/>
-    <quality>korrektur1,kilde,side</quality>
+    <quality>korrektur1,korrektur2,kilde,side</quality>
 </head>
 <body>
 <poetry>
@@ -12555,7 +12555,7 @@ Har dræbt en enkelt Nattergal.
         <note>Gendigtning af Friedrich von Sallet: <xref type="translation" poem="sallet2019090802"/>.</note>
     </notes>
     <source pages="313-315"/>
-    <quality>korrektur1,kilde,side</quality>
+    <quality>korrektur1,korrektur2,kilde,side</quality>
 </head>
 <body>
 <poetry>
@@ -12624,7 +12624,7 @@ Tilsidst maa det dog fremad rykke:
         <note>Gendigtning af Charles Sprague: <xref type="translation" poem="sprague2018111101"/>.</note>
     </notes>
     <source pages="315-316"/>
-    <quality>korrektur1,kilde,side</quality>
+    <quality>korrektur1,korrektur2,kilde,side</quality>
 </head>
 <body>
 <poetry>
@@ -12679,7 +12679,7 @@ Tilbede kun Naturens Gud.
     <toctitle>- Johan Vogl: Serenaden</toctitle>
     <firstline>Donna Laura, Donna Laura!</firstline>
     <source pages="316-318"/>
-    <quality>korrektur1,kilde,side</quality>
+    <quality>korrektur1,korrektur2,kilde,side</quality>
 </head>
 <body>
 <poetry>
@@ -12762,7 +12762,7 @@ Gaae paa Gangene og lytte.
         <note unknown-original-by="waiblinger" />
     </notes>
     <source pages="318-320"/>
-    <quality>korrektur1,kilde,side</quality>
+    <quality>korrektur1,korrektur2,kilde,side</quality>
 </head>
 <body>
 <poetry>
@@ -12803,7 +12803,7 @@ Hvem veed, var det Længsel eller Sult!
 
 O, vi hinanden saa godt forstode;
 At vi elskedes, kan man let formode.
-Man har jo ei samme Død og Skik,
+Man har jo ei samme Dyd og Skik,
 Een mangler hvad den Anden fik.
 
 Til min Yngling havde jeg ham kaaret;
@@ -12935,7 +12935,7 @@ Som før: ,,,,Nei, vi er Syv!''''
         <note>Gendigtning af Joseph Christian von Zedlitz: <xref type="translation" poem="zedlitz2019120701"/>.</note>
     </notes>
     <source pages="323-325"/>
-    <quality>korrektur1,kilde,side</quality>
+    <quality>korrektur1,korrektur2,kilde,side</quality>
 </head>
 <body>
 <poetry>
@@ -13026,7 +13026,7 @@ Ved Midnatstid i Byen.
     <subtitle>(Tydsk Folkevise)</subtitle>
     <firstline>Nu kommen er min Sørgetid</firstline>
     <source pages="325-326"/>
-    <quality>korrektur1,kilde,side</quality>
+    <quality>korrektur1,korrektur2,kilde,side</quality>
 </head>
 <body>
 <poetry>
@@ -13047,7 +13047,7 @@ Lysthauge i det Fjerne.
 
 Paa Glimmer og paa Funker hang
 Min Hauge let i Lunden,
-Og da jeg traadte mig derind -
+Og da jeg traadte tryg derind -
 Som Moselys forsvunden.
 
 Gud give, at jeg blot var død
@@ -13078,7 +13078,7 @@ Saa heed, saa strid af Smerte.
         <note unknown-original-by="daumer" />
     </notes>
     <source pages="326-333"/>
-    <quality>korrektur1,kilde,side</quality>
+    <quality>korrektur1,korrektur2,kilde,side</quality>
 </head>
 <body>
 <poetry>
@@ -13363,7 +13363,7 @@ Min Hvile - o hvor fri og stolt!
         <note unknown-original-by="daumer" />
     </notes>
     <source pages="333-335"/>
-    <quality>korrektur1,kilde,side</quality>
+    <quality>korrektur1,korrektur2,kilde,side</quality>
 </head>
 <body>
 <poetry>
@@ -13440,7 +13440,7 @@ Engang i hede Helvede.
         <note>Disse tekster er i Samlede Skrifter, 1976, samlet i <xref poem="aarestrup2019021110"/> og altså ikke tilhørende det gamle testamente.</note>
     </notes>
     <source pages="335-336"/>
-    <quality>korrektur1,kilde,side</quality>
+    <quality>korrektur1,korrektur2,kilde,side</quality>
 </head>
 <body>
 <poetry>
@@ -13517,7 +13517,7 @@ Fordoblet dine Dage.
 Paa denne Tid, da Kongevælde
 Tidt stævnes ind for Dommerskranken,
 Vil jeg et Træk af den fortælle,
-Det falder mig just nu i Tanken.
+Der falder mig just nu i Tanken.
 
 Et tusind Aar og noget mere,
 Efter at Jesus Christ fik Livet,
@@ -13650,7 +13650,7 @@ Kun mine egne Sønner prøved
 Paa Sligt - det fuldt og fast jeg troede.
 
 Og for at ei Barmhjertigheden
-Retfærdigen skulde krænke,
+Retfærdigheden skulde krænke,
 Saa slukked Lyset jeg i Vreden,
 Og Blodet - hvis det var - lod stænke.
 
@@ -13687,12 +13687,12 @@ Maanskinscabinettet samle.
 I de bløde Lænestole
 Damerne med Atlasslæbet,
 Blændende sig atter kaste,
-Munden smiler rosenlæbet.
+Munden smiler, rosenlæbet.
 
-Ridderen, som fra Tapetet
+Ridderne, som paa Tapetet
 Knapt om Dagen man kan mærke,
 Læne sig til Stoleryggen,
-Brune, skjæggede og stjærk.
+Brune, skjæggede og stærke.
 
 Gjennem Buevindvet glimre
 De forgyldte Instrumenter;
@@ -13701,8 +13701,8 @@ Over støvede Tangenter.
 
 Klang fra de forsvundne Tider,
 O vidunderlig at høre!
-Gammedags Galanterier
-Hviskes i et yndigt Øre.
+Gammeldags Galanterier
+Hvidskes i et yndigt Øre.
 
 Næsten kunde man misunde
 Dette Skyggeliv, hvis ikke -
@@ -13719,7 +13719,7 @@ Spøgelser kan ei fremtræde!
 Ja, i Mindets Dæmringstime
 Lever op den gamle Glæde.
 
-Mange lyse Nætter, fulde
+Mange lyse Sjæle-Nætter
 Med en yndig Gjenfærdsvrimmel
 Ønsker jeg en ung Veninde:
 Ret en fuld Erindringshimmel.

--- a/fdirs/aarestrup/1976-1.xml
+++ b/fdirs/aarestrup/1976-1.xml
@@ -106,7 +106,7 @@ Saa iled han hurtig i bælmørke Nat
    Ung <sc>Fulda</sc> at fæste.
 
 <num>XVI</num>Da Solen stod høit, i hvælved Capel
-   Da Bryllup mon stande,
+   Det Bryllup mon stande,
 De Riddersmænd ønsked ham alle godt Hæld
    Og Lykke for sande.
 
@@ -410,7 +410,7 @@ Naar af det rygende Svælg Ildsluen flammende staaer,
 Mod din giftsvangre Natsjæl! - Hæv kun dit dødkolde Iisspyd!
 Drag i din Vælde kun frem! ha, men jeg trodser din Magt!
 Phøibos Apollon, du Straalende! høit anraaber din Søn dig,
-Ei om at fylde hans Sjæl mægtigt med Sangdriftens Ild,
+Ei om at fylde hans Sjæl mægtig med Sangdriftens Ild,
 Ei om at stemme hans Luth til sødthensmeltende Samklang;
 Nei! om din kraftige Bistand Frostkjempen brat at betvinge;
 Du kan kun fængsle hans Arm, grusom han leer af mit Mod. -
@@ -448,7 +448,7 @@ Hæv, kjælne Cither, hæv din Røst!
 <num>II</num>Ak, Lina, hør min stille Sang!
 En bange Hilsen den dig bringer;
 Tung er af Graad de lette Vinger,
-Som fordum den mod Hilmen svang.
+Som fordum den mod Himlen svang.
 
 <num>III</num>Forgjængeligheds blege Glød
 Nu Midnats kolde Møe omfatter;
@@ -487,7 +487,7 @@ Sin blanke Vogn paa Skyens Vei!
 
 <num>X</num>Den kommer med sit Brudeblus,
 Den troer - ak! at i Linas Kammer
-For mig et kjærligt Hjerter flammer;
+For mig et kjærligt Hjerte flammer;
 Fly, Maane, fly! og sluk dit Blus!
 
 <num>XI</num>Vel Farven svandt, og Gittret svandt,
@@ -527,7 +527,7 @@ Sukked i snehvide Dragt.
 
     <num>III</num>Thi mulmsort Nat
     Og Vinterkuld,
-    Det nøgle Krat
+    Det nøgne Krat
     Af Snee saa fuld
 Til Jomfruen beiled saa lidet huld.
 
@@ -562,7 +562,7 @@ Nu slynger om hende, i landlig Dands,
 I Græsset, Violer at sanke,
 Hører hvad Sangeren spaaer:
     Hvert muntert Sind,
-    Hver Rosenkund
+    Hver Rosenkind
 Fanger en Brudgom i Aar,
 Skjøn som den blomstrende Vaar!
 
@@ -652,7 +652,7 @@ Mit Valdhorns Røst i dunkle Lund:
 Hvorfor skal jeg vel sørge, hvorfor græde,
 At Elskte ei den søde Lue kjender,
 Som længst alt i mit unge Hjerte brænder,
-Og min blege Digte rosenklæde?
+Og mine blege Digte rosenklæde?
 
 Hvorfor skal jeg vel sørge, hvorfor græde,
 At hun sit Stjerneblik fra mig bortvender,
@@ -893,7 +893,7 @@ Fremlyste Dagen brat.
 <num>XXXVI</num>Guldklokken høit fra Taarnet klang,
 En Stork derhen sig svang;
 De blanke Mure skinned,
-De høie Port opsprang.
+Den høie Port opsprang.
 
 <num>XXXVII</num>Glammed bidske Hunde høit,
 Stamped stolten Hest;
@@ -1028,7 +1028,7 @@ Kunde dog vel sagtens vide,
 Hendes Sanger maatte fatte,
 Hvad det hulde Øie siger -
 Kjære Hanne! glad og ærlig
-Dig jeg rækker Sommenrosen,
+Dig jeg rækker Sommerrosen,
 Fuld af Ømhed, rød af Sang.
 
    ---
@@ -1050,7 +1050,7 @@ Dog jo ei at give nogen.''
 Stille, stille, søde Musa!
 Hvem du Rosen undte, veed jeg.
 Hende vil jeg Stenglen give,
-Tornet vil, men frisk og haabgrøn.
+Tornet vel, men frisk og haabgrøn.
 Hun vil Gaven venlig tage,
 For at stille Sorgen din,
 Og din Sangers Ønske er, at
@@ -1060,7 +1060,7 @@ Ret den Kjære saare maae.
    ---
 
 Understærke Troldomstraade
-Om min Sjæl sit Næt udspeder.
+Om min Sjæl sit Næt udspænder.
 Sødt dit Navn i Sangens Kilder
 Vinker mig med mørke Gaader;
 Lige Alder Engen smykked
@@ -1268,7 +1268,7 @@ Og sin Skjødhund Vilhelmine,
 Gjertrud, ak, sin Pavian,
 Og sin lille Kat Nanette,
 Saa maaskee den smaae Rosette
-Dog din Frier elske kan!
+Dog sin Frier elske kan!
 </poetry>
 </body>
 </text>
@@ -1325,7 +1325,7 @@ Den heller intet af! -
 Man bandt den Hellige paa Ryggen sine Hænder,
 og hugged saa hans Hoved af;
 Hør nu, min Ven, hvad sig begav:
-Han tog det op og trykket det til Brystet -
+Han tog det op og trykked det til Brystet -
 ,,Hvorledes? med Hænderne paa Ryggen?''
 Ak nei! et Barn kan det begribe:
 Han tog det op med sine Tænder!
@@ -1348,7 +1348,7 @@ Raad <sc>Wilm</sc> i sine Breve sender meget Sand,
 Som Rigsforretningshjulet vilde staae paa Stand,
 Hvis han dem Tid at tørres gav;
 O Forfængeligheds Bedrag!
-Hans Breve ere af Natur tørre.
+Hans Breve ere af Naturen tørre.
 </poetry>
 </body>
 </text>
@@ -1358,7 +1358,7 @@ Hans Breve ere af Natur tørre.
 <head>
     <title>Paakaldelse</title>
     <firstline>Melpomene, er det dig, som</firstline>
-    <quality>korrektur1,kilde,side</quality>
+    <quality>korrektur1,korrektur2,kilde,side</quality>
     <source pages="48"/>
 </head>
 <body>
@@ -1389,7 +1389,7 @@ Englen ligger nyefødt der! -
 <head>
     <title>Idyll</title>
     <firstline>Rask om Hjørnehuset, som gynger i Solen sit Jernskjold</firstline>
-    <quality>korrektur1,kilde,side</quality>
+    <quality>korrektur1,korrektur2,kilde,side</quality>
     <source pages="49-54"/>
 </head>
 <body>
@@ -1441,7 +1441,7 @@ Lister paa Tæerne sig bagom den snakkende Landglut,
 Favner det smekkre Liv, og trykker paa Munden et Saftkys.
 Nu ere Pigerne færdig til Farten; de ile til Døren.
 Ane, den smilkende Kudsk, alt sidder med Tømmen og Pidsken;
-Derpaa Jomfru Johanne let Vognstigen betræder,
+Derpaa Jomfru Johanne let Vognstigen træder,
 Svinger sig ind, opklapper med Haanden de stoppede Hynder,
 Glatter sig Klæderne ned, af Frygt for hæslige Folder.
 Ei et Under, at hun er Husets og Faderens Afgud!
@@ -1472,7 +1472,7 @@ Tæt til Vesten af Hvergarn, der prydes med Perlemorsknapper,
 Holder han Solbærflasken, bestemt for den gamle Jens Peersen,
 Og paa det vaadtnedkjæmmede Haar, stolt prunker Kasketten,
 Lysblaa, med en Dusk, om Skyggen en glindsende Sølvrand.
-Vognen rasler af sted; hvor Glutterne hilse og nikke!
+Vognen rasler afsted; hvor Glutterne hilse og nikke!
 Faderen lænet til Gadedørsstolpen, sin Nathue løfter.
 Men paa Hjørnet endnu maae Hestene standse, thi Pigen,
 Sendt fra forsigtige Moer, dem bringer et Klæde, som Drengen
@@ -1487,7 +1487,7 @@ Dundrende rulle de bort - Gud glæde dem alle paa Landet!
 <head>
     <title>Vinvela</title>
     <firstline>Hvor hviler, hvor hviler den faure Svend?</firstline>
-    <quality>korrektur1,kilde,side</quality>
+    <quality>korrektur1,korrektur2,kilde,side</quality>
     <source pages="55-58"/>
 </head>
 <body>
@@ -1629,7 +1629,7 @@ Og Taarerne var den eneste Brøde.
 
 O lader os stræbe i Daad og i Sang
 At vorde et Barn af dybere Klang,
-Skjøndt <i>store</i> vi Synderes <i>større</i> nu har,
+Skjøndt <i>store</i> vi Synderne <i>større</i> nu har,
 Som eengang et lille, uskyldigt vi var!
 </poetry>
 </body>
@@ -1680,7 +1680,7 @@ Ak, din Braad, den gjør dog ondt!
 <poetry>
 Her ruge huuslige Høns, og her Theoriens Kalkuner
 Rolig i Redernes Straa over de elskede Æg;
-Snart utaalmodlge dog blegnebbede Kyllinger pikke
+Snart utaalmodige dog blegnebbede Kyllinger pikke
 Skallens Omgivning itu - Vingerne prøve de vil.
 Ak, men fra Reden til Truget, og atter fra Truget til Reden,
 Dog med Manerer og Pomp, gaaer deres søvnige Gang.
@@ -1762,7 +1762,7 @@ Staaer Poesiens maanedunkle Lære.
 <head>
     <title>Fostbrødrene</title>
     <firstline>Ung Svanhild stander i Borgegaard</firstline>
-    <quality>korrektur1,kilde,side</quality>
+    <quality>korrektur1,korrektur2,kilde,side</quality>
     <source pages="67-76"/>
 </head>
 <body>
@@ -1808,7 +1808,7 @@ Og Skyggerne lured bag Skovens Krat,
 Den Jomfru vandred i Lunden ind,
 Hvor Roser lue i Maaneskin.
 
-Kun Vinden lefled i Eliegrene,
+Kun Vinden lefled i Ellegrene,
 Saa rædsom truede Fjeldets Stene.
 
 Da sad paa Stubbe en rynket Qvinde,
@@ -1826,7 +1826,7 @@ Om Raad og Bistand den Møe hende bad:
 ,,Tidt søgte jeg dig i Skoven her;
 Det Raad er godt, som Sindet har kjær.
 
-Thi sug mig Gamle, ved <sc>Thursers</sc> Liv!
+Thi siig mig Gamle, ved <sc>Thursers</sc> Liv!
 Skal Sol imorgen mig see som Viv?''
 
 I Mørket ud fra dybe Hule
@@ -2008,7 +2008,7 @@ Blegt lyser Maanen et Dødningebeen.
 <head>
     <title>Bakkehulen</title>
     <firstline>Paa Marken ligger en Bakke stor</firstline>
-    <quality>korrektur1,kilde,side</quality>
+    <quality>korrektur1,korrektur2,kilde,side</quality>
     <source pages="77-81"/>
 </head>
 <body>
@@ -2135,7 +2135,7 @@ Sletingen af Gjæsterne kom forsilde!
 <head>
     <title>Syekurven</title>
     <firstline>Mystiske Redskab, som tidt laae henslængt i Ro hos Quitaren</firstline>
-    <quality>korrektur1,kilde,side</quality>
+    <quality>korrektur1,korrektur2,kilde,side</quality>
     <source pages="82-84"/>
 </head>
 <body>
@@ -2190,7 +2190,7 @@ Jagede Fjenden paa Flugt - o det var Kurvens Triumf!
 <head>
     <title>Til den bortreiste</title>
     <firstline>I hvor du ogsaa kjører</firstline>
-    <quality>korrektur1,kilde,side</quality>
+    <quality>korrektur1,korrektur2,kilde,side</quality>
     <source pages="85"/>
 </head>
 <body>
@@ -2231,7 +2231,7 @@ Saa døde jeg af Sorg!
 <head>
     <title>Til Sommerluften</title>
     <firstline>O du blaae Luft! kom du, en venlig Engel</firstline>
-    <quality>korrektur1,kilde,side</quality>
+    <quality>korrektur1,korrektur2,kilde,side</quality>
     <source pages="86"/>
 </head>
 <body>
@@ -2263,7 +2263,7 @@ Hæv da, hæv fromt op mod de klare Egne
 <head>
     <title>Aftensang</title>
     <firstline>Taus er den stille Bye</firstline>
-    <quality>korrektur1,kilde,side</quality>
+    <quality>korrektur1,korrektur2,kilde,side</quality>
     <source pages="87"/>
 </head>
 <body>
@@ -2294,7 +2294,7 @@ Hvo som paa Sorgen bær
 <head>
     <title>Et Epigram</title>
     <firstline>Den gamle B. skjøn Ida monne sit Hjerte skjænke</firstline>
-    <quality>korrektur1,kilde,side</quality>
+    <quality>korrektur1,korrektur2,kilde,side</quality>
     <source pages="88"/>
 </head>
 <body>
@@ -2309,7 +2309,7 @@ Ak stakkels Glut! hvor er hun tidlig bleven Enke! -
 <head>
     <title>Hver sørger for sine</title>
     <firstline>Baronen beiler for sin Søn hos Mine</firstline>
-    <quality>korrektur1,kilde,side</quality>
+    <quality>korrektur1,korrektur2,kilde,side</quality>
     <source pages="88"/>
 </head>
 <body>
@@ -2325,7 +2325,7 @@ Baronen ikke andre Sønner har.
 <head>
     <title>Kaaberne</title>
     <firstline>I fordumstid holdt Konen Joseph fast ved Kaaben</firstline>
-    <quality>korrektur1,kilde,side</quality>
+    <quality>korrektur1,korrektur2,kilde,side</quality>
     <source pages="88"/>
 </head>
 <body>
@@ -2343,7 +2343,7 @@ Selv Konen ind i Kaaben.
 <head>
     <title>Conversation</title>
     <firstline>Du søde Ven, jeg kunde spise dig!</firstline>
-    <quality>korrektur1,kilde,side</quality>
+    <quality>korrektur1,korrektur2,kilde,side</quality>
     <source pages="89"/>
 </head>
 <body>
@@ -2365,7 +2365,7 @@ Jeg længdes efter Kalvesteg.
 <head>
     <title>Ved Evalds Grav</title>
     <firstline>Evald, fromme Genius</firstline>
-    <quality>korrektur1,kilde,side</quality>
+    <quality>korrektur1,korrektur2,kilde,side</quality>
     <source pages="90-91"/>
 </head>
 <body>
@@ -2422,7 +2422,7 @@ Kalder mig til Aftensang!
 <head>
     <title>Naaden!</title>
     <firstline>Hvor er Du Engel, som min Sjæl tilbeder?</firstline>
-    <quality>korrektur1,kilde,side</quality>
+    <quality>korrektur1,korrektur2,kilde,side</quality>
     <keywords>sonnet</keywords>
     <source pages="92"/>
 </head>
@@ -2453,14 +2453,14 @@ Mens Naadens Kys Du giver ham i Døden.
 <head>
     <title>Camilla</title>
     <firstline>Det blæser koldt derude</firstline>
-    <quality>korrektur1,kilde,side</quality>
+    <quality>korrektur1,korrektur2,kilde,side</quality>
     <source pages="93-116"/>
 </head>
 <body>
 <poetry>
 <num>I</num>Det blæser koldt derude,
 Paa Jorden ligger Løvet,
-Gjennem Anden paa min Rude
+Gjennem Aanden paa min Rude
 Seer Skyen ind vemodig og bedrøvet;
 Og da i Sjælen mig nu klart vil blive
 Et Billed, som jeg elsker,
@@ -2599,7 +2599,7 @@ Den røde Sol bag Løvet,
 Mathilde Barnet fritted,
 Om dets Forældre, hvi det stod bedrøvet
 I øde Skov og græd ved Nattetide;
-Men Barnet tang, og intet
+Men Barnet taug, og intet
 De om dets dunkle Skjæbne fik at vide.
 
 <num>XIX</num>Dog da hun skulde sige
@@ -2973,7 +2973,7 @@ Og Sorgen smeltede i Graad fra Øiet.
 <num>LXI</num>Det var mod Aftenstunden,
 Da Gudmund tog sin Cither;
 Alt Maanen var oprunden,
-Og straalte gjennem Klrkegaardens Gitter.
+Og straalte gjennem Kirkegaardens Gitter.
 Mathilde sad hvor fordum sad Camilla,
 Ved Arnens blege Lue;
 Albertus sukked gjennem Aftnens Stille.
@@ -3031,7 +3031,7 @@ Og bad til hendes Ord at laane Øre:
     Stod for hendes stille Ønsker.
     Men til Slaget kaldte Krigens
     Gjaldrende Trompet den Elskte.
-    Sorgfuld! var det slemme Budskab:
+    Sorgfuldt! var det slemme Budskab:
     Død i Kampen er Albertus;
     Graaden blev de skjønne Øines
     Eneste og tro Veninde,
@@ -3083,9 +3083,9 @@ Og bad til hendes Ord at laane Øre:
     Og Elisa pleied Barnet
     Med en Moders ømme Omhu
     I sin Hyttes trange Armod.
-    Blegt var Barnet, lugt den Elskov,
+    Blegt var Barnet, liigt den Elskov,
     Som det Livet havde skjænket,
-    O men skjønt som Kj ærligheden,
+    O men skjønt som Kjærligheden,
     Der endnu i Mindets Drømme
     Trøstede den arme Moder. -
     Ak, men grumt Orkaner rase,
@@ -3152,7 +3152,7 @@ De gav ham rørte deres fromme Hænder.
 <head>
     <title>Til min Lyra</title>
     <firstline>Elskte Lyra, du min Sorgs Veninde</firstline>
-    <quality>korrektur1,kilde,side</quality>
+    <quality>korrektur1,korrektur2,kilde,side</quality>
     <source pages="117"/>
 </head>
 <body>
@@ -3179,7 +3179,7 @@ I Sangens Have.
 <head>
     <title>Jesus paa Havet</title>
     <firstline>En Aftenstund den Herre Christ mon vandre</firstline>
-    <quality>korrektur1,kilde,side</quality>
+    <quality>korrektur1,korrektur2,kilde,side</quality>
     <source pages="118"/>
 </head>
 <body>
@@ -3218,7 +3218,7 @@ Men Havets Bølger rolige og klare.
 <head>
     <title>Til et Barn</title>
     <firstline>O hulde Barn, du med det lyse Øie</firstline>
-    <quality>korrektur1,kilde,side</quality>
+    <quality>korrektur1,korrektur2,kilde,side</quality>
     <notes>
         <note>Mottoet stammer fra <a poet="goethe">Goethes</a> <i>Der Zauberflöte zweyter Teil</i> (1802).</note>
     </notes>
@@ -3257,14 +3257,14 @@ O smiil, smiil sødt! vor Fryd i Himlen er.
 <head>
     <title>Sørgedragten</title>
     <firstline>See I Floret om min Elsktes</firstline>
-    <quality>korrektur1,kilde,side</quality>
+    <quality>korrektur1,korrektur2,kilde,side</quality>
     <source pages="120-121"/>
 </head>
 <body>
 <poetry>
 <num>I</num>See I Floret om min Elsktes
 Gule, silkebløde Lokker?
-Bæver saa ei Alteriuen,
+Bæver saa ei Alterluen,
 Klar og gylden, blødtomkrandset
 Af sin dunkle Virakskye?
 
@@ -3311,7 +3311,7 @@ Den har Ida skjænket mig!
 <head>
     <title>De forelskets April</title>
     <firstline>Skyerne komme og gaae, Violer sankes paa Volden</firstline>
-    <quality>korrektur1,kilde,side</quality>
+    <quality>korrektur1,korrektur2,kilde,side</quality>
     <source pages="122"/>
 </head>
 <body>
@@ -3328,7 +3328,7 @@ Dog paany kun et Smiil - og der staaer Roser i Øst
 <head>
     <title>Holberg</title>
     <firstline>Ei du det Yndige tog og de skjønne Former og bygged</firstline>
-    <quality>korrektur1,kilde,side</quality>
+    <quality>korrektur1,korrektur2,kilde,side</quality>
     <source pages="122"/>
 </head>
 <body>
@@ -3347,7 +3347,7 @@ Sjælden dig Pegasus bar, selv du en Kraftvinge var.
 <head>
     <title>Satiren</title>
     <firstline>Lystig, Svende, kaster i Diglen de blanke Metaller!</firstline>
-    <quality>korrektur1,kilde,side</quality>
+    <quality>korrektur1,korrektur2,kilde,side</quality>
     <source pages="122"/>
 </head>
 <body>
@@ -3364,7 +3364,7 @@ Varslende - ikke om Ild - nei! om det smagløse Vand
 <head>
     <title>Betlersken med sit Barn</title>
     <firstline>Stakkels Barn, sov ved mit Bryst!</firstline>
-    <quality>korrektur1,kilde,side</quality>
+    <quality>korrektur1,korrektur2,kilde,side</quality>
     <source pages="123-125"/>
 </head>
 <body>
@@ -3431,7 +3431,7 @@ Gud sig over os forbarme!
 <head>
     <title>Minas Dødssang</title>
     <firstline>Søster, syng saa muntert ei!</firstline>
-    <quality>korrektur1,kilde,side</quality>
+    <quality>korrektur1,korrektur2,kilde,side</quality>
     <source pages="126-127"/>
 </head>
 <body>
@@ -3547,15 +3547,15 @@ Og en Rosenbusk blev al min Smerte.
    <title>Morgenen</title>
    <toctitle>Morgenen</toctitle>
    <indextitle>Morgenen</indextitle>
-   <firstline>Naar Morgenen phantaserer paa sin Lyre</firstline>
+   <firstline>Naar Morgnen phantaserer paa sin Lyre</firstline>
    <quality>korrektur1,korrektur2,kilde,side</quality>
    <keywords>sonnet</keywords>
    <source pages="129"/>
 </head>
 <body>
 <poetry>
-Naar Morgenen phantaserer paa sin Lyre
-Og den Accorder sødt fra Leiet kalde:
+Naar Morgnen phantaserer paa sin Lyre
+Og dens Accorder sødt fra Leiet kalde:
 Træd ud da i den store Dæmrings-Halle!
 Hør Lærkechorets fromme Ouverture!
 
@@ -3588,7 +3588,7 @@ Lad freidigt Mod i Morgenluft sig bade!
 <body>
 <poetry>
 Alt Dagens Melodrama sig udfolder.
-Med Sang og Klang og festlig der fremskrider,
+Med Sang og Klang og festlig det fremskrider,
 Fra Himmelkuplen Straalen blank nedglider,
 Og Sandet brænder Pillegrimmens Saaller.
 
@@ -3636,7 +3636,7 @@ Opad gaaer Veien, skraa er steds vor Standen.
 
 List dig da hen fjern fra den store Vrimmel!
 Kik gjennem Ruden paa din Elsktes Vaaning,
-Og skriv en Elskovsbrev paa Himmelranden!
+Og skriv et Elskovsbrev paa Himmelranden!
 </poetry>
 </body>
 </text>
@@ -3712,7 +3712,7 @@ Hun løfter ei Amor til Brystet.
 <head>
     <title>Flodpigens Vise</title>
     <firstline>Jeg sad derhjemme fro og glad</firstline>
-    <quality>korrektur1,kilde,side</quality>
+    <quality>korrektur1,korrektur2,kilde,side</quality>
     <source pages="134-135"/>
 </head>
 <body>
@@ -3806,7 +3806,7 @@ Eders Duft skal hendes Drøm omflyde,
 <head>
     <title>Guldringen</title>
     <firstline>Ved Stranden sad den Pigelil</firstline>
-    <quality>korrektur1,kilde,side</quality>
+    <quality>korrektur1,korrektur2,kilde,side</quality>
     <source pages="137-138"/>
 </head>
 <body>
@@ -3863,7 +3863,7 @@ Eders Duft skal hendes Drøm omflyde,
 <head>
     <title>Til den forladte</title>
     <firstline>O du stakkels fromme Lilieklokke</firstline>
-    <quality>korrektur1,kilde,side</quality>
+    <quality>korrektur1,korrektur2,kilde,side</quality>
     <source pages="139"/>
 </head>
 <body>
@@ -3900,7 +3900,7 @@ Naar kun trofast du vil elske mig.
 <head>
     <title>Syner</title>
     <firstline>Jeg seer et Land, og seer en Fredens Engel</firstline>
-    <quality>korrektur1,kilde,side</quality>
+    <quality>korrektur1,korrektur2,kilde,side</quality>
     <source pages="140"/>
 </head>
 <body>
@@ -3930,7 +3930,7 @@ Den klare Taare og det dunkle Øie.
 <head>
     <title>Kys og Anelse</title>
     <firstline>Gjerne jeg i stille Drømme</firstline>
-    <quality>korrektur1,kilde,side</quality>
+    <quality>korrektur1,korrektur2,kilde,side</quality>
     <source pages="141-142"/>
 </head>
 <body>
@@ -4003,7 +4003,7 @@ Gløder Kysset gjennem Flammen.
 <head>
     <title>I Hjertets Dyb sig dunkle Toner rørte</title>
     <firstline>I Hjertets Dyb sig dunkle Toner rørte</firstline>
-    <quality>korrektur1,kilde,side</quality>
+    <quality>korrektur1,korrektur2,kilde,side</quality>
     <keywords>sonnet</keywords>
     <source pages="143"/>
 </head>
@@ -4034,7 +4034,7 @@ Og dig min dunkle Elskovsrose bringe?
 <head>
     <title>Ei hvo jeg er kan jeg Dig rede gjøre</title>
     <firstline>Ei hvo jeg er kan jeg Dig rede gjøre</firstline>
-    <quality>korrektur1,kilde,side</quality>
+    <quality>korrektur1,korrektur2,kilde,side</quality>
     <keywords>sonnet</keywords>
     <source pages="143-144"/>
 </head>
@@ -4065,7 +4065,7 @@ Ved Maanens Lys vi under Pilen græde.
 <head>
     <title>Men straf ei grumt den stille Alf i Skoven</title>
     <firstline>Men straf ei grumt den stille Alf i Skoven</firstline>
-    <quality>korrektur1,kilde,side</quality>
+    <quality>korrektur1,korrektur2,kilde,side</quality>
     <keywords>sonnet</keywords>
     <source pages="144-145"/>
 </head>
@@ -4100,7 +4100,7 @@ Og Dig forklaret evig tør ombølge -
     <title>Kjendetegnet paa Utroskab</title>
     <subtitle>(Ideen efter Gerstenberg)</subtitle>
     <firstline>Saa smuk, saa rød, de kjære Pigers Lyst</firstline>
-    <quality>korrektur1,kilde,side</quality>
+    <quality>korrektur1,korrektur2,kilde,side</quality>
     <source pages="146-149"/>
 </head>
 <body>
@@ -4132,7 +4132,7 @@ Naar til en Anden hun sit Hjerte bringer.
 Ak, raabte han, din Bøn gjør mig tilskamme;
 Kan Amor dæmpe Kjærlighedens Flamme?
 
-<num>IV</num>Med gyldne Plil at skyde Saar paa Saar
+<num>IV</num>Med gyldne Piil at skyde Saar paa Saar
 Til Kuld og Frost og Staal sig skiller ad,
 Og Hjerterne i lysen Lue staaer
 Som fordumstid den stolte Trojæ Stad,
@@ -4202,7 +4202,7 @@ At Lila kan den kjære <i>Troskab</i> prise!
 <head>
     <title>Mine Haab</title>
     <firstline>Herud i Luften, Vingerne at tumle</firstline>
-    <quality>korrektur1,kilde,side</quality>
+    <quality>korrektur1,korrektur2,kilde,side</quality>
     <keywords>sonnet</keywords>
     <source pages="150"/>
 </head>
@@ -4235,7 +4235,7 @@ Med dem jeg synker blødende i Sivet.
 <head>
     <title>Til Amanda</title>
     <firstline>O du, som syg og svag, med bange Taarer</firstline>
-    <quality>korrektur1,kilde,side</quality>
+    <quality>korrektur1,korrektur2,kilde,side</quality>
     <keywords>sonnet</keywords>
     <source pages="151"/>
 </head>
@@ -4268,7 +4268,7 @@ Men ved hans kjære Haand kun vanke modig.
 <head>
     <title>Den forkjølede Amor</title>
     <firstline>Ved et Kildespring i den grønne Lund</firstline>
-    <quality>korrektur1,kilde,side</quality>
+    <quality>korrektur1,korrektur2,kilde,side</quality>
     <source pages="152-155"/>
 </head>
 <body>
@@ -4412,7 +4412,7 @@ Op til dit Skjød, o Herre mild!
 <head>
     <title>Med en Confirmations Rose</title>
     <firstline>Lille Rose, vær ei bange!</firstline>
-    <quality>korrektur1,kilde,side</quality>
+    <quality>korrektur1,korrektur2,kilde,side</quality>
     <source pages="157"/>
 </head>
 <body>
@@ -4444,7 +4444,7 @@ Husk, tør du i Kirken smile!
 <head>
     <title>Sygdommen</title>
     <firstline>Hvem er du med de askeblege Lokker</firstline>
-    <quality>korrektur1,kilde,side</quality>
+    <quality>korrektur1,korrektur2,kilde,side</quality>
     <source pages="158"/>
 </head>
 <body>
@@ -4468,7 +4468,7 @@ Barn, uskyldig; min Moder er Barmhjertigheden.
 <head>
     <title>Da Amanda var syg</title>
     <firstline>Jeg kan ei synge, min Amanda tier</firstline>
-    <quality>korrektur1,kilde,side</quality>
+    <quality>korrektur1,korrektur2,kilde,side</quality>
     <source pages="159"/>
 </head>
 <body>
@@ -4505,7 +4505,7 @@ Saa takker jeg og priser Dig for Sorgen!
 <head>
     <title>Afsted</title>
     <firstline>Farvel, min Fryd, Farvel!</firstline>
-    <quality>korrektur1,kilde,side</quality>
+    <quality>korrektur1,korrektur2,kilde,side</quality>
     <source pages="160"/>
 </head>
 <body>
@@ -4537,7 +4537,7 @@ Følg mig til Graven! -
 <head>
     <title>Hvidtfeldt</title>
     <firstline>De lange Snekker laae paa Rad</firstline>
-    <quality>korrektur1,kilde,side</quality>
+    <quality>korrektur1,korrektur2,kilde,side</quality>
     <source pages="161-163"/>
 </head>
 <body>
@@ -4626,7 +4626,7 @@ Vi vove fuldt det samme!
 <head>
     <title>Elegie</title>
     <firstline>Hvor min Hauges Grønt i Høsten skrantner og blegner</firstline>
-    <quality>korrektur1,kilde,side</quality>
+    <quality>korrektur1,korrektur2,kilde,side</quality>
     <source pages="164"/>
 </head>
 <body>
@@ -4649,7 +4649,7 @@ Maanen, med tvivlsomt Lys, seer gjennem Grenene ned.
 <head>
     <title>Sonett</title>
     <firstline>Elskte, er du bange for de Døde?</firstline>
-    <quality>korrektur1,kilde,side</quality>
+    <quality>korrektur1,korrektur2,kilde,side</quality>
     <keywords>sonnet</keywords>
     <source pages="165"/>
 </head>
@@ -4680,7 +4680,7 @@ Luer høiest Kjærlighedens Varme.
 <head>
     <title>Bøn</title>
     <firstline>Tag ei fra mig dine kjære Hænder!</firstline>
-    <quality>korrektur1,kilde,side</quality>
+    <quality>korrektur1,korrektur2,kilde,side</quality>
     <keywords>sonnet</keywords>
     <source pages="166"/>
 </head>
@@ -4711,7 +4711,7 @@ Frels mig, frels fra disse Slangebugter!
 <head>
     <title>Skjøn Anna</title>
     <firstline>Der laae saa tykt paa Gaden med Snee</firstline>
-    <quality>korrektur1,kilde,side</quality>
+    <quality>korrektur1,korrektur2,kilde,side</quality>
     <source pages="167-168"/>
 </head>
 <body>
@@ -4763,7 +4763,7 @@ Da var skjøn Anna kold og død.
 <head>
     <title>Aftensang</title>
     <firstline>Iler nu fra eders Hytter</firstline>
-    <quality>korrektur1,kilde,side</quality>
+    <quality>korrektur1,korrektur2,kilde,side</quality>
     <source pages="169-170"/>
 </head>
 <body>
@@ -4805,7 +4805,7 @@ Sine Børn op til sit Hjerte!
 <head>
     <title>Om min Muse</title>
     <firstline>Hvem Musen er, vil du vide</firstline>
-    <quality>korrektur1,kilde,side</quality>
+    <quality>korrektur1,korrektur2,kilde,side</quality>
     <source pages="171-173"/>
 </head>
 <body>
@@ -4877,7 +4877,7 @@ Og med mig til Himmelen gaae.
 <head>
     <title>Lucca Signorelli</title>
     <firstline>I Husets dunkle Halle</firstline>
-    <quality>korrektur1,kilde,side</quality>
+    <quality>korrektur1,korrektur2,kilde,side</quality>
     <source pages="174-176"/>
 </head>
 <body>
@@ -4952,7 +4952,7 @@ Blev indtil Taarer rørt.
 <head>
     <title>Længsel</title>
     <firstline>Skjøndt jeg er ung og stærk, har Mod og Lykke</firstline>
-    <quality>korrektur1,kilde,side</quality>
+    <quality>korrektur1,korrektur2,kilde,side</quality>
     <source pages="177"/>
 </head>
 <body>
@@ -4981,7 +4981,7 @@ Og vær, for Jesu Skyld, en naadig Dommer!
 <head>
     <title>Elegie</title>
     <firstline>O hvor det lyser roligt, klart I mit drømmende Indre!</firstline>
-    <quality>korrektur1,kilde,side</quality>
+    <quality>korrektur1,korrektur2,kilde,side</quality>
     <source pages="178"/>
 </head>
 <body>
@@ -5007,7 +5007,7 @@ Speiler forfængelig glad Hjertet i Sangens Pokal.
 <head>
     <title>Den bortfløine Elskov</title>
     <firstline>Min Elskov vilde flyve bort</firstline>
-    <quality>korrektur1,kilde,side</quality>
+    <quality>korrektur1,korrektur2,kilde,side</quality>
     <source pages="179-181"/>
 </head>
 <body>
@@ -5073,7 +5073,7 @@ Nu flyver den vist aldrig bort!
 <head>
     <title>Begeistringen og Ordet</title>
     <firstline>Dernede ved den grønne Aae</firstline>
-    <quality>korrektur1,kilde,side</quality>
+    <quality>korrektur1,korrektur2,kilde,side</quality>
     <source pages="182-183"/>
 </head>
 <body>
@@ -5085,7 +5085,7 @@ Der sidder under Hyttetag
 En Møe den lange Sommerdag,
 Tør ei ad Glæden vinke.
 
-<num>II</num>Deroppe paa det faøie Slot,
+<num>II</num>Deroppe paa det høie Slot,
 Omhvælvet kun af Himlens Blaat
 Og kun med det for Øie,
 Der staaer saa bold en Ungersvend
@@ -5100,7 +5100,7 @@ Da toner en dybsindig Klang,
 Da maae vi Alle lytte.
 
 <num>IV</num>Som Fløiten i sit dunkle Bryst,
-Den Pige gj emmer Sang og Røst.
+Den Pige gjemmer Sang og Røst.
 Men naar fra Borgens Kroner
 Nedsvæver, fuld af hellig Ild,
 En Elskovsaande stærk og mild,
@@ -5190,7 +5190,7 @@ Den rene, uskyldige Klang!
 <head>
     <title>Digterskjæbne</title>
     <firstline>Usalige Poet! Dig, ak, snart i en Bog</firstline>
-    <quality>korrektur1,kilde,side</quality>
+    <quality>korrektur1,korrektur2,kilde,side</quality>
     <source pages="186"/>
 </head>
 <body>
@@ -5211,7 +5211,7 @@ Han rumler, tumler om - den rev ham ogsaa ned!
 <head>
     <title>Havfruen</title>
     <firstline>Dronning Thora gik paa Øen</firstline>
-    <quality>korrektur1,kilde,side</quality>
+    <quality>korrektur1,korrektur2,kilde,side</quality>
     <source pages="187-192"/>
 </head>
 <body>
@@ -5363,7 +5363,7 @@ Kjæmper paa det stolte Hav.
 <head>
     <title>Ønskerne</title>
     <firstline>Mangen Digter har sjunget</firstline>
-    <quality>korrektur1,kilde,side</quality>
+    <quality>korrektur1,korrektur2,kilde,side</quality>
     <source pages="193-194"/>
 </head>
 <body>
@@ -5453,7 +5453,7 @@ Dog lærte snart at elske dem, som Du -
 <head>
     <title>Til Thorvaldsen</title>
     <firstline>Du drog til Roma bort, til fjerne, velske Lande</firstline>
-    <quality>korrektur1,kilde,side</quality>
+    <quality>korrektur1,korrektur2,kilde,side</quality>
     <source pages="196"/>
 </head>
 <body>
@@ -5488,7 +5488,7 @@ O Thorvaldsen, fra Danmark vriste Savnets Braad!
 <head>
     <title>Til mine Øine</title>
     <firstline>O græd ei, stakkels, kjære, syge Børn</firstline>
-    <quality>korrektur1,kilde,side</quality>
+    <quality>korrektur1,korrektur2,kilde,side</quality>
     <source pages="197"/>
 </head>
 <body>
@@ -5592,7 +5592,7 @@ Ei meer; de frygte Døden.
 At hæve sine Blikke.
 Han græd, han skjalv som Sivet,
 Og sukked: jeg vil drage
-I Fængslets Død tilbage,
+I Fængslets Dyb tilbage,
 Min Gud, og vinde Livet.
 
 <num>XI</num>Beegfakler brændte. Hallen
@@ -5610,7 +5610,7 @@ Men han — Guds Vidne — smiilte.
     <title>Den 4de Juli 1823</title>
     <subtitle>Mel. Ung Adelsteen paa Thinge stod &amp;c.</subtitle>
     <firstline>Kan man vel synge muntert nok</firstline>
-    <quality>korrektur1,kilde,side</quality>
+    <quality>korrektur1,korrektur2,kilde,side</quality>
     <dates>
         <event>1823-07-04</event>
     </dates>
@@ -5751,7 +5751,7 @@ Du skræmmer Ingen bort, du smiler, rækker Haanden;
 Med Guldsnor om sin Hat, fuldpaaklædt vandrer Aanden.
 Og vil man følge dig til Gravens stille Læ,
 Da gaaer du langsomt hen, hen til et Hyldetræ.
-Opklappet, pyntet nyt, den smalle Høi sig strækker,
+Opklappet, pyntet nys, den smalle Høi sig strækker,
 Og Arv har hegnet den med tætte Buxbomhækker.
 Did gaaer Pernille tidt, bevæget, sælsom rørt,
 Om Morgenen, med Sand og Blomster i sit Skjørt.
@@ -5767,7 +5767,7 @@ Det kjære Instrument, som var hans Holberg kjær.
 <head>
     <title>D: 22de Septbr 1824</title>
     <firstline>Jeg tar Dit Billed frem, at dæmpe Qualer</firstline>
-    <quality>korrektur1,kilde,side</quality>
+    <quality>korrektur1,korrektur2,kilde,side</quality>
     <keywords>sonnet</keywords>
     <dates>
         <event>1824-09-22</event>
@@ -5801,7 +5801,7 @@ O al min Glæde er en stille Klage!
 <head>
     <title>Frøkenen og Gartneren</title>
     <firstline>Gartner, kan jeg faae hos Dem</firstline>
-    <quality>korrektur1,kilde,side</quality>
+    <quality>korrektur1,korrektur2,kilde,side</quality>
     <source pages="207"/>
 </head>
 <body>
@@ -5834,7 +5834,7 @@ Men vær vaersom, see dig for,
 <head>
     <title>Romanze</title>
     <firstline>Det var et frygteligt blæsende Vær</firstline>
-    <quality>korrektur1,kilde,side</quality>
+    <quality>korrektur1,korrektur2,kilde,side</quality>
     <source pages="208-212"/>
 </head>
 <body>
@@ -5845,7 +5845,7 @@ Det hvirvlede baade med Hatte og Fjær,
 Og Læggene saae man blotted.
 
 <num>II</num>Vi kom just fra Præsten, min Kone og jeg -
-Vor Bolig behøves er vide -
+Vor Bolig behøves ei vide -
 Nok, at vi tog den nærmeste Vei,
 og krydsed med Vinden paa Side.
 
@@ -5966,7 +5966,7 @@ Det skylder jeg ham altsammen
 <head>
     <title>Den Betænksomme</title>
     <firstline>Du gaaer saalænge og hegler</firstline>
-    <quality>korrektur1,kilde,side</quality>
+    <quality>korrektur1,korrektur2,kilde,side</quality>
     <source pages="213-215"/>
 </head>
 <body>
@@ -6053,7 +6053,7 @@ Naar man bær sig ad som et Fæ?
 <head>
     <title>Kone, Kone, hjem du gaa</title>
     <firstline>Kone, Kone, hjem du gaa</firstline>
-    <quality>korrektur1,kilde,side</quality>
+    <quality>korrektur1,korrektur2,kilde,side</quality>
     <source pages="216-217"/>
 </head>
 <body>
@@ -6107,7 +6107,7 @@ Siden vil jeg hjemad gaae.
 <head>
     <title>Idyll</title>
     <firstline>Ved det klare Morgengry</firstline>
-    <quality>korrektur1,kilde,side</quality>
+    <quality>korrektur1,korrektur2,kilde,side</quality>
     <source pages="218-220"/>
 </head>
 <body>
@@ -6191,7 +6191,7 @@ Er de tætte Buske.
 Nys stod han i Blomster, nu bæres han bort.
 Den evige Hikke
 Den loved ei godt, det saae jeg forud.
-Vor Herre ham sendte det ranglede Bud,
+Vor Herre ham sendte det ranglende Bud,
 Han tøvede ikke.
 Hvis Himlen gjenlyder af jublende Stemme
 Og ikkun af Gammen bestaaer
@@ -6212,7 +6212,7 @@ Det var ham saa klogt som alt andet.
 <num>III</num>Chatollet er lukt,
 Forseglet — tomt — blev aldrigen brugt.
 Hør, Liigvognen runger!
-Der hænge de Fugle, han satte i Hæk
+Der hænger de Fugle, han satte i Hæk
 Saa kort for sin Afgang; flyv I kun væk,
 Flyv ud, mine Unger,
 Og syng paa Stakittet om Graven -
@@ -6224,7 +6224,7 @@ Deroppe i Paradiishaven?
 En Punscheskaal. Ak, imod Jammer og Vee
 Et Skjold her i Verden.
 Farvel, min Broder, farvel paa dit Tog!
-Strø Blomster, Drenge, tykt paa hans Laag!
+Strøe Blomster, Drenge, tykt paa hans Laag!
 Syng Visen, han digted, her er den!
 Liigbærere, drik til den kryddrede Kringle!
 En Taar endnu, det glider nok ned;
@@ -6314,7 +6314,7 @@ Og halvt i Himlen bragt.
     <firstline>Jeg sad med dig bag Malver, huldt i Skygge</firstline>
     <source pages="226"/>
     <keywords>sonnet</keywords>
-    <quality>korrektur1,kilde,side</quality>
+    <quality>korrektur1,korrektur2,kilde,side</quality>
 </head>
 <body>
 <poetry>

--- a/fdirs/aarestrup/1976-2.xml
+++ b/fdirs/aarestrup/1976-2.xml
@@ -23,7 +23,7 @@
 <head>
    <title>Du søde Barn, saa længselsfuld og stille</title>
    <firstline>Du søde Barn, saa længselsfuld og stille</firstline>
-   <quality>korrektur1,kilde,side</quality>
+   <quality>korrektur1,korrektur2,kilde,side</quality>
    <keywords>sonnet</keywords>
    <source pages="1"/>
 </head>
@@ -54,7 +54,7 @@ O Coelestine - har du glemt det alt?
 <head>
    <title>Sonnet</title>
    <firstline>Blus, Kinder ei saa purpurrøde!</firstline>
-   <quality>korrektur1,kilde,side</quality>
+   <quality>korrektur1,korrektur2,kilde,side</quality>
    <keywords>sonnet</keywords>
    <source pages="2"/>
 </head>
@@ -85,14 +85,14 @@ Maa vige Sædet med sin Liliestengel.
 <head>
    <title>Jeg gik saa tidt til disse Klippestene</title>
    <firstline>Jeg gik saa tidt til disse Klippestene</firstline>
-   <quality>korrektur1,kilde,side</quality>
+   <quality>korrektur1,korrektur2,kilde,side</quality>
    <keywords>sonnet</keywords>
    <source pages="3"/>
 </head>
 <body>
 <poetry>
 Jeg gik saa tidt til disse Klippestene
-Ned af hvis Mus de kolde Kilder skylle,
+Ned ad hvis Mus de kolde Kilder skylle,
 Hvis Krat og Ranker Vandreren indhylle -
 Der var en Ro, en Fred - jeg var alene.
 
@@ -153,7 +153,7 @@ Til Elskovs Eensomhed der hører <i>tvende</i>.
 <head>
    <title>Hvor Alt er taust. Hvert Blad, hver løvrig Ranke</title>
    <firstline>Hvor Alt er taust. Hvert Blad, hver løvrig Ranke</firstline>
-   <quality>korrektur1,kilde,side</quality>
+   <quality>korrektur1,korrektur2,kilde,side</quality>
    <keywords>sonnet</keywords>
    <source pages="5"/>
 </head>
@@ -223,7 +223,7 @@ Var det det hele? - Lad mig ha'e Ro -
 <head>
     <title>Farvel, min gode Nicoline!</title>
     <firstline>Farvel, min gode Nicoline!</firstline>
-    <quality>korrektur1,kilde,side</quality>
+    <quality>korrektur1,korrektur2,kilde,side</quality>
     <source pages="7-8"/>
 </head>
 <body>
@@ -295,7 +295,7 @@ Vent ham ei længer, du Danmarks friske, yndige Sommer
 Vent ham ei længer med Blomster og Glæde; han kommer ei mere
 Ei til Velkomst, Venner, bereder det duftende Bæger
 Han, som vi rakte det helst, vor Fischer, kommer ei mere.
-Fjern, hvor Javaneren samler paa fugtige Marker sin Riisfrugt
+Fjernt, hvor Javaneren samler paa fugtige Marker sin Riisfrugt
 Standste hans Vei; der lagde han træt sig til Hvile, og Palmen
 Breder sit prægtige Blad høitidelig over hans Gravhøi.
 O hvor længtes vi Alle! hvor speidende søgte ei Blikket
@@ -306,10 +306,10 @@ Og naar det banked paa Døren med svag, eiendommelig Banken -
 Ak, det var ham dog ei! ei vor Vens alvorlige Ansigt
 Mørknet af Solen, men lyst af det mildeste, reneste Venskab
 O bebreider ham intet! han veeg jo beskeden for eder,
-I, som foragte en Sjæl, der har barnligen offret sig Kunsten
+I, som foragter en Sjæl, der har barnligen offret sig Kunsten
 Eder han veeg; han veeg for den nordiske Kuld, og i Syden
 Favnte ham togange hedt, med begeistrende Skjønhed, Naturen
-Ak og trediegang i et Kys tilaaned ham Døden -
+Ak og trediegang i et Kys tilaanded ham Døden -
 Nu i sin evige Fred forklaret han svæver omkring os,
 Venskab ham ofrer og længe skal offre ham hædrende Veemod.
 
@@ -424,14 +424,14 @@ Og Piger strømme, for at see dig, til mig.
 <head>
     <title>Paa Fjeldet -</title>
     <firstline>Higende, høi</firstline>
-    <quality>korrektur1,kilde,side</quality>
+    <quality>korrektur1,korrektur2,kilde,side</quality>
     <source pages="15-16"/>
 </head>
 <body>
 <poetry>
 <num>I</num>Higende, høi
 Svømmer Skyen heroppe;
-Vandfaldets Støl
+Vandfaldets Støi
 Trodser blandt Granernes Toppe;
 Eensomheds Lyst
 Fylder vort Bryst.
@@ -559,7 +559,7 @@ Den som Vor Herre bedst for Tungebaandet skar,
 Han - efter de fornødne Buk -
 Tog Ordet først og sagde med et Suk,
 Idet han peged paa sin Ven: ,,De seer
-Der en Ulykkelig - lad mig ei sige meer!
+Her en Ulykkelig - lad mig ei sige meer!
 Hans hele Slægt, jeg selv, vi skal
 Taknemligen erkjende det, ifald
 De kan igjen forskaffe Manden
@@ -611,7 +611,7 @@ Det Gale fra det Kloge ei at kjende.
 <head>
     <title>Min høitærede kjære Ven og Velynder</title>
     <firstline>Min høitærede kjære Ven og Velynder</firstline>
-    <quality>korrektur1,kilde,side</quality>
+    <quality>korrektur1,korrektur2,kilde,side</quality>
     <source pages="21-23"/>
 </head>
 <body>
@@ -659,7 +659,7 @@ Hold det tyst, jeg lyver godt, pyteheia
 <num>IX</num>Du kan tro, Brændvinssuppen her man kjender,
 En Bouteille efter Tønderne stadigt man brænder,
 Lugten kjends tre Fjerdingvei, polemeia,
-Hold det tyst, og sug det ei, pyteheia
+Hold det tyst, og siig det ei, pyteheia
 
 <num>X</num>Du kan tro, Tobakspiben Munden passer
 Femten Piber jeg ryger uden Grimasser
@@ -693,7 +693,7 @@ Farnu vel og lev galant, pyteheia.
 <head>
     <title>I Vers, Fritz Timm, hvad mere er, i Stanzer</title>
     <firstline>I Vers, Fritz Timm, hvad mere er, i Stanzer</firstline>
-    <quality>korrektur1,kilde,side</quality>
+    <quality>korrektur1,korrektur2,kilde,side</quality>
     <keywords>byron</keywords>
     <source pages="24-29"/>
 </head>
@@ -902,7 +902,7 @@ Vi støie, larme, sukke og forgaae.
 </head>
 <body>
 <poetry>
-<num>I</num>Min Elskte! Orglet toner -
+<num>I</num>Min Elskte! Orglet lyder -
 O den catolske Sang
 Jeg kan den ei beskrive
 Hørte Du den engang.
@@ -946,7 +946,7 @@ Og vækker og kysser Din Mund?
 <head>
     <title>Nu tændes Stjernen</title>
     <firstline>Nu tændes Stjernen</firstline>
-    <quality>korrektur1,kilde,side</quality>
+    <quality>korrektur1,korrektur2,kilde,side</quality>
     <source pages="33-34"/>
 </head>
 <body>
@@ -1058,7 +1058,7 @@ Hvor kan man være svag og hjertesvimmel.
 <head>
     <title>Kjære Fritz! titusind Tak</title>
     <firstline>Kjære Fritz! titusind Tak</firstline>
-    <quality>korrektur1,kilde,side</quality>
+    <quality>korrektur1,korrektur2,kilde,side</quality>
     <source pages="37-38"/>
 </head>
 <body>
@@ -1109,7 +1109,7 @@ Jeg nyser gandskevist, og siger Tak.
 <head>
     <title>Kjære Heidenhelm! Undskyld jeg trætter</title>
     <firstline>Kjære Heidenhelm! Undskyld jeg trætter</firstline>
-    <quality>korrektur1,kilde,side</quality>
+    <quality>korrektur1,korrektur2,kilde,side</quality>
     <dates>
         <written>1833-01-20</written>
     </dates>
@@ -1148,7 +1148,7 @@ Vil De ham bringe, næst Billetter,
 Som indskudt jeg i Brevet sætter,
 Hiin Rest af Penge, og - da det ei mætter -
 Fem Daler til, fra Deres Ven, hans Fætter?
-Hvis denne Bøn De venllgen udretter,
+Hvis denne Bøn De venligen udretter,
 De mig i bundløs Gjeld til Deres Godhed sætter.
 Med mange Hilsener til Dem og Den, De gjætter!
 
@@ -1164,7 +1164,7 @@ Med mange Hilsener til Dem og Den, De gjætter!
 <head>
     <title>Kjære Christian! gode Fætter!</title>
     <firstline>Kjære Christian! gode Fætter!</firstline>
-    <quality>korrektur1,kilde,side</quality>
+    <quality>korrektur1,korrektur2,kilde,side</quality>
     <source pages="41-42"/>
 </head>
 <body>
@@ -1209,14 +1209,14 @@ Til Dig og alle Dine hjemme, Fætter.
 <head>
     <title>Fra Øen, hvor en stor, elskværdig Slægt</title>
     <firstline>Fra Øen, hvor en stor, elskværdig Slægt</firstline>
-    <quality>korrektur1,kilde,side</quality>
+    <quality>korrektur1,korrektur2,kilde,side</quality>
     <source pages="43"/>
 </head>
 <body>
 <poetry>
 Fra Øen, hvor en stor, elskværdig Slægt
-Vil yde Deres Deillge sin Varetægt
-Ledsaget af den hølstnaturlige Affect,
+Vil yde Deres Deilige sin Varetægt
+Ledsaget af den høistnaturlige Affect,
 Der opstaaer ved det Tryllendes Aspect,
 Maa det vel synes underligt, naar frækt
 En uvedkommende Spar Knægt:
@@ -1258,7 +1258,7 @@ Og jeg - med dybeste Respect
 <body>
 <poetry>
 <num>I</num>Deres Skaal,
-De, hvis Maal
+Dem, hvis Maal
 Er den vigtige Sag
 At gjøre ved Kjærlighed Gavn! - o ja!
 I hvis Arm
@@ -1340,7 +1340,7 @@ Gid altid vort Venskab bestaae!
     <dates>
         <written>1833-03-01</written>
     </dates>
-    <quality>korrektur1,kilde,side</quality>
+    <quality>korrektur1,korrektur2,kilde,side</quality>
     <source pages="47-48"/>
 </head>
 <body>
@@ -1387,7 +1387,7 @@ Men nu - jeg seer nok Rynkerne, Ballin;
 Jeg hører Dig i Tanker sige: piin
 Mig ikke længer med Dit Hviin! -
 Og jeg er redebon, at ende min
-[ ]ige Rimepistel; kort, jeg hilser Dig og Din
+lige Rimepistel; kort, jeg hilser Dig og Din
 Høitærede Familie, Ballin,
 Samt vores fælleds Venne-Magazin
 I Kjøbenhavn og deromkring, fra mig og min,
@@ -1409,7 +1409,7 @@ Og er bestandig
     <dates>
         <written>1833-03-20</written>
     </dates>
-    <quality>korrektur1,kilde,side</quality>
+    <quality>korrektur1,korrektur2,kilde,side</quality>
     <source pages="49-50"/>
 </head>
 <body>
@@ -1521,7 +1521,7 @@ See denne Bakke, omvæltet af Furen!
 Der dømtes fordum, midt i Naturen.
 
 <num>VII</num>See dem med Ro! Den Vrimmel, hvis Raab
-Bringer dig Hylding, har Tillid og Haab.
+Bringer dig Hyldning, har Tillid og Haab.
 Velkommen derfor! Selv jeg dig følger
 Ærefrygtsfuld til min Grændse af Bølger.
 </poetry>
@@ -1535,7 +1535,7 @@ Velkommen derfor! Selv jeg dig følger
     <dates>
         <event>1833-06-15</event>
     </dates>
-    <quality>korrektur1,kilde,side</quality>
+    <quality>korrektur1,korrektur2,kilde,side</quality>
     <source pages="53"/>
 </head>
 <body>
@@ -1578,7 +1578,7 @@ Der fryder som Din Kjærlighed!&#160;&#160;:/:
     <subtitle><w>Mel.</w> Im Wald und auf der Heide.</subtitle>
     <firstline>Lad Sangens Toner raade!</firstline>
     <source pages="54-56"/>
-    <quality>korrektur1,kilde,side</quality>
+    <quality>korrektur1,korrektur2,kilde,side</quality>
 </head>
 <body>
 <poetry>
@@ -1652,7 +1652,7 @@ Ham styrke Druens Blod!
 <head>
     <title>Karls Vise</title>
     <firstline>Det blæser og regner og siger: dryp, dryp, dryp!</firstline>
-    <quality>korrektur1,kilde,side</quality>
+    <quality>korrektur1,korrektur2,kilde,side</quality>
     <source pages="57-58"/>
 </head>
 <body>
@@ -1699,7 +1699,7 @@ Før kommer dog ikke min egen søde Bess
 <head>
     <title>W. Hogarths sidste Malerie</title>
     <firstline>Der ligger Tiden sidstegang paa Rumpen</firstline>
-    <quality>korrektur1,kilde,side</quality>
+    <quality>korrektur1,korrektur2,kilde,side</quality>
     <source pages="59-61"/>
     <!-- TODO: Find maleriet -->
 </head>
@@ -1786,7 +1786,7 @@ Saa moersomt sanddrue, evig gyselige.
 <head>
     <title>Epigrammer</title>
     <firstline>Malm - siges - er i hans Basun</firstline>
-    <quality>korrektur1,kilde,side</quality>
+    <quality>korrektur1,korrektur2,kilde,side</quality>
     <source pages="62-67"/>
     <keywords>boye,hauch,oehlenschlaeger,heibergjl,heibergjohanne,andersen,ingemann,molbechsr,winther,hertzh,tullin,overskou,grundtvig,shakespeare,scott</keywords>
 </head>
@@ -1999,7 +1999,7 @@ Har man just det Søde nødig.
 <head>
     <title>Til Herman Timm</title>
     <firstline>Kjære Herman! At forlængst jeg ikke skrev, var slemt</firstline>
-    <quality>korrektur1,kilde,side</quality>
+    <quality>korrektur1,korrektur2,kilde,side</quality>
     <source pages="68-74"/>
 </head>
 <body>
@@ -2043,7 +2043,7 @@ Og Scener - ak,
 Fra Drengealdren af, fra Tiden,
 Da vi var smaae,
 /: Du var bestandig høi, skjøndt du var liden :/
-t Erindrings-Dyb jeg saae.
+I Erindrings-Dyb jeg saae.
 Vi sad i Skolen, sang,
 Og læste Religion med Tang.
 Jeg seer endnu den lille Holsteins Næse løbe
@@ -2144,7 +2144,7 @@ Du vilde gjøre mig et Venskabsstykke, Ven,
 Hvis Du engang gik hen
 Og saae hvordan det egentligen sammenhængte
 Med ham og hans, hvormeget og hvortil de trængte.
-Sug til ham, han kan frit
+Siig til ham, han kan frit
 Tilskrive mig, og som han vil, saa tidt.
 
 ---
@@ -2195,7 +2195,7 @@ Jeg glemmer ikke Hornsyld, glemmer ikke
 Hans Engle-Frue, fromme Datter Mikke.
 Hvergang han gjæsted os, vor By,
 Mig var han som en Tordensky,
-En hellig, svævende fra Siranden,
+En hellig, svævende fra Stranden,
 Den sorte Dragt, de hvide Haar om Hueranden,
 Den store Runeskrift paa Panden,
 I Øiet Lyn, og i hans Barm
@@ -2224,7 +2224,7 @@ Levvel! Din mest hengivne blandt Emiler.
 <head>
     <title>Din Følelse er Aske</title>
     <firstline>Din Følelse er Aske</firstline>
-    <quality>korrektur1,kilde,side</quality>
+    <quality>korrektur1,korrektur2,kilde,side</quality>
     <source pages="75"/>
 </head>
 <body>
@@ -2251,7 +2251,7 @@ Ak, at den var forbi!
       <note type="credits">Bidrag fra Brian Bentsen.</note>
    </notes>
    <source pages="76-77"/>
-   <quality>korrektur1,kilde,side</quality>
+   <quality>korrektur1,korrektur2,kilde,side</quality>
 </head>
 <body>
 <poetry>
@@ -2306,7 +2306,7 @@ I Skyggen hen og sover.
     <dates>
         <written>1834-05-01</written>
     </dates>
-    <quality>korrektur1,kilde,side</quality>
+    <quality>korrektur1,korrektur2,kilde,side</quality>
 </head>
 <body>
 <poetry>
@@ -2367,10 +2367,10 @@ O, at vi havde Vinger
 
 <num>XII</num>Kom giv mig Drengen, Amme!
 Tag Huen af ham skynd dig.
-O hvor hams lille Hoved
+O hvor hans lille Hoved
 I Solen skinner yndig.
 
-<num>XIII</num>See til din Søn, Sabinski!
+<num>XIII</num>See her din Søn, Sabinski!
 Som jeg har født med Smerte
 En Arving til din Adel
 Din Tapperhed, dit Hjerte.
@@ -2458,7 +2458,7 @@ Blot et Ord, blot et Blik, saa er det Hele forspildt.
 <head>
     <title>Besværgelsen</title>
     <firstline>Det var en Tryllegrotte</firstline>
-    <quality>korrektur1,kilde,side</quality>
+    <quality>korrektur1,korrektur2,kilde,side</quality>
     <source pages="84-85"/>
 </head>
 <body>
@@ -2515,7 +2515,7 @@ Jeg kan ei huske mere.
 <head>
     <title>Besværgelsen</title>
     <firstline>Jeg hørte det med Gysen</firstline>
-    <quality>korrektur1,kilde,side</quality>
+    <quality>korrektur1,korrektur2,kilde,side</quality>
     <source pages="86-89"/>
 </head>
 <body>
@@ -2654,7 +2654,7 @@ Hun ændsede ei, at en Sjæl forgik,
 <head>
     <title>En Nordamerikaner, Hobson heed han</title>
     <firstline>En Nordamerikaner, Hobson heed han</firstline>
-    <quality>korrektur1,kilde,side</quality>
+    <quality>korrektur1,korrektur2,kilde,side</quality>
     <source pages="92-93"/>
 </head>
 <body>
@@ -2748,7 +2748,7 @@ Min Djævlefrækhed, og min Spot.
       <note type="credits">Bidrag fra Klaus R. Frederiksen.</note>
    </notes>
    <source pages="95-96"/>
-   <quality>korrektur1,kilde,side</quality>
+   <quality>korrektur1,korrektur2,kilde,side</quality>
 </head>
 <body>
 <poetry>
@@ -3021,7 +3021,7 @@ Jeg hørte Taffeluhret pikke
     <title>Til C. R.</title>
     <subtitle>der havde foræret mig en himmelblaa, med Guld og Perler broderet Pung</subtitle>
     <firstline>Skjøndt med Begeistring jeg har nu i Lommen</firstline>
-    <quality>korrektur1,kilde,side</quality>
+    <quality>korrektur1,korrektur2,kilde,side</quality>
     <source pages="105"/>
 </head>
 <body>
@@ -3057,7 +3057,7 @@ Men neppe halvt kan komme, over Læben.
 <head>
    <title>Tag dette Kys, og tusind til, du Søde</title>
    <firstline>Tag dette Kys, og tusind til, du Søde</firstline>
-   <quality>korrektur1,kilde,side</quality>
+   <quality>korrektur1,korrektur2,kilde,side</quality>
    <keywords>sonnet</keywords>
    <source pages="106"/>
 </head>
@@ -3090,7 +3090,7 @@ Og dog et smukt og snevert, i Sonetter.
     <firstline>En deilig Aften? Stille, sølvklart Vandet!</firstline>
     <keywords>sonnet</keywords>
     <source pages="107"/>
-    <quality>korrektur1,kilde,side</quality>
+    <quality>korrektur1,korrektur2,kilde,side</quality>
 </head>
 <body>
 <poetry>
@@ -3119,7 +3119,7 @@ Tilgiv - jeg ændsed ei din Aftenrøde!
 <head>
    <title>Enthusiasme</title>
    <firstline>O, jeg ændser ei mit Danmarks</firstline>
-   <quality>korrektur1,kilde,side</quality>
+   <quality>korrektur1,korrektur2,kilde,side</quality>
     <source pages="108"/>
 </head>
 <body>
@@ -3196,7 +3196,7 @@ O, den altfor runde Skulder!
 <head>
     <title>Hvilke Ætherregioner</title>
     <firstline>Hvilke Ætherregioner</firstline>
-    <quality>korrektur1,kilde,side</quality>
+    <quality>korrektur1,korrektur2,kilde,side</quality>
     <source pages="111"/>
 </head>
 <body>
@@ -3221,7 +3221,7 @@ Maa man ufrivillig knæle.
 <head>
     <title>Fremad!</title>
     <firstline>O, hvem der var et lille Noer igjen</firstline>
-    <quality>korrektur1,kilde,side</quality>
+    <quality>korrektur1,korrektur2,kilde,side</quality>
     <source pages="112"/>
 </head>
 <body>
@@ -3250,7 +3250,7 @@ Maa man ufrivillig knæle.
     <subtitle>istedet for et Brev fra hendes Elsker</subtitle>
     <firstline>Hvor gjerne jeg endogsaa vil</firstline>
     <keywords>winther</keywords>
-    <quality>korrektur1,kilde,side</quality>
+    <quality>korrektur1,korrektur2,kilde,side</quality>
     <source pages="113-117"/>
 </head>
 <body>
@@ -3399,7 +3399,7 @@ Vi efter Trinene alt lytte.
 <head>
     <title>Skyggerne</title>
     <firstline>Det er en grusom Skik iblandt de Vilde</firstline>
-    <quality>korrektur1,kilde,side</quality>
+    <quality>korrektur1,korrektur2,kilde,side</quality>
     <source pages="118"/>
 </head>
 <body>
@@ -3415,7 +3415,7 @@ Hvergang du standsed - ha forvovne Lykke
 Berørte jeg din søde, kjælne Skygge
 Jeg fulgte Dig, min Skygge din
 Den svulmede, den strakte sig og iilte
-Især naar Himlens Maane smulte
+Især naar Himlens Maane smiilte
 O hvor mit Hjerte henrykt bæved
 Naar begge Skygger i hinanden svæved
 Det kjælne, dunkle Væsen, dit,
@@ -3449,7 +3449,7 @@ Hvidglødende du mig om Halsen faldt.
 <head>
     <title>Det Blaat, som kaldes Himmelblaat</title>
     <firstline>Det Blaat, som kaldes Himmelblaat</firstline>
-    <quality>korrektur1,kilde,side</quality>
+    <quality>korrektur1,korrektur2,kilde,side</quality>
     <source pages="120"/>
 </head>
 <body>
@@ -3475,7 +3475,7 @@ De meningsløse Drømme bort?
       <note type="credits">Bidrag fra Brian Bentsen.</note>
    </notes>
    <source pages="121"/>
-   <quality>korrektur1,kilde,side</quality>
+   <quality>korrektur1,korrektur2,kilde,side</quality>
 </head>
 <body>
 <poetry>
@@ -3506,13 +3506,13 @@ Han veed at hugge Knuden rask itu! -
 <head>
     <title>Vor Glæde tager da sin Flugt</title>
     <firstline>Vor Glæde tager da sin Flugt</firstline>
-    <quality>korrektur1,kilde,side</quality>
+    <quality>korrektur1,korrektur2,kilde,side</quality>
     <source pages="122"/>
 </head>
 <body>
 <poetry>
 Vor Glæde tager da sin Flugt
-Som Himlens Spfaærer sin, i Løn
+Som Himlens Sphærer sin, i Løn
 Sødttonende den hele Nat
 Uhørt af Jordens dorske Søn.
 </poetry>
@@ -3526,7 +3526,7 @@ Uhørt af Jordens dorske Søn.
     <dates>
         <written>1836-01-07</written>
     </dates>
-    <quality>korrektur1,kilde,side</quality>
+    <quality>korrektur1,korrektur2,kilde,side</quality>
     <keywords>winther</keywords>
     <source pages="123-125"/>
 </head>
@@ -3625,7 +3625,7 @@ Hr Christian Petersen.
 <head>
     <title>Tilgiv mig, kjære Ven, at ei forlængst jeg takked</title>
     <firstline>Tilgiv mig, kjære Ven, at ei forlængst jeg takked</firstline>
-    <quality>korrektur1,kilde,side</quality>
+    <quality>korrektur1,korrektur2,kilde,side</quality>
     <source pages="126-128"/>
 </head>
 <body>
@@ -3690,7 +3690,7 @@ I alle Maader bær Dig ad;
 Halværgerlig, at midt i Dine Guders Dyrkning,
 Hvor mindste Kedsomhed er Solformørkning,
 Du maa befatte Dig med dette Væv,
-Med disse Rum og Tankeskræv,
+Med disse Riim og Tankeskræv,
 Jeg, som en Edderkop,
 Har af mit Blækhorn haspet op.
 Jeg er i frygteligt Humeur;
@@ -3728,7 +3728,7 @@ Til
 <head>
     <title>Hvor det glæder mig, at du er kaldet, glem os ikke</title>
     <firstline>Hvor det glæder mig, at du er kaldet, glem os ikke</firstline>
-    <quality>korrektur1,kilde,side</quality>
+    <quality>korrektur1,korrektur2,kilde,side</quality>
     <source pages="129"/>
 </head>
 <body>
@@ -3774,7 +3774,7 @@ Rosen fandt sin Sjæls Udkaarne i den grønne Semperviv
 Trives denne i dens Nærhed, kan ei Rosen skrante hen
 Mellem Planter, mellem Stene, mellem alle Verdens Dyr
 Virke Sympathiens Kræfter, selv mellem stolte Mænd
-Hvor er den, som ikke føler, at hans Liv mon plat forgaae
+Hvor er den, som ikke føler, at hans Liv maa plat forgaae
 Findes ei det Skjød, hvori han lægge kan sit Hoved hen?
 Hvor er den saa strenge Qvinde, at hun ikke sygner bleg
 Naar hun, som en Ranke, rives fra den elskte Ungersvend?
@@ -3802,7 +3802,7 @@ At din Kamp, som for at værge Ungerne en Løves,
 Naar jeg lokket af din Skjønhed, som en Bi af Liliens,
 Sank imod dit Bryst og søgte søde Kys, behøves?
 Føler du ei, denne Modstand strider mod Naturen?
-Qvæler den ei Hjertets bedre Stemme, naar den øves?
+Qvæler du ei Hjertets bedre Stemme, naar den øves?
 Alt, hvormed en Viisdomshaand har Verden sammenslynget,
 Alle Baand, som sammenholde Livets Række, kløves;
 Alt, hvad Gud har foranstaltet til sin Skabnings Bedste,
@@ -3821,7 +3821,7 @@ Trods din Vægring, hvilken Dyst endnu af mig skal prøves.
 <head>
     <title>Nu, da vor Jubelfests Fanfaronader, kjære Ven</title>
     <firstline>Nu, da vor Jubelfests Fanfaronader, kjære Ven</firstline>
-    <quality>korrektur1,kilde,side</quality>
+    <quality>korrektur1,korrektur2,kilde,side</quality>
     <source pages="134-138"/>
 </head>
 <body>
@@ -3942,7 +3942,7 @@ Skilt fra mig ved et Rum, Sjælene ei kan forstaae.
 Tankerne vaagne om dem, de Venner, der nylig forlod os,
 For i den brogede Stad Vinterens Lede at fly.
 Tankerne vaagne om dig, Veninde, du Blide af Hjertet,
-Englen for mine Smaa, Husets fortrolige Gjæst.
+Englen for mine Smaa, Husets fortroligste Gjæst.
 Gjerne en Stund om den lysende Arne vi trykked os sammen,
 Vexled skjemtrige Ord, havde vi dig i vor Ring.
 Men paa Papiir, med konstige Skrifttræk nøder mig Skjæbnen
@@ -3955,23 +3955,23 @@ Dig, som jeg veed med mig i Forening elsker det Skjønne,
 Dig, hvis følsomme Sjæl ærer det Gode saa høit!
 Hilsen bringer jeg Dig, fra mig det kjærligste Budskab
 Hilsen fra mine Børn, Hilsen og Kys fra min Viv.
-Haabet vi nære, at Reisen gik godt, at karsk ved sit Sybord,
+Haabet vi nære, at Reisen gik godt, at karsk ved dit Sybord,
 Nu, da det hælder mod Nat, sysler din flittige Haand;
 At dine fagre Veninder, de ædle Døttre af Manden,
 Der, Odysseus liig, tumles fra Strand og til Strand,
 Kyndig paa Alt, hvad Jorden og Havet vidunderligt eier,
 Alle befinde sig vel, alle med Glæde i Sind
 Gjensaae Absalons myldrende By og de ragende Taarne
-Alle, som savnede vi, venligt erindrende os.
+Alle, som savnende vi, venligt erindrende os.
 Beed dem, over den glimrende Omgangs tusinde Fortrin, ei glemme
-Hvem, uden Smiger eller Skrømt, er dem hengivne og tro,
+Hvem, uden Smiger og Skrømt, er dem hengivne og tro,
 Hvem deres Gjenkomst hid til Fædreneborgen opliver
 Som, med den kommende Sol, Blomsternes tidlige Flor
 Hils dem tusinde Gange, saavelsom Grev Julius han der
 Altid minder mig om Shakspears dybsindige Prinds,
-Han, hvo hvem jeg ei veed hvad meest fortjener Beundring,
+Han, hos hvem jeg ei veed hvad meest fortjener Beundring,
 Enten det barnlige Sind, eller den skjærpede Kløgt
-Her er Tingenes Gnag den sædvanlige jævne og brede
+Her er Tingenes Gang den sædvanlige jævne og brede
 Rødsand buldrer af Storm, Skipperne ventes med Angst
 Stundom Aftnen forsamler en Flok om det duftende Theebord,
 Strikkepindene gaae, Øinene, Tungerne med.
@@ -3986,7 +3986,7 @@ Taler et Fiirkløver snart Kortenes mystiske Sprog.
 Saadan gaaer Tiden hen; man lever, skjøndt neppe det mærkes;
 Deri, troer jeg, bestaaer just det lyksalige Liv.
 Himlen er immermørk, indsvøbt i Skyerne, tragisk,
-Ikke en Rist, som er lys, ikke en Plet, som er blaa.
+Ikke en Rift, som er lys, ikke en Plet, som er blaa.
 Meer langmodig, veed jeg, Camelen ei drager i Ørken,
 End paa Bøndernes Vogn jeg den moradsige Vei;
 Ingen Bjørn i Hi, paa Mus og visnede Blade
@@ -4057,7 +4057,7 @@ At Madonnas Lampe brænder
 
 <num>III</num>Tag imod vor Mildhedsgave!
 Beed Andægtige, som knæle
-I Capellet, løste Bønnen
+I Capellet, løfte Bønnen
 For to elskovsfulde Sjæle!
 
 <num>IV</num>At den Kummer, som de føle,
@@ -4124,7 +4124,7 @@ Sommerlæ hedder mit Træ.
 <head>
     <title>Til Fylla</title>
     <firstline>O hvor gjerne gav jeg ikke</firstline>
-    <quality>korrektur1,kilde,side</quality>
+    <quality>korrektur1,korrektur2,kilde,side</quality>
     <source pages="147-148"/>
 </head>
 <body>
@@ -4184,7 +4184,7 @@ Er kun en Tanke! er kun en Sang!
 <head>
    <title>Sølvbryllupsvise</title>
    <firstline>Hvad er Kjærligheds Vaar</firstline>
-   <quality>korrektur1,kilde,side</quality>
+   <quality>korrektur1,korrektur2,kilde,side</quality>
    <keywords>lejlighedsdigtning</keywords>
    <source pages="149-150"/>
 </head>
@@ -4204,7 +4204,7 @@ Men da Drømmen forsvandt,
 Siig os hvad vi fandt?
 Knap Mindet - ikke sandt?
 
-<num>II</num>Nei, nu er du for slem!
+<num>II</num>Nei, den Sats er for slem!
 Sagtens gives der dem,
 For hvilke Elskovs Sol ei oprandt;
 Som ei saae nogen Frugt,
@@ -4235,8 +4235,8 @@ Men Huset holdt han af.
 <num>IV</num>Derfor Slægtning og Ven
 Derfor Datter og Søn,
 En Skaal for Brudeparret, de To,
-Der i femogtyve Aar,
-Der i Høst som i Vaar,
+Der i Høst, som i Vaar,
+Som i Dage, i Aar,
 Var enige og troe!
   Rosen, de dannede
     Til Krands,
@@ -4325,7 +4325,7 @@ Ei det Navn var mit.
 
 <num>VI</num>O, men du - Veninde!
 Klare Maane! - O
-Dine blide Straaler
+Dine blege Straaler
 Gav mit Hjerte Ro
 
 <num>VII</num>Du har seet min Taare
@@ -4334,7 +4334,7 @@ Naar du stille lyste
 Over Bjerg og Dal
 
 <num>VIII</num>Du har hørt mig sukke
-Paa den høie Borg -
+Paa din høie Borg -
 Som dit Næ forsvinder,
 Svinde lad min Sorg!
 </poetry>
@@ -4399,7 +4399,7 @@ Kom hid til min Barm, Millioner!''
 Som lettelig lod sig formode -
 Var ogsaa dumdristig og vild
 Og efter hans krusede Hoede.
-,,Heel lukkelig Manden vel var,
+,,Heel lykkelig Manden vel var,
 Der fandt sig en elskelig Qvinde;
 Men bedre det var dog, et Par,
 En Snees endnu bedre at finde!''
@@ -4436,7 +4436,7 @@ Da kunde mig hver Svanebarm benaue,
 Og alle Elskovshymner maatte Taarer til.
 
 <num>III</num>Jeg fandt saa majestætisk eet og andet,
-Som andre finde umaadeligt og smaat;
+Som andre finde maadeligt og smaat;
 Jeg fandt vort hele Liv var saare vandet,
 Og at kun Hippokrenes Kilde smagte godt.
 
@@ -4458,7 +4458,7 @@ Langt over det, at ingen Mangler see.
 <num>VII</num>Nu er mig Verden bleven fuld og fyldig
 Nu Livet blomstrer mig med Fryd og Held;
 Og Hjemmel har jeg for min Dom, en gyldig,
-Dens Skaber selv, der fandt, at Alt var vel.
+Den Skabers selv, der fandt, at Alt var vel.
 </poetry>
 </body>
 </text>
@@ -4467,7 +4467,7 @@ Dens Skaber selv, der fandt, at Alt var vel.
 <head>
     <title>Med en kasse eau de cologne</title>
     <firstline>Blandt Ting, vi søgte om, der kunde passe</firstline>
-    <quality>korrektur1,kilde,side</quality>
+    <quality>korrektur1,korrektur2,kilde,side</quality>
     <source pages="159"/>
 </head>
 <body>
@@ -4508,7 +4508,7 @@ Hvis bruunlige Trængsel
 Din Tinding omflokker.
 
 Forgjæves! Min Tanke
-Kun vandrer og leder
+Kun aander og leder
 Om Lokkernes Ranke,
 Du fletter og breder
 - - - - - - - - - -
@@ -4639,7 +4639,7 @@ Henslørende over
 Blegrøde Koraller;
 
 <num>VII</num>Paa mørke Aurikler,
-Paa dufende Klaser,
+Paa duftende Klaser,
 Hvis Tykning sig vikler
 Om blændende Vaser.
 
@@ -4675,7 +4675,7 @@ Hvor finder jeg eder?
 <head>
     <title>Min tunge Taare sank</title>
     <firstline>Min tunge Taare sank</firstline>
-    <quality>korrektur1,kilde,side</quality>
+    <quality>korrektur1,korrektur2,kilde,side</quality>
     <source pages="167"/>
 </head>
 <body>
@@ -4734,7 +4734,7 @@ Som Duggens Diamanter;
 
 <num>VI</num>Og kunde ikke skjælnes,
 Skjøndt fra den bedske Kilde
-Fra lune himmelfaldne,
+Fra hine himmelfaldne,
 Forfriskende og milde,
 
 <num>VII</num>Med alle Regnbufarver,
@@ -4764,7 +4764,7 @@ Naar det er tømt til Bunden.
 <head>
     <title>Høistammede Rose</title>
     <firstline>Høistammede Rose</firstline>
-    <quality>korrektur1,kilde,side</quality>
+    <quality>korrektur1,korrektur2,kilde,side</quality>
     <source pages="170"/>
 </head>
 <body>
@@ -4786,7 +4786,7 @@ Til Støtte i Jorden
 <head>
     <title>Paa en Skraaning imod Skoven</title>
     <firstline>Paa en Skraaning imod Skoven</firstline>
-    <quality>korrektur1,kilde,side</quality>
+    <quality>korrektur1,korrektur2,kilde,side</quality>
     <source pages="171"/>
 </head>
 <body>
@@ -4804,7 +4804,7 @@ Sad paa Bænken to Matroser
 <head>
     <title>Den synger over mit Hoved</title>
     <firstline>Den synger over mit Hoved</firstline>
-    <quality>korrektur1,kilde,side</quality>
+    <quality>korrektur1,korrektur2,kilde,side</quality>
     <source pages="171"/>
 </head>
 <body>
@@ -4821,7 +4821,7 @@ Digter! kan du ei høre!
 <head>
     <title>Busken med røde Knupper</title>
     <firstline>Busken med røde Knupper</firstline>
-    <quality>korrektur1,kilde,side</quality>
+    <quality>korrektur1,korrektur2,kilde,side</quality>
     <source pages="171"/>
 </head>
 <body>
@@ -4836,7 +4836,7 @@ Granen med gyldne Dupper.
 <head>
     <title>Hvor sig Løvet eensomt fletter</title>
     <firstline>Hvor sig Løvet eensomt fletter</firstline>
-    <quality>korrektur1,kilde,side</quality>
+    <quality>korrektur1,korrektur2,kilde,side</quality>
     <source pages="171"/>
 </head>
 <body>
@@ -4855,7 +4855,7 @@ Fuglen ved dit Fodtrin spretter.
    <notes>
        <note>Indtastet af Estrid Bjerregård.</note>
    </notes>
-   <quality>korrektur1,kilde,side</quality>
+   <quality>korrektur1,korrektur2,kilde,side</quality>
    <source pages="172-176"/>
 </head>
 <body>
@@ -5031,7 +5031,7 @@ Vær for mig det Virkelige!
     <title>Frøerne -</title>
     <firstline>Hvor her er smukt ved Vandet</firstline>
     <source pages="178-179"/>
-    <quality>korrektur1,kilde,side</quality>
+    <quality>korrektur1,korrektur2,kilde,side</quality>
 </head>
 <body>
 <poetry>
@@ -5093,7 +5093,7 @@ Og har det Haab, der er en Evighed.
 <head>
     <title>Vi sad i Vinternatten</title>
     <firstline>Vi sad i Vinternatten</firstline>
-    <quality>korrektur1,kilde,side</quality>
+    <quality>korrektur1,korrektur2,kilde,side</quality>
     <source pages="181"/>
 </head>
 <body>
@@ -5201,7 +5201,7 @@ Som truer med at knække;
 Hun skyder Trillebøren,
 Som Hunden hjelper trække.
 
-<num>V</num>Om sine brune Skuldre
+<num>V</num>Om hendes brune Skuldre
 Har hun et fattigt Stykke
 Og paa den unge Pande
 Kun Svedens Perlesmykke.
@@ -5217,7 +5217,7 @@ Staaer Glæden uforfærdet.
 <text id="aarestrup20190209117" variant="aarestrup2018110602" skip-index="true">
 <head>
     <title>Digternes Prydelse</title>
-    <quality>korrektur1,kilde,side</quality>
+    <quality>korrektur1,korrektur2,kilde,side</quality>
     <source pages="186-188"/>
 </head>
 <body>

--- a/fdirs/aarestrup/1976-3.xml
+++ b/fdirs/aarestrup/1976-3.xml
@@ -222,7 +222,7 @@ Flammen, der fra Ovnen lyser,
 Som en Bussemand dig kyser.
 
 <num>VII</num>Og du troer, din Storm fordriver
-Blomstringsmodet fra sit Skryd?
+Blomstringsmodet med sit Skryd?
 Naar den unge Møe os bliver,
 Har vi Vaarens bedste Dyd;
 Du, med dine lange River
@@ -482,7 +482,7 @@ Af en lønlig Drift, fast uden Villie.
 See da - som paa Lyngens brune Flade,
 Som paa Heire-Axet over Tilie,
 Som paa flygtigt Skum af en Najade,
-Som paa Mosbundens gule Lilie,
+Som paa Mosebundens gule Lilie,
 Som paa Kalkkorallens Svamp og Plade,
 Som paa Strandens spraglede Conchilie -
 Nogle Øieblik paa disse Blade,
@@ -697,7 +697,7 @@ Af Klippen, blodig saaret, han Frist for Livet fandt.
 
 Iiskolde Stænk fra Strømmen det hede Blod ham kjøle;
 Vildt stirrer han ned, og hører Slusen brøle.
-Det sorter for hans Blik - hjælp Gud! - hans Kraft forsager -
+Det sortner for hans Blik - hjælp Gud! - hans Kraft forsager -
 Da føler han sig løftet, en Haand ham opad drager.
 
 Med saaret Knæ og Skulder paa Klippens Blok han staaer,
@@ -942,7 +942,7 @@ Forbløder sig og døer -
 Halloh, Halloh, Halloh, Halloh!
 Hvor Hundekobblet gjøer -
 
-Der blomstrer opgsaa stille
+Der blomstrer ogsaa stille
 I Skyggen Blomster vilde,
 Og der er Græsset blødt;
 Og fløiter Nattergalen,
@@ -1043,7 +1043,7 @@ Mit: da capo! hidindtil.
 
 Men dog kjær, ei sandt, af Natten? -
 Ja; det Ord, at gjemt til den
-Egentligt er gjemt til Katten,
+Egentlig er gjemt til Katten,
 Er Bagtalelse, min Ven!
 
 Noget maa du Maanen unde? -
@@ -1077,7 +1077,7 @@ Og jeg venter, Ingen kommer,
 Trøster mig den smukke Sang.
 
 Ah, i Birkelundens Midte
-Jægerhuset? - Lag mig gaae!
+Jægerhuset? - Lad mig gaae!
 Veed du ikke, een kan fritte
 Meer end ti kan svare paa.
 </poetry>
@@ -1173,7 +1173,7 @@ Naar Faren er forbi, saa maa den være glemt.
 Han tog sin Viv paa Skjødet, trak Kufferten frem,
 Og viste, hvad fra Reisen han bragte med sig hjem.
 Af Silketøj og Linned saa lystelig en Skat;
-Et Tut med Sølverpenge den var i Krogen sat.
+En Tut med Sølverpenge den var i Krogen sat.
 
 Lysvaagen ud af Reden den lille Gut da sprang,
 Den stumped' Skjorte ham om Benene hang.
@@ -1957,7 +1957,7 @@ Ulykken rammer Alle!
 Men Greven stod bag Døren -
 Det Syn ham ei forlysted -
 Han stødte hende Dolken
-Til Hæften ind i Brystet.
+Til Hæftet ind i Brystet.
 
 Ulykken rammer Alle!
 
@@ -2347,7 +2347,7 @@ Og Qvinderne med Krandse.
 Men ungen Radbod mødte dem
 I Harnisk og med Landse.
 
-Og Bondes Blod i Strømme flød
+Og Bondens Blod i Strømme flød
 Alt paa hans egen Ager,
 Som Bierne i Kuben døe
 I egne Honningkager.
@@ -2643,7 +2643,7 @@ Den Krands, den voxer og den bliver,
 Uvisnelig, en evig Fryd.
 
 Hvad Duggen er for Rosens Rødme,
-Er Viin for Læbers Rosenild,
+Er Viin for Læbens Rosenild,
 Lad derfor Sødt berøre Sødme,
 Løft Glassets skjønne Farvespil!
 
@@ -2757,7 +2757,7 @@ Flammen, der fra Ovnen lyser,
 Som en Busemand dig kyser.
 
 Tro ei, at din Storm fordriver
-Blomstringsmodet med dit Skryd -
+Blomstringsmodet med sit Skryd -
 Naar den unge Mø os bliver,
 Har vi Vaarens bedste Pryd;
 Du, med dine lange River,
@@ -3334,7 +3334,7 @@ En Skare Folk, som græde.
 
 Hvorhen, Signor Dottore?
 Med Hastværk han sig skyndte;
-Det hele Gade lugter
+Den hele Gade lugter
 Endnu af Pebermynte.
 
 Friseuren her jeg kjender -
@@ -3839,7 +3839,7 @@ Ved Tanken om din Galde blot, at zittre.
 9.
 Blomst af Pelargonien,
 Din fine Tegning fik mig til at tænke,
-Vi sad en Sommenqvæld i Catalonien.
+Vi sad en Sommerqvæld i Catalonien.
 
 10.
 Søde Narcisse,
@@ -4303,7 +4303,7 @@ Tillad, at jeg trykker om Livet dig, Søde;
 Seer du? Solen gaaer ned og Alperne gløde.
 
 6.
-Eqvilibrist, som baglæns bøiet fra Pælen
+Eqvilibrist, som baglængs bøiet fra Pælen
 Løfter den Skilling, man smed dig ved Hælen;
 Heller, som du, gad jeg søge min Skilling,
 End, blodrød ved et Buk, i den modsatte Stilling.
@@ -4497,7 +4497,7 @@ Ved Hjelp af Øielaaget.
 
 Bag denne gamle Træstub
 Et Baand, et løsnet, bandt hun -
-Og hvor Markiser lufter
+Og hvor Markisen lufter
 Paa Hjørnet der, forsvandt hun.
 
 Jeg skimtede i Mørket
@@ -4702,7 +4702,7 @@ Af Himmelbuen blaaner,
 Hvem flygtigt et Par Stjerner
 Halv skamfuldt Øiet laaner;
 
-Hvori, hvor du blot vilde
+Hvori, hvis du blot vilde
 Ud over Randen kikke,
 Du saae, skjøndt lidt formørket,
 Dit Engleansigt nikke -
@@ -6096,13 +6096,13 @@ Den dræbende Forandring!
    <title>En Afsked</title>
    <toctitle>En Afsked</toctitle>
    <indextitle>En Afsked</indextitle>
-   <firstline>O, intet Under, de bevares</firstline>
+   <firstline>O, intet Under, du bevares</firstline>
    <quality>korrektur1,korrektur2,kilde,side</quality>
    <source pages="219"/>
 </head>
 <body>
 <poetry>
-O, intet Under, de bevares
+O, intet Under, du bevares
 Med Laas og Lukke, som en Skat,
 At En - jeg veed nok hvem - dig vogter
 Med Argusøine Dag og Nat.
@@ -6112,7 +6112,7 @@ Som Flagermuus omkring et Baal,
 Og at jeg selv beruset tumler
 Som Bremsen fra en Nektarskaal.
 
-Al Sommerblæstens vame Blødhed
+Al Sommerblæstens varme Blødhed
 Er i din melkehvide Arm,
 Al Blomsterskjønhed i Naturen
 Har fyldt og rundet denne Barm.
@@ -6595,7 +6595,7 @@ Minder om det danske Flag.
 
 <num>V</num>Det skal ingen Feighed plette -
 Venner, Mod i Farens Stund!
-Her vi følge Hjemmets rette
+Her vi føle Hjemmets rette
 Toner gaae fra Mund til Mund;
 Her, om end i Tvang og Baand,
 Spore vi den danske Aand.
@@ -6696,7 +6696,7 @@ Over det elskede Støv flyde den strømmende Graad.
       <note>Fire sonnetter som er trykt i <i>Kjøbenhavnsposten</i>, 11. Oktober 1838.  En senere rettet renskrift af disse fire samt een ekstra tilføjet sonnet findes som <xref poem="aarestrup1838-56a3"/> i <i>Utrykte digte</i> (1838-56).</note>
    </notes>
    <keywords>lejlighedsdigtning,rom,thorvaldsen,sonnet</keywords>
-   <quality>korrektur1</quality>
+   <quality>korrektur1,korrektur2</quality>
    <source pages="239-241"/>
 </head>
 <body>
@@ -6735,7 +6735,7 @@ I Alle, som i Hjertet føler stille
 For Konstens ædle Sprog et dunkelt Nemme.
 
 Det er ei blot til de studeerte Hjerner,
-Eiheller blot til Mænd med Baand og Stjerner,
+Ei heller blot til Mænd med Baand og Stjerner,
 Skjønhedsgudinden kaster sine Blikke -
 
 Almuens Barn, hvis Kræfter Ingen maalte,
@@ -6753,7 +6753,7 @@ Tilstede just med Sang og Flag og Grene,
 Ved hin Velkomstens prægtigskjønne Scene -
 Det Vidne tør dog Musen dristig bære:
 At samme Følelser vi Alle nære,
-Og lige hjertelig det Alle mene.
+Og lige hjerteligt det Alle mene.
 
 Saavidt som Danmark grønnes under Lide,
 Er ingen Sjæl, som ikke byder Gjæsten
@@ -6774,7 +6774,7 @@ Og det mest Straalende paa Høitidsdagen?
 Det var - hvortil man snart igjen see Magen! -
 Det Ideales Seier over Trangen,
 Det Ædles sikkre Høide over Rangen,
-Og en Forstummelse af Hverdagsklangen.
+Og en Forstummelse af Hverdagsklagen.
 
 Det var ei nogen Jublen hen i Taaget,
 Ei noget Skraal af sammenløbne Drenge,
@@ -6799,7 +6799,7 @@ Uændset holdt tilbage, dog tilsidst udbryder.
 <num>I</num>Paa denne Tid, da Kongevælde
 Tidt stævnes ind for Dommerskranken,
 Vil jeg et Træk af den fortælle,
-Det falder mig, just nu, i Tanken.
+Der falder mig, just nu, i Tanken.
 
 <num>II</num>Et tusind Aar og noget mere
 Efterat Jesus Christ fik Livet,
@@ -6831,7 +6831,7 @@ Nær var han slumret ind omsider -
 Dog pludselig han Farve skifter,
 Og Haanden hen mod Dolken glider.
 
-<num>VIII</num>,,Hvad - raber han - hvad seer mit Øie?
+<num>VIII</num>,,Hvad - raaber han - hvad seer mit Øie?
 En ukjendt Skabning hid sig vover?
 Mon foran Slottets gyldne Fløie
 Min kongelige Livvagt sover?
@@ -6932,7 +6932,7 @@ Kun mine egne Sønner prøved
 Paa Sligt - det fuldt og fast jeg troede.
 
 <num>XXVIII</num>Og for at ei Barmhjertigheden
-Retfærdigen skulde krænke,
+Retfærdigheden skulde krænke,
 Saa slukked Lyset jeg i Vreden,
 Og Blodet - hvis det var - lod stænke!
 
@@ -7423,7 +7423,7 @@ Han steg med Lyset op paa Bordets Skive,
 Og lod sin Haand henover Kalken svæve -
 
 <num>VIII</num>,,<w>Mene, mene, tekel, upharsin!</w>''<note>Se <xref bibel="bibeldaniel05,25-28"/>.</note> vare
-De Ord, som han paa Husets Dække tegnet,
+De Ord, som han paa Husets Dække tegned,
 Imedens om hans Knæ min Børneskare
 Og alt mit Tyende af Rædsel blegned.
 
@@ -7434,7 +7434,7 @@ Bestandig for den Dødeliges Øre! -
 
 <nonum><center>- - -</center></nonum>
 
-<num>X</num>Jeg kjender ham, som har mig Muret mærket
+<num>X</num>Jeg kjender ham, som har mig Muren mærket
 Med hine Alvorsord af Oldsskriften:
 En rastløs Mand, der lægger Haand paa Værket,
 En Guds Herold, der kalder til Bedriften!
@@ -7450,7 +7450,7 @@ Der gjerne, medens det er Tid, udriver
 Sit Land af Faren - skjøndt en Røst i Ørken!
 
 <num>XIII</num>Og dog en Ven af Barnlighed og Ynde,
-En Elsker af, at høre Lyre klinge,
+En Elsker af, at høre Lyren klinge,
 Naar danske Muser Væddestrid begynde -
 Ham disse Linier min Hilsen bringe!
 </poetry>
@@ -7468,7 +7468,7 @@ Ham disse Linier min Hilsen bringe!
 <poetry>
 <num>I</num>Fra grønne Bakker - svulmende paa Øen
 Som ude paa det Dybe Havets Bølge -
-Skal min Blik til Horizonten følge
+Skal mine Blik til Horizonten følge
 Dit hvide Seil henover Østersøen.
 
 <num>II</num>Du reiser bort til Nordens Klippestrande,
@@ -7483,7 +7483,7 @@ Dog Kæmpefoden meer og mere løfter!
 
 <num>IV</num>Forstaa hans Vink! Lad nordisk Mod og Mæle
 Forkynde Fremmede hvorfra du stammer!
-Fortvivl ei om det Fædreland! Det ammer
+Fortvivl ei om dit Fædreland! Det ammer
 Et Kuld, som Trældomsaaget ei skal qvæle.
 
 <num>V</num>Fortæl, at Frihedslyst i Danmark svulmer!
@@ -7619,7 +7619,7 @@ En gudhengiven Ro er der i Taaren,
 Der offres til den forudgangne Kjære;
 Hvor Egeløvet vikler sig om Kaarden,
 Har dyrebare Hænder til hans Ære
-Lagt Krandt ved Krands - fra Blomsterhaven
+Lagt Krands ved Krands - fra Blomsterhaven
 Et ømt Farvel, en Afskedsduft i Graven!
 
 <num>V</num>I Fred han hvile nær sin skjønne Bolig,
@@ -7756,7 +7756,7 @@ Den gyldne Nøgle, Kongen ham betroede,
 Var intet tomt Symbol - ham kunde man
 Betroe sig til, med Tryghed; - paa hans Bryst
 Var Ridderkorset ingen Ironi,
-Thi bagved slog der ridderligste Hjerte -
+Thi bagved slog det ridderligste Hjerte -
 Hvor er en Røst, der kan benegte det?
 Hans <w>Sind</w> var adeligt, hans Mod var mandigt,
 Hans blanke Skjold var uden mindste Plet;
@@ -7766,7 +7766,7 @@ Den Strid, som det Forkrænkelige kæmper,
 Og det Udødelige kun bestaaer;
 Og sank han end i Knæ, lidt efter lidt,
 Ei Utaalmodighedens Suk blev hørt,
-Et Bitterhedens Skrig - Da Timen kom,
+Ei Bitterhedens Skrig - Da Timen kom,
 Var han beredt - Et Smiil var hans Farvel!
 
 Og derfor bringe vi Dig <w>vort</w> Farvel,
@@ -7893,7 +7893,7 @@ Til Hermelinet og Kaaben.
 <num>XXI</num>,,Men Frihed vil han med Djævels Magt
 ,,- Som i en Feber han tørster -
 ,,Fri vil han være, om selv i Pagt
-,,Med tydste Grever og Fyrster.
+,,Med tydske Grever og Fyrster.
 
 <num>XXII</num>,,Jeg siger: rolig, min søde Bror!
 ,,Du gjør mig næsten forskrækket;
@@ -8075,13 +8075,13 @@ Hver Draabe Blod, som I gav hen,
 Har Danmarks Arm forstærket.
 Vi hæve den paa nordisk Viis
 Til Løvtets Tegn for Eder:
-Om Folkets Tak, om Mandoms Priis
+Om Folkets Tak, om Manddoms Priis
 Saavidt sig Danmark breder.
 
 <num>VI</num>Og Kongen, som dets første Mand,
 Sin Hyldest aabenbarer.
 See! Kongesalen aabned han
-For dine tappre Skarer.
+For sine tappre Skarer.
 Hans Fødselsdag - den feires bedst
 Af Troskab, Mod og Ære,
 Og derfor skal ved Eders Fest
@@ -8193,7 +8193,7 @@ Fik de med i dyben Grav.''
 <num>XIX</num>,,Døden sang alt for mit Øre.
 Dig, min Viv, jeg tænkte paa.
 Ei min Arm jeg kunde røre,
-Stiv at Svømning, kold og blaa.''
+Stiv af Svømning, kold og blaa.''
 
 <num>XX</num>,,See, da greb mig under Brystet
 Hænder dybt fra Nøkkens Hiem,
@@ -8202,7 +8202,7 @@ Førtes jeg paa Havet frem.''
 
 <num>XXI</num>,,Ved de stærke Glimt fra Himlen
 Saae jeg Havfrubarmens Snee,
-Saae jeg, mid i Bølgevrimlen,
+Saae jeg, midt i Bølgevrimlen,
 Hendes Perletænder lee.''
 
 <num>XXII</num>,,Saae jeg hendes glatte Skuldre,

--- a/fdirs/aarestrup/1976-4.xml
+++ b/fdirs/aarestrup/1976-4.xml
@@ -23,7 +23,7 @@
 <head>
    <title>Fremtiden</title>
    <firstline>Alting bagvendt og forkludret!</firstline>
-   <quality>korrektur1,kilde,side</quality>
+   <quality>korrektur1,korrektur2,kilde,side</quality>
    <source pages="1-2"/>
 </head>
 <body>
@@ -70,7 +70,7 @@ Som en Ulv i Lænker, brumme.
 <head>
    <title>Den første Bøn</title>
    <firstline>Ungersvendens Eed jeg kjender</firstline>
-   <quality>korrektur1,kilde,side</quality>
+   <quality>korrektur1,korrektur2,kilde,side</quality>
    <source pages="3"/>
 </head>
 <body>
@@ -109,7 +109,7 @@ Elsk mig lidt og elsk mig længe!
 <head>
    <title>Drømmen</title>
    <firstline>Jeg drømte, at jeg saae dig staae</firstline>
-   <quality>korrektur1,kilde,side</quality>
+   <quality>korrektur1,korrektur2,kilde,side</quality>
    <source pages="4-5"/>
 </head>
 <body>
@@ -156,7 +156,7 @@ Min Mund, den var saa kold som Sne .
 <head>
    <title>Gaadeløsningen</title>
    <firstline>Dit drømmerige, tankefyldte</firstline>
-   <quality>korrektur1,kilde,side</quality>
+   <quality>korrektur1,korrektur2,kilde,side</quality>
    <source pages="6"/>
 </head>
 <body>
@@ -192,7 +192,7 @@ Hvad nytter det, man holder Hoedet?
    <notes>
       <note>Titlen er fra Juvenal, Satire I, 30, og kan oversættes til »Det er vanskeligt ikke at skrive en satire«.</note>
    </notes>
-   <quality>korrektur1,kilde,side</quality>
+   <quality>korrektur1,korrektur2,kilde,side</quality>
    <source pages="7"/>
 </head>
 <body>
@@ -214,14 +214,14 @@ Dog passe, at man ei fordærver Maven.
 <text id="aarestrup2001061301a" variant="aarestrup2018110603" skip-index="true">
 <head>
    <title>Kjære Ven! Jeg har faaet en Maneer</title>
-   <quality>korrektur1,kilde,side</quality>
+   <quality>korrektur1,korrektur2,kilde,side</quality>
    <source pages="8-10"/>
 </head>
 <body>
 <prose>
 <right>Nysted 23de Dcbr. 1837</right>
 
-     Kjære Ven! Jeg har faaet en Maneer - som Du seer - der behager mig, om ikke Andre, meer og meer, - hvorved jeg i en Fart, - meget snart, - og med al Uleilighed spart, - kan gjøre mit Inderste klart, - sige hvad jeg vil, rimet og rart, - paa en konstig Art, - og uden Beskyldelse - for Mangel paa givne Løfters Opfyldelse - Ja, jeg kan hive, - drive - alle mulige Sager ind i Brevets fiirkantede Skive, - om de var nok saa stive. - Saaledes for Exempel - rækker jeg Dig nu, under eget Stempel, - mit poetiske Tempel, - ikke af Kort, - der falde omkuld og veires bort, - men af Blade, - saa hvide og fine som om de gjemte Chocolade, - og beder Dig indstændigst, - ubændigst, - hvormeget end Interessen - byder Dig, at det, der kommer fra Pressen - snarest muligt kritiseres - maltraiteres, - spoleres - og som Maculatur til Kræmmerhuse approberes, - at Du, siger jeg, dog, - af Venskab for mig arme Skrog - og min Bog, - gjør Alt hvad Du anseer for Mulighed, - for at prise i Digtekonsten min Duelighed, - min Muses Jomfrulighed; - at Du løfter til Skyerne, - og udbasunerer i Byerne - min Pens elastiske, - plastiske, - bombastiske - Sprætninger og Sprutninger, - min Hjernes gode Beslutninger, - til Trods for Forstandens Forputninger; - min Ærefrygt for det Loyale, - Colossale, - Ideale, - Universale, - og at Du skjuler mit Hang til det Gale, - Fatale, - Liberale, - Triviale, - uden Hoved og Hale, - der lyser ud af min Tale. - Jeg beder Dig, ikke genere - Dig for at recommandere - til Alle og Enhver, - men især - ved L'hombrebordet i Klubberne, - paa Børsen til ærlige Folk og Beskupperne, - i Damecircler til Egestubberne, - saavelsom til Rosenknupperne - mig, din intimeste Ven iblandt Aarestrupperne!
+     Kjære Ven! Jeg har faaet en Maneer - som Du seer - der behager mig, om ikke Andre, meer og meer, - hvorved jeg i en Fart, - meget snart, - og med al Uleilighed spart, - kan gjøre mit Inderste klart, - sige hvad jeg vil, rimet og rart, - paa en konstig Art, - og uden Beskyldelse - for Mangel paa givne Løfters Opfyldelse - Ja, jeg kan hive, - drive - alle mulige Sager ind i Brevets fiirkantede Skive, - om de var nok saa stive. - Saaledes for Exempel - rækker jeg Dig nu, under eget Stempel, - mit poetiske Tempel, - ikke af Kort, - der falde omkuld og veires bort, - men af Blade, - saa hvide og fine som om de gjemte Chocolade, - og beder Dig indstændigst, - ubændigst, - hvormeget end Interessen - byder Dig, at det, der kommer fra Pressen - snarest muligt kritiseres - maltraiteres, - spoleres - og som Maculatur til Kræmmerhuse approberes, - at Du, siger jeg, dog, - af Venskab for mig arme Skrog - og min Bog, - gjør Alt hvad Du anseer for Mulighed, - for at prise i Digtekonsten min Duelighed, - min Muses Jomfrulighed; - at Du løfter til Skyerne, - og udbasuner i Byerne - min Pens elastiske, - plastiske, - bombastiske - Sprætninger og Sprutninger, - min Hjernes gode Beslutninger, - til Trods for Forstandens Forputninger; - min Ærefrygt for det Loyale, - Colossale, - Ideale, - Universale, - og at Du skjuler mit Hang til det Gale, - Fatale, - Liberale, - Triviale, - uden Hoved og Hale, - der lyser ud af min Tale. - Jeg beder Dig, ikke genere - Dig for at recommandere - til Alle og Enhver, - men især - ved L'hombrebordet i Klubberne, - paa Børsen til ærlige Folk og Beskupperne, - i Damecircler til Egestubberne, - saavelsom til Rosenknupperne - mig, din intimeste Ven iblandt Aarestrupperne!
      Lad Ingen læse, - stikke sin Næse - i dette Mudder - og Sludder; - især ikke den, med mine Sager i længere Tid asende, - stakkels Winther, saa bliver han rasende. - Men hils Din Broder, - No 2 blandt gode Ho'eder, - hvem jeg snart skriver til, som jeg formoder; - og hende, - som Du har gjort til tvende, - maaskee til trende, - O, jeg er reent overende! - din søde, - bløde, - kjærlige, - herlige - Ægtehustru og Frue, - der smykker Din Sal og Din Stue, - bedre end Raphaels ypperste Billede, - om Du det stillede - hen, - min Ven, - farveblændende, - hjertetændende, - Uskyld og Fromhed sendende, - paa Skjødet en Engel, - i Haanden en Liliestengel. -
      Og nu, farvel! Han, som kaster - Sneen om vaklende Taarne og vildfarne Master, - klumper Havet til Iis, - og lader Stjernerne synge sin Priis, - han vogte Dig Huset for Fare! - Han Dit Hjerte og Alt, hvad dertil hører, bevare! - i det nye Aar som i det gamle! - Han eengang os Alle, som glade Børn, om sin Skammel forsamle! - -
 
@@ -234,14 +234,14 @@ Dog passe, at man ei fordærver Maven.
 <text id="aarestrup2001061302b" variant="aarestrup2001061302a" skip-index="true">
 <head>
    <title>Kjære værslevske Venner!</title>
-   <quality>korrektur1,kilde,side</quality>
+   <quality>korrektur1,korrektur2,kilde,side</quality>
    <source pages="11-13"/>
 </head>
 <body>
 <prose>
 <right>Nysted 24de December 1837,</right>
 
-     Kjære værslevske Venner! - Tag af mine Hænder - det, som I kjender, - den lille Gnist af Digterild, som brænder - ihvordan jeg mig ender og vender, - hvordan i Aaget man ogsaa mig spænder, - hvor haard end Nødden er under mine Tænder, - modtag disse Blade, jeg sender; - de muddrede, - pluddrede, - forkluddrede - har I ingen Andeel i; men desmere i de hjertelige, - vellystsmertelige, - hyggelige, - ikke altfor vederstyggelige, - kortsagt heldige og lykkelige. - Lad disse Blade kalde tilbage, - Venner, de henrundne Dage, - da jeg drak i Eders Huus - af det gjæstfrie Kruus, - tog mig en Priis, Isak, af dit Snuus, - og da Din Thrine dækked mig Disken, - med Fuglen og Fisken, - med Kniv og Gaffel, - med Viin og Karaffel, - Syltetøi og Vaffel, - og Eders Vittighed lyste over det landlige Taffel. - Lad disse Blade kalde tilbage - de henrundne Dage, - da Munterhed og Skrantenhed, - Glæde og Vrantenhed, - Overgivenhed og Trøstighed, - Hengivenhed og Lystighed, - Gebursdagsl'homberen og Onsdagswisthen, - Jordbærret paa Ranken og Abrikosen paa Qvisten, - Paaskeæget og Julegrøden, - Maaneskinnet og Aftenrøden, - hvert Skud, hvori vi forgrenede, - hver Glut, som Gud os forlehnede, - os meer og meer forenede. - Lad disse Blade kalde tilbage - de henrundne Dage, - samle - det Gamle, - fæste - det Næste, - gjæste - det Nye og hvad endnu kan reste, - samt anbefale mig paa det Bedste - til alle nordsjællandske Præstekoner og Præste. - Vi leve her som I sagtens kan tænke, - som en Hund i sin Lænke, - en Fugl i sit Buur, - vor hele Opmuntring er den gamle Madam Suhr. - Det fyger - og ryger, - knærker - og værker, - hvæser - og blæser; - istedenfor at leve, jeg læser; - Brændet er vaadt, - Tørven lugter ikke godt, - Brødet raat, - Melkefadet blaat, - Børnenes Næser fulde af -; - Alle Blade ere faldne af Rosen; - Posekiggerne føle paa Posen; - Tiggerunger løbe omkring med Lasen - om Hasen; - vores Præst er ikke engang en Æsel, men et Asen, - og Byfogdens nye Seletøi hele Julestadsen. - Men Du, Gudværelovet, - er lykkelig med dit overgivne Thrine, - mere vant til Børn, end til Mavepine; - Din nye Frøken, - der, hvis du har glemt det, kan lære Dig Brøken; - Faster - i Sengens varme Plaster; - Hanne - med den kloge Pande; - Nicoline og Emilie - den ene en Conchilie - den anden en Lilie; - Rasmus og Mølle - en Prygl og en Kølle; - Jacobus, - der studerer paa sin Globus; - og endnu mange, - som ikke mine Riim kan lange. - Ja, Du er lykkelig, - det siger jeg udtrykkelig, - og Han, som gjorde Dig Marken grødende, - Svinet fødende, - Dit Hjerte elskeligt og glødende, - Han vogte og bevare, - med sine Engles Jule- og Nytaarsskare - Dig og Dine, - saavelsom mig og mine; - Han i det nye Aar os lette, - hvad vi skal bære, som han har gjort i dette; - Han knytte med sin Haand - uopløseligen vore Venskabsbaand, - og blæse paa os med sin Aand!
+     Kjære værslevske Venner! - Tag af mine Hænder - det, som I kjender, - den lille Gnist af Digterild, som brænder - ihvordan jeg mig ender og vender, - hvordan i Aaget man ogsaa mig spænder, - hvor haard end Nødden er under mine Tænder, - modtag disse Blade, jeg sender; - de muddrede, - pluddrede, - forkluddrede - har I ingen Andeel i; men desmere i de hjertelige, - lystigsmertelige, - hyggelige, - ikke altfor vederstyggelige, - kortsagt heldige og lykkelige. - Lad disse Blade kalde tilbage, - Venner, de henrundne Dage, - da jeg drak i Eders Huus - af det gjæstfrie Kruus, - tog mig en Priis, Isak, af dit Snuus, - og da Din Thrine dækked mig Disken, - med Fuglen og Fisken, - med Kniv og Gaffel, - med Viin og Karaffel, - Syltetøi og Vaffel, - og Eders Vittighed lyste over det landlige Taffel. - Lad disse Blade kalde tilbage - de henrundne Dage, - da Munterhed og Skrantenhed, - Glæde og Vrantenhed, - Overgivenhed og Trøstighed, - Hengivenhed og Lystighed, - Gebursdagsl'homberen og Onsdagswisthen, - Jordbærret paa Ranken og Abrikosen paa Qvisten, - Paaskeæget og Julegrøden, - Maaneskinnet og Aftenrøden, - hvert Skud, hvori vi forgrenede, - hver Glut, som Gud os forlehnede, - os meer og mere forenede. - Lad disse Blade kalde tilbage - de henrundne Dage, - samle - det Gamle, - fæste - det Næste, - gjæste - det Nye og hvad endnu kan reste, - samt anbefale mig paa det Bedste - til alle nordsjællandske Præstekoner og Præste. - Vi leve her som I sagtens kan tænke, - som en Hund i sin Lænke, - en Fugl i sit Buur, - vor hele Opmuntring er den gamle Madam Suhr. - Det fyger - og ryger, - knærker - og værker, - hvæser - og blæser; - istedenfor at leve, jeg læser; - Brændet er vaadt, - Tørven lugter ikke godt, - Brødet raat, - Melkefadet blaat, - Børnenes Næser fulde af -; - Alle Blade ere faldne af Rosen; - Posekiggerne føle paa Posen; - Tiggerunger løbe omkring med Lasen - om Hasen; - vores Præst er ikke engang en Æsel, men et Asen, - og Byfogdens nye Seletøi hele Julestadsen. - Men Du, Gudværelovet, - er lykkelig med dit overgivne Thrine, - mere vant til Børn, end til Mavepine; - Din nye Frøken, - der, hvis du har glemt det, kan lære Dig Brøken; - Faster - i Sengens varme Plaster; - Hanne - med den kloge Pande; - Nicoline og Emilie - den ene en Conchilie - den anden en Lilie; - Rasmus og Mølle - en Prygl og en Kølle; - Jacobus, - der studerer paa sin Globus; - og endnu mange, - som ikke mine Riim kan lange. - Ja, Du er lykkelig, - det siger jeg udtrykkelig, - og Han, som gjorde Dig Marken grødende, - Svinet fødende, - Dit Hjerte elskeligt og glødende, - Han vogte og bevare, - med sine Engles Jule- og Nytaarsskare - Dig og Dine, - saavelsom mig og mine; - Han i det nye Aar os lette, - hvad vi skal bære, som han har gjort i dette; - Han knytte med sin Haand - uopløseligen vore Venskabsbaand, - og blæse paa os med sin Aand!
 
 <right>Alle Dines og Din Ven</right>
 <right>     E Aarestrup     </right>
@@ -253,7 +253,7 @@ Dog passe, at man ei fordærver Maven.
 <head>
    <title>Tilegnelse</title>
    <firstline>Her seer Du nogle Digte</firstline>
-   <quality>korrektur1,kilde,side</quality>
+   <quality>korrektur1,korrektur2,kilde,side</quality>
    <source pages="14"/>
 </head>
 <body>
@@ -291,7 +291,7 @@ Men kun, kun <w>ved Dit Øre</w>!
 <head>
    <title>Kongens Skaal</title>
    <firstline>En Konge, veed vi, fødes</firstline>
-   <quality>korrektur1,kilde,side</quality>
+   <quality>korrektur1,korrektur2,kilde,side</quality>
    <keywords>lejlighedsdigtning</keywords>
    <source pages="15-17"/>
 </head>
@@ -381,7 +381,7 @@ Og hans i sidste Led!
 <head>
    <title>Gravrøsten</title>
    <firstline>Omfyget af Sneen</firstline>
-   <quality>korrektur1,kilde,side</quality>
+   <quality>korrektur1,korrektur2,kilde,side</quality>
    <source pages="18-20"/>
 </head>
 <body>
@@ -453,7 +453,7 @@ Dødfrossen og stille.
 <head>
    <title>Den har du tabt, den Kjæde</title>
    <firstline>Den har du tabt, den Kjæde</firstline>
-   <quality>korrektur1,kilde,side</quality>
+   <quality>korrektur1,korrektur2,kilde,side</quality>
    <source pages="21-22"/>
 </head>
 <body>
@@ -508,7 +508,7 @@ Det kan du aldrig miste.
    <notes>
       <note>O. Bang er den ansete læge Oluf Lundt Bang (kaldet Ole Bang; 1788-1877), også virksom som skribent. Farfader til <a person="bang">Herman Bang</a>.</note>
    </notes>
-   <quality>korrektur1,kilde,side</quality>
+   <quality>korrektur1,korrektur2,kilde,side</quality>
    <source pages="23-26"/>
 </head>
 <body>
@@ -624,7 +624,7 @@ Hvile Lægehaanden ud!
    <notes>
        <note>En rettet renskrift af sonnetter, hvoraf de fire blev trykt i <i>Kjøbenhavnsposten</i>, 11. Oktober 1838.  Cf. den trykte udgave af sonetterne (<xref poem="aarestrup2019020206"/>) i <i>Digte, trykt efter 1837</i>.</note>
    </notes>
-   <quality>korrektur1,kilde,side</quality>
+   <quality>korrektur1,korrektur2,kilde,side</quality>
    <keywords>lejlighedsdigtning,rom,thorvaldsen,sonnet</keywords>
    <source pages="27-30"/>
 </head>
@@ -724,7 +724,7 @@ Og det mest Straalende paa Høitidsdagen?
 Det var - hvortil man snart igjen see Magen! -
 Det Ideales Seier over Trangen,
 Det Ædles sikkre Høide over Rangen,
-Og en Forstummelse af Hverdags-Klangen.
+Og en Forstummelse af Hverdags-Klagen.
 
 Det var ei nogen Jublen hen i Taaget,
 Ei noget Skraal af sammenløbne Drenge,
@@ -741,7 +741,7 @@ Uændset holdt tilbage, dog tilsidst udbryder.
 <head>
    <title>Critik</title>
    <firstline>Hvad Publikum har fundet for et Hold</firstline>
-   <quality>korrektur1,kilde,side</quality>
+   <quality>korrektur1,korrektur2,kilde,side</quality>
    <source pages="31"/>
 </head>
 <body>
@@ -758,7 +758,7 @@ En nøgen Philosoph og en paaklædt Apoll.
 <head>
    <title>Yndig er Ourebygaard</title>
    <firstline>Yndig er Ourebygaard i Sommerens blussende Skjønhed</firstline>
-   <quality>korrektur1,kilde,side</quality>
+   <quality>korrektur1,korrektur2,kilde,side</quality>
    <keywords>heksameter</keywords>
    <source pages="32-34"/>
 </head>
@@ -818,7 +818,7 @@ Og at den herlige Flor længe maa blomstre som nu -
    <title>Min Ven - Christian Petersen!</title>
    <toctitle>Min Ven - Christian Petersen!</toctitle>
    <indextitle>Min Ven - Christian Petersen!</indextitle>
-   <quality>korrektur1,kilde,side</quality>
+   <quality>korrektur1,korrektur2,kilde,side</quality>
    <source pages="35-37"/>
 </head>
 <body>
@@ -840,7 +840,7 @@ Og at den herlige Flor længe maa blomstre som nu -
 <head>
    <title>Kjøbenhavnske Minder</title>
    <firstline>O I grønne Bastioner</firstline>
-   <quality>korrektur1,kilde,side</quality>
+   <quality>korrektur1,korrektur2,kilde,side</quality>
    <source pages="38-41"/>
 </head>
 <body>
@@ -959,7 +959,7 @@ Alle Venner snart mig glemt.
    <title>Mit Brev jeg sender</title>
    <toctitle>Mit Brev jeg sender</toctitle>
    <indextitle>Mit Brev jeg sender</indextitle>
-   <quality>korrektur1,kilde,side</quality>
+   <quality>korrektur1,korrektur2,kilde,side</quality>
    <source pages="42-44"/>
 </head>
 <body>
@@ -978,7 +978,7 @@ Alle Venner snart mig glemt.
        <line>- Mel: Der er et Land, dets Sted er høit mod Norden. Weyse -</line>
    </subtitle>
    <firstline>To grønne Øer sig mod Syden runde</firstline>
-   <quality>korrektur1,kilde,side</quality>
+   <quality>korrektur1,korrektur2,kilde,side</quality>
    <source pages="45-46"/>
 </head>
 <body>
@@ -1035,7 +1035,7 @@ Men i hvert ærligt Hjerte, som du vandt!
 <head>
    <title>Kom, Gudsengel, stille Død</title>
    <firstline>Kom, Gudsengel, stille Død</firstline>
-   <quality>korrektur1,kilde,side</quality>
+   <quality>korrektur1,korrektur2,kilde,side</quality>
    <source pages="47-48"/>
 </head>
 <body>
@@ -1077,7 +1077,7 @@ Kun et Drag til Afskedssukket!
 <head>
    <title>Til Kritikerne</title>
    <firstline>Om Aanden skulde flagre noget vildt</firstline>
-   <quality>korrektur1,kilde,side</quality>
+   <quality>korrektur1,korrektur2,kilde,side</quality>
    <source pages="49"/>
 </head>
 <body>
@@ -1114,7 +1114,7 @@ Om den veed ikkun Guderne Besked.
 <head>
    <title>Patriotisk Elegie</title>
    <firstline>Der var en Tid mit Fødeland</firstline>
-   <quality>korrektur1,kilde,side</quality>
+   <quality>korrektur1,korrektur2,kilde,side</quality>
    <source pages="50-52"/>
 </head>
 <body>
@@ -1201,7 +1201,7 @@ Der gav os Naadestødet
 <head>
    <title>Forskjønnelsen</title>
    <firstline>Der var mere i mit Hjerte</firstline>
-   <quality>korrektur1,kilde,side</quality>
+   <quality>korrektur1,korrektur2,kilde,side</quality>
    <source pages="53-54"/>
 </head>
 <body>
@@ -1249,7 +1249,7 @@ Er i Nattens Mulm at see.
    <title>Prolog</title>
    <subtitle>til en dramatisk Forestilling til Bedste for de vandlidte Jyder.</subtitle>
    <firstline>Vort Hjem er paa den lave Ø</firstline>
-   <quality>korrektur1,kilde,side</quality>
+   <quality>korrektur1,korrektur2,kilde,side</quality>
    <source pages="55-57"/>
 </head>
 <body>
@@ -1325,12 +1325,12 @@ Et ubetydeligt, et ringe Aften-Tidsfordriv.
 <text id="aarestrup2019013011" variant="aarestrup2001061801" skip-index="true">
 <head>
    <title>Paa en Dag, der er bestemt Lykønskninger og Foræringer</title>
-   <quality>korrektur1,kilde,side</quality>
+   <quality>korrektur1,korrektur2,kilde,side</quality>
    <source pages="58-59"/>
 </head>
 <body>
 <prose>
-     Paa en Dag, der er bestemt Lykønskninger og Foræringer - til Kjærligheds og Hengivenheds følsomme Erklæringer - og skulde være fri for alle kolde Besværinger - for alle Livets destoværre bittre Belæringer - var det Bestemmelsen for dette Blad - naar man skidlte det ad - at det skulde indeholde noget, jeg veed nok hvad - noget moderne æsthetisk - og dog gammeldags ethisk - noget tiltrækkende magnetisk - egentlig poetisk - og om det var muligt virkelig prophetisk - noget, man ikke kunde læse uden at smile - noget, der ikke traf, som en Tordenkile - men hvori dog hørtes Klang af Apollos Pile - noget, der ikke mindede om kritiske File - men om varme Sommerbølger, der ile - og i en yndig Natur indbyde til Hvile. - Det skulde forsvare sin Plads - ved Siden af en Krands og et Blomsterglas - det skulde være tilpas - mellem de udsøgteste Sager - i et Skjønheds-Lager - uden at være anstrængende - paatrængende - eller overhængende - skulde det harmonere - for ikke at sige concurrere - med hvad de fineste Hænder brodere - med hvad taknemlige Hjerter - ved Nattens eensomme Kjerter - have udgrundet - og udfundet - omdisputeret - og udspeculeret - men hvad neppe Nogen før i Dag har udspioneret - det skulde, for at sige det Høieste - og angive Alt paa det Nøieste - paa en af Aarets faureste Feste - passe for den Bedste - det skulde, skjøndt gjennem en Pen, der hører til de strideste, - ikke uskyldighvideste, - tale til den Blideste, - det skulde, skjøndt kommen fra en af de Uregjerligste og Vildeste - ikke saare den Beskedneste og Stilleste - det skulde ønske Held og Lykke - over den, der fortjener alle Glæders Smykke - det skulde vise hen i Tiden - og pege paa Alt ved Siden, - der i skjønne Omflettelser - er fuldt af rige Forjettelser; - det skulde være Billedet af alle Gavers Rundhed - det skulde love Karskhed og Sundhed - det skulde være den sande Veltalenheds Eftertragtelse, - og udtrykke Følelser af Hengivenhed og Høiagtelse. - Det ar Fornemmelsen - af hvad det skulde og burde, det var Bestemmelsen - Maalet, som sattes
+     Paa en Dag, der er bestemt Lykønskninger og Foræringer - til Kjærligheds og Hengivenheds følsomme Erklæringer - og skulde være fri for alle kolde Besværinger - for alle Livets destoværre bittre Belæringer - var det Bestemmelsen for dette Blad - naar man skildte det ad - at det skulde indeholde noget, jeg veed nok hvad - noget moderne æsthetisk - og dog gammeldags ethisk - noget tiltrækkende magnetisk - egentlig poetisk - og om det var muligt virkelig prophetisk - noget, man ikke kunde læse uden at smile - noget, der ikke traf, som en Tordenkile - men hvori dog hørtes Klang af Apollos Pile - noget, der ikke mindede om kritiske File - men om varme Sommerbølger, der ile - og i en yndig Natur indbyde til Hvile. - Det skulde forsvare sin Plads - ved Siden af en Krands og et Blomsterglas - det skulde være tilpas - mellem de udsøgteste Sager - i et Skjønheds-Lager - uden at være anstrængende - paatrængende - eller overhængende - skulde det harmonere - for ikke at sige concurrere - med hvad de fineste Hænder brodere - med hvad taknemlige Hjerter - ved Nattens eensomme Kjerter - have udgrundet - og udfundet - omdisputeret - og udspeculeret - men hvad neppe Nogen før i Dag har udspioneret - det skulde, for at sige det Høieste - og angive Alt paa det Nøieste - paa en af Aarets faureste Feste - passe for den Bedste - det skulde, skjøndt gjennem en Pen, der hører til de strideste, - ikke uskyldighvideste, - tale til den Blideste, - det skulde, skjøndt kommen fra en af de Uregjerligste og Vildeste - ikke saare den Beskedneste og Stilleste - det skulde ønske Held og Lykke - over den, der fortjener alle Glæders Smykke - det skulde vise hen i Tiden - og pege paa Alt ved Siden, - der i skjønne Omflettelser - er fuldt af rige Forjettelser; - det skulde være Billedet af alle Gavers Rundhed - det skulde love Karskhed og Sundhed - det skulde være den sande Veltalenheds Eftertragtelse, - og udtrykke Følelser af Hengivenhed og Høiagtelse. - Det var Fornemmelsen - af hvad det skulde og burde, det var Bestemmelsen - Maalet, som sattes
 </prose>
 </body>
 </text>
@@ -1340,7 +1340,7 @@ Et ubetydeligt, et ringe Aften-Tidsfordriv.
 <head>
    <title>Bliv ved, bliv ved, med Klokkerne at kime</title>
    <firstline>Bliv ved, bliv ved, med Klokkerne at kime</firstline>
-   <quality>korrektur1,kilde,side</quality>
+   <quality>korrektur1,korrektur2,kilde,side</quality>
    <source pages="60"/>
 </head>
 <body>
@@ -1357,7 +1357,7 @@ Vil man, at du skal gloe, og ikke tænke.
 <head>
    <title>Jeg var et Barn - mit Blod saa sagte løb</title>
    <firstline>Jeg var et Barn - mit Blod saa sagte løb</firstline>
-   <quality>korrektur1,kilde,side</quality>
+   <quality>korrektur1,korrektur2,kilde,side</quality>
    <source pages="61"/>
 </head>
 <body>
@@ -1382,7 +1382,7 @@ At du vil ogsaa lære mig at græde. -
    <notes>
       <note>Digtet stammer fra sommeren 1840, og refererer til en Samtale mellem Aarestrup og <a person="molbechsr">Chr. Molbech</a>.</note>
    </notes>
-   <quality>korrektur1,kilde,side</quality>
+   <quality>korrektur1,korrektur2,kilde,side</quality>
    <source pages="62"/>
 </head>
 <body>
@@ -1401,7 +1401,7 @@ Det Reenforglemte og det Længstforsvundne,
    <title>Til Frøken Christine Rosenørn-Lehn</title>
    <subtitle>den 10de December 1840.</subtitle>
    <firstline>Spaniens Land gjenlyder ei længer af tonende Sange</firstline>
-   <quality>korrektur1,kilde,side</quality>
+   <quality>korrektur1,korrektur2,kilde,side</quality>
    <keywords>heksameter,lejlighedsdigtning</keywords>
    <source pages="63-64"/>
 </head>
@@ -1433,7 +1433,7 @@ Kun i den huuslige Kreds, hvor Skjønhed groer som Violen,
 Nysudsprungen og bly - men med forfriskende Duft -;
 Kun i det stille Hjem, hvor Uskylds yndige Gratie
 Fostrer med venlig Haand Cyprias kurrende Fugl; -
-Kun til den eensomme Øre, det barnligt lyttende Hjerte,
+Kun til det eensomme Øre, det barnligt lyttende Hjerte,
 Tør han, en Høitidsdag, hvidske sin sagteste Klang.
 Modtag da, i Din Sal, hvor Freden og Lykken har hjemme,
 Fagre Veninde, mit Digts stille, lykønskende Ord!
@@ -1445,7 +1445,7 @@ Fagre Veninde, mit Digts stille, lykønskende Ord!
 <head>
    <title>Critik</title>
    <firstline>Jeg har seet den store Digter</firstline>
-   <quality>korrektur1,kilde,side</quality>
+   <quality>korrektur1,korrektur2,kilde,side</quality>
    <source pages="65"/>
 </head>
 <body>
@@ -1482,7 +1482,7 @@ I en simpel Hodvandsflaske.
 <head>
    <title>Den 1ste Januar 1841</title>
    <firstline>Nymaanen skinner over Søens Flade</firstline>
-   <quality>korrektur1,kilde,side</quality>
+   <quality>korrektur1,korrektur2,kilde,side</quality>
    <dates>
        <event>1841-01-01</event>
    </dates>
@@ -1553,7 +1553,7 @@ En fattig Digters ufuldførte Klade!
 <head>
    <title>Er Du en Christen? - spurgte du mig nylig</title>
    <firstline>Er Du en Christen? - spurgte du mig nylig</firstline>
-   <quality>korrektur1,kilde,side</quality>
+   <quality>korrektur1,korrektur2,kilde,side</quality>
    <source pages="68-69"/>
 </head>
 <body>
@@ -1606,7 +1606,7 @@ Og turde ei paa Porten kime.
    <toctitle>Deres Naade Fru Kammerherreinde, Baronesse Rosenørn-Lehn</toctitle>
    <indextitle>Deres Naade Fru Kammerherreinde, Baronesse Rosenørn-Lehn</indextitle>
    <firstline>Italiens Sanger slaaer som Nattergalen</firstline>
-   <quality>korrektur1,kilde,side</quality>
+   <quality>korrektur1,korrektur2,kilde,side</quality>
    <keywords>lejlighedsdigtning,thovaldsen,sonnet</keywords>
    <source pages="70"/>
 </head>
@@ -1619,7 +1619,7 @@ Og Mængden lytter, aandeløs, i Salen.
 
 Morgenbelysningen i Schweitzerdalen,
 Naar Alpetinderne i Purpur svømme,
-Begeistrer Maleren; Konstvenner drømme,
+Begeistrer Maleren; Konstvenner dømme,
 Og Publikum forbauses ved hans Malen.
 
 Hvor store Kræfter sig til Maalet skynde
@@ -1637,7 +1637,7 @@ Og af den Dyd, hvorom kun sjelden tales.
 <text id="aarestrup2001061802" skip-index="true">
 <head>
    <title>Høivelbaarne Hr. Greve</title>
-   <quality>korrektur1,kilde,side</quality>
+   <quality>korrektur1,korrektur2,kilde,side</quality>
    <source pages="71-72"/>
 </head>
 <body>
@@ -1653,7 +1653,7 @@ Og af den Dyd, hvorom kun sjelden tales.
    <title>Til Frøken Warenka Rosenkrantz</title>
    <subtitle>d. 21 Oct 1842.</subtitle>
    <firstline>Din Vugge gik ved Brum af Nordhavsrøsten</firstline>
-   <quality>korrektur1,kilde,side</quality>
+   <quality>korrektur1,korrektur2,kilde,side</quality>
    <keywords>lejlighedsdigtning,sonnet</keywords>
    <dates>
        <event>1842-10-21</event>
@@ -1687,7 +1687,7 @@ Som Brud og Viv det skjønne Engestofte.
 <head>
    <title>Flugt</title>
    <firstline>Jeg har seet den store Verden!</firstline>
-   <quality>korrektur1,kilde,side</quality>
+   <quality>korrektur1,korrektur2,kilde,side</quality>
    <source pages="74"/>
 </head>
 <body>
@@ -1724,7 +1724,7 @@ Til sin Ørkens vilde Hule.
 <head>
    <title>Trøst</title>
    <firstline>Beilere paa alle Kanter!</firstline>
-   <quality>korrektur1,kilde,side</quality>
+   <quality>korrektur1,korrektur2,kilde,side</quality>
    <source pages="75"/>
 </head>
 <body>
@@ -1761,7 +1761,7 @@ Thi hun elsker sit Uhyre.
 <text id="aarestrup2001061805" skip-index="true">
 <head>
    <title>Idet jeg føler det som en indre Pligt</title>
-   <quality>korrektur1,kilde,side</quality>
+   <quality>korrektur1,korrektur2,kilde,side</quality>
    <source pages="76-78"/>
 </head>
 <body>
@@ -1776,7 +1776,7 @@ Thi hun elsker sit Uhyre.
 <head>
    <title>Med Roser og Ranunkler</title>
    <firstline>Med Roser og Ranunkler</firstline>
-   <quality>korrektur1,kilde,side</quality>
+   <quality>korrektur1,korrektur2,kilde,side</quality>
    <source pages="79-80"/>
 </head>
 <body>
@@ -1824,7 +1824,7 @@ Det var mig nok - jeg drømte.
 <head>
    <title>O hvor smukt dette Landskabs Form i sit dæmrende Mørke!</title>
    <firstline>O hvor smukt dette Landskabs Form i sit dæmrende Mørke!</firstline>
-   <quality>korrektur1,kilde,side</quality>
+   <quality>korrektur1,korrektur2,kilde,side</quality>
    <source pages="81-82"/>
 </head>
 <body>
@@ -1868,7 +1868,7 @@ Og - der sees vi igjen, der samles, der favnes vi atter!
         <event>1845-07-12</event>
     </dates>
     <firstline>En Krands af Livets Vaar og Sommer bunden</firstline>
-    <quality>korrektur1,kilde,side</quality>
+    <quality>korrektur1,korrektur2,kilde,side</quality>
     <source pages="83-84"/>
 </head>
 <body>
@@ -1939,7 +1939,7 @@ Maa daglig svulme frisk og skjøn!
 <poetry>
 <num>I</num>Fra grønne Bakker - svulmende paa Øen
 Som ude paa det Dybe Havets Bølge -
-Skal min Blik til Horizonten følge
+Skal mine Blik til Horizonten følge
 Dit hvide Seil henover Østersøen.
 
 <num>II</num>Du reiser bort til Nordens Klippestrande,
@@ -1981,7 +1981,7 @@ Farvel, naar Stjernen leder dig om Natten!
    <title>Til - - -</title>
    <subtitle>(I Anledning af en tilsendt Pengepung)</subtitle>
    <firstline>Tak for den Silkeskjønhed</firstline>
-   <quality>korrektur1,kilde,side</quality>
+   <quality>korrektur1,korrektur2,kilde,side</quality>
    <keywords>lejlighedsdigtning</keywords>
    <source pages="87"/>
 </head>
@@ -2074,7 +2074,7 @@ Og han tog den sølvindlagte
 Kuglebøsse med det samme;
 
 <num>XII</num>Tog det guldbeslagne Krudthorn —
-Søg at gjøre jer elskvværdig!
+Søg at gjøre jer elskværdig!
 Mumled han, og spændte Hanen:
 Jomfru Else! Jeg er færdig!
 
@@ -2105,7 +2105,7 @@ Nu ved Siden af sin Beiler.
 <head>
    <title>Det fryser ved Octobers klare Maane</title>
    <firstline>Det fryser ved Octobers klare Maane</firstline>
-   <quality>korrektur1,kilde,side</quality>
+   <quality>korrektur1,korrektur2,kilde,side</quality>
    <keywords>sonnet</keywords>
    <source pages="91"/>
 </head>
@@ -2136,7 +2136,7 @@ Farvel! Farvel! Hvem undres, at det Skjønne
 <head>
    <title>Her rasler Skoven og her suser Sivet</title>
    <firstline>Her rasler Skoven og her suser Sivet</firstline>
-   <quality>korrektur1,kilde,side</quality>
+   <quality>korrektur1,korrektur2,kilde,side</quality>
    <source pages="92"/>
 </head>
 <body>
@@ -2168,7 +2168,7 @@ Hvor Leda, i sin Uskyld, klapped Svanen.
 <head>
    <title>Paa Rosenborg, der vil I jer forsamle</title>
    <firstline>Paa Rosenborg, der vil I jer forsamle</firstline>
-   <quality>korrektur1,kilde,side</quality>
+   <quality>korrektur1,korrektur2,kilde,side</quality>
    <keywords>sonnet</keywords>
    <source pages="93"/>
 </head>
@@ -2199,7 +2199,7 @@ En Samling nye Snurrepiberier.
 <head>
    <title>Raskelsen</title>
    <firstline>At varetage Folkets dyre Skat</firstline>
-   <quality>korrektur1,kilde,side</quality>
+   <quality>korrektur1,korrektur2,kilde,side</quality>
    <keywords>sonnet</keywords>
    <source pages="94"/>
 </head>
@@ -2230,7 +2230,7 @@ Sig Krigens Gud, med heelt opsmøgne Ærmer.
 <head>
    <title>Valget</title>
    <firstline>Kom, danske Folk! Tørklædet over Næsen!</firstline>
-   <quality>korrektur1,kilde,side</quality>
+   <quality>korrektur1,korrektur2,kilde,side</quality>
    <keywords>sonnet</keywords>
    <source pages="95"/>
 </head>
@@ -2259,15 +2259,15 @@ Hvad greb du der? Ih, fy for en Ulykke!
 
 <text id="aarestrup2019013031" variant="aarestrup1999032901">
 <head>
-   <title>Den stakkelse Blindebuk! Han gjør sit Bedste</title>
-   <firstline>Den stakkelse Blindebuk! Han gjør sit Bedste</firstline>
-   <quality>korrektur1,kilde,side</quality>
+<title>Den stakkels Blindebuk! Han gjør sit Bedste</title>
+   <firstline>Den stakkels Blindebuk! Han gjør sit Bedste</firstline>
+   <quality>korrektur1,korrektur2,kilde,side</quality>
    <keywords>sonnet</keywords>
    <source pages="96"/>
 </head>
 <body>
 <poetry>
-Den stakkelse Blindebuk! Han gjør sit Bedste
+Den stakkels Blindebuk! Han gjør sit Bedste
 Han lytter, standser, vender sig i Hast,
 Gjør lange Spring og atter korte Kast -
 Raadvild hvor han skal sine Næver fæste.
@@ -2295,7 +2295,7 @@ See saa! Lad nu en Anden gaae iblinde!
    <notes>
       <note>Den teologiske professor H.N. Clausen (1793-1877).</note>
    </notes>
-   <quality>korrektur1,kilde,side</quality>
+   <quality>korrektur1,korrektur2,kilde,side</quality>
    <keywords>sonnet</keywords>
    <source pages="97"/>
 </head>
@@ -2331,7 +2331,7 @@ En Bitterhed, hvis Ret jeg ei benegter.
         Manuskript fra Det Kongelige Bibliotek. <!-- Manglende entydig KB-katalogmatch; gemt uden object-id indtil bekræftelse. -->
       </picture>
    </pictures>
-   <quality>korrektur1,kilde,side</quality>
+   <quality>korrektur1,korrektur2,kilde,side</quality>
    <keywords>sonnet</keywords>
    <source pages="98"/>
 </head>
@@ -2362,7 +2362,7 @@ Saa tælle Peer og Povl paa deres Knapper.
 <head>
    <title>Af Krigens Trommer og Trompeter skræmmet</title>
    <firstline>Af Krigens Trommer og Trompeter skræmmet</firstline>
-   <quality>korrektur1,kilde,side</quality>
+   <quality>korrektur1,korrektur2,kilde,side</quality>
    <keywords>sonnet</keywords>
    <source pages="99"/>
 </head>
@@ -2398,7 +2398,7 @@ En sagte Bøn, - men som i Himlen høres.
 </head>
 <body>
 <poetry>
-    Min Herrer og Damer!
+    Mine Herrer og Damer!
 Jeg seer i Deres spændte Miner en -
 En Agtpaagivenhed, der faaer mig til
 At veie hvert et Ord, hver Haandbevægelse
@@ -2435,7 +2435,7 @@ Det sympathetisk-skjønne Broderskab
 Af Godt og Venligt, Muntert og Uskyldigt -
 Paa gammel Dansk: det reent Selskabelige.
 Det søger man selv midt i Sommerglæden,
-Hvor Eensombeden dog kan yndigt bygge
+Hvor Eensomheden dog kan yndigt bygge
 I Rosers Mørke og i Skovens Skygge -
 Hvormeget meer maae man i Vinterkulden
 Tye til den Varme, venligt Samqvem bringer
@@ -2471,7 +2471,7 @@ Gjensidigt ydes vore Præstationer;
 Han: Bidrag til vor Aftenunderholdning!
 Og vi: vort Bidrag til hans Vinterrejse!
 Dermed er Alle tjent - og Konstens Musa,
-Der skjuler sig i Aften halv undseelig
+Der skjuler sig i Aften halvt undseelig
 Maaskee engang vil skjænke os sit Blik
 Fuldt af Erkjendtlighed og Velbehag. -
 </poetry>
@@ -2482,7 +2482,7 @@ Fuldt af Erkjendtlighed og Velbehag. -
 <head>
    <title>Naar jeg i Eenrum færdes</title>
    <firstline>Naar jeg i Eenrum færdes</firstline>
-   <quality>korrektur1,kilde,side</quality>
+   <quality>korrektur1,korrektur2,kilde,side</quality>
    <source pages="103-104"/>
 </head>
 <body>
@@ -2570,8 +2570,8 @@ Med Lunten tændt, ved vaade Telte,
 Vi sætte her en Gaas paa Spil
 Og Ruderkonge morsomt vælte.
 Halvhundred Aar var det en Skik,
-At den, der fik det femte Stik,
-Som Seierherre hjem han gik,
+At den, som fik det femte Stik,
+Som Seiersherre hjem han gik,
 Og tog sit Bytte, Mortensgaasen.
 
 <num>IV</num>Med rolig Stolthed selv han bar
@@ -2580,7 +2580,7 @@ Jo mere tung og hvid den var,
 Jo større Daad blev ham tilregnet;
 Jo mere feed, jo mere drøi,
 Jo flere Kys, jo mere Støi;
-Om Halsen Viv og Børn bam fløi
+Om Halsen Viv og Børn ham fløi
 Til Priis og Tak for Mortensgaasen.
 
 <num>V</num>Og denne Skik - som Odin selv
@@ -2602,19 +2602,19 @@ De gode gamle Skikke leve!
         <line>den 14de Marts 1851</line>
         <line>Mel. At kjøre Vatten og kjøre Ved.</line>
     </subtitle>
-    <firstline>Der er saa lyst udi Gispens Gaard</firstline>
+    <firstline>Der er saa lyst udi Bispens Gaard</firstline>
     <source pages="107-108"/>
     <dates>
         <event>1851-03-14</event>
     </dates>
-    <quality>korrektur1,kilde,side</quality>
+    <quality>korrektur1,korrektur2,kilde,side</quality>
     <notes>
         <note>Melodi som den norske folkevise <xref poem="folkeviserno2018080401"/>.</note>
     </notes>
 </head>
 <body>
 <poetry>
-<num>I</num>Der er saa lyst udi Gispens Gaard,
+<num>I</num>Der er saa lyst udi Bispens Gaard,
 Som hang en Sommersol foroven;
 Musikkens Toner mod Loftet slaaer,
 Som alle Fugle sang i Skoven.
@@ -2661,7 +2661,7 @@ Vor Vert og vor Vertinde leve!
 <head>
     <title>Den 19de Juni 1851</title>
     <firstline>Den 19de Juni 1851</firstline>
-    <quality>korrektur1,kilde,side</quality>
+    <quality>korrektur1,korrektur2,kilde,side</quality>
     <source pages="109-111"/>
 </head>
 <body>
@@ -2697,7 +2697,7 @@ Der i Mandens og Ynglingens Bryst
 Blev knyttet af mægtige Guder.
 
 <num>VII</num>Hav Tak for det Vidnesbyrd derom,
-Jeg fik fra den Henipelske Lade -
+Jeg fik fra den Hempelske Lade -
 En poetisk Luftning, idag det kom,
 Med Duft af de friskeste Blade.
 
@@ -2797,7 +2797,7 @@ Sin Fødselsdag, i Vennekredsen her.
 Forynget Kraft i hendes Hjerte strømmer,
 Og Helbred straaler fra det glade Blik:
 Paa hendes Sundhed Bægeret sig tømmer,
-Og gode Dufter imod Himlen gik!
+Og gode Ønsker imod Himlen gik!
 
 <num>IV</num>O ædle Frue, som Dit Hjem forskjønner
 Ved milde Dyder, from og vennehuld,
@@ -2815,7 +2815,7 @@ Fordi, <w>Pauline Holsten</w>, Du er her!
 <head>
     <title>Cotillon-Deviser</title>
     <firstline>Jeg elsker Dig, du faureste Pige paa Jorden!</firstline>
-    <quality>korrektur1,kilde,side</quality>
+    <quality>korrektur1,korrektur2,kilde,side</quality>
     <source pages="115-119"/>
 </head>
 <body>
@@ -2981,7 +2981,7 @@ Odin var eenøiet, om De erindrer.
 <head>
    <indextitle>Tør jeg haabe, yndigste Neglike</indextitle>
    <firstline>Tør jeg haabe, yndigste Neglike?</firstline>
-   <quality>korrektur1,kilde,side</quality>
+   <quality>korrektur1,korrektur2,kilde,side</quality>
    <source pages="119"/>
 </head>
 <body>
@@ -3005,41 +3005,41 @@ De taer feil, min Herre, jeg vil ikke.
 <num>I</num>Man har Sagn om Borgtapeter,
 Hundredaarige, paa hvilke
 De afblegede Figurer,
-Syede Sting i Sting af Silke,
+Syete Sting i Sting af Silke,
 
-<num>II</num>Faae et sælsomt Liv om Natten,
-Stige ned og, som det gamle
-Herskab fordumstider, sig i
-Maanskinscabinettet samle.
+<num>II</num>Faae et sælsomt Liv om Natten -
+Stige ned, og - som i gamle
+Dage, sig i Riddersalen
+Hyggeligt og muntert samle.
 
 <num>III</num>I de bløde Lænestole
-Damerne med Atlasslæbet,
-Blændende sig atter kaste,
-Munden smiler rosenlæbet.
+Damerne, med Atlasslæbet,
+Blændende sig atter kaste -
+Munden smiler, rosenlæbet.
 
 <num>IV</num>Ridderen, som fra Tapetet
-Knapt om Dagen man kan mærke,
-Læne sig til Stoleryggen,
-Brune, skjæggede og stjærk.
+Bleg og gusten man erindrer,
+Læner sig paa Stoleryggen,
+Stærk, sortskjæget - Øiet tindrer.
 
-<num>V</num>Gjennem Buevindvet glimre
-De forgyldte Instrumenter;
-Hvide Skyggehænder jage
-Over støvede Tangenter.
+<num>V</num>Guld og Perlemoder glimrer
+Paa de gamle Instrumenter -
+Og ætherisk hvide Hænder
+Trykke støvede Tangenter.
 
-<num>VI</num>Klang fra de forsvundne Tider,
-O vidunderlig at høre!
-Gammedags Galanterier
-Hviskes i et yndigt Øre.
+<num>VI</num>O vidunderlige Toner!
+Klang af svundne Tider høres!
+Damens fine Haand med Anstand
+Op til Ridderskjæget føres -
 
 <num>VII</num>Næsten kunde man misunde
-Dette Skyggeliv, hvis ikke -
-See! hun blegner bag sin Vifte,
-Angst for Morgenrødens Blikke.
+Dette Skyggeliv - hvis ikke -
+See! Hun blegner bag sin Vifte,
+Døsig stirrer Herrens Blikke -
 
 <num>VIII</num>Selv den tappre Ridder gyser,
-Smutter, som den hele Vrimmel,
-Ind i Muren, i Tapetet;
+Smutter som den hele Vrimmel,
+Ind i Muren, i Tapetet -
 Dagen seer kun Støv og Skimmel.
 
 <num>IX</num>O, hvor skjønne, nydelige
@@ -3048,8 +3048,8 @@ Ja, i Mindets Dæmringstime
 Lever op den gamle Glæde.
 
 <num>X</num>Mange lyse Nætter, fulde
-Med en yndig Gjenfærdsvrimmel
-Ønsker jeg en ung Veninde:
+Af en yndig Gjenfærdsvrimmel,
+Ønsker jeg en ung Veninde,
 Ret en fuld Erindringshimmel.
 </poetry>
 </body>
@@ -3063,7 +3063,7 @@ Ret en fuld Erindringshimmel.
        <line>Til Christian Petersen.</line>
    </subtitle>
    <firstline>Man har Sagn om Borgtapeter</firstline>
-   <quality>korrektur1,kilde,side</quality>
+   <quality>korrektur1,korrektur2,kilde,side</quality>
    <source pages="122-125"/>
 </head>
 <body>
@@ -3088,8 +3088,8 @@ Neppe kjendelig for Synet -
 Læner sig paa Stoleryggen,
 Stærk, sortskjæget, dunkelbrynet.
 
-<num>V</num>Gjennem Buevinvet glimre
-De forgjyldte Instrumenter -
+<num>V</num>Gjennem Buevindvet glimre
+De forgyldte Instrumenter -
 Hvide Skyggehænder jage
 Over støvede Tangenter.
 
@@ -3103,7 +3103,7 @@ Dette Skyggeliv, hvis ikke -
 See! Hun blegner bag sin Vifte,
 Angst for Morgenrødens Blikke.
 
-<num>VIII</num>Selv den tappre Ridder gyser,
+<num>VIII</num>Selv den tapre Ridder gyser,
 Smutter som den hele Vrimmel
 Ind i Muren, i Tapetet -
 Dagen seer kun Støv og Skimmel
@@ -3115,7 +3115,7 @@ Færdsel ogsaa Sjælens Mærker,
 De forsvundne Sympathiers
 Efterladte Billedværker.
 
-<num>X</num>Glemsel, som et Møl, den gnaver,
+<num>X</num>Glemsel, som et Møl, dem gnaver,
 Tiden slukker deres Farve -
 Kun Erindringsnatten bringer
 Flygtigt liv i deres Larve.
@@ -3130,7 +3130,7 @@ Falmede Figurer, - lægge
 Sig paa den bekjendte Sopha
 Og gemytligt Benet strække.
 
-<num>XIII</num>Fruen, men ætherisk Hvidhed,
+<num>XIII</num>Fruen, med ætherisk Hvidhed,
 Bringer Lampen. - Marianes
 Øine funkle med et Mørke,
 Hvori Sjælens Flammer anes.
@@ -3158,7 +3158,7 @@ Ak, idet jeg Brevet slutter.
    <title>Man har Sagn om Borgtapeter</title>
    <subtitle>III</subtitle>
    <firstline>Man har Sagn om Borgtapeter</firstline>
-   <quality>korrektur1,kilde,side</quality>
+   <quality>korrektur1,korrektur2,kilde,side</quality>
    <source pages="126-128"/>
 </head>
 <body>
@@ -3181,7 +3181,7 @@ Munden smiler, rosenlæbet.
 <num>IV</num>Ridderne, som paa Tapetet
 Man om Dagen knapt kan mærke,
 Læne sig til Stoleryggen,
-Brune, skjægede og stærke.
+Brune, skjæggede og stærke.
 
 <num>V</num>Støvede Tangenter trykkes -
 Svundne Toner kan man høre -
@@ -3200,7 +3200,7 @@ Dagen seer kun Støv og Skimmel. -
 
 <num>VIII</num>Saadan gaaer det ogsaa Venskabs
 Stille Tegn og Billedværker,
-De forsvundne Symphatiers
+De forsvundne Sympathiers
 Efterladte Mindesmærker.
 
 <num>IX</num>Glemsel, som et Møl, dem gnaver,
@@ -3235,7 +3235,7 @@ Verset her paa Bladet slutter.
        <line>Til Andreas Krogh.</line>
    </subtitle>
    <firstline>Man har Sagn om Borgtapeter</firstline>
-   <quality>korrektur1,kilde,side</quality>
+   <quality>korrektur1,korrektur2,kilde,side</quality>
    <source pages="129-131"/>
 </head>
 <body>
@@ -3257,8 +3257,8 @@ Munden smiler rosenlæbet.
 
 <num>IV</num>Ridderne som man om Dagen
 Paa Tapetet knapt kan mærke,
-Læne sig til Stoleryggen,
-Brune skjægede og stærke.
+Læne sig paa Stoleryggen,
+Brune skjæggede og stærke.
 
 <num>V</num>Støvede Tangenter trykkes -
 O vidunderligt at høre!
@@ -3275,9 +3275,9 @@ Smutter, som den hele Vrimmel
 Ind i Muren, i Tapetet -
 Dagen seer kun Støv og Skimmel. -
 
-<num>VIII</num>Saadan gaaer det ogsaa Sjælenss
+<num>VIII</num>Saadan gaaer det ogsaa Sjælens
 Underfulde Billedværker,
-De forsvundne Symphatiers
+De forsvundne Sympathiers
 Efterladte Mindesmærker.
 
 <num>IX</num>Glemsel som et Møl dem gnaver,
@@ -3288,9 +3288,9 @@ Flygtigt Liv i deres Larve.
 <num>X</num>Og, som fra Tapetet, stige
 Falmede Figurer, - lægge
 Sig paa den bekjendte Sopha
-Og gemytligt Benet strækket.
+Og gemytligt Benet strække.
 
-<num>XI</num>Blade i den gamle Bøger
+<num>XI</num>Blade i de gamle Bøger
 Stoppe sig den gamle Pibe;
 Ja, de trofastgamle Hænder
 Hjerteligt hinanden gribe.
@@ -3312,7 +3312,7 @@ Kjære Krogh; Epistlen slutter.
 <head>
    <title>Du var henrivende paa Børneballet</title>
    <firstline>Du var henrivende paa Børneballet</firstline>
-   <quality>korrektur1,kilde,side</quality>
+   <quality>korrektur1,korrektur2,kilde,side</quality>
    <source pages="132"/>
 </head>
 <body>
@@ -3345,7 +3345,7 @@ Hvordan Du kan fortumle og fortrylle.
 <head>
    <title>Epilog</title>
    <firstline>Tillad - jeg har endnu et Ord</firstline>
-   <quality>korrektur1,kilde,side</quality>
+   <quality>korrektur1,korrektur2,kilde,side</quality>
    <source pages="133-134"/>
 </head>
 <body>
@@ -3389,17 +3389,17 @@ Til alle Sider sprede sig
 Thalias vinterkjære Gjæster -
 Modtag da her mit Afskedsord!
 Tilgiv, jeg hvidsker mit Farvel,
-Men  <w>Bønnen om</w>, at huske paa,
-Ved Fuglesangen i den Grønne
+Med  <w>Bønnen om</w>, at huske paa,
+Ved Fuglesangen i det Grønne
 Og Aftenstiernen i det Blaa, -
 At, skal en Gjenklang af det <w>Skjønne</w>,
 Som jeg, med mine svage Kræfter,
 Med Ungdomshaabet, stræber efter, -
 Skal  <w>det</w> gjenfødes her og prøves -
 Saa vid det: Eders Hjelp behøves!
-Saa maa - hos Krebsen, jeg forlod,
+Saa maa - hos Kredsen, jeg forlod,
 Hos Konstens Venner og Veninder -
-<w>Det</w> styrker mig, at jeg gjenfinder
+<w>Det</w> styrke mig, at jeg gjenfinder
 Den Skaansomhed, som gav mig Mod!
 </poetry>
 </body>
@@ -3409,7 +3409,7 @@ Den Skaansomhed, som gav mig Mod!
 <head>
     <title>O min Ven, min Ven Don Carlo</title>
     <firstline>O min Ven, min Ven Don Carlo</firstline>
-    <quality>korrektur1,kilde,side</quality>
+    <quality>korrektur1,korrektur2,kilde,side</quality>
     <dates>
         <written>1852-09-24</written>
     </dates>
@@ -3439,8 +3439,8 @@ Af Dit Venskab, Carl, bevæget,
 Af det tro, det tyveaarige!
 Og af Thoras Kys beruset,
 
-<num>V</num>Af det tre die - Jord og Himmel!
-Trende Kvs i tvende Somre!
+<num>V</num>Af det tredie - Jord og Himmel!
+Trende Kys i tvende Somre!
 Det maa gjøre en Omvæltning
 I mit Levnets stille Omløb;
 
@@ -3454,7 +3454,7 @@ Kulingen fra Nord paa Beltet,
 Med en næsten Storm, jog ikke
 Blodet bort af mine Kinder.
 
-<num>VIII</num>Selv i Læ af Hjemmets Mure,
+<num>VIII</num>Selv i Le af Hjemmets Mure,
 I de aabne, kjære Arme,
 Var endnu den sagte Skjælven,
 Afskedsrusen, i mit Hjerte.
@@ -3578,7 +3578,7 @@ Meld Dem min Salutaziòne!
 <text id="aarestrup1999032910" skip-index="true">
 <head>
    <title>Min elskte Viv</title>
-   <quality>korrektur1,kilde,side</quality>
+   <quality>korrektur1,korrektur2,kilde,side</quality>
    <source pages="141"/>
 </head>
 <body>
@@ -3595,7 +3595,7 @@ Hilsen til Alle! især til Emilie!
 <head>
    <title>I Sydens Dal den hvide Fos sig styrter</title>
    <firstline>I Sydens Dal den hvide Fos sig styrter</firstline>
-   <quality>korrektur1,kilde,side</quality>
+   <quality>korrektur1,korrektur2,kilde,side</quality>
    <source pages="142-143"/>
 </head>
 <body>
@@ -3605,7 +3605,7 @@ Fra Gletscheriis og snebedækte Fjeld
 Og skjuler blandt Kastanier og Myrter
 De kjøle Bølgers yndigtsnoete Væld
 Men ogsaa Danmarks Bøgeskove dækker
-En Skjønhed i sin sommergrømme Krands
+En Skjønhed i sin sommergrønne Krands
 En speilglat Søe, der smilende sig strækker
 Og viser Gjenskin af hver yndig Glands
 
@@ -3641,7 +3641,7 @@ Som huldt I mindes Furresøens Kyst.
    <notes>
       <note>Melodi som i Bellmanns <xref poem="bellman2001061367"/>.</note>
    </notes>
-   <quality>korrektur1,kilde,side</quality>
+   <quality>korrektur1,korrektur2,kilde,side</quality>
    <keywords>lejlighedsdigtning</keywords>
    <source pages="143-144"/>
 </head>
@@ -3717,7 +3717,7 @@ Bland Roserne med Guld!
 <head>
    <title>Paa Sengen skrev du det, med Taarer tunge</title>
    <firstline>Paa Sengen skrev du det, med Taarer tunge</firstline>
-   <quality>korrektur1</quality>
+   <quality>korrektur1,korrektur2</quality>
    <source pages="145"/>
 </head>
 <body>
@@ -3755,7 +3755,7 @@ I er af hines Qvad kun Efterrunget.
 <head>
    <title>At Alperne vil speile sig i Beltet</title>
    <firstline>At Alperne vil speile sig i Beltet</firstline>
-   <quality>korrektur1</quality>
+   <quality>korrektur1,korrektur2</quality>
    <source pages="146"/>
 </head>
 <body>
@@ -3811,7 +3811,7 @@ Et tredie Liv han tænder.
 <head>
    <title>Hellige Ensomhed</title>
    <firstline>Hellige Ensomhed</firstline>
-   <quality>korrektur1</quality>
+   <quality>korrektur1,korrektur2</quality>
    <source pages="148"/>
 </head>
 <body>
@@ -3847,7 +3847,7 @@ Skjøndt jeg var drenget og vild.
 <head>
    <title>Jeg saa dig blusse og jeg skjalv</title>
    <firstline>Jeg saa dig blusse og jeg skjalv</firstline>
-   <quality>korrektur1</quality>
+   <quality>korrektur1,korrektur2</quality>
    <source pages="149"/>
 </head>
 <body>
@@ -3866,7 +3866,7 @@ En ubegrændset Lyst.
 <head>
     <title>Meget Lolland mig gav, den frugtbare Ø, da jeg som Fremmed</title>
     <firstline>Meget Lolland mig gav, den frugtbare Ø, da jeg som Fremmed</firstline>
-    <quality>korrektur1,kilde,side</quality>
+    <quality>korrektur1,korrektur2,kilde,side</quality>
     <source pages="150-151"/>
 </head>
 <body>
@@ -3901,7 +3901,7 @@ Skjønhedens, Konstens Asyl - nei deres Fæstning og Borg.
     <title>Fik Kong Midas for sin Smag</title>
     <subtitle>Mel: Vil du være stærk og fri</subtitle>
     <firstline>Fik Kong Midas for sin Smag</firstline>
-    <quality>korrektur1,kilde,side</quality>
+    <quality>korrektur1,korrektur2,kilde,side</quality>
     <source pages="152"/>
 </head>
 <body>
@@ -3923,7 +3923,7 @@ Kløgt i Pandeskalden!
 <head>
     <title>De første Skarer er forsvundne</title>
     <firstline>De første Skarer er forsvundne</firstline>
-    <quality>korrektur1,kilde,side</quality>
+    <quality>korrektur1,korrektur2,kilde,side</quality>
     <source pages="153"/>
 </head>
 <body>
@@ -3947,7 +3947,7 @@ Ha - livløs faldt hun om i Vrimlen. -
 <head>
    <title>Et deiligt Sommerliv</title>
    <firstline>Et deiligt Sommerliv</firstline>
-   <quality>korrektur1</quality>
+   <quality>korrektur1,korrektur2</quality>
    <source pages="154"/>
 </head>
 <body>
@@ -3962,7 +3962,7 @@ Et prægtigt Mandomsliv - jeg tegner og jeg læser.
 <head>
    <title>Du var den fine Rose</title>
    <firstline>Du var den fine Rose</firstline>
-   <quality>korrektur1</quality>
+   <quality>korrektur1,korrektur2</quality>
    <source pages="154"/>
 </head>
 <body>
@@ -3979,7 +3979,7 @@ Som fyldte sig med Duften.
 <head>
    <title>Her var end Naturen samlet</title>
    <firstline>Her var end Naturen samlet</firstline>
-   <quality>korrektur1</quality>
+   <quality>korrektur1,korrektur2</quality>
    <source pages="154"/>
 </head>
 <body>
@@ -3996,7 +3996,7 @@ Paa den med sin matte Haand.
 <head>
    <title>Embryo</title>
    <firstline>Saaledes sad vi ofte sammen</firstline>
-   <quality>korrektur1</quality>
+   <quality>korrektur1,korrektur2</quality>
    <source pages="155"/>
 </head>
 <body>
@@ -4016,7 +4016,7 @@ Og hvor det var, det veed vi ikke.
 <head>
    <title>Fragment</title>
    <firstline>Mistvivlende kun Sjælen trækker</firstline>
-   <quality>korrektur1</quality>
+   <quality>korrektur1,korrektur2</quality>
    <source pages="156"/>
 </head>
 <body>
@@ -4033,7 +4033,7 @@ Og Landet gabende seer op -
 <head>
    <title>Men fra Erindringen, det Svundne</title>
    <firstline>Men fra Erindringen, det Svundne</firstline>
-   <quality>korrektur1</quality>
+   <quality>korrektur1,korrektur2</quality>
    <source pages="156"/>
 </head>
 <body>
@@ -4050,7 +4050,7 @@ Paa melankolske Monumenter.
 <head>
    <title>I disse Sneeregioner</title>
    <firstline>I disse Sneeregioner</firstline>
-   <quality>korrektur1</quality>
+   <quality>korrektur1,korrektur2</quality>
    <source pages="157"/>
 </head>
 <body>
@@ -4065,7 +4065,7 @@ Der findes Alperoser, Knogler
 <head>
    <title>Det er min Pligt, det føler jeg, at skrive</title>
    <firstline>Det er min Pligt, det føler jeg, at skrive</firstline>
-   <quality>korrektur1</quality>
+   <quality>korrektur1,korrektur2</quality>
    <source pages="157"/>
 </head>
 <body>
@@ -4080,7 +4080,7 @@ Og melde Dig, vi er endnu ilive
 <head>
    <title>O alle Jordens Engleglutter</title>
    <firstline>O alle Jordens Engleglutter</firstline>
-   <quality>korrektur1</quality>
+   <quality>korrektur1,korrektur2</quality>
    <source pages="157"/>
 </head>
 <body>
@@ -4095,7 +4095,7 @@ Er min Rosauras Attributer
 <head>
     <title>Christiansholm med Borg og Skove</title>
     <firstline>Christiansholm med Borg og Skove</firstline>
-    <quality>korrektur1,kilde,side</quality>
+    <quality>korrektur1,korrektur2,kilde,side</quality>
     <source pages="158-159"/>
 </head>
 <body>
@@ -4119,7 +4119,7 @@ Hvor den stille Sølvsky svæver,
 Taarnet nu sig hæver.
 
 <num>III</num>Og hvor fordum Vikingskaren
-Gjemte Pul og Spyd,
+Gjemte Piil og Spyd,
 Tømte Hornet efter Faren
 Sang til Skjoldelyd -
 Sidder Tænkeren i Salen
@@ -4161,7 +4161,7 @@ Og sin Christians Lykke.
 <head>
     <title>Vi har ført op et lille Skuespil</title>
     <firstline>Vi har ført op et lille Skuespil</firstline>
-    <quality>korrektur1,kilde,side</quality>
+    <quality>korrektur1,korrektur2,kilde,side</quality>
     <source pages="160-161"/>
 </head>
 <body>
@@ -4220,7 +4220,7 @@ Svagt Udtryk kun af Kjærligheden her.
 <head>
     <title>Munter og tidlig til Krigens Skare</title>
     <firstline>Munter og tidlig til Krigens Skare</firstline>
-    <quality>korrektur1,kilde,side</quality>
+    <quality>korrektur1,korrektur2,kilde,side</quality>
     <source pages="162"/>
 </head>
 <body>
@@ -4256,7 +4256,7 @@ Gid vi maa gjøre jer Glæde igjen.
 <head>
    <title>Möge den Sund aufschäumen, den Wald durchsausen der Ostwind</title>
    <firstline>Möge den Sund aufschäumen, den Wald durchsausen der Ostwind</firstline>
-   <quality>korrektur1</quality>
+   <quality>korrektur1,korrektur2</quality>
    <keywords>heksameter</keywords>
    <source pages="163-164"/>
 </head>
@@ -4264,9 +4264,9 @@ Gid vi maa gjøre jer Glæde igjen.
 <poetry>
 Möge den Sund aufschäumen, den Wald durchsausen der Ostwind
 Ziehend das trübe Gewölk schwärzen die heitere Luft:
-Uns bleibt dennoch der Sinn frish, voll fröhlicher Kraft in der Kälte
+Uns bleibt dennoch der Sinn frisch, voll fröhlicher Kraft in der Kälte
 Dankend zu feiern den Tag, der uns so Schönes gebracht.
-Hohes Gefühl durchflammt den Britten beÿm Nahmen des Shakspear
+Hohes Gefühl durchflammt den Britten beym Nahmen des Schakspear
 Er der Dichter-Coloss. Vieles und Grosses dazu
 Haben sich Deutsche zu rühmen, da Herrlichste doch ist der Göthe
 Spanier lächeln stolz, zeigend Cervantes Gedicht
@@ -4288,7 +4288,7 @@ Dänen ein göttliches Heil, Deutschen ein wonniges Glück.
 <head>
     <title>Kong Fredrik gav sit vise Bud</title>
     <firstline>Kong Fredrik gav sit vise Bud</firstline>
-    <quality>korrektur1,kilde,side</quality>
+    <quality>korrektur1,korrektur2,kilde,side</quality>
     <source pages="165-166"/>
 </head>
 <body>
@@ -4430,7 +4430,7 @@ Hvor finder jeg eder?
 <head>
     <title>Ud i den friske Luft! Ud i den frie Natur!</title>
     <firstline>Ud i den friske Luft! Ud i den frie Natur!</firstline>
-    <quality>korrektur1,kilde,side</quality>
+    <quality>korrektur1,korrektur2,kilde,side</quality>
     <source pages="171-172"/>
 </head>
 <body>
@@ -4492,7 +4492,7 @@ Suk ei meer! Suk ei meer!
 <head>
     <title>Lærken hun sjunger og Klokken gaaer</title>
     <firstline>Lærken hun sjunger og Klokken gaaer</firstline>
-    <quality>korrektur1,kilde,side</quality>
+    <quality>korrektur1,korrektur2,kilde,side</quality>
     <source pages="173-174"/>
 </head>
 <body>
@@ -4522,7 +4522,7 @@ Hun kom herned fra sit høie Slot
 Mens Taagen stod paa og Græsset var vaadt,
 Men aldrig saasnart hun paa Veien var,
 Før Luften saae ud som en Lilie klar,
-Og i Skoven nikkede Løv og Rus
+Og i Skoven nikkede Løv og Riis
 Den ædelig Frøken saameget til Priis.
 Men hvad ligger vel for Snekke der,
 Og hure kommer til Lands den her?
@@ -4550,7 +4550,7 @@ Hjelp, St Birgitt! han har ondt i Hu.
     <notes>
         <note>Se også <xref poem="aarestrup20190210108"/>.</note>
     </notes>
-    <quality>korrektur1,kilde,side</quality>
+    <quality>korrektur1,korrektur2,kilde,side</quality>
     <source pages="175-176"/>
 </head>
 <body>
@@ -4601,7 +4601,7 @@ Den svævende Jomfrulighed.
 <head>
     <title>Afsides i en Dal, hvor sjælden Solen kommer</title>
     <firstline>Afsides i en Dal, hvor sjælden Solen kommer</firstline>
-    <quality>korrektur1,kilde,side</quality>
+    <quality>korrektur1,korrektur2,kilde,side</quality>
     <source pages="177-178"/>
 </head>
 <body>
@@ -4648,7 +4648,7 @@ Bort fra sit drømte Eden.
 <head>
     <title>Bag Hyttens Ruder smaa</title>
     <firstline>Bag Hyttens Ruder smaa</firstline>
-    <quality>korrektur1,kilde,side</quality>
+    <quality>korrektur1,korrektur2,kilde,side</quality>
     <source pages="179-180"/>
 </head>
 <body>
@@ -4693,7 +4693,7 @@ Lokken som paa Panden triller
 <head>
     <title>Den regndryppende Sandvei</title>
     <firstline>Kattehale og Ranunkler</firstline>
-    <quality>korrektur1,kilde,side</quality>
+    <quality>korrektur1,korrektur2,kilde,side</quality>
     <source pages="180"/>
 </head>
 <body>
@@ -4712,7 +4712,7 @@ Mellem høie Rugax staae
 <head>
    <title>Ei de snoe sig om det Stive</title>
    <firstline>Ei de snoe sig om det Stive</firstline>
-   <quality>korrektur1,kilde,side</quality>
+   <quality>korrektur1,korrektur2,kilde,side</quality>
    <source pages="181"/>
 </head>
 <body>
@@ -4736,7 +4736,7 @@ Gud har dannet, egenhændigt.
 <head>
    <title>Saae jeg ikke Dine spredes</title>
    <firstline>Saae jeg ikke Dine spredes</firstline>
-   <quality>korrektur1,kilde,side</quality>
+   <quality>korrektur1,korrektur2,kilde,side</quality>
    <source pages="181"/>
 </head>
 <body>
@@ -4756,7 +4756,7 @@ I min Sjæl
 <head>
     <title>Fiskeren</title>
     <firstline>Malerie - flyvende Skum -</firstline>
-    <quality>korrektur1,kilde,side</quality>
+    <quality>korrektur1,korrektur2,kilde,side</quality>
     <source pages="182"/>
 </head>
 <body>

--- a/fdirs/aarestrup/1976-5.xml
+++ b/fdirs/aarestrup/1976-5.xml
@@ -25,7 +25,7 @@
     <toctitle>Anakreon: Nu velan da, flinke Maler</toctitle>
     <subtitle>Εἰς την ἑαυτου ἑταιραν.</subtitle>
     <firstline>Nu velan da, flinke Maler</firstline>
-    <quality>korrektur1,kilde,side</quality>
+    <quality>korrektur1,korrektur2,kilde,side</quality>
     <notes>
         <note>Gendigtning af Anakreontika <xref type="translation" poem="anakreontika2025122828"/>.</note>
     </notes>
@@ -78,7 +78,7 @@ Billed, taler du ei ogsaa?
     <title>Tilstaaelsen</title>
     <toctitle>Blumenhagen: Tilstaaelsen</toctitle>
     <firstline>Den gule Strøm i Aftenrøden bølger</firstline>
-    <quality>korrektur1,kilde,side</quality>
+    <quality>korrektur1,korrektur2,kilde,side</quality>
     <source pages="11-12"/>
 </head>
 <body>
@@ -93,12 +93,12 @@ Da hist ved Rankens Drueguld hun vendte
 Da Elskovs søde Ahnelser hun tændte
    I Barmen mig.
 
-Vaarknuppper slyngde over Blomsterbanen
+Vaarknupper slyngde over Blomsterbanen
    En broget Krands,
 Og Phantasia sang paa Sølversvanen
    I Rosenglands.
 
-Tidt Ungersvendes Graad i stille Kammer
+Tidt Ungersvendens Graad i stille Kammer
    Paa Blomsten randt,
 Naar aldrig Barmens stærke Attraaesflammer
    Han mildned fandt.
@@ -137,7 +137,7 @@ Blidt toner det, som fjerne Sølverklokker:
         <note unknown-original-by="falk" />
     </notes>
     <source pages="13-14"/>
-    <quality>korrektur1,kilde,side</quality>
+    <quality>korrektur1,korrektur2,kilde,side</quality>
 </head>
 <body>
 <poetry>
@@ -190,7 +190,7 @@ At savne sit lille spæde Noer.
     <title>Til Taalmodigheden</title>
     <toctitle>—: Til Taalmodigheden</toctitle>
     <firstline>En herlig Dyd vil jeg nu vove</firstline>
-    <quality>korrektur1,kilde,side</quality>
+    <quality>korrektur1,korrektur2,kilde,side</quality>
     <notes>
         <note>Oversættelse af Johannes Falk: <xref type="translation" poem="falk2019093001"/>.</note>
     </notes>
@@ -256,7 +256,7 @@ Vi sees igjen, Taalmodighed!
     <notes>
         <note>Oversættelse af Fouqué: <xref type="translation" poem="fouque2019112501"/>.</note>
     </notes>
-    <quality>korrektur1,kilde,side</quality>
+    <quality>korrektur1,korrektur2,kilde,side</quality>
     <source pages="17-18"/>
 </head>
 <body>
@@ -316,7 +316,7 @@ Med Citherspil og Sang.
     <title>Trøstens Vise</title>
     <toctitle>—: Trøstens Vise</toctitle>
     <firstline>Frisk, nye Menniskbilled</firstline>
-    <quality>korrektur1,kilde,side</quality>
+    <quality>korrektur1,korrektur2,kilde,side</quality>
     <notes>
         <note unknown-original-by="fouque" />
     </notes>
@@ -418,7 +418,7 @@ I Herrens Jubelsang.
     <notes>
         <note unknown-original-by="fouque" />
     </notes>
-    <quality>korrektur1,kilde,side</quality>
+    <quality>korrektur1,korrektur2,kilde,side</quality>
     <source pages="22"/>
 </head>
 <body>
@@ -440,7 +440,7 @@ Skilsmis er saa beedsk en Drik.
 Vandringsmand, hør du mit Raad,
 Frygtens Ord dig slet kun sømme,
 Uden Afsked drag med Mod!
-Dig dig Kjærest mildt til dømme.
+Din Dig Kjærest mildt vil dømme.
 Brænder et Farvel dit Sind,
 Syng det gjennem Vindvet ind.
 
@@ -449,7 +449,7 @@ Sangen tryller Frygt til Haaben,
 Liv og Lyst af dorskt og dødt,
 Gjør dit Bryst for Glæden aaben.
 Et Farvel, som Sang frembær,
-At den halve Gjenkomst er.
+Alt den halve Gjenkomst er.
 
 <nonum><right><i>la Motte Fouqué.</i></right></nonum>
 </poetry>
@@ -465,7 +465,7 @@ At den halve Gjenkomst er.
         <note>Cf. <xref bibel="bibelmatt12,36"/>.</note>
         <note>Oversættelse af Goethe: <xref type="translation" poem="goethe2019013101"/>.</note>
     </notes>
-    <quality>korrektur1,kilde,side</quality>
+    <quality>korrektur1,korrektur2,kilde,side</quality>
     <keywords>sonnet</keywords>
     <source pages="23"/>
 </head>
@@ -503,7 +503,7 @@ Saa bliver Dommedag fast til et Aar.
         <note>Dateret: 1818.</note>
         <note>Oversættelse af Goethe: <xref type="translation" poem="goethe2019013102"/>.</note>
     </notes>
-    <quality>korrektur1,kilde,side</quality>
+    <quality>korrektur1,korrektur2,kilde,side</quality>
     <keywords>sonnet</keywords>
     <source pages="24"/>
 </head>
@@ -540,7 +540,7 @@ Og maatte dog iblandt nu ogsaa lime.
     <notes>
         <note>Oversættelse af Goethe: <xref type="translation" poem="goethe2000010807"/>.</note>
     </notes>
-    <quality>korrektur1,kilde,side</quality>
+    <quality>korrektur1,korrektur2,kilde,side</quality>
     <source pages="25"/>
 </head>
 <body>
@@ -565,7 +565,7 @@ Og Fremtiden Gud overlade.
     <notes>
         <note>Oversættelse af Johann Nikolaus Götz: <xref type="translation" poem="goetzn2026072301"/>.</note>
     </notes>
-    <quality>korrektur1,kilde,side</quality>
+    <quality>korrektur1,korrektur2,kilde,side</quality>
     <source pages="26"/>
 </head>
 <body>
@@ -594,7 +594,7 @@ Gjennemmarsch vi kun forlange.
     <notes>
         <note>Oversættelse af Johann Nikolaus Götz: <xref type="translation" poem="goetzn2026072302"/>.</note>
     </notes>
-    <quality>korrektur1,kilde,side</quality>
+    <quality>korrektur1,korrektur2,kilde,side</quality>
     <source pages="26"/>
 </head>
 <body>
@@ -617,7 +617,7 @@ Men andre kun, og kun for allersidste Gang.
     <notes>
         <note>Oversættelse af Johann Nikolaus Götz: <xref type="translation" poem="goetzn2026072303"/>.</note>
     </notes>
-    <quality>korrektur1,kilde,side</quality>
+    <quality>korrektur1,korrektur2,kilde,side</quality>
     <source pages="27"/>
 </head>
 <body>
@@ -639,7 +639,7 @@ Bar du ei Vintren i dit Hjerte!
     <title>Degnens Eventyr</title>
     <toctitle>Gubitz: Degnens Eventyr</toctitle>
     <firstline>Henrykt end af Kysset, sidst jeg</firstline>
-    <quality>korrektur1,kilde,side</quality>
+    <quality>korrektur1,korrektur2,kilde,side</quality>
     <notes>
         <note unknown-original-by="gubitz" />
     </notes>
@@ -714,7 +714,7 @@ Og det reent fordømte Stød.
     <notes>
         <note>Gendigtning af Theodor Körner: <xref type="translation" poem="koerner2019050101"/>.</note>
     </notes>
-    <quality>korrektur1,kilde,side</quality>
+    <quality>korrektur1,korrektur2,kilde,side</quality>
     <source pages="30-31"/>
 </head>
 <body>
@@ -761,7 +761,7 @@ Glimter gjennem eders Taarer,
 Glimter gjennem eders Glæde
 Til mig, som fra Himmerig.
 
-O, saa hør nu Sang'rens Hilsen! —
+O, saa her nu Sang'rens Hilsen! —
 Vil I Ungersvenden kjærlig,
 Liig de ev'ge Dioskurer,
 Lyse gjennem Livets Bølger?
@@ -778,7 +778,7 @@ Vil I mine Stjerner være,
     <title>Digter-Veer</title>
     <toctitle>Schwab: Digter-Veer</toctitle>
     <firstline>Ikke veed jeg hvad jeg vil</firstline>
-    <quality>korrektur1,kilde,side</quality>
+    <quality>korrektur1,korrektur2,kilde,side</quality>
     <notes>
         <note unknown-original-by="schwab" />
     </notes>
@@ -824,7 +824,7 @@ Ei! det var en lille Vise!
     <notes>
         <note>Gendigtning af C. A. Tiedge: <xref type="translation" poem="tiedge2019021501"/>.</note>
     </notes>
-    <quality>korrektur1,kilde,side</quality>
+    <quality>korrektur1,korrektur2,kilde,side</quality>
     <source pages="33-34"/>
 </head>
 <body>
@@ -892,7 +892,7 @@ Naar man nu eengang maa?
     <notes>
         <note>Gendigtning af Hans Aßmann Freiherr von Abschatz: <xref type="translation" poem="abschatz2019120701"/>.</note>
     </notes>
-    <quality>korrektur1,kilde,side</quality>
+    <quality>korrektur1,korrektur2,kilde,side</quality>
     <source pages="35"/>
 </head>
 <body>
@@ -931,7 +931,7 @@ Elskov gjør, at jeg maa døe!
         <note>Gendigtning af Hans Aßmann Freiherr von Abschatz: <xref type="translation" poem="abschatz2019120702"/>.</note>
     </notes>
     <source pages="36-37"/>
-    <quality>korrektur1,kilde,side</quality>
+    <quality>korrektur1,korrektur2,kilde,side</quality>
 </head>
 <body>
 <poetry>
@@ -1052,7 +1052,7 @@ Ved et saa sødt Bedrag.
         <note>Gendigtning af »'Tis not your saying that you love«.</note>
         <note unknown-original-by="behn" />
     </notes>
-    <quality>korrektur1,kilde,side</quality>
+    <quality>korrektur1,korrektur2,kilde,side</quality>
     <source pages="40"/>
 </head>
 <body>
@@ -1085,7 +1085,7 @@ Men vel mit arme Liv.
     <notes>
         <note>Gendigtning af Carl Michaël Bellmans »Fredmans Epistler nr. 36.« (<xref type="translation" poem="bellman2001061336"/>).</note>
     </notes>
-    <quality>korrektur1,kilde,side</quality>
+    <quality>korrektur1,korrektur2,kilde,side</quality>
     <source pages="41-46"/>
 </head>
 <body>
@@ -1274,7 +1274,7 @@ Haab at let fra Skrub og Riis
     <notes>
         <note>Gendigtning af Pierre-Jean de Béranger: <xref type="translation" poem="beranger2019120701"/>.</note>
     </notes>
-    <quality>korrektur1,kilde,side</quality>
+    <quality>korrektur1,korrektur2,kilde,side</quality>
     <source pages="47"/>
 </head>
 <body>
@@ -1311,7 +1311,7 @@ Da jeg slap Naalen for Theatrets Ære,
     <notes>
         <note>Gendigtning af Pierre-Jean de Béranger: <xref type="translation" poem="beranger2019120702"/>.</note>
     </notes>
-    <quality>korrektur1,kilde,side</quality>
+    <quality>korrektur1,korrektur2,kilde,side</quality>
     <source pages="48-49"/>
 </head>
 <body>
@@ -1374,7 +1374,7 @@ Miau! Miau! gaae ligedan.
     <notes>
         <note>Gendigtning af Pierre-Jean de Béranger: <xref type="translation" poem="beranger2019120703"/>.</note>
     </notes>
-    <quality>korrektur1,kilde,side</quality>
+    <quality>korrektur1,korrektur2,kilde,side</quality>
     <source pages="50-51"/>
 </head>
 <body>
@@ -1428,7 +1428,7 @@ Og lad os beholde vor Ven.
     <notes>
         <note>Gendigtning af Pierre-Jean de Béranger: <xref type="translation" poem="beranger2019120704"/>.</note>
     </notes>
-    <quality>korrektur1,kilde,side</quality>
+    <quality>korrektur1,korrektur2,kilde,side</quality>
     <source pages="52-54"/>
 </head>
 <body>
@@ -1516,7 +1516,7 @@ Min lille Hanne, min Hannemoer!
     <notes>
         <note>Gendigtning af Pierre-Jean de Béranger: <xref type="translation" poem="beranger2019120705"/>.</note>
     </notes>
-    <quality>korrektur1,kilde,side</quality>
+    <quality>korrektur1,korrektur2,kilde,side</quality>
     <source pages="55-56"/>
 </head>
 <body>
@@ -1580,7 +1580,7 @@ Med Friheden er det forbi.
     <notes>
         <note>Gendigtning af Pierre-Jean de Béranger: <xref type="translation" poem="beranger2019120706"/>.</note>
     </notes>
-    <quality>korrektur1,kilde,side</quality>
+    <quality>korrektur1,korrektur2,kilde,side</quality>
     <source pages="57-58"/>
 </head>
 <body>
@@ -1589,7 +1589,7 @@ Selv du vil ældes, som i Ungdom smiler;
 Selv du vil ældes; jeg snart være død.
 Dog dobbelt giver Tiden, skjøndt den iler,
 Hver Dag, med dig jeg henrykt nød.
-O overlev migl Ingen Alder kue
+O overlev mig! Ingen Alder kue
 Den Lærdom, jeg dig gav! glem aldrig den!
 Men i din stille Krog, som gammel Frue,
 Gjentag ved Lampen Digtet af din Ven.
@@ -1607,7 +1607,7 @@ Og spørges dig: var han da ret elskværdig?
 Svar uden Rødme dem: jeg elskte ham.
 Var han istand til Ondt? Var han letfærdig?
 Svar dem med Stolthed blot: jeg elskte ham.
-O slig, til hvilken høi og føelsom Lue
+O siig, til hvilken høi og føelsom Lue
 Hans glade Strengespil rev Hjertet hen;
 Og i din stille Krog, som gammel Frue,
 Gjentag ved Lampen Digtet af din Ven.
@@ -1643,7 +1643,7 @@ Gjentag ved Lampen Digtet af din Ven.
     <notes>
         <note>Gendigtning af Pierre-Jean de Béranger: <xref type="translation" poem="beranger2019120707"/>.</note>
     </notes>
-    <quality>korrektur1,kilde,side</quality>
+    <quality>korrektur1,korrektur2,kilde,side</quality>
     <source pages="59-60"/>
 </head>
 <body>
@@ -1726,13 +1726,13 @@ Som jeg har seet til sultne Fugle
 At kaste Korn ved Juletid.
 Hun kaldte dem, og deres Hoppen
 Var Elskovsvinket for en Ven -
-O fagre Træ med Snee med Toppen
+O fagre Træ med Snee paa Toppen
 Fordømte Vaar, er du alt der igjen?
 
 Var ikke du, saa saae jeg hende
 Berede sig til Nattens Ro
 Og frisk, som vi Aurora kjende,
-At løste tidlig sit Rideau.
+At løfte tidlig sit Rideau.
 Endnu hver Aften kunde sukkes:
 Min skjønne Stjerne synker hen,
 Hun slumrer ind, og Lampen slukkes.
@@ -1742,8 +1742,8 @@ Jeg beder om en Vinter, Guder!
 O, at jeg hørte muntre Knald
 Af Haglen paa de blanke Ruder
 Og saae de hvide Sneefogs Fald!
-Hvad nytte Skyerne, som ile,
-Den lange Dag, hvad nytter den?
+Hvad nytter Skyerne, som ile,
+Din lange Dag, hvad nytter den?
 Jeg seer ei hende mere smile -
 Fordømte Vaar, er du alt der igjen?
 
@@ -1760,7 +1760,7 @@ Fordømte Vaar, er du alt der igjen?
     <notes>
         <note>Gendigtning af Gottfried August Bürger: <xref type="translation" poem="burger2019021301"/>.</note>
     </notes>
-    <quality>korrektur1,kilde,side</quality>
+    <quality>korrektur1,korrektur2,kilde,side</quality>
     <source pages="63-64"/>
 </head>
 <body>
@@ -1820,7 +1820,7 @@ Jeg blev med eet uhyre from.
     <notes>
         <note>Robert Burns: <xref type="translation" poem="burns2000083001"/>.</note>
     </notes>
-    <quality>korrektur1,kilde,side</quality>
+    <quality>korrektur1,korrektur2,kilde,side</quality>
     <source pages="65"/>
 </head>
 <body>
@@ -1858,8 +1858,8 @@ Om det var titusind Miil.
     <notes>
         <note>Robert Burns: <xref type="translation" poem="burns2000083002"/>.</note>
     </notes>
-    <quality>korrektur1,kilde,side</quality>
-    <source pages="66"/>
+    <quality>korrektur1,korrektur2,kilde,side</quality>
+    <source pages="66-67"/>
 </head>
 <body>
 <poetry>
@@ -2057,7 +2057,7 @@ Forbi - han ligger for hendes Fødder.
 
 Og hvad er Verden dem ved Siden
 Med alle Skiftninger af Tiden?
-Dens Jord og Sky, dens levende Vrimmel
+Dens Jord og Luft, dens levende Vrimmel
 Er Intet nu mod deres Himmel.
 De ændse oven, neden, rundt omkring,
 Som Døde, om dem Ingenting;
@@ -2084,7 +2084,7 @@ De dybe Suk, det lange Favntags Lyst,
 Der nu gad vare evig, Bryst mod Bryst,
 Da Parisina frygter, ingen Straale
 Af Himlen meer kan hendes Ansigt taale,
-Som om hver stille medvidende Stjerne
+Som om hver mild medvidende Stjerne
 Betragted hendes Feiltrin fra det Fjerne -
 De dybe Suk, det lange Favntags Lyst
 Til Pletten lænker dem, Bryst imod Bryst.
@@ -2097,7 +2097,7 @@ Til lønligt Leie Hugo iler,
 Forelsket i, hvad ei er hans;
 Men hun et skyldigt Hoved hviler
 Ved Siden af troskyldig Mands.
-I Federhede Blodet strømmer,
+I Feberhede Blodet strømmer,
 Med Luekind, i Skræk, hun drømmer,
 Hun mumler i urolig Vaande
 Et Navn, hun tør ved Dag ei aande,
@@ -2235,7 +2235,7 @@ Den stolte Holdning overmande.
 Og Azo talte: ,,endnu igaar
 En Viv og Søn velsigned mine Aar;
 Men denne Morgen har forandret Tingen:
-Før Tagen hælder har jeg Ingen.
+Før Dagen hælder har jeg Ingen.
 Mit Liv skal tæres eensomt hen;
 Dog, lad det skee! - det er ei stort!
 Der aander ingen Fjende eller Ven,
@@ -2290,7 +2290,7 @@ Skal vidne for dig fra de Døde,
 Hvor trofast og hvor dyrebar
 Som Elsker du og Fader var.
 Vel sandt, jeg mig mod dig forbrød -
-Men Ondt mod Ondt - det ei fortrød
+Men Ondt for Ondt - det ei fortrød
 Det andet Offer for dit Overmod,
 Den Brud, du mig fratage lod -
 Du saae og tilbad hendes Ynde -
@@ -2316,9 +2316,9 @@ Naar Pauken klang, og Kampskriget lød:
 ,,For Estes Banner Seir eller Død!''
 Jeg vil ei Forsvar, vil ei Rettergang,
 Ja ei bønfalde vil jeg dig engang
-Om nogle Timer eller Dages Frist -
+Om nogle Timers eller Dages Frist -
 De rulle med mit Støv dog hen tilsidst -
-Den Slags Henrykkelse, jeg nylig nød,
+Det Slags Henrykkelse, jeg nylig nød,
 Kan endes kun, og gjør det og, med Død -
 Lad end mit Navn, min Fødsel være ringe
 Og dit høibaarne Slægtskab tvinge
@@ -2342,7 +2342,7 @@ Jeg agted ikke meer end du tilvisse,
 Naar Hjelmen blinked om din Isse,
 Og vi, jevnsides, rede
 Henover faldne Mænd i Slagets Hede:
-Hvad er fordi, er Intet, og tilsidst
+Hvad er forbi, er Intet, og tilsidst
 Er det, som kommer, det, som gik;
 Dog gad jeg dengang lukt mit Blik:
 Thi skjøndt min Moder du bedrog forvist
@@ -2455,7 +2455,7 @@ Med renest Glands, skyfriest Blaat;
 Dens Aftenlysning rød
 Sig over Hugos uheldsvangre Hoved gjød,
 Mens han, sit sidste Skriftemaal
-Fremstammende med stille Taal
+Fremstammede med stille Taal
 Og angerfuld Hengivenhed
 For Munken bøies ned,
 At høre Ordet, som forkynder
@@ -2482,7 +2482,7 @@ Det er forbi - tæt er de ham afskaaren -
 Den Trøie, til det Sidste baaren -
 Det Skierf, ham Parisina gav,
 Maa ham ei pryde i hans Grav.
-Alt det man kaster nu tilside,
+Alt det maa kastes nu tilside,
 Og omkring Øiet Klædet slaaes, det hvide;
 Men nei - nei, denne sidste Skam
 Skal ikke overgaae hans Blik og ham:
@@ -2497,7 +2497,7 @@ Mig ud af Verden med mit frie Blik -
 Hug!'' og idet han Ordet sagde,
 Han Hovedet paa Blokken lagde;
 Det var det sidste Ord, da han sig bukked:
-,,Hug!'' og glimtende faldt Huggget -
+,,Hug!'' og glimtende faldt Hugget -
 Sprang Hovedet - og livløs, fuld
 Af røde Pletter, Kroppen sank omkuld
 I Sandet, som hver dyb Blodaare slukked
@@ -2571,7 +2571,7 @@ Hvad eller hun i Timen, i den samme,
 For mere hastig Marter maatte synke,
 Liig ham, hun saae Blodøxen ramme,
 Idet hun Deel i Bøddelhugget tog,
-Og Hjertet, fuldt af Hast, som for at ynke
+Og Hjertet, fuld af Hast, som for at ynke
 Den Sønderknuste, brast, idet det slog, -
 Man veed det ei - og Ingen faaer det vide:
 Men hvad hun ogsaa maatte lide,
@@ -2579,7 +2579,7 @@ Begyndte hendes Liv, og endte det med Qvide!
 
 Og Azo fandt en anden Brud,
 Og bolde Sønner gav ham Gud;
-Men ingen dog faa elskelig og brav
+Men ingen dog saa elskelig og brav
 Som han, der smuldred i sin Grav;
 Og var de end - hans kolde Blik
 Kun flygtigt over deres Blomstring gik;
@@ -2649,13 +2649,13 @@ Og aldrig meer et Løv sig kruser.
     <notes>
         <note>Gendigtning af Byrons <xref type="translation" poem="byron2002022501"/>.</note>
     </notes>
-    <quality>korrektur1,kilde,side</quality>
+    <quality>korrektur1,korrektur2,kilde,side</quality>
     <source pages="92-93"/>
 </head>
 <body>
 <poetry>
 Saa lyse Haar, saa mørke Blik,
-Saa blaa, som den, din Moder fik;
+Saa blaa, som dem, din Moder fik;
 En saadan Mund, hvis Gruber smaae
 Og Smiil til alles Hjerter gaae,
 Gjenkalder en forsvunden Lyst,
@@ -2706,7 +2706,7 @@ Ungdom ei slukker Hjertets Drift
     <notes>
         <note>Gendigtning af Byron: <xref type="translation" poem="byron2002022502"/>.</note>
     </notes>
-    <quality>korrektur1,kilde,side</quality>
+    <quality>korrektur1,korrektur2,kilde,side</quality>
     <source pages="94-95"/>
 </head>
 <body>
@@ -2766,7 +2766,7 @@ Mit Ansigt rødmede af Blue.
     <notes>
         <note>Oversættelse af Cornwalls <xref type="translation" poem="cornwall2002022501"/>.</note>
     </notes>
-    <quality>korrektur1,kilde,side</quality>
+    <quality>korrektur1,korrektur2,kilde,side</quality>
     <source pages="96"/>
 </head>
 <body>
@@ -2799,7 +2799,7 @@ Til min Arm, mit Bryst.
     <notes>
         <note>Oversættelse af Cornwalls <xref type="translation" poem="cornwall2019013101"/>.</note>
     </notes>
-    <quality>korrektur1,kilde,side</quality>
+    <quality>korrektur1,korrektur2,kilde,side</quality>
     <source pages="97"/>
 </head>
 <body>
@@ -2832,7 +2832,7 @@ Uden hun var kjælen med.
     <notes>
         <note>Oversættelse af Cornwalls <xref type="translation" poem="cornwall2019013102"/>.</note>
     </notes>
-    <quality>korrektur1,kilde,side</quality>
+    <quality>korrektur1,korrektur2,kilde,side</quality>
     <keywords>drikkevise</keywords>
     <source pages="98"/>
 </head>
@@ -2879,7 +2879,7 @@ Drik, og drukn i Glæde Verden.
     <notes>
         <note>Oversættelse af Cowpers <xref type="translation" poem="cowper2019013101"/>.</note>
     </notes>
-    <quality>korrektur1,kilde,side</quality>
+    <quality>korrektur1,korrektur2,kilde,side</quality>
     <source pages="99"/>
 </head>
 <body>
@@ -2922,7 +2922,7 @@ Paafølges maaskee af et Smiil
         <note>Gendigtning af Allan Cunningham: <xref type="translation" poem="cunningham2019090803"/>.</note>
     </notes>
     <firstline>Kom, Pige, snør dig rank</firstline>
-    <quality>korrektur1,kilde,side</quality>
+    <quality>korrektur1,korrektur2,kilde,side</quality>
     <source pages="100-101"/>
 </head>
 <body>
@@ -2977,7 +2977,7 @@ Og vær vor Dronning, Anna.
         <note>Gendigtning af Allan Cunningham: <xref type="translation" poem="cunningham2019090802"/>.</note>
     </notes>
     <source pages="102-103"/>
-    <quality>korrektur1,kilde,side</quality>
+    <quality>korrektur1,korrektur2,kilde,side</quality>
 </head>
 <body>
 <poetry>
@@ -3029,7 +3029,7 @@ Den kan vort Elskovsblik forstaae.
     <notes>
         <note>Gendigtning af Allan Cunningham: <xref type="translation" poem="cunningham2019090801"/>.</note>
     </notes>
-    <quality>korrektur1,kilde,side</quality>
+    <quality>korrektur1,korrektur2,kilde,side</quality>
     <source pages="104"/>
 </head>
 <body>
@@ -3075,7 +3075,7 @@ Behængt med Havets Skum.
         <note>Gendigtning af Allan Cunningham: <xref type="translation" poem="cunningham2019090804"/>.</note>
     </notes>
     <source pages="105-106"/>
-    <quality>korrektur1,kilde,side</quality>
+    <quality>korrektur1,korrektur2,kilde,side</quality>
 </head>
 <body>
 <poetry>
@@ -3138,7 +3138,7 @@ Den kjække Hak Humle.
     <notes>
         <note>Oversættelse af Casimir Delavigne: <xref type="translation" poem="delavigne2019013101"/>.</note>
     </notes>
-    <quality>korrektur1,kilde,side</quality>
+    <quality>korrektur1,korrektur2,kilde,side</quality>
     <source pages="107-108"/>
 </head>
 <body>
@@ -3146,7 +3146,7 @@ Den kjække Hak Humle.
 Ja, jeg adlyder Dig; jeg sværger, tøiles skal
 Hver Ubesindighed, hvis Ild med Skræk Dig fylder.
 Jeg sværger det, ved Guderne, ei saares skal
-De søde Blu, som mig, saa hidsende, fortryller.
+Den søde Blu, som mig, saa hidsende, fortryller.
 
 Ja, ved Dig selv jeg sværger - Eden gaaer saa vidt -
 Min Haand skal ei forraade Din hvorom der sukkes,
@@ -3188,7 +3188,7 @@ Jeg sværger - - Ha - hvem der? - O jeg har intet svoret!
         <note>Gendigtnings af Goethes <xref type="translation" poem="goethe2000082802"/>.</note>
         <note>Fra brev 1. juli 1826 til Frk. Caroline Aagaard, senere Fru Aarestrup.</note>
     </notes>
-    <quality>korrektur1,kilde,side</quality>
+    <quality>korrektur1,korrektur2,kilde,side</quality>
     <source pages="109"/>
 </head>
 <body>
@@ -3274,7 +3274,7 @@ Sol synker alt, snart funkle mine Stjerner -
         <note>Gendigtning af Goethe: <xref type="translation" poem="goethe2000082803"/>.</note>
         <note>Fra brev 1. juli 1826 til Frk. Caroline Aagaard, senere Fru Aarestrup.</note>
     </notes>
-    <quality>korrektur1,kilde,side</quality>
+    <quality>korrektur1,korrektur2,kilde,side</quality>
     <source pages="111"/>
 </head>
 <body>
@@ -3289,8 +3289,8 @@ Forgjæves op i Luften slaaer,
 Naar, i det klare Rum forborgen,
 Høit over ham en Lærke slaaer:
 
-Saaledes søger mange Gange
-Mit Blik af Land og Søen hen.
+Saaledes søger mangegange
+Mit Blik ad Land og Søen hen.
 Dig kalde alle mine Sange:
 O Elskte, kom! o kom igjen!
 
@@ -3309,7 +3309,7 @@ O Elskte, kom! o kom igjen!
         <note>Gendigtning af Goethe: <xref type="translation" poem="goethe2000082805"/>.</note>
         <note>Fra brev 1. juli 1826 til Frk. Caroline Aagaard, senere Fru Aarestrup.</note>
     </notes>
-    <quality>korrektur1,kilde,side</quality>
+    <quality>korrektur1,korrektur2,kilde,side</quality>
     <source pages="112-113"/>
 </head>
 <body>
@@ -3457,7 +3457,7 @@ Mit stille Haab, min bange Tro.
     <notes>
         <note>Fragment af Goethes <xref type="translation" poem="goethe2000082804"/>.</note>
     </notes>
-    <quality>korrektur1,kilde,side</quality>
+    <quality>korrektur1,korrektur2,kilde,side</quality>
     <source pages="117"/>
 </head>
 <body>
@@ -3491,7 +3491,7 @@ Hin skjælmske Gud har ham bedraget,
     <notes>
         <note>Gendigtning af Goethe: <xref type="translation" poem="goethe2000082806"/>.</note>
     </notes>
-    <quality>korrektur1,kilde,side</quality>
+    <quality>korrektur1,korrektur2,kilde,side</quality>
     <source pages="118"/>
 </head>
 <body>
@@ -3534,7 +3534,7 @@ Paa denne dunkle Jord.
     <notes>
         <note>Gendigtning af Goethe: <xref type="translation" poem="goethe2000082807"/>.</note>
     </notes>
-    <quality>korrektur1,kilde,side</quality>
+    <quality>korrektur1,korrektur2,kilde,side</quality>
     <source pages="119"/>
 </head>
 <body>
@@ -3563,7 +3563,7 @@ Agt det vel, og du vil immer give. -
     <notes>
         <note>Gendigtning af Goethe: <xref type="translation" poem="goethe2000082808"/>.</note>
     </notes>
-    <quality>korrektur1,kilde,side</quality>
+    <quality>korrektur1,korrektur2,kilde,side</quality>
     <source pages="120"/>
 </head>
 <body>
@@ -3581,7 +3581,7 @@ Maatte fast en Verden dræbes.
 Fast en Verdens Liv, som følte
 Svulmende en indre Lyst,
 Anede alt Bulbuls Elskov
-For det duftopfyldt Bryst.
+For det duftopfyldte Bryst.
 
 Dog - den Tanke skal os ikke
 Glæden, som vi nyde, qvæle.
@@ -3601,7 +3601,7 @@ Offret Myriader Sjæle?
     <notes>
         <note>Gendigtning af Goethes <xref type="translation" poem="goethe2000082809"/>.</note>
     </notes>
-    <quality>korrektur1,kilde,side</quality>
+    <quality>korrektur1,korrektur2,kilde,side</quality>
     <source pages="121"/>
 </head>
 <body>
@@ -3648,7 +3648,7 @@ Just i dette Øieblik.
         <note unknown-original-by="grotius" />
         <!-- Den korrekte titel er Hugo Grotius: »Epithalamium Potteii« -->
     </notes>
-    <quality>korrektur1,kilde,side</quality>
+    <quality>korrektur1,korrektur2,kilde,side</quality>
     <source pages="122-123"/>
 </head>
 <body>
@@ -3722,7 +3722,7 @@ Men til trods at handle, ogsaa.
     <notes>
         <note>Gendigtning af Heinrich Heines <xref type="translation" poem="heine2000082601"/>.</note>
     </notes>
-    <quality>korrektur1,kilde,side</quality>
+    <quality>korrektur1,korrektur2,kilde,side</quality>
     <source pages="124"/>
 </head>
 <body>
@@ -3765,7 +3765,7 @@ Og drømme en salig Drøm.
     <notes>
         <note>Gendigtning af Heinrich Heines <xref type="translation" poem="heine2000082602"/>.</note>
     </notes>
-    <quality>korrektur1,kilde,side</quality>
+    <quality>korrektur1,korrektur2,kilde,side</quality>
     <source pages="125"/>
 </head>
 <body>
@@ -3803,7 +3803,7 @@ Vi blive rolig dernede.
     <notes>
         <note>Gendigtning af Heinrich Heines <xref type="translation" poem="heine2000082603"/>.</note>
     </notes>
-    <quality>korrektur1,kilde,side</quality>
+    <quality>korrektur1,korrektur2,kilde,side</quality>
     <source pages="126-127"/>
 </head>
 <body>
@@ -3833,7 +3833,7 @@ Der Skilderhuset staaer.
 En Soldat i rød Mundering
 Op og ned paa Posten gaaer.
 
-Han leger med Muskettet,
+Han leger med Musketten,
 Den funkler i Aftenqvæld,
 Han præsenterer og skuldrer -
 Gud give, han skjød mig ihiel!
@@ -3851,7 +3851,7 @@ Gud give, han skjød mig ihiel!
     <notes>
         <note>Gendigtning af Heinrich Heines <xref type="translation" poem="heine2000082604"/>.</note>
     </notes>
-    <quality>korrektur1,kilde,side</quality>
+    <quality>korrektur1,korrektur2,kilde,side</quality>
     <source pages="128"/>
 </head>
 <body>
@@ -3884,7 +3884,7 @@ Saa var der sletintet at holde sig til.
     <notes>
         <note>Oversættelse af Heinrich Heine: <xref type="translation" poem="heine2000082605"/>.</note>
     </notes>
-    <quality>korrektur1,kilde,side</quality>
+    <quality>korrektur1,korrektur2,kilde,side</quality>
     <source pages="129"/>
 </head>
 <body>
@@ -3922,7 +3922,7 @@ Spillet den døende Gladiator.
     <notes>
         <note>Gendigtning af Heinrich Heine: <xref type="translation" poem="heine2000082606"/>.</note>
     </notes>
-    <quality>korrektur1,kilde,side</quality>
+    <quality>korrektur1,korrektur2,kilde,side</quality>
     <source pages="130"/>
 </head>
 <body>
@@ -3960,7 +3960,7 @@ Er hændet mig eengang før.
     <notes>
         <note>Gendigtning af Heinrich Heine: <xref type="translation" poem="heine2000082607"/>.</note>
     </notes>
-    <quality>korrektur1,kilde,side</quality>
+    <quality>korrektur1,korrektur2,kilde,side</quality>
     <source pages="131"/>
 </head>
 <body>
@@ -3993,7 +3993,7 @@ Elskede, hvad vil du meer?
     <notes>
         <note>Gendigtning af Heinrich Heine: <xref type="translation" poem="heine2000082608"/>.</note>
     </notes>
-    <quality>korrektur1,kilde,side</quality>
+    <quality>korrektur1,korrektur2,kilde,side</quality>
     <source pages="132"/>
 </head>
 <body>
@@ -4026,7 +4026,7 @@ Græd over saadan en Konst.
     <notes>
         <note>Gendigtning af Heinrich Heines <xref type="translation" poem="heine2000082609"/>.</note>
     </notes>
-    <quality>korrektur1,kilde,side</quality>
+    <quality>korrektur1,korrektur2,kilde,side</quality>
     <source pages="133"/>
 </head>
 <body>
@@ -4054,8 +4054,8 @@ Urnen med min Elskovs Aske.
     <notes>
         <note>Gendigtning af Heinrich Heines <xref type="translation" poem="heine2002020388"/>.</note>
     </notes>
-    <quality>korrektur1,kilde,side</quality>
-    <source pages="134"/>
+    <quality>korrektur1,korrektur2,kilde,side</quality>
+    <source pages="134-135"/>
 </head>
 <body>
 <poetry>
@@ -4072,7 +4072,7 @@ Overalt, overalt,
 I Stormens Susen, i Havets Brusen
 Og i mit eget Suk -
 
-Med dette lette Rør skrev jeg i Sandet:
+Med det lette Rør skrev jeg i Sandet:
 ,,Agnes, jeg elsker dig!''
 Dog ondskabsfulde Bølger udgjød sig
 Over den søde Bekjendelse,
@@ -4129,7 +4129,7 @@ Tyrker og Græker, Hegel og Gaasen,
 Orangelunden og Vagtparader,
 Berlin og Schilda og Tunis og Hamborg,
 Men fremfor Alt den Elskedes Billed,
-Englehovedet paa Rhinskovenes Guldgrund.
+Englehovedet paa Rhinskvinens Guldgrund.
 O hvor skjøn! hvor skjøn er du, Elskte!
 Du er som en Rose!
 Ikke som Rosen fra Schiras,
@@ -4197,7 +4197,7 @@ Dreier sig hele den drukne Verden.
     <notes>
        <note>Oversættelse af Heines <xref type="translation" poem="heine2017081901"/>.</note>
     </notes>
-    <quality>korrektur1,kilde,side</quality>
+    <quality>korrektur1,korrektur2,kilde,side</quality>
     <source pages="139"/>
 </head>
 <body>
@@ -4230,7 +4230,7 @@ For, som Guderne, at sove.
     <notes>
         <note>Gendigtning af Heinrich Heines <xref type="translation" poem="heine2018120905"/>.</note>
     </notes>
-    <quality>korrektur1,kilde,side</quality>
+    <quality>korrektur1,korrektur2,kilde,side</quality>
     <source pages="140"/>
 </head>
 <body>
@@ -4258,7 +4258,7 @@ Udvider atter sig Sjælen.
     <notes>
         <note>Gendigtning af Heinrich Heines <xref type="translation" poem="heine2018120906"/>.</note>
     </notes>
-    <quality>korrektur1,kilde,side</quality>
+    <quality>korrektur1,korrektur2,kilde,side</quality>
     <source pages="141"/>
 </head>
 <body>
@@ -4296,7 +4296,7 @@ Amor troer jeg, at han hedder.
     <notes>
         <note>Gendigtning af Heinrich Heine: <xref type="translation" poem="heine2018120904"/>.</note>
     </notes>
-    <quality>korrektur1,kilde,side</quality>
+    <quality>korrektur1,korrektur2,kilde,side</quality>
     <source pages="142"/>
 </head>
 <body>
@@ -4324,7 +4324,7 @@ Troer jeg, er med blandt de Sammensvorne.
     <notes>
         <note>Gendigtning af Heinrich Heine: <xref type="translation" poem="heine2018120901"/>.</note>
     </notes>
-    <quality>korrektur1,kilde,side</quality>
+    <quality>korrektur1,korrektur2,kilde,side</quality>
     <source pages="143"/>
 </head>
 <body>
@@ -4356,7 +4356,7 @@ Henrykt med Stjernerne talte?
     <notes>
         <note>Gendigtning af Heinrich Heine: <xref type="translation" poem="heine2018120902"/>.</note>
     </notes>
-    <quality>korrektur1,kilde,side</quality>
+    <quality>korrektur1,korrektur2,kilde,side</quality>
     <source pages="144"/>
 </head>
 <body>
@@ -4384,7 +4384,7 @@ Den trykkede vi itu.
     <notes>
         <note>Gendigtning af Heinrich Heine: <xref type="translation" poem="heine2018120804"/>.</note>
     </notes>
-    <quality>korrektur1,kilde,side</quality>
+    <quality>korrektur1,korrektur2,kilde,side</quality>
     <source pages="145"/>
 </head>
 <body>
@@ -4416,7 +4416,7 @@ Og Solen smiilte, Fuglene sang.
     <notes>
         <note>Gendigtning af Heinrich Heine: <xref type="translation" poem="heine2018120903"/>.</note>
     </notes>
-    <quality>korrektur1,kilde,side</quality>
+    <quality>korrektur1,korrektur2,kilde,side</quality>
     <source pages="146"/>
 </head>
 <body>
@@ -4450,7 +4450,7 @@ Og for Poesie det gaaer.
     <notes>
         <note>Gendigtning af Heinrich Heine: <xref type="translation" poem="heine2019013101"/>.</note>
     </notes>
-    <quality>korrektur1,kilde,side</quality>
+    <quality>korrektur1,korrektur2,kilde,side</quality>
     <source pages="147"/>
 </head>
 <body>
@@ -4484,7 +4484,7 @@ Seer igjen, og dette Pludder.
     <notes>
         <note>Gendigtning af Heinrich Heine: <xref type="translation" poem="heine2018120802"/>.</note>
     </notes>
-    <quality>korrektur1,kilde,side</quality>
+    <quality>korrektur1,korrektur2,kilde,side</quality>
     <source pages="148"/>
 </head>
 <body>
@@ -4546,7 +4546,7 @@ Til du faar din Næse blodig.
     <notes>
         <note>Gendigtning af Heinrich Heine: <xref type="translation" poem="heine2019021401"/>.</note>
     </notes>
-    <quality>korrektur1,kilde,side</quality>
+    <quality>korrektur1,korrektur2,kilde,side</quality>
     <source pages="150-152"/>
 </head>
 <body>
@@ -4649,7 +4649,7 @@ Ind i Væggen, i Tapetet.
     <notes>
         <note>Gendigtning af Heinrich Heine: <xref type="translation" poem="heine2000010802"/>.</note>
     </notes>
-    <quality>korrektur1,kilde,side</quality>
+    <quality>korrektur1,korrektur2,kilde,side</quality>
     <source pages="153"/>
 </head>
 <body>
@@ -4680,7 +4680,7 @@ Sætter sig ved din Seng og strikker.
         <!-- Ms.: dateret 16 August 1838 -->
     </notes>
     <source pages="154"/>
-    <quality>korrektur1,kilde,side</quality>
+    <quality>korrektur1,korrektur2,kilde,side</quality>
 </head>
 <body>
 <poetry>
@@ -4757,7 +4757,7 @@ Og snapper dem alle baade.
     <title>Sjælevandringen</title>
     <toctitle>Houwald: Sjælevandringen</toctitle>
     <firstline>Naar jeg for Planten stille staaer</firstline>
-    <quality>korrektur1,kilde,side</quality>
+    <quality>korrektur1,korrektur2,kilde,side</quality>
     <notes>
         <note unknown-original-by="houwald" />
     </notes>
@@ -4813,7 +4813,7 @@ Opvaagnet af en dunkel Nat.
 Og derfor tykkes mig, jeg kan
 Troe Sjælevandringslæren sand;
 Hvor skulde jeg vel lære,
-Slig hvordan ellers jeg forstod,
+Siig hvordan ellers jeg forstod,
 Hvad Skovens Blomst og Fugl og Flod
 Opfyldes af og ere?
 Hvad? — eller har jeg denne Lyst,
@@ -4832,7 +4832,7 @@ Fordi det Alt er i mit Bryst?
     <notes>
         <note>Gendigtning af Vicor Hugo: <xref type="translation" poem="hugo2019112501"/>.</note>
     </notes>
-    <quality>korrektur1,kilde,side</quality>
+    <quality>korrektur1,korrektur2,kilde,side</quality>
     <source pages="158"/>
 </head>
 <body>
@@ -4863,7 +4863,7 @@ Ha — livløs faldt hun om i Vrimlen. -
     <notes>
         <note>Gendigtning af Vicor Hugo: <xref type="translation" poem="hugo2019112502"/>.</note>
     </notes>
-    <quality>korrektur1,kilde,side</quality>
+    <quality>korrektur1,korrektur2,kilde,side</quality>
     <source pages="159-168"/>
 </head>
 <body>
@@ -4981,7 +4981,7 @@ Himlen flere Stjerner, Havet flere Perler.
 
 Mit Kongerige udstrækker sig bag disse Catacomber,
 Som synes Bjerge, men ikke ere uden Grave,
-Ligetil den Mur, som et ledigt Folk forgjæves omlejrede sig med,
+Ligetil den Mur, som et ledigt Folk forgjæves leirede sig med,
 Der, ligesom et Belte hvor en Cathey aander,
     Heelt omkredsende et Rige,
 Bevogter i Universet ligesom en fremmed Verden.
@@ -5131,7 +5131,7 @@ Pludselig forsvinder det for deres troløse Syn — —
     <title>Péri</title>
     <toctitle>—: Péri</toctitle>
     <firstline>Mit Hjem er Østerland, hvor Dagens Lys sig reiser</firstline>
-    <quality>korrektur1,kilde,side</quality>
+    <quality>korrektur1,korrektur2,kilde,side</quality>
     <notes>
         <note>Omdigtning af fire strofer i Aarestrups <xref poem="aarestrup2019021122,69-92"/>.</note>
     </notes>
@@ -5182,7 +5182,7 @@ Truer, naar han nærmer sig at høre Havet bruse.
     <notes>
         <note>Omdigtning af otte strofer (samt sidste strofe) fra Aarestrups <xref poem="aarestrup2019021122,14-68"/>.</note>
     </notes>
-    <quality>korrektur1,kilde,side</quality>
+    <quality>korrektur1,korrektur2,kilde,side</quality>
     <source pages="171-173"/>
 </head>
 <body>
@@ -5359,7 +5359,7 @@ Du fordrer Hoveder ved Festen,
 Just naar dit Blik blev mere blidt.
 
 Ah! Jalousiens vilde Glæde!
-Du deilige, men grumme Mø!
+Du deilige, men grumme Møe!
 Tilgiv mig disse Smaa, som græde,
 Hvor saae man Blomsterplettens Spæde
 I Rosenbuskens Skygge døe?
@@ -5457,7 +5457,7 @@ Over hine Bjerges Række
 Med et evigt Sneelag paa;
 I, hvis spæde Struber fylde
 Markerne, som Ax forgylde,
-Med Canzoner, der fortrylle,
+Men Canzoner, som fortrylle,
 Op i Luften, Lærker smaa!
 
 Speid fra Bjerget og fra Byen,
@@ -5488,7 +5488,7 @@ Strakt mod Hjemmet med min Mand?
 <poetry>
 Jeg drømmer vaagen Dag og Nat, med Feberglød,
     Forgjæves stiger Sukket;
-Min Albaide bar alt længst i Gravens Skjød
+Min Albaide har alt længst i Gravens Skjød
     De brune Øine lukket.
 
 Hun var kun femten Aar, mig tro, mit Liv, min Lyst
@@ -5554,7 +5554,7 @@ Og kan ei samle meer de sønderhugne Led,
     <notes>
         <note>Gendigtning af Victor Hugo: <xref type="translation" poem="hugo2019021202"/>.</note>
     </notes>
-    <quality>korrektur1,kilde,side</quality>
+    <quality>korrektur1,korrektur2,kilde,side</quality>
     <source pages="182-185"/>
 </head>
 <body>
@@ -5665,7 +5665,7 @@ I dit Gravcapel de ligge —
 Du skal i den samme Grav!
 
 Derfor hidtil, blank og aaben,
-Uden Balg jeg bar mit Vaab -
+Uden Balg jeg bar mit Vaaben -
 See mit Blik! ei en Vasals! —
 For, i Hevnens Time vakkert
 Trygt at støde denne Daggert,
@@ -5684,7 +5684,7 @@ Bøddel, i din brune Hals!
     <notes>
         <note>Gendigtning af Victor Hugo: <xref type="translation" poem="hugo2019021201"/>.</note>
     </notes>
-    <quality>korrektur1,kilde,side</quality>
+    <quality>korrektur1,korrektur2,kilde,side</quality>
     <source pages="186"/>
 </head>
 <body>
@@ -5719,7 +5719,7 @@ Sagde, idet de væltede Skummet fra deres Pande:
     <notes>
         <note>Gendigtning af Justinus Kerner: <xref type="translation" poem="kerner2018120901"/>.</note>
     </notes>
-    <quality>korrektur1,kilde,side</quality>
+    <quality>korrektur1,korrektur2,kilde,side</quality>
     <source pages="187"/>
 </head>
 <body>
@@ -5804,7 +5804,7 @@ Der græsser Hesten i Maaneskin.
         <note>Gendigtning af Justinus Kerner: <xref type="translation" poem="kerner2018120903"/>.</note>
     </notes>
     <source pages="190-191"/>
-    <quality>korrektur1,kilde,side</quality>
+    <quality>korrektur1,korrektur2,kilde,side</quality>
 </head>
 <body>
 <poetry>
@@ -5909,7 +5909,7 @@ Vi Foraarsvenner to!
     <notes>
         <note>Richard Lovelace: <xref type="translation" poem="lovelace2000082901"/>.</note>
     </notes>
-    <quality>korrektur1,kilde,side</quality>
+    <quality>korrektur1,korrektur2,kilde,side</quality>
     <source pages="194"/>
 </head>
 <body>
@@ -5943,7 +5943,7 @@ Var mig ei Æren dyr.
         <note>Oversættelse af Lib. 1. epig. 73.</note>
         <note>Gendigtning af Martials <xref type="translation" poem="martial2026072601"/>.</note>
     </notes>
-    <quality>korrektur1,kilde,side</quality>
+    <quality>korrektur1,korrektur2,kilde,side</quality>
     <source pages="195"/>
 </head>
 <body>
@@ -5967,7 +5967,7 @@ Krybskytter øve din Dont - Du er unægtelig snild!
         <note>Oversættelse af Lib. 1. epig. 46.</note>
         <note>Gendigtning af Martials <xref type="translation" poem="martial2026072602"/>.</note>
     </notes>
-    <quality>korrektur1,kilde,side</quality>
+    <quality>korrektur1,korrektur2,kilde,side</quality>
     <source pages="195"/>
 </head>
 <body>
@@ -5987,7 +5987,7 @@ Og hvis selv du har Hast, siig det, saa giver jeg Tid.
     <title>Byttet</title>
     <toctitle>Martin: Byttet</toctitle>
     <firstline>Mig disse Blomsters Valg og dette</firstline>
-    <quality>korrektur1,kilde,side</quality>
+    <quality>korrektur1,korrektur2,kilde,side</quality>
     <!-- TODO: Find originalen (Martin) -->
     <source pages="196"/>
 </head>
@@ -6027,7 +6027,7 @@ Yndige Digt, du her har sagt.
         <note>Oversættelse af <xref poem="anonym1600de2023120401"/>.</note>
         <note>Paul Frederiksen har gjort opmærksom på, at komponisten Ambrosius Metzger (1573–1632) ikke er forfatter til ovennævnte originaltekst, men derimod satte sangen til melodi.</note>
     </notes>
-    <quality>korrektur1,kilde,side</quality>
+    <quality>korrektur1,korrektur2,kilde,side</quality>
     <source pages="197-198"/>
 </head>
 <body>
@@ -6079,7 +6079,7 @@ Trav, Ganger, trav!
         <note>Oversættelse af Thomas Moore: <xref type="translation" poem="moore2000082932"/>.</note>
     </notes>
     <source pages="199"/>
-    <quality>korrektur1,kilde,side</quality>
+    <quality>korrektur1,korrektur2,kilde,side</quality>
 </head>
 <body>
 <poetry>
@@ -6088,26 +6088,26 @@ Er vi vis paa at finde en Hjertenskær,
 Og at, fjernedes vi fra den elskede Ven,
 Har vi blot at elske den, som er nær!
 Vort Hjerte, som Ranken, leder omkring,
-Kan ei blomstre alene, vil groe, hvor det vil,
-Det vil favne den mærmeste, vakkreste Ting,
-Det kan slynge sig om og klynge sig til.
+Kan ei blomstre alene, vil groe, hvor den vil,
+Den vil favne den nærmeste, vakkreste Ting,
+Den kan slynge sig om og klynge sig til.
 O den søde Trøst, at, hvert Sted, hver Stund
 Findes altid en Ting, som er yndig og kjær,
 At vi, fjernet fra elskede Læber, kun
-Har at elske de Læber, som komme os nær
+Har at elske de Læber, som kommer os nær
 
 Det var Skam, naar Blomster smile os til,
 Efter Rosen blot at søge og see,
 Og saa riig er jo Verden paa Øine med Ild,
 Det var flaut at elske kun to eller tre.
-Thi Elskov og Paafuglens Vinger er saa,
+Thi Elskovs og Paafuglens Vinger er saa,
 De er deilige begge, men skifte Couleur,
 Og hvor ny Skjønhed med Glands falder paa,
 Ere Elskovs Fjer ei de samme som før.
 O den søde Trøst, at, hvert Sted, hver Stund,
 Findes altid en Ting, som er yndig og kjær,
 At vi, fjernet fra elskede Læber, kun
-Har at elske de Læber, som komme os nær.
+Har at elske de Læber, som kommer os nær.
 
 <nonum><right><i>Th. Moore.</i></right></nonum>
 </poetry>
@@ -6128,10 +6128,10 @@ Har at elske de Læber, som komme os nær.
 </head>
 <body>
 <poetry>
-Man vil vide, at Harpen, jeg slaaer for min Mø,
-Den var eengang en Havfru, som sang under Sø,
-Og som sværmed hver Aften i Bølgernes blaae,
-For paa Stranden en Yngling, hun elsked, at naae.
+Man vil vide, at Harpen, jeg slaaer for min Møe,
+Den var eengang en Havfru, som sang under Søe,
+Og som sværmed hver Aften i Bølgernes blaa,
+For paa Stranden den Yngling, hun elsked, at naae.
 
 Hendes Elskov forsmaaedes, hun sukked forladt,
 Sine Guldhaar hun vædet med Taarer hver Nat,
@@ -6139,7 +6139,7 @@ Indtil Himlen med Ynk over tro Elskovs Nød
 Den skjøn Havfru gav Form af en Strengeleg sød.
 
 Endnu Kinden gav Smiil, endnu Barmen steg rund,
-Da hver Søskjønhed svandt i den klangfulde Bund.
+Da hver Søeskjønhed svandt i den klangfulde Bund.
 Hendes Haar, hver en Lok, der af Taarer var fuld,
 Over Armene sænktes som Strenge af Guld
 
@@ -6161,7 +6161,7 @@ Er du fjern, tone Sorg, tone Lyst, er du nær.
     <notes>
         <note>Thomas Moore: <xref type="translation" poem="moore2000082940"/>.</note>
     </notes>
-    <quality>korrektur1,kilde,side</quality>
+    <quality>korrektur1,korrektur2,kilde,side</quality>
     <source pages="201-202"/>
 </head>
 <body>
@@ -6184,7 +6184,7 @@ Lesbia klæder sig i Guld
 Men hendes Lemmer er forklemte
 Intet Fyld af Skjønheds Huld
 Synes at staae hvor Gud bestemte
-O min Noras Dragt et let
+O min Noras Dragt er let
 Den flagrer hen som Morgenduften
 Giver hver en Skjønhed Ret
 At synke, svulme frit i Luften
@@ -6221,7 +6221,7 @@ Som varmer dine Blik, o Nora Creina.
     <notes>
         <note>Thomas Moore: <xref type="translation" poem="moore2000082950"/>.</note>
     </notes>
-    <quality>korrektur1,kilde,side</quality>
+    <quality>korrektur1,korrektur2,kilde,side</quality>
     <source pages="203"/>
 </head>
 <body>
@@ -6230,7 +6230,7 @@ I Midnattens Time, ved Stjernegraad vil jeg gaae
 Til den Dal, vi elskte, hvis Løndom Dig lykkelig saae
 Og jeg troer, hvis Aander kan undfly, komme os nær
 Erindrende Stedet for Glæde, saa kommer du der
-At sige mig: Elskov er til, selv bah Himlens Blaa
+At sige mig: Elskov er til, selv bag Himlens Blaa
 
 Og jeg synger den Sang som henreev os, dengang
 Vore Stemmers forenede Røst som een Stemme klang
@@ -6251,7 +6251,7 @@ Istemmende svagt den eengang saa elskede Sang.
     <notes>
         <note>Thomas Moore: <xref type="translation" poem="moore2000082953"/>.</note>
     </notes>
-    <quality>korrektur1,kilde,side</quality>
+    <quality>korrektur1,korrektur2,kilde,side</quality>
     <source pages="204"/>
 </head>
 <body>
@@ -6291,7 +6291,7 @@ Den Vises Kikkert kan ei genere, du
     <notes>
         <note>Thomas Moore: <xref type="translation" poem="moore2000082956"/>.</note>
     </notes>
-    <quality>korrektur1,kilde,side</quality>
+    <quality>korrektur1,korrektur2,kilde,side</quality>
     <source pages="205"/>
 </head>
 <body>
@@ -6332,7 +6332,7 @@ Og som Natten vor Død nærmes hellig og mild.
     <notes>
         <note>Thomas Moore: <xref type="translation" poem="moore2000082958"/>.</note>
     </notes>
-    <quality>korrektur1,kilde,side</quality>
+    <quality>korrektur1,korrektur2,kilde,side</quality>
     <source pages="206"/>
 </head>
 <body>
@@ -6377,7 +6377,7 @@ Skal vogte Ilden, tændt af Dig!
     <notes>
         <note>Oversættelse af Thomas Moore: <xref type="translation" poem="moore2018111201"/>.</note>
     </notes>
-    <quality>korrektur1,kilde,side</quality>
+    <quality>korrektur1,korrektur2,kilde,side</quality>
     <source pages="207"/>
 </head>
 <body>
@@ -6421,7 +6421,7 @@ Paany fortryllet, flyer til dig!
     <notes>
         <note>Gendigtning af Thomas Moore: <xref type="translation" poem="moore2018111206"/>.</note>
     </notes>
-    <quality>korrektur1,kilde,side</quality>
+    <quality>korrektur1,korrektur2,kilde,side</quality>
     <source pages="208"/>
 </head>
 <body>
@@ -6455,7 +6455,7 @@ Du har jo lært mig det i Mørke!
     <notes>
         <note>Oversættelse af Thomas Moore: <xref type="translation" poem="moore2018121105"/>.</note>
     </notes>
-    <quality>korrektur1,kilde,side</quality>
+    <quality>korrektur1,korrektur2,kilde,side</quality>
     <source pages="209"/>
 </head>
 <body>
@@ -6484,7 +6484,7 @@ Er Livets Sol alt gaaet bort.
     <notes>
         <note>Oversættelse af Thomas Moore: <xref type="translation" poem="moore2019013101"/>.</note>
     </notes>
-    <quality>korrektur1,kilde,side</quality>
+    <quality>korrektur1,korrektur2,kilde,side</quality>
     <source pages="210"/>
 </head>
 <body>
@@ -6512,7 +6512,7 @@ Saa sov du, eller lad kun saa.
     <notes>
         <note>Oversættelse af Thomas Moore: <xref type="translation" poem="moore2018111302"/>.</note>
     </notes>
-    <quality>korrektur1,kilde,side</quality>
+    <quality>korrektur1,korrektur2,kilde,side</quality>
     <source pages="211"/>
 </head>
 <body>
@@ -6537,7 +6537,7 @@ Og ingen Snak meer om saa lidt.
     <notes>
         <note>Oversættelse af Thomas Moore: <xref type="translation" poem="moore2019090701"/>.</note>
     </notes>
-    <quality>korrektur1,kilde,side</quality>
+    <quality>korrektur1,korrektur2,kilde,side</quality>
     <source pages="212"/>
 </head>
 <body>
@@ -6562,7 +6562,7 @@ Indbunden, ak, giv vore Arme kun Leilighed.
     <notes>
         <note>Gendigtning af Thomas Moore: <xref type="translation" poem="moore2018111203"/>.</note>
     </notes>
-    <quality>korrektur1,kilde,side</quality>
+    <quality>korrektur1,korrektur2,kilde,side</quality>
     <source pages="213"/>
 </head>
 <body>
@@ -6591,8 +6591,8 @@ At jeg maa bede: stands dem ikke!
     <notes>
         <note>Gendigtning af Thomas Moore: <xref type="translation" poem="moore2019090702"/>.</note>
     </notes>
-    <quality>korrektur1,kilde,side</quality>
-    <source pages="214-215"/>
+    <quality>korrektur1,korrektur2,kilde,side</quality>
+    <source pages="214-216"/>
 </head>
 <body>
 <poetry>
@@ -6670,7 +6670,7 @@ Og skræmmer fra Slaget dens hellige Due!
     <notes>
         <note>Oversættelse af Thomas Moore: <xref type="translation" poem="moore2018121001"/>.</note>
     </notes>
-    <quality>korrektur1,kilde,side</quality>
+    <quality>korrektur1,korrektur2,kilde,side</quality>
     <source pages="217"/>
 </head>
 <body>
@@ -6703,7 +6703,7 @@ Undtagen dem af Himlens Vinde?
     <notes>
         <note>Oversættelse af Thomas Moore: <xref type="translation" poem="moore2019090703"/>.</note>
     </notes>
-    <quality>korrektur1,kilde,side</quality>
+    <quality>korrektur1,korrektur2,kilde,side</quality>
     <source pages="218-219"/>
 </head>
 <body>
@@ -6762,7 +6762,7 @@ Uhørt af Jordens dorske Søn.
         <note>Oversættelse af Thomas Moore: <xref type="translation" poem="moore2018121104"/>.</note>
     </notes>
     <source pages="220-221"/>
-    <quality>korrektur1,kilde,side</quality>
+    <quality>korrektur1,korrektur2,kilde,side</quality>
 </head>
 <body>
 <poetry>
@@ -6848,10 +6848,10 @@ Men jo mere i hende Gudinden jeg fandt,
 Jo meer - og hun feilede mindst, det er sandt -
 Tog hun mig for en lille Hansqvast.
 
-Saa sagtnedes det, indtil Hanne mig jog
+Saa sagtnedes det, til at Hanne mig jog
 I Snaren igjen med sit Blik.
 Men Hanne, fandt jeg, var saa sprænglærd og klog,
-Og det Meste jeg fik var Logik
+At det meste jeg fik var Logik
 Jeg forlod denne Sappho derfor i Hast,
 Om en bedre Logik fik jeg Nys,
 Hvis Subtilitet er et sødt Øiekast,
@@ -6864,7 +6864,7 @@ Om til Himlen den nærmeste Sti.
 Ida! i Henrykkelsens Flugt var mit Ord:
 Hvor er Himlen for dig og for mig?
 Jeg troer, jeg kan finde den her paa vor Jord,
-Og, ikke langt borte, i dig!
+Og, ikke langtborte, i dig!
 
 <nonum><right><i>Th. Moore.</i></right></nonum>
 
@@ -6959,7 +6959,7 @@ O, Cara - er der Tegn til Liv?
         <note>Gendigtning af Thomas Moore: <xref type="translation" poem="moore2018121002"/>.</note>
     </notes>
     <source pages="226"/>
-    <quality>korrektur1,kilde,side</quality>
+    <quality>korrektur1,korrektur2,kilde,side</quality>
 </head>
 <body>
 <poetry>
@@ -7060,13 +7060,13 @@ Og roe deres hvide Kanoe.
     <notes>
         <note>Gendigtning af Thomas Moore: <xref type="translation" poem="moore2019090704"/>.</note>
     </notes>
-    <quality>korrektur1,kilde,side</quality>
+    <quality>korrektur1,korrektur2,kilde,side</quality>
     <source pages="229-230"/>
 </head>
 <body>
 <poetry>
 O lad os ei ved Stranden mere
-Den eensomslyngte Vej spadsere
+Den eensomslyngte Vei spadsere
 Saa malerisk, saa vild!
 Thi ei for os, der, som du kjender,
 Bør ikkun være simple Venner
@@ -7104,7 +7104,7 @@ Det var et Sted, en Tid, — Man kunde
 Umulig nogen Plet udgrunde
 Meer fristende end hiin
 Du Søde, lad os aldrig mere
-Den eensomslyngte Vel spadsere
+Den eensomslyngte Vei spadsere
 Det bliver vor Ruin.
 
 <nonum><right><i>Th. Moore.</i></right></nonum>
@@ -7120,7 +7120,7 @@ Det bliver vor Ruin.
     <notes>
         <note>Gendigtning af Thomas Moore: <xref type="translation" poem="moore2019090705"/>.</note>
     </notes>
-    <quality>korrektur1,kilde,side</quality>
+    <quality>korrektur1,korrektur2,kilde,side</quality>
     <source pages="231-232"/>
 </head>
 <body>
@@ -7146,7 +7146,7 @@ Til Neas øre burde jage
 For deres Hjerteangst at skjule.
 
 O, tænk dig deres Indholds Drist;
-Tænk Alt, hvad af en Mø tør høres;
+Tænk Alt, hvad af en Møe tør høres;
 Og stands ej, før din Kind, bevidst,
 Høit blusser ved den Streng, der røres.
 
@@ -7241,7 +7241,7 @@ Og saadan - kysser jeg din Mund!
     <notes>
         <note>Gendigtning af anden del af Thomas Moores <xref type="translation" poem="moore2018111205,37-56"/>.</note>
     </notes>
-    <quality>korrektur1,kilde,side</quality>
+    <quality>korrektur1,korrektur2,kilde,side</quality>
     <source pages="235"/>
 </head>
 <body>
@@ -7482,7 +7482,7 @@ Da du til Barmen dengang sank mig glad,
 Bandt Elskov os - vi skilles aldrig ad!
 
 Og da jeg Navne dig gav, Veninde,
-De bedste Navne, jeg kuude finde,
+De bedste Navne, jeg kunde finde,
 Mit Liv, mit søde Liv, blandt andre fleer;
 Din Sølvrøst tonte: hvor kan du falde
 Just paa dit Liv mig, dit Liv at kalde?
@@ -7497,9 +7497,9 @@ At være Sjælen, som ei skill's fra dig!
 
 <text id="aarestrup20190130164" variant="aarestrup2018111209">
 <head>
-    <title>En Tid vil komme, Rædselsstund</title>
-    <toctitle>—: En Tid vil komme, Rædselsstund</toctitle>
-    <firstline>En Tid vil komme, Rædselsstund</firstline>
+    <title>En Tid vil komme, Rædselstund</title>
+    <toctitle>—: En Tid vil komme, Rædselstund</toctitle>
+    <firstline>En Tid vil komme, Rædselstund</firstline>
     <notes>
         <note>Oversættelse af Thomas Moore: <xref type="translation" poem="moore2018121103"/>.</note>
     </notes>
@@ -7508,7 +7508,7 @@ At være Sjælen, som ei skill's fra dig!
 </head>
 <body>
 <poetry>
-En Tid vil komme, Rædselsstund
+En Tid vil komme, Rædselstund
 For ham, der tog sin Flugt
 I Ungdoms glade Foraarslund
 Og nød som sin hver Frugt
@@ -7516,12 +7516,12 @@ Naar denne Lyst har ham forladt
 Den Drøm, saa dyb, saa kjær,
 Saa er det Tid at døe, døe brat -
 Hvad eier Livet meer?
-Den Tid vil komme, Rædselsstund
+Den Tid vil komme, Rædselstund
 For ham, der tog sin Flugt
 I Ungdoms glade Foraarslund
 Og nød som sin hver Frugt.
 
-Naar Sol gaaer ned i afrisk Sø,
+Naar Sol gaaer ned i afrisk Søe,
 Paa Timen er det Nat
 Saa hurtig skulde Livet døe
 Af Elskovs Lys forladt -
@@ -7529,7 +7529,7 @@ Ei ulme dorsk - som her tillands
 En Dag med Skumringsblik,
 Den kolde Rest af svunden Glands
 Af Ild, som længst forgik
-O Tid vil komme, Rædselsstund
+En Tid vil komme, Rædselstund
 For ham, der tog sin Flugt
 I Ungdoms glade Foraarslund
 Og nød som sin hver Frugt.
@@ -7609,26 +7609,26 @@ Være hos dig! hvis Forandring,
 
 <text id="aarestrup20190130167" variant="aarestrup2018111206">
 <head>
-    <title>Ro sagte, Koerkarl, hid</title>
-    <toctitle>—: Ro sagte, Koerkarl, hid, at ingens Øren veed</toctitle>
-    <firstline>Ro sagte, Roerkarl, hid, at ingens Øren veed</firstline>
+    <title>Ro sagte, Rorkarl, hid</title>
+    <toctitle>—: Ro sagte, Rorkarl, hid, at ingens Øren veed</toctitle>
+    <firstline>Ro sagte, Rorkarl, hid, at ingens Øren veed</firstline>
     <notes>
         <note>Oversættelse af Thomas Moore: <xref type="translation" poem="moore2018121012"/>.</note>
     </notes>
     <source pages="246"/>
-    <quality>korrektur1,kilde,side</quality>
+    <quality>korrektur1,korrektur2,kilde,side</quality>
 </head>
 <body>
 <poetry>
-Ro sagte, Roerkarl, hid, at ingens Øren veed
+Ro sagte, Rorkarl, hid, at ingens Øren veed
 Undtagen hendes kun paa Jord, hvorhen vi gleed
 Var Himlen riig paa Tunger som paa Øine - mangetak
 Saa fik om unge Folk som mig man Snik for Snak
 
-Læg stille, Roerkarl, an! hys hys som sagt.
+Læg stille, Rorkarl, an! hys hys som sagt.
 Jeg stiger paa Balkonens Gitterværk, du holder Vagt.
 O havde vi for Himlens Skyld det halve Bryderie,
-Som Dag og Nat for Damernes hvad var for Engle vi!
+Som Dag og Nat for Pigernes hvad var for Engle vi!
 
 <nonum><right><i>Th. Moore.</i></right></nonum>
 </poetry>
@@ -7742,7 +7742,7 @@ O havde jeg bare Tid dertil,
 Fanny kjære! saa sukkede jeg,
 Og hvert et Smiil, al Øiets Ild
 Det blev til Graad for dig.
-Mcd Elskov, Slummer og Skiemt
+Med Elskov, Slummer og Skiemt
 Mit Liv er saa occupeert,
 At Timen, til Graaden bestemt,
 Har altid mit Hjerte geneert.
@@ -7871,7 +7871,7 @@ Hvem sukker for Gamle, naar Unge kan faaes?
         <note>Gendigtning af Thomas Moore: <xref type="translation" poem="moore2019020101"/>.</note>
     </notes>
     <source pages="254"/>
-    <quality>korrektur1,kilde,side</quality>
+    <quality>korrektur1,korrektur2,kilde,side</quality>
 </head>
 <body>
 <poetry>
@@ -7880,14 +7880,14 @@ Og aldrig skal denne Lykke forspildes
 Er Elskov en Fader til Fryd, saa skal baade
 Hun og jeg have Fryd overmaade
 
-Kom, hvad er sødest af Alt? spurgte nyt jeg.
+Kom, hvad er sødest af Alt? spurgte nys jeg.
 Det der! hun skreg, og gav søde Kys mig
 Ha Chloe, din blussende Kind bliver rødere,
 Den siger, du veed af Ting, som er sødere
 
 Saamænd om jeg gjør, hun svor - og i det samme
 Fik Barmen Gjenskin som af en Flamme
-Var det saa, jeg sagde det strax pa Minutten
+Var det saa, jeg sagde det strax paa Minutten
 Men Damon, kjære, maaskee kjender du den?
 
 <nonum><right><i>Th. Moore.</i></right></nonum>
@@ -7962,7 +7962,7 @@ Med Blus paa din Kind, med Øine, som smile?
     Vil du, vil du, vil du, vil du
         Hvile, min Glut?
 
-Men varm som din Muud er Roserne ikke;
+Men varm som din Mund er Roserne ikke;
 Ei Duggen saa sød som de Kys, vi vil drikke.
     Vil du, vil du, vil du, vil du
         Kysse mig, Glut?
@@ -7986,7 +7986,7 @@ End duftende Roser og selv dine Kys!
     <notes>
         <note>Gendigtning af Thomas Moore: <xref type="translation" poem="moore201908235"/>.</note>
     </notes>
-    <quality>korrektur1,kilde,side</quality>
+    <quality>korrektur1,korrektur2,kilde,side</quality>
     <source pages="257"/>
 </head>
 <body>
@@ -8016,7 +8016,7 @@ At skaffe Amor Ro og Hvile
     <notes>
         <note>Gendigtning af Thomas Moore: <xref type="translation" poem="moore2019090801"/>.</note>
     </notes>
-    <quality>korrektur1,kilde,side</quality>
+    <quality>korrektur1,korrektur2,kilde,side</quality>
     <source pages="258"/>
 </head>
 <body>
@@ -8045,7 +8045,7 @@ Udsprudlende Sødme og Kraft.
         <note>Maj 1834.</note>
         <note>Gendigtning af Wilhelm Müllers <xref type="translation" poem="muellerw2002022501"/>.</note>
     </notes>
-    <quality>korrektur1,kilde,side</quality>
+    <quality>korrektur1,korrektur2,kilde,side</quality>
     <source pages="259-260"/>
 </head>
 <body>
@@ -8093,7 +8093,7 @@ Her er dit Hvilested!
     <notes>
         <note>Gendigtning af Mussets <xref type="translation" poem="musset2002022501"/>.</note>
     </notes>
-    <quality>korrektur1,kilde,side</quality>
+    <quality>korrektur1,korrektur2,kilde,side</quality>
     <source pages="261-262"/>
 </head>
 <body>
@@ -8222,7 +8222,7 @@ Du favner grædende et Liig.
     <notes>
         <note>Gendigtning af Rückert: <xref type="translation" poem="rueckert2018121103"/>.</note>
     </notes>
-    <quality>korrektur1,kilde,side</quality>
+    <quality>korrektur1,korrektur2,kilde,side</quality>
     <source pages="265-266"/>
 </head>
 <body>
@@ -8286,7 +8286,7 @@ Seer den fra sin Sky.
     <notes>
         <note>Gendigtning af Rückert: <xref type="translation" poem="rueckert2019013101"/>.</note>
     </notes>
-    <quality>korrektur1,kilde,side</quality>
+    <quality>korrektur1,korrektur2,kilde,side</quality>
     <source pages="267"/>
 </head>
 <body>
@@ -8397,7 +8397,7 @@ Hvis ikke, bliv ude.
     <notes>
         <note>Gendigtning af Rückert: <xref type="translation" poem="rueckert2018111301"/>.</note>
     </notes>
-    <quality>korrektur1,kilde,side</quality>
+    <quality>korrektur1,korrektur2,kilde,side</quality>
     <source pages="271"/>
 </head>
 <body>
@@ -8425,7 +8425,7 @@ Spøger med Kjærligheds Smerter.
     <notes>
         <note>Gendigtning af Rückert: <xref type="translation" poem="rueckert2019021203"/>.</note>
     </notes>
-    <quality>korrektur1,kilde,side</quality>
+    <quality>korrektur1,korrektur2,kilde,side</quality>
     <source pages="272-274"/>
 </head>
 <body>
@@ -8506,7 +8506,7 @@ Men uden Kjerne, tog.
 For Chalifens høie Porte,
 For Chalifen Alraschids,
 Stod Abu Nuvas, hans Digter;
-Man idag ei strax ham indlod,
+Strax idag man ei ham indlod,
 Thi hans Herre overveied
 Først en Spas, han vilde prøve.
 
@@ -8518,7 +8518,7 @@ Derpaa for mig Digtren ind!
 Da han nu var traadt i Kredsen
 Til sin Plads, hvor den ham tilkom,
 Lod sig Talen muntert høre,
-Hver gav sine Ord tilbedste;
+Hver gav sine Ord til bedste;
 Pludselig dem dog afbryder
 Herskeren og raaber opbragt:
 
@@ -8650,7 +8650,7 @@ Glad ved Livet, uden Frygt.
     <toctitle>—: Vidtdreven Kjærlighed</toctitle>
     <indextitle>Vidtdreven Kjærlighed</indextitle>
     <firstline>Jeg elsker Alt, som har med Dig en Liighed -</firstline>
-    <quality>korrektur1,kilde,side</quality>
+    <quality>korrektur1,korrektur2,kilde,side</quality>
     <notes>
         <note>Gendigtning af Rückert: <xref type="translation" poem="rueckert2018111302"/>.</note>
     </notes>
@@ -8691,7 +8691,7 @@ Hvor sjelden trænger ind til Kongers Løndomskammer
 De Undertryktes Raab og de Forfulgtes Jammer!
 
 Men han har gjort ved Hovedgjærdet af sin Seng
-En Klokke indadtil, og udadtil en Streng
+En Klokke indentil, og udentil en Streng
 
 Og har bekjendtgjort: hvo, som Tryk og Vold erfoer,
 Han skal kun nærme sig og trække denne Snor
@@ -8700,7 +8700,7 @@ Og hvergang nu for Kongens Øre Klokken lyder,
 Saa vaagner han og veed hvad denne Klang betyder.
 
 Saa hjelper han til Ret, forvandler Ondt til Gode
-Og skader Lykke i det Land, ham Gud betroede.
+Og skaber Lykke i det Land, ham Gud betroede.
 
 Og mangen Mislighed har han saaledes jevnet,
 Og i en føie Tid har Klokken Ro ham levnet
@@ -8709,10 +8709,10 @@ Da, som til Hvile just han laae med stort Behag
 Fornam han Klokkens Røst og Strengens stærke Drag
 
 Hvo er det Menneske, som saa umenneskelig ringer?
-Det var et Æsel, Herre! Budet Svar ham bringer
+Det var et Æsel, Herre! Buddet Svar ham bringer
 
 Et stakkels Æsel, allevegne øm og saaret,
-Forgnavet og hudløst paa Boven og paa Laaret
+Forgnavet og hudløs paa Boven og paa Laaret
 
 Hans Tilstand raabte høit, han kunde Ord undvære,
 At ham var paalagt meer, end Ryggen kunde bære
@@ -8720,7 +8720,7 @@ At ham var paalagt meer, end Ryggen kunde bære
 God Røgt og Pleie bød ham Kongen flux at give
 Og lod som Lov for Landet den Anordning skrive:
 
-At Ingen maatte meer med Hunsdyr saadan handle,
+At Ingen maatte meer med Huusdyr saadan handle,
 At Kongens Ro til Uro skulde sig forvandle
 
 Da han ei kunde Hvilens rette Sødme smage,
@@ -8740,7 +8740,7 @@ Naar, om ei Mennesker, saa Dyrene dog klage.
         <note>Gendigtning af Rückert: <xref type="translation" poem="rueckert2018121101"/> in: <i>Brahmanishe Erzählungen</i> (1839).</note>
     </notes>
     <source pages="283-284"/>
-    <quality>korrektur1,kilde,side</quality>
+    <quality>korrektur1,korrektur2,kilde,side</quality>
 </head>
 <body>
 <poetry>
@@ -8793,7 +8793,7 @@ Og gift med een, der føder mig en saadan Glut.
     <notes>
         <note>Gendigtning af Rückert: <xref type="translation" poem="rueckert2019021201"/> in: <i>Brahmanishe Erzählungen</i> (1839).</note>
     </notes>
-    <quality>korrektur1,kilde,side</quality>
+    <quality>korrektur1,korrektur2,kilde,side</quality>
     <source pages="285"/>
 </head>
 <body>
@@ -8835,7 +8835,7 @@ Viis derfor ingen Harm! Tak vil jeg ei begjære.
     <notes>
         <note>Gendigtning af Rückert: <xref type="translation" poem="rueckert2019021202"/> in: <i>Brahmanishe Erzählungen</i> (1839).</note>
     </notes>
-    <quality>korrektur1,kilde,side</quality>
+    <quality>korrektur1,korrektur2,kilde,side</quality>
     <source pages="286"/>
 </head>
 <body>
@@ -8873,7 +8873,7 @@ Gaa, Stjerne, Maane, Sol! Meld mig hos eders Herre!
     <indextitle>Aphorismer</indextitle>
     <linktitle>Aphorismer</linktitle>
     <firstline>Mod Kjærlighed Forstanden har den Skik</firstline>
-    <quality>korrektur1,kilde,side</quality>
+    <quality>korrektur1,korrektur2,kilde,side</quality>
     <notes>
         <note unknown-original-by="rueckert" />
     </notes>
@@ -8971,7 +8971,7 @@ Vilde man blive rædsom tilmode,
 Naar ikke en Deel af de slette
 Anstillede sig som gode.
 
-<num>19.</num>At vogte sig, vilde man godt forstase,
+<num>19.</num>At vogte sig, vilde man godt forstaae,
 Hvis foran Vinen kom Hovedpinen —
 Men altid kommer den ovenpaa,
 Og hvem kan tænke paa den ved Vinen?
@@ -8991,7 +8991,7 @@ Og Dig intet Slemt er truffet.
     <title>Ritorneller</title>
     <toctitle>—: Ritorneller</toctitle>
     <firstline>Giv mig at drikke!</firstline>
-    <quality>korrektur1,kilde,side</quality>
+    <quality>korrektur1,korrektur2,kilde,side</quality>
     <notes>
         <note unknown-original-by="rueckert" />
     </notes>
@@ -9108,7 +9108,7 @@ Saalænge nogen troer paa Gud.
 
 Og om i Mørket end fortæres
 Hvad Gud indblæste mig, mit Ord -
-Den ene Lyd, den kun undværes
+Den ene Lyd, den kan undværes
 I tusindstemmet Tordenchor.
 
 Man maa ei troe, Foraaret ender
@@ -9130,7 +9130,7 @@ Har dræbt en enkelt Nattergal.
         <note>Gendigtning af Friedrich von Sallet: <xref type="translation" poem="sallet2019090802"/>.</note>
     </notes>
     <source pages="295-296"/>
-    <quality>korrektur1,kilde,side</quality>
+    <quality>korrektur1,korrektur2,kilde,side</quality>
 </head>
 <body>
 <poetry>
@@ -9272,7 +9272,7 @@ Kan I modstaae Sangen længer?
 Hør de bløde Elskovstoner!
 Lad os aabne Gittrets Stænger -
 
-Nei, Duegna, vogt dig! Aldrig
+Nei, Duenna, vogt dig! Aldrig
 Vil jeg saadan Daarskab øve.
 Nei - kun bag Gardinets Folder
 Lidt at speide vil jeg prøve.
@@ -9283,7 +9283,7 @@ Hvilken ung og herlig Ridder!
 Træk Gardinet meer tilside!
 
 ,,Nu, det skee, hvad kan det skade?
-Intet vi i Gruuden vove;
+Intet vi i Grunden vove;
 Leonat er jo alene,
 Alle Folk i Huset sove.''
 
@@ -9302,7 +9302,7 @@ Efter Jagten haardt af Træthed.
 Kun et Tryk - nok et - nu seer du,
 Gittret aabner sig med Lethed.
 
-Ei, Duegna, ei, Duenna,
+Ei, Duenna, ei, Duenna,
 Altfor vidt er du alt gangen;
 Jeg staaer Fare for min Ære
 Ved saa daarlig Lyst til Sangen.
@@ -9377,7 +9377,7 @@ Hvem veed, var det Længsel eller Sult!
 
 O vi hinanden saa godt forstode
 At vi elskedes, kan man let formode.
-Man har jo ei samme Død og Skik
+Man har jo ei samme Dyd og Skik
 Een mangler hvad den anden fik.
 
 Til min Yngling havde jeg ham kaaret,
@@ -9403,7 +9403,7 @@ Sat for en Faareost i Pant.
     <notes>
         <note unknown-original-by="waiblinger" />
     </notes>
-    <quality>korrektur1,kilde,side</quality>
+    <quality>korrektur1,korrektur2,kilde,side</quality>
     <source pages="304"/>
 </head>
 <body>
@@ -9445,7 +9445,7 @@ En saadan Nat kan ligne Døden.
     <notes>
         <note>Gendigtning af Wilhelm Waiblinger: <xref type="translation" poem="waiblinger2019090801"/>.</note>
     </notes>
-    <quality>korrektur1,kilde,side</quality>
+    <quality>korrektur1,korrektur2,kilde,side</quality>
     <source pages="305-321"/>
 </head>
 <body>
@@ -9457,7 +9457,7 @@ Synge lidt om Carnevallet?
 Biens Flugt Du før besang jo
 Hulde Piger, skiønne Koner,
 Priste selve Blomsterduften,
-Og hvorfor el disse Sværme,
+Og hvorfor ei disse Sværme,
 Honningdrukne, glade Fugle
 Der omsuse Romas Krandse?
 
@@ -9486,7 +9486,7 @@ Obeliskus ned til Grunden
 Ned til Capitolets Trapper,
 Saae ei disse guldbroderte
 Purpurteppers Farvespil
-Vifte fra Galeon og Mure
+Vifte fra Balcon og Mure
 
 O tie stille! her i Syden
 Flagre hvide Kugler — hvilken
@@ -9609,7 +9609,7 @@ De er bedre end Paladsets!
 Hvilken Dragt! Oldtidens Qvinder
 Er det, eller ogsaa Fablens,
 Og kun ved en saadan Barm
-Er opstaget store Slægter.
+Er opstaaet store Slægter.
 
 Blomster smile ud af Haarets
 Ravnemørke, og den hvide
@@ -9635,11 +9635,11 @@ Og den brede Arlecchina
 Flyver mig forbi med Bjælder!
 Hvor den hvide Særk dem klæder
 Snoet om Barmen Purpur-Skjærfet
-Bliv du fjern! tag Dig jagt!
+Bliv du fjern! tag Dig iagt!
 Farlige er deres Saxe!
 
 Rask! prøv Lykken! Denne Time
-Kommer ei igjen! Jaar Masken
+Kommer ei igjen! Naar Masken
 Falder, sees maaskee et Øie
 Klart og kjælent! Spøgen dækker
 Alvor siden; brug Forstanden,
@@ -9681,7 +9681,7 @@ Ingen veed det, har jeg Maske.
 Dog forraader hende Stemmen,
 Fulde Nattergaletoner
 Og de sorte Lokkers Bølgning,
-Paa den purpurve Baret jeg
+Paa den purpurne Baret jeg
 Kjender noksom hendes Tærne
 Nu er mit, mit Bedste fundet,
 Man umættelig i Lyst
@@ -9692,7 +9692,7 @@ Hopper her et Par i Pjalter
 Deres vilde Saltarello!
 Medens hist paa høie Sæder
 Siddes ret fortrolig sammen
-Og man skjæmter, tagler Spøgen,
+Og man skjæmter, taaler Spøgen,
 Paa den mødende Bekjendt
 Falder puddrende Confetti.
 
@@ -9849,7 +9849,7 @@ Og hvorfor ei? Render hornet
 Hestefodet, Sort i Rødt,
 Lucifer ej selv i Trængslen?
 
-Som man ved den Eisktes Afskeed,
+Som man ved den Elsktes Afskeed,
 Endnu i det længste Kys gad
 Drikke Fryd og Lyst for evig,
 Suge salig Trøst for stedse,
@@ -9905,7 +9905,7 @@ Sig i Mængdens Vrimmel taber
 
 Endnu gløder, endnu zittrer
 I den farvede Belysning
-Al phantastisk-fine Lege
+Af phantastisk-fine Lege
 Romas nye Pragt, da slukke
 Efterhaanden alle Lys sig,
 Hele Tryllelivet svinder,
@@ -9935,7 +9935,7 @@ Sjunken hen i Nattens Alvor.
     <notes>
         <note>Gendigtning af Wordsworths <xref type="translation" poem="wordsworth2002022501"/>.</note>
     </notes>
-    <quality>korrektur1,kilde,side</quality>
+    <quality>korrektur1,korrektur2,kilde,side</quality>
     <source pages="322-325"/>
 </head>
 <body>
@@ -10166,7 +10166,7 @@ Af rosenduftberuste Nattergale.
 
 ---
 
-    Hvilken Glads i Himlens Stjerner!
+    Hvilken Glands i Himlens Stjerner!
     Opad kun kan Aanden glædes!
     Dagens Færd og Sorg hernede,
     Jordens Liv maa tungt begrædes!
@@ -10205,7 +10205,7 @@ Af rosenduftberuste Nattergale.
 
     Han fører strax til Stalden
     Hvert Faar, som fra den rette Vei
-    Og Kippens lune Stue
+    Og Kneipens lune Stue
     Har sig forvildet af hans Trop
 
     Han viste mig paa Bunden
@@ -10233,7 +10233,7 @@ Af rosenduftberuste Nattergale.
     Ræk mig Purpurmunden,
     Tag mig Favn i Favn!
     Jeg, som uden dig
-    Her i Solens Straaler
+    Just i Solens Straaler
     Som et Gjenfærd maaler
     Bleg min Dødningvei;
     Hist i Mørkets Timer,
@@ -10308,7 +10308,7 @@ Min Hvile o hvor fri og stolt!
 
     Vil du paa eengang vise
     Et evigt Liv os Trætte,
-    Befal blot Aftenvinden
+    Befal blot Østenvinden
     Dit lange Slør at lette!
 
 ---
@@ -10393,7 +10393,7 @@ Saa farvel! saa siig: begrav ham nu!
     Bring mig med et Ord at sige,
     Bring, o Mundskjænk, bring mig Viin! -
 
-    Viin, at jeg maa Kutten vadske,
+    Viin, at jeg kan Kutten vadske,
     Vadske reen for Hovmods Pletter
     Og for Hadets sorte Striber,
     Viin, at jeg med styrket Arm
@@ -10549,7 +10549,7 @@ Lysthauge i det Fjerne.
 
 Paa Glimmer og paa Funker hang
 Min Hauge let i Lunden,
-Og da jeg traadte mig derind
+Og da jeg traadte tryg derind
 Som Moselys forsvunden -
 
 Gud give, at jeg blot var død
@@ -10572,7 +10572,7 @@ Saa heed, saa strid af Smerte.
     <notes>
         <note>* Dette Digt er af Liebenberg trykt sammen med <a poem="aarestrup20190130191">foregaaende Digt</a> under Fællestitlen: ,,Tydske Folkeviser'' og med Undertitel: ,,Den lille Frits til sine Venner''.</note>
     </notes>
-    <quality>korrektur1,kilde,side</quality>
+    <quality>korrektur1,korrektur2,kilde,side</quality>
     <source pages="344"/>
 </head>
 <body>
@@ -10584,7 +10584,7 @@ Og ei om nogen Bussemand.
 Ak havde jeg en Elskerinde!
 
 Ak havde jeg en Elskerinde!
-Saa slukkede jeg Lyset kjæt
+Saa slukkede jeg Lyset kjæk
 Og skulde nok til Sengen finde
 I Mørke uden mindste Skræk.
 Ak havde jeg en Elskerinde!
@@ -10592,7 +10592,7 @@ Ak havde jeg en Elskerinde!
 Ak havde jeg en Elskerinde!
 Vi skulde nok i Skole gaae,
 Selv der troer jeg, jeg kyssed hende,
-Om Madam Brønbek saae derpaa -
+Om Madam Grønbek saae derpaa -
 Ak havde jeg en Elskerinde!
 
 Ak jeg har ingen Elskerinde!
@@ -10612,7 +10612,7 @@ Ak, jeg har ingen Elskerinde.
         <note>* Efter Digtet angives Kilden, saavel for dette som <a poem="aarestrup2019021113">efterfølgende Digt</a>: <i>Theater des Hindus. Aus der engl. Übertragung des Sanscrit-Originals, von Wilson, Weimar. 1830 31 (af Stykket Malati og Madhava).</i> Aarestrups egentlige Kilde er en Anmeldelse af denne Bog i ,,Literatur-Blatt'' Nr. 26 (9. Marts) 1832.</note>
         <!-- TODO: Find en facsimile af originalen fra ,,Literatur-Blatt'' -->
     </notes>
-    <quality>korrektur1,kilde,side</quality>
+    <quality>korrektur1,korrektur2,kilde,side</quality>
     <source pages="345"/>
 </head>
 <body>
@@ -10634,7 +10634,7 @@ Der synger om sin Lidenskab
 Nyd denne søde Vellugt, som
 Bayaerne paa Søen brede ud,
 Jasminerne, som sig om Bredden trænge -
-Bemærk, hvor venlig disse Bjerge smile,
+Bemærk, hvor venligt disse Bjerge smile,
 Med blomstrende Kutaja trindt besat,
 Til høit mod Toppene, hvor Skyer
 Udbredes mørkt, Paafuglene en Glæde.
@@ -10646,13 +10646,13 @@ Udbredes mørkt, Paafuglene en Glæde.
 <head>
     <title>Indisk Elskovsklage</title>
     <firstline>I disse Knupper seer jeg hendes Skjønhed</firstline>
-    <quality>korrektur1,kilde,side</quality>
+    <quality>korrektur1,korrektur2,kilde,side</quality>
     <source pages="346-347"/>
 </head>
 <body>
 <poetry>
 I disse Knupper seer jeg hendes Skjønhed,
-O i Gazellens Øine hendes Blik.
+Og i Gazellens Øine hendes Blik.
 Og hendes Holdning Elephanten stjal;
 Kun Blæsten eier hendes skjønne Flugt! ....
 Og hun blev dræbt! Hver Yndighed
@@ -10666,7 +10666,7 @@ En deilig Pige, og om I vide
 Hvor hun har dvælet? Jeg vil beskrive hende,
 I hendes Bryst der raser Elskovs Styrke;
 Men hendes ydre Form henrykker Alle.
-Vii mig! Paafuglen, med sit Glædesspring,
+Vee mig! Paafuglen, med sit Glædesspring,
 Tilintetgjør min Græmmelse ved Skrig,
 Chacoren flyver, vild af Øine, efter
 Sin Hun ..... En Abe hist for Spøg
@@ -10715,7 +10715,7 @@ En Solskjærm? -
 <head>
     <title>Venetiansk Canonette</title>
     <firstline>Min Anneke, mærk</firstline>
-    <quality>korrektur1,kilde,side</quality>
+    <quality>korrektur1,korrektur2,kilde,side</quality>
     <source pages="348-349"/>
 </head>
 <body>
@@ -10759,7 +10759,7 @@ Er just som jeg vil.
     <title>Tusskhandel</title>
     <subtitle>(ungersk Folkevise)</subtitle>
     <firstline>Kom hid, søde Jomfru, saa lækker og fiin</firstline>
-    <quality>korrektur1,kilde,side</quality>
+    <quality>korrektur1,korrektur2,kilde,side</quality>
     <source pages="350"/>
 </head>
 <body>
@@ -10776,7 +10776,7 @@ $
 <head>
     <title>Rosine, du skjønne</title>
     <firstline>Rosine, du skjønne</firstline>
-    <quality>korrektur1,kilde,side</quality>
+    <quality>korrektur1,korrektur2,kilde,side</quality>
     <source pages="351-354" />
 </head>
 <body>
@@ -10858,7 +10858,7 @@ Til Fred og Ro
 
 Men naar er Tiden?
 Snart, vil jeg tro —
-Den nøle Viden
+Den nøie Viden
 Er Himlen jo.
 
 Jeg gjør et Bryllup
@@ -10886,7 +10886,7 @@ Det kan du tro.
 <text id="aarestrup2019021129" skip-index="true">
 <head>
     <title>Hurra Courage, Bagage</title>
-    <quality>korrektur1,kilde,side</quality>
+    <quality>korrektur1,korrektur2,kilde,side</quality>
     <source pages="357-358"/>
     <notes>
         <note>Oversættelse af prosastykkerne i Carl Michael Bellman: <xref type="translation" poem="bellman2001061359"/>.</note>
@@ -10915,7 +10915,7 @@ Det kan du tro.
 <head>
     <title>Et Riimbrev, kjære Glut, her førstegang jeg skriver</title>
     <firstline>Et Riimbrev, kjære Glut, her førstegang jeg skriver</firstline>
-    <quality>korrektur1,kilde,side</quality>
+    <quality>korrektur1,korrektur2,kilde,side</quality>
     <source pages="361-363"/>
 </head>
 <body>
@@ -10994,7 +10994,7 @@ Min Broder, Jomfru Møller, M
     <notes>
         <note>* Følgebrev med en Proptrækker til Borgmester Ravnkilde i Sakskøbing. Underskrevet: E A. Ms. og Proptrækker tilhører Bogbindermester Anker Kyster.</note>
     </notes>
-    <quality>korrektur1,kilde,side</quality>
+    <quality>korrektur1,korrektur2,kilde,side</quality>
     <source pages="364"/>
 </head>
 <body>
@@ -11012,7 +11012,7 @@ Sundhed og Held, det Bedste man kan tænke
 <text id="aarestrup2019021203" skip-index="true">
 <head>
     <title>Kjære Christian</title>
-    <quality>korrektur1,kilde,side</quality>
+    <quality>korrektur1,korrektur2,kilde,side</quality>
     <dates>
         <written>1842-04-21</written>
     </dates>
@@ -11024,7 +11024,7 @@ Sundhed og Held, det Bedste man kan tænke
 <nonum><right><small>Saxkjøbing 21. April 1842</small></right></nonum>
 
     Kjære Christian!
-  Min hjerteligste Tak for den Redebonhed og Omhu, hvormed Du øjeblikkelig besvarede mit sidste Brev — Gud veed af hvilken Dato. Jeg har fra Morgen til Aften havt et saa fatiguerende Jay med Praxis, at jeg ikke har havt nogen Time til at fatte og samle mig i, idetmindste ikke god nok til at besvare Dine venlige Linier og sige Dig min Tak, som Du fortjente. Jeg har betragtet Udsigterne ved Glostrup, Ballerup og Smørum, baade øverst og nederst, og med Nathansonsk Nøjagtighed beregnet de 15,488 Legemer, jeg vilde fane at øve mig paa — men — (Det er et indholdsrigt Men, skjøndt jeg ikke kan sætte dets Indhold tydelig fra hinanden.) Mine 8 Poder, — Deres forlollandskede Fader og Moder, — vore Nyeboder — (jeg har bygget igjen iaar), de faa gode Hoeder, — men utallige andre Goder, — og den trivielle Magelighed, — hvori man saa gierne med en vis Behagelighed, — roder, — (Noget Du kjender, som jeg formoder) — (ikke at tale — om den gale — Greve og min nakskovske Broder, —) at slide og sprætte — sig løs fra alt dette, — hører til de Ting, der ikke ere lette, — og som man egentlig betænker sig paa med Rette. — Jeg har i denne Tid havt en Epidemi, — den er destoværre snart forbi, — men der er altid lidt Fortjeneste i — og megen Beskjæftigelse med, — snart paa det ene, snart paa det andet Sted, — og naar jeg saadan farer mellem Landsby og Skov, — seer en Bonde drive sin Plov, — træder ind til hans Kone, som er meget vov, — eller curerer lidt paa Grev Gersdorff-Hardenberg-Reventlov, — saa tænker jeg: tog du til Sjælland, saa — <i>Dog</i> — — - Af denne logiske Tankegang kan Du begribe med hvilken Omhu jeg har veiet det store Spørgsmaal: ,,Blive eller Flytte'', der næsten for en stakkels Practikus falder sammen med Hamlets ,,to be or not to be''. Jeg maatte absolut have meer, end Udsigter til Udkomme, naar jeg med godt Mod skulde forlade mine Lollændere og søge andetstedshen; — og den for mig total ubekjendte Egn, Opholdsstedet paa Landet, den evige Kjørsel, det manglende Apothek, de smaa Colonier af udvandrende med: Candidater, de lindbergske Agitationer, — summa summarum: Locomotivet er ikke stærkt nok; det stærkeste Stød faaer Sagen ved mine Venners Ønske og circumspecte Raad; men noget lignende Alvorligt har jeg dog ikke truffet paa, og jeg lader derfor Sagen gaae. Chr. Winther bragte mig Hilsen fra Dig; og jeg kan nu hilse Dig fra ham. Han har det godt, — i Maribo; — han har Ro. — Han prøver ikke, som jeg, hvormegen Tid det spilder, — at spise ved hundrede Bispegilder, — at fare derfra til Tangforretninger, — svare til Folks Forudsætninger, — betænke sig paa, om Børn bør gaae med Haaret løst eller i Fletninger; — kortsagt, drive sin Dag bort i de trivielleste Retninger. — Tobaksrygning er et Selvmord; det har jeg mærket; Geisten gaaer væk, langsomt, men sikkert; for at Overgangen kan skee med saamegen Comfort som muligt, skylder jeg mig selv og min Omgivelse, at gjennem Dig ordinere mig nogle taalelig gode og priisbillige Cigarer ved Lejlighed. Item, for at formindske min Fedme og Blidhed, en Syre, Vinedike, som sidst et Halvanker, som Skipperen kan faae tilbage eller selv bringer med. Men ingen Parmesanost, den er for dyr. Min Kone fælder oeconomiske Taarer, hvergang hun seer den tomme Skal, som Miderne have udhulet; men send forresten efter Din Phantasie, og — NB. lad følge en Generalliste over samtlige Artikler og <i>mærk</i> udvendig Pakkernes Indhold, da der før har været megen Ulejlighed og Mas med Opløsning og Indbinding, for at erfare Indholdet. En Spegepølse er spiist for Myseost, og en Myseost for en Oxetunge, af Mangel paa Paaskrift. Men kunde Du sende mig i fiint, fiint Papiir et ,,sempre'' eller ,,dolce'' af Signora Forconi, saa vilde Du delicatere mine Øren, ligesaameget som Du fryder min Sjæl med Din Pens humoristiske Arbeider. — Hvad der ahnedes, er skeet. Længe har jeg i mit stille Sind, naar jeg tænkte paa Din Broder Carl, raabt: Coraggio! Su presto! Evviva! Allegramente! — Nu er det skeet. Han modtager idag lettera di congratulazione fra mig, og jeg ønsker snarest muligt at kunne sende ham et Epitalamio. — Du veed, jeg sværmer for Thora Lytthans — ah, povero me! — Men tal ikke om det — silenzio! per amor di Dio! — Tilgiv, kjære Christiano, mine Tankers Travolgimento, mine Skriveriers elendige Manifattura, den sædvanlige Trebbiatura af mit lollandske Lune, og modtag mit hjerteligste danske Haandtryk, og hav al den Nydelse, Foraaret kan bringe, og al den Profitto, Handelen kan skaffe en nomo di garbo e di bel tempo!
+  Min hjerteligste Tak for den Redebonhed og Omhu, hvormed Du øjeblikkelig besvarede mit sidste Brev — Gud veed af hvilken Dato. Jeg har fra Morgen til Aften havt et saa fatiguerende Jav med Praxis, at jeg ikke har havt nogen Time til at fatte og samle mig i, idetmindste ikke god nok til at besvare Dine venlige Linier og sige Dig min Tak, som Du fortjente. Jeg har betragtet Udsigterne ved Glostrup, Ballerup og Smørum, baade øverst og nederst, og med Nathansonsk Nøjagtighed beregnet de 15,488 Legemer, jeg vilde faae at øve mig paa — men — (Det er et indholdsrigt Men, skjøndt jeg ikke kan sætte dets Indhold tydelig fra hinanden.) Mine 8 Poder, — Deres forlollandskede Fader og Moder, — vore Nyeboder — (jeg har bygget igjen iaar), de faa gode Hoeder, — men utallige andre Goder, — og den trivielle Magelighed, — hvori man saa gierne med en vis Behagelighed, — roder, — (Noget Du kjender, som jeg formoder) — (ikke at tale — om den gale — Greve og min nakskovske Broder, —) at slide og sprætte — sig løs fra alt dette, — hører til de Ting, der ikke ere lette, — og som man egentlig betænker sig paa med Rette. — Jeg har i denne Tid havt en Epidemi, — den er destoværre snart forbi, — men der er altid lidt Fortjeneste i — og megen Beskjæftigelse med, — snart paa det ene, snart paa det andet Sted, — og naar jeg saadan farer mellem Landsby og Skov, — seer en Bonde drive sin Plov, — træder ind til hans Kone, som er meget vov, — eller curerer lidt paa Grev Gersdorff-Hardenberg-Reventlov, — saa tænker jeg: tog du til Sjælland, saa — <i>Dog</i> — — - Af denne logiske Tankegang kan Du begribe med hvilken Omhu jeg har veiet det store Spørgsmaal: ,,Blive eller Flytte'', der næsten for en stakkels Practikus falder sammen med Hamlets ,,to be or not to be''. Jeg maatte absolut have meer, end Udsigter til Udkomme, naar jeg med godt Mod skulde forlade mine Lollændere og søge andetstedshen; — og den for mig total ubekjendte Egn, Opholdsstedet paa Landet, den evige Kjørsel, det manglende Apothek, de smaa Colonier af udvandrende med: Candidater, de lindbergske Agitationer, — summa summarum: Locomotivet er ikke stærkt nok; det stærkeste Stød faaer Sagen ved mine Venners Ønske og circumspecte Raad; men noget lignende Alvorligt har jeg dog ikke truffet paa, og jeg lader derfor Sagen gaae. Chr. Winther bragte mig Hilsen fra Dig; og jeg kan nu hilse Dig fra ham. Han har det godt, — i Maribo; — han har Ro. — Han prøver ikke, som jeg, hvormegen Tid det spilder, — at spise ved hundrede Bispegilder, — at fare derfra til Tangforretninger, — svare til Folks Forudsætninger, — betænke sig paa, om Børn bør gaae med Haaret løst eller i Fletninger; — kortsagt, drive sin Dag bort i de trivielleste Retninger. — Tobaksrygning er et Selvmord; det har jeg mærket; Geisten gaaer væk, langsomt, men sikkert; for at Overgangen kan skee med saamegen Comfort som muligt, skylder jeg mig selv og min Omgivelse, at gjennem Dig ordinere mig nogle taalelig gode og priisbillige Cigarer ved Lejlighed. Item, for at formindske min Fedme og Blidhed, en Syre, Vinedike, som sidst et Halvanker, som Skipperen kan faae tilbage eller selv bringer med. Men ingen Parmesanost, den er for dyr. Min Kone fælder oeconomiske Taarer, hvergang hun seer den tomme Skal, som Miderne have udhulet; men send forresten efter Din Phantasie, og — NB. lad følge en Generalliste over samtlige Artikler og <i>mærk</i> udvendig Pakkernes Indhold, da der før har været megen Ulejlighed og Mas med Opløsning og Indbinding, for at erfare Indholdet. En Spegepølse er spiist for Myseost, og en Myseost for en Oxetunge, af Mangel paa Paaskrift. Men kunde Du sende mig i fiint, fiint Papiir et ,,sempre'' eller ,,dolce'' af Signora Forconi, saa vilde Du delicatere mine Øren, ligesaameget som Du fryder min Sjæl med Din Pens humoristiske Arbeider. — Hvad der ahnedes, er skeet. Længe har jeg i mit stille Sind, naar jeg tænkte paa Din Broder Carl, raabt: Coraggio! Su presto! Evviva! Allegramente! — Nu er det skeet. Han modtager idag lettera di congratulazione fra mig, og jeg ønsker snarest muligt at kunne sende ham et Epitalamio. — Du veed, jeg sværmer for Thora Lytthans — ah, povero me! — Men tal ikke om det — silenzio! per amor di Dio! — Tilgiv, kjære Christiano, mine Tankers Travolgimento, mine Skriveriers elendige Manifattura, den sædvanlige Trebbiatura af mit lollandske Lune, og modtag mit hjerteligste danske Haandtryk, og hav al den Nydelse, Foraaret kan bringe, og al den Profitto, Handelen kan skaffe en nomo di garbo e di bel tempo!
                     Din
                       E Aarestrup.
 

--- a/fdirs/aarestrup/1976-6.xml
+++ b/fdirs/aarestrup/1976-6.xml
@@ -52,7 +52,7 @@ Saa loe I til I sprak ihjel.
    <dates>
        <event>1818-04-03</event>
    </dates>
-   <quality>korrektur1</quality>
+   <quality>korrektur1,korrektur2</quality>
    <keywords>sonnet</keywords>
    <source pages="3"/>
 </head>
@@ -85,7 +85,7 @@ Dig, hulde Genius, Dig har han rakt den!
 <head>
    <title>Rimbrev til Jomfru Anna Aagaard</title>
    <firstline>Hvis jeg ei skrev et Brev til min Cousine</firstline>
-   <quality>korrektur1</quality>
+   <quality>korrektur1,korrektur2</quality>
    <source pages="4"/>
 </head>
 <body>
@@ -125,7 +125,7 @@ See, saa nu fik jeg dog et Brev til min Cousine!
 <head>
    <title>Rimbrev til Anna Aagaard</title>
    <firstline>Cousine, Legesøster og Veninde!</firstline>
-   <quality>korrektur1</quality>
+   <quality>korrektur1,korrektur2</quality>
    <source pages="5"/>
 </head>
 <body>
@@ -136,7 +136,7 @@ Lad mig i Hast - tilgiv! -
 Og paa en lille Strimmel
 Lagt inden i det Brev,
 Min Kone for at Ønske Dig til Lykke skrev,
-Lad mig min Fø1else udtrykke,
+Lad mig min Følelse udtrykke,
 Og ønske, søde Anna, Dig et Liv,
 Som du fortjener, fuldt af Himmel,
 Af Kjærlighed og Held!
@@ -152,7 +152,7 @@ Af Kjærlighed og Held!
    <title>Rimbrev til Sophie Hansen</title>
    <toctitle>Rimbrev til Sophie Hansen</toctitle>
    <indextitle>Rimbrev til Sophie Hansen</indextitle>
-   <quality>korrektur1</quality>
+   <quality>korrektur1,korrektur2</quality>
    <source pages="5-6"/>
 </head>
 <body>
@@ -166,7 +166,7 @@ Af Kjærlighed og Held!
 <head>
    <title>Tilegnelse til Amalie Raben</title>
    <firstline>Du ser i mine Digte</firstline>
-   <quality>korrektur1</quality>
+   <quality>korrektur1,korrektur2</quality>
    <source pages="7"/>
 </head>
 <body>
@@ -204,7 +204,7 @@ Conchylie, der koger.
    <dates>
        <event>1854-06-05</event>
    </dates>
-   <quality>korrektur1,kilde,side</quality>
+   <quality>korrektur1,korrektur2,kilde,side</quality>
    <source pages="7-8"/>
 </head>
 <body>


### PR DESCRIPTION
## Resumé

- korrekturlæser alle 990 Aarestrup-tekster, hvor der findes en faksimile
- retter afskriftsfejl ved side-for-side-sammenligning med de otte kilder
- retter tre kildeintervaller og faksimileomfanget for 1863-udgaven
- markerer de gennemgåede tekster med `korrektur2` eller `korrektur3`

## Test

- `xmllint --noout` på alle otte ændrede XML-filer
- `npm test -- --runInBand __tests__/xml.js __tests__/kalliopework-relaxng.test.js __tests__/workfiles.test.js __tests__/encoding.test.js __tests__/textrefs.test.js`
- `git diff --check`
