### PR TITLE
Korrekturlæs Oehlenschlæger mod facsimiler

### DIFF
--- a/fdirs/oehlenschlaeger/1861-24.xml
+++ b/fdirs/oehlenschlaeger/1861-24.xml
@@ -2091,6 +2091,7 @@ Herr Erik faldt ned i en Askehob.
   Ham vil vi hædre:
   Han skal <w>atter</w> finde.''
   Saa synge de, og svinde.
+  Lufttonerne døe.
 
     Hrymfaxe, den sorte,
   Puster, og dukker,
@@ -2098,7 +2099,7 @@ Herr Erik faldt ned i en Askehob.
   Morgenens Porte
   Delling oplukker.
   Og Skinfaxe traver
-  I stråalende Lue
+  I straalende Lue
   Paa Himlens Bue.
 
     Ved lune Skov


### PR DESCRIPTION
## Hvad er ændret

Oehlenschlægers syv værker med registrerede facsimiler er gennemgået mod de lokale facsimilebilleder i `/Volumes/Alma/Faksimiler/`.

I bind 24 er to afvigelser rettet:

- Den manglende verslinje `Lufttonerne døe.` er tilføjet.
- `stråalende` er rettet til originalens `straalende`.

De øvrige OCR-kandidater er kontrolleret mod originaltrykkene og er bevarede, fordi gentagelserne står i facsimilerne.

## Validering

- 2.508 facsimilesider gennemgået med Fraktur-OCR som afvigelsesfilter og visuel kontrol af kandidater.
- 30 relevante Jest-tests består.
- XML-format, encoding og OCR-kandidattest består.
