### PR TITLE
Korrekturlæs Drachmann mod facsimiler

### DIFF
--- a/fdirs/drachmann/1877d.xml
+++ b/fdirs/drachmann/1877d.xml
@@ -461,7 +461,7 @@ Og i susende Fart gik det nedover, ned;
 Der stod Røg under Kilken; den tændte, den sved.
 Dalen i Dampe; de slukkedes ej;
 Herrer og Trælle de løb deres Vej;
-Og i dampendeBlod sank Normannernes Klinge. —
+Og i dampende Blod sank Normannernes Klinge. —
 Danmark, hvi blev Du saa ringe?
 Danmark, hvor bliver Du af!
 
@@ -481,7 +481,7 @@ Danmark, hvor bliver Du af!
 
 Der er stænget mod Sønder, trangt imod Nord;
 Vi har løbet vor Skude paa Land.
-Vi har ryddet vor Vold, men, forladt afvorBro’r,
+Vi har ryddet vor Vold, men, forladt af vor Bro’r,
 Har vi tappet vort Blod, til vor næstsidste Mand;
 Og nu nyder vi, hvad vi har nemmet:
 Tvedragt er Herre i Hjemmet.

--- a/fdirs/drachmann/1879.xml
+++ b/fdirs/drachmann/1879.xml
@@ -4441,7 +4441,7 @@ Og Himlens høje Loft gav Plads for Skyer,
 som flagred, Fugle lig, henover Sø,
 og Skibe dukked frem ind under Ø,
 en Sejlerskare, som sin Dug fornyer,
-nåar Vinden stiller, eller raadsnar tyer,
+naar Vinden stiller, eller raadsnar tyer,
 naar Stormen farver begsort Kimingranden,
 i sikker Havn hos Landets gæstfri Byer,
 for ej at kastes masteløs paa Stranden.

--- a/fdirs/drachmann/1879r.xml
+++ b/fdirs/drachmann/1879r.xml
@@ -1010,7 +1010,7 @@ det var Solild, som inde
 bag Skallerne ulmed.
 Saa rusked og rev det
 med haarde Hænder.
-»HvadI« tænkte Druen,
+»Hvad!« tænkte Druen,
 »er det saadan vi ender?«
 
 Der blev stampet og trampet
@@ -2115,7 +2115,7 @@ Saa sang min Fugl. Jeg sad og saa’
 en Vaardag ud over Verden,
 og krydset var Himmelens tindrende Blaa
 af de luftige Flyveres Færden.
-De sang. De jublende Toner foT
+De sang. De jublende Toner for
 afsted med de legende Vinde,
 men Genlyden satte sit blivende Spor
 dybt i mit Hjærte inde.

--- a/fdirs/drachmann/1892.xml
+++ b/fdirs/drachmann/1892.xml
@@ -64,7 +64,7 @@ Og Skrædderen maaler og skærer og sy’r
 <body>
 <poetry>
 I Magsvejr søgte jeg engang
-   ind til det Og amle DannevanOg —
+   ind til det gamle Dannevang —
    stemt var jeg for en blid Idyl:
       men det var ikke <i>Jeres</i> Skyld!
 

--- a/fdirs/drachmann/1901.xml
+++ b/fdirs/drachmann/1901.xml
@@ -131,7 +131,7 @@ Først et Sus - som om en Verden
     Spirer bryder, Stængler skyder,
     Skyens Dugg sin Aande gyder
         gennem Træets nøgne Krone
-    og med aåbent Barneøje
+    og med aabent Barneøje
         ler den første Anemone!
 
 Myldrens Myldren - lilla - hvide


### PR DESCRIPTION
## Hvad er ændret

Korrigerer syv sikre afskrifts-/OCR-fejl i Drachmanns værker efter kontrol mod facsimiler:

- manglende mellemrum i `dampende Blod` og `af vor Bro’r`
- fejllæsningerne `naar`, `»Hvad!«` og `for`
- `gamle Dannevang`
- `aabent Barneøje`

## Validering

- Facsimilesiderne er kontrolleret direkte.
- OCR-kandidaterne er gennemgået; resterende kandidater er legitime historiske former.
- `git diff --check`
- 56 test-suiter bestået.
- 2404 tests bestået.

Den urelaterede ændring i `fdirs/winther/1872.xml` er ikke medtaget.
