### PR TITLE
Tilføj facsimile til Hvide Blomster

### DIFF
--- a/fdirs/rodeh/1892.xml
+++ b/fdirs/rodeh/1892.xml
@@ -9,13 +9,7 @@
    <pictures>
        <picture type="titlepage" src="1892-p1.jpg">Titelbladet til <i>Hvide Blomster</i> (1892).<br/>Helge Rode / Hvide Blomster / Digte // Kjøbenhavn / Forlagt af I. H. Schubothes Boghandel / Græbes Bogtrykkeri / 1892</picture>
    </pictures>
-<!--
-Siderne findes som hvor XX er 01, 02, ...
-http://kb-images.kb.dk/public/adl/rode/rode_01/rode_01_0XX/full/!2000,/0/native.jpg
-
-Titelsiderne findes som hvor XX er 01, 02, ...
-http://kb-images.kb.dk/public/adl/rode/rode_01/rode_01_fm_0XX/full/!2000,/0/native.jpg
--->
+   <source href="https://soeg.kb.dk/permalink/45KBDK_KGL/1o797oc/alma99125394024705763" facsimile="130025463332-color" facsimile-pages-num="151" facsimile-pages-offset="15">Helge Rode: <i>Hvide Blomster</i>, I. H. Schubothes Boghandel, Kbh., 1892.</source>
   <quality>korrektur1</quality>
 </workhead>
 <workbody>


### PR DESCRIPTION
## Resumé

- erstatter de forældede ADL-facsimilehenvisninger i `fdirs/rodeh/1892.xml`
- knytter værket til den nye facsimilepakke på 151 sider med sideoffset 15
- tilføjer det verificerede permalink til Det Kgl. Biblioteks digitale post

## Baggrund

Værket manglede en aktiv facsimilekilde og havde kun redaktionelle kommentarer med ældre ADL-billed-URL’er. De nye facsimiler og thumbnails er bygget fra `130025463332-color.pdf` og synkroniseret til Kalliope-serveren.

## Validering

- `npm test` — 57 testsuiter og 2.412 tests består
- 151 fuldstørrelsessider og 1.359 thumbnails er genereret og synkroniseret
- PDF-checksummen matcher mellem den lokale pakke og serveren
- en fuld side og en thumbnail svarer med HTTP 200 fra webserveren

Fixes #950
