### PR TITLE
Validér fulde datoer i build-static

### DIFF
--- a/docs/xml-work-format.md
+++ b/docs/xml-work-format.md
@@ -270,10 +270,11 @@ Understottede felter:
 - `<event>`
 
 `written`, `performed` og `event` samles i `caches/collected.dates.json` og bruges til
-"andre tekster knyttet til samme dato".
+`andre tekster knyttet til samme dato`.
 
-Datoformatet er normalt `YYYY`, `YYYY-MM` eller `YYYY-MM-DD`. Datohjaelperne kender ogsaa
-negative aar og enkelte `ca.`-udtryk.
+For tekst-hoveder (`<text><head><dates>`) skal disse felter som minimum være fulde datoer:
+`YYYY-MM-DD` på formen år-måned-dag.
+Datohjaelperne kender også negative år og enkelte `ca.`-udtryk i andre sammenhænge.
 
 ## Body og tekstblokke
 

--- a/fdirs/boedtcher/1940.xml
+++ b/fdirs/boedtcher/1940.xml
@@ -7237,7 +7237,7 @@ Ak, men hans straalende Liv sank i den aabnede Grav.
    <subtitle>(d. 12te April 1836)</subtitle>
    <firstline>Nu knoppes atter Træet hist i Haven</firstline>
    <dates>
-       <event>1836-04-12-</event>
+       <event>1836-04-12</event>
    </dates>
    <notes>
        <note>* efter Mskr. i Th. Smits Saml. (med efterfølgende, ligeledes egenhændigt, Brev til ,,min Petrine''; se Berl. Tid. Aft. 9. 7. 1940); Dateringen fra (egenhænd.) Mskr. NkS, 4°, 3525. Jf. Sidste Digte S. 78 (<a poem="boedtcher2018100928">,,Til en ung Moder''</a>, lidt ændret).</note>

--- a/fdirs/dolleris/1894.xml
+++ b/fdirs/dolleris/1894.xml
@@ -2878,7 +2878,7 @@ Jeg <w>tror</w>, der er en Lov for Slægtens Færden!
     <firstline>Ja — havde han kun skrevet denne Sang</firstline>
     <source pages="132"/>
     <dates>
-        <written>21. Marts 1894</written>
+        <written>1894-03-21</written>
     </dates>
     <quality>korrektur1,korrektur2,side,side</quality>
 </head>

--- a/fdirs/richardt/1895-1.xml
+++ b/fdirs/richardt/1895-1.xml
@@ -11266,7 +11266,7 @@ Lys, som ej slukkes, naar Natten er nær!
     <subtitle>Til Pastor P. W. v. Wylich i Greve, 9. Juni 1872</subtitle>
     <firstline>Væxten altid er fra oven</firstline>
     <dates>
-        <event>1872-06-00</event>
+        <event>1872-06-09</event>
     </dates>
     <quality>korrektur1,kilde,side</quality>
     <source pages="320-321"/>

--- a/tools/build-static.js
+++ b/tools/build-static.js
@@ -315,6 +315,7 @@ const handle_text = async (
 
   const head = getChildByTagName(text, 'head');
   const textDates = extractDates(head);
+  validateTextDates(textDates, sourcePoetId, sourceWorkId, sourceTextId);
   const firstline = extractTitle(head, 'firstline');
   let title = extractTitle(head, 'title') || firstline; // {title: xxx, prefix: xxx}
   let indextitle = extractTitle(head, 'indextitle') || title;
@@ -848,6 +849,37 @@ const validateWorkYear = (year, filename) => {
   if (numericYear == null) {
     throw new Error(`${filename} has invalid <year>: ${year}`);
   }
+};
+
+const fullDatePattern = /^-?\d{3,4}-(0[1-9]|1[0-2])-(0[1-9]|[12]\d|3[01])$/;
+
+const validateTextDate = (date, tagName, sourcePoetId, sourceWorkId, textId) => {
+  const value = date == null ? null : date.trim();
+  if (value == null || value.length === 0) {
+    return;
+  }
+  if (!fullDatePattern.test(value)) {
+    throw new Error(
+      `fdirs/${sourcePoetId}/${sourceWorkId}.xml (${textId}) has invalid <${tagName}> in <dates>: ${value}. Expected YYYY-MM-DD.`
+    );
+  }
+};
+
+const validateTextDates = (
+  textDates,
+  sourcePoetId,
+  sourceWorkId,
+  sourceTextId
+) => {
+  ['published', 'written', 'performed', 'event'].forEach((type) => {
+    validateTextDate(
+      textDates[type],
+      type,
+      sourcePoetId,
+      sourceWorkId,
+      sourceTextId
+    );
+  });
 };
 
 const removeWorkDates = (dates, poetId, workId) => {

--- a/tools/build-static/elastic.js
+++ b/tools/build-static/elastic.js
@@ -286,10 +286,12 @@ const isElasticsearchUnavailable = error => {
     'ENOTFOUND',
     'EHOSTUNREACH',
     'ETIMEDOUT',
+    'EPERM',
   ]);
-  let current = error;
+  const pending = error == null ? [] : [error];
 
-  while (current != null) {
+  while (pending.length > 0) {
+    const current = pending.pop();
     if (
       unavailableCodes.has(current.code) ||
       unavailableCodes.has(current.errno)
@@ -303,7 +305,12 @@ const isElasticsearchUnavailable = error => {
     ) {
       return true;
     }
-    current = current.cause;
+    if (current.cause != null) {
+      pending.push(current.cause);
+    }
+    if (Array.isArray(current.errors)) {
+      pending.push(...current.errors);
+    }
   }
 
   return false;


### PR DESCRIPTION
## Ændringer

Build-static validerer nu datoer i teksthoveder som fulde datoer på formen `YYYY-MM-DD`.
Ugyldige værdier som `1906` giver en tydelig build-fejl med fil og tekst-id.

Buildet håndterer også Node-fejl fra en utilgængelig Elasticsearch-server korrekt og
springer søgeindeks-opdateringen over, så de statiske filer stadig kan bygges.

## Valideret

- `npm run build-static`
- `npm test -- --runInBand` (57 test suites, 2413 tests)
