### PR TITLE
Fremhæv links med tilgængelig understregning

### DIFF
--- a/components/breadcrumbs.js
+++ b/components/breadcrumbs.js
@@ -207,6 +207,9 @@ const Breadcrumbs = (props) => {
           flex-wrap: wrap;
           line-height: 19px;
         }
+        nav :global(a) {
+          text-decoration: none;
+        }
         nav:empty::before {
           content: 'Kalliope';
           visibility: hidden;

--- a/components/countrypicker.js
+++ b/components/countrypicker.js
@@ -39,7 +39,7 @@ const CountryPicker = (props) => {
   });
   const joinedItems = joinWithCommaAndOr(items, _('eller', lang));
   return (
-    <div style={style}>
+    <div className="country-picker" style={style}>
       <div>
         {_('Skift mellem', lang)} {joinedItems}
         {_('digtere', lang)}.

--- a/components/external-identifier-links.js
+++ b/components/external-identifier-links.js
@@ -36,7 +36,7 @@ const ExternalIdentifierLinks = ({
     return (
       <section className="external-identifiers references" aria-label={heading}>
         <h3>{heading}</h3>
-        <TwoColumns>{items}</TwoColumns>
+        <TwoColumns noLinkUnderline>{items}</TwoColumns>
         <style jsx>{`
           .references {
             margin-bottom: 40px;

--- a/components/page.js
+++ b/components/page.js
@@ -204,7 +204,19 @@ const Page = (props) => {
           }
           :global(a) {
             color: ${CommonData.linkColor};
+            text-decoration-thickness: 0.5px !important;
+          }
+          :global(.prose-paragraph a),
+          :global(.poem-line a) {
+            text-decoration: underline;
+            text-underline-offset: 0.12em;
+          }
+          :global(.tabs a) {
             text-decoration: none;
+          }
+          :global(a:focus-visible) {
+            outline: 2px solid ${CommonData.linkColor};
+            outline-offset: 3px;
           }
           :global(a):global(.lighter) {
             color: ${CommonData.lightLinkColor};

--- a/components/picture.js
+++ b/components/picture.js
@@ -34,7 +34,10 @@ const FigCaption = (props) => {
       <>
         {' '}
         <Tooltip text={tooltip}>
-          <a href={picture.remoteUrl} aria-label={tooltip}>
+          <a
+            href={picture.remoteUrl}
+            aria-label={tooltip}
+            className="remote-picture-link">
             ⌘
           </a>
         </Tooltip>
@@ -86,6 +89,12 @@ const FigCaption = (props) => {
           margin-top: 8px;
           font-size: 16px;
           line-height: 1.4;
+        }
+        figcaption :global(a) {
+          text-decoration-thickness: 0.5px !important;
+        }
+        figcaption :global(a.remote-picture-link) {
+          text-decoration: none !important;
         }
       `}</style>
     </figcaption>

--- a/components/sectionedlist.js
+++ b/components/sectionedlist.js
@@ -17,7 +17,7 @@ const SectionedList = ({ sections }) => {
     );
   });
   return (
-    <TwoColumns>
+    <TwoColumns noLinkUnderline>
       {renderedGroups}
       <style jsx>{`
         :global(.list-section) {

--- a/components/twocolumns.js
+++ b/components/twocolumns.js
@@ -1,12 +1,20 @@
 const TwoColumns = (props) => {
+  const className = props.noLinkUnderline
+    ? 'two-columns no-link-underline'
+    : 'two-columns';
+
   return (
-    <div className="two-columns">
+    <div className={className}>
       {props.children}
       <style jsx>{`
         div.two-columns {
           width: 100%;
           columns: 2;
           column-gap: 30px;
+        }
+
+        div.two-columns.no-link-underline :global(a) {
+          text-decoration: none;
         }
 
         @media (max-width: 480px) {

--- a/pages/alltexts.js
+++ b/pages/alltexts.js
@@ -113,7 +113,7 @@ const AllTextsPage = (props) => {
       menuItems={tabs}
       selectedMenuItem={type}>
       <div style={{ lineHeight: 1.5 }}>
-        <TwoColumns>{renderedLines}</TwoColumns>
+        <TwoColumns noLinkUnderline>{renderedLines}</TwoColumns>
       </div>
       <div style={{ margin: '40px 0 10px 0', fontSize: '1.5em' }}>
         {letterPicker}

--- a/pages/index.js
+++ b/pages/index.js
@@ -174,17 +174,19 @@ let Index = (props) => {
       menuItems={kalliopeMenu()}
       selectedMenuItem="index"
       paging={paging}>
-      <PageLead>
-        {_(
-          'Kalliope er et digitalt bibliotek for poesi og klassisk litteratur. Her finder du digte, oversættelser, forfatterbiografier og litterære noter, frit tilgængeligt og forbundet gennem personer, værker, steder og historiske perioder.',
-          lang
-        )}
-      </PageLead>
-      <SidebarSplit sidebar={sidebar}>
-        <div>
-          <News news={news} lang={lang} />
-        </div>
-      </SidebarSplit>
+      <div className="front-page">
+        <PageLead>
+          {_(
+            'Kalliope er et digitalt bibliotek for poesi og klassisk litteratur. Her finder du digte, oversættelser, forfatterbiografier og litterære noter, frit tilgængeligt og forbundet gennem personer, værker, steder og historiske perioder.',
+            lang
+          )}
+        </PageLead>
+        <SidebarSplit sidebar={sidebar}>
+          <div>
+            <News news={news} lang={lang} />
+          </div>
+        </SidebarSplit>
+      </div>
     </Page>
   );
 };

--- a/pages/mentions.js
+++ b/pages/mentions.js
@@ -49,7 +49,7 @@ const Section = (props) => {
   return (
     <div className="list-section" style={{ marginBottom: '40px' }}>
       <h3 style={{ columnSpan: 'all' }}>{title}</h3>
-      <TwoColumns>{items}</TwoColumns>
+      <TwoColumns noLinkUnderline>{items}</TwoColumns>
       <style jsx>{`
         h3 {
           font-weight: 300;

--- a/pages/museums.js
+++ b/pages/museums.js
@@ -6,6 +6,7 @@ import * as Links from '../components/links.js';
 import Page from '../components/page.js';
 import PageLead from '../components/pagelead.js';
 import SectionedList from '../components/sectionedlist.js';
+import TwoColumns from '../components/twocolumns.js';
 import ErrorPage from './error.js';
 
 const countryNames = {
@@ -121,8 +122,8 @@ const MuseumsPage = (props) => {
       {groupBy === 'country' ? (
         <SectionedList sections={sections} />
       ) : (
-        <div className="two-columns" style={{ lineHeight: 1.7 }}>
-          {items}
+        <div style={{ lineHeight: 1.7 }}>
+          <TwoColumns noLinkUnderline>{items}</TwoColumns>
         </div>
       )}
     </Page>

--- a/pages/poets.js
+++ b/pages/poets.js
@@ -215,7 +215,14 @@ const Poets = (props) => {
         countryToURL={countryCodeToURL}
         selectedCountry={country}
       />
-      {renderedGroups}
+      <div className="poets-overview">
+        {renderedGroups}
+      </div>
+      <style jsx>{`
+        :global(.poets-overview a) {
+          text-decoration: none;
+        }
+      `}</style>
     </Page>
   );
 };

--- a/pages/works.js
+++ b/pages/works.js
@@ -158,7 +158,7 @@ const WorksPage = (props) => {
       <div className="two-columns no-link-underline">
         {stack}
         <style jsx>{`
-          :global(.no-link-underline a) {
+          :global(.no-link-underline a:not([href*='/museum/'])) {
             text-decoration: none;
           }
           :global(.nodata) {

--- a/pages/works.js
+++ b/pages/works.js
@@ -155,9 +155,12 @@ const WorksPage = (props) => {
       poet={poet}
       selectedMenuItem="works">
       <PageLead>{worksLead(poet, lang)}</PageLead>
-      <div className="two-columns">
+      <div className="two-columns no-link-underline">
         {stack}
         <style jsx>{`
+          :global(.no-link-underline a) {
+            text-decoration: none;
+          }
           :global(.nodata) {
             padding: 30px 0;
           }


### PR DESCRIPTION
## Ændringer

- Gør understregninger på links 0,5 px globalt.
- Fjern understregning fra navigation, brødkrummer, billedets `⌘`-link og oversigter.
- Bevar understregning på museumlinks i værkoversigten, mens værklinks er uden understregning.
- Brug den fælles to-kolonnevariant til relevante listeoversigter.
- Tilføj tydelig tastaturfokus på links.

## Validering

- `npm test` (57 test suites, 2.412 tests bestået)

Fixes #1441
