### PR TITLE
Prompt 1: Collect text quality checks

### DIFF
--- a/__tests__/poem-lines.js
+++ b/__tests__/poem-lines.js
@@ -1,330 +1,47 @@
-import fs from 'fs';
-import { fileExists, loadText } from '../tools/libs/helpers.js';
-
-function flatten(arr) {
-  return [].concat(...arr);
-}
-
-function fail(message) {
-  throw new Error(message);
-}
-
-function checkNotesGroups(filename, data) {
-  const headRegexp = /<(workhead|head)>[\s\S]*?<\/\1>/g;
-  const idRegexp = /<(?:text|section)[^>]*\sid="([^"]+)"/g;
-  let currentId = 'workhead';
-  const ids = Array.from(data.matchAll(idRegexp));
-  let idIndex = 0;
-  let headMatch;
-
-  while ((headMatch = headRegexp.exec(data)) != null) {
-    while (idIndex < ids.length && ids[idIndex].index < headMatch.index) {
-      currentId = ids[idIndex][1];
-      idIndex += 1;
-    }
-    const notesGroups = headMatch[0].match(/<notes>/g) || [];
-    if (notesGroups.length > 1) {
-      throw new Error(
-        `fdirs/${filename} ${currentId} has ${notesGroups.length} <notes> groups.`
-      );
-    }
-  }
-}
-
-function stripXmlComments(data) {
-  return data.replace(/<!--[\s\S]*?-->/g, '');
-}
-
-function textIds(data) {
-  const idRegexp = /<(?:text|section)[^>]*\sid="([^"]+)"/g;
-  return Array.from(stripXmlComments(data).matchAll(idRegexp)).map(
-    (match) => match[1]
-  );
-}
-
-function textAliases(data) {
-  const partRegexp = /<(?:text|section)\b[^>]*>/g;
-  return Array.from(stripXmlComments(data).matchAll(partRegexp)).flatMap(
-    (partMatch) => {
-      const part = partMatch[0];
-      const idMatch = part.match(/\sid="([^"]+)"/);
-      const aliasesMatch = part.match(/\saliases="([^"]*)"/);
-
-      if (idMatch == null || aliasesMatch == null) {
-        return [];
-      }
-
-      return aliasesMatch[1]
-        .split(',')
-        .map((alias) => alias.trim())
-        .filter((alias) => alias.length > 0)
-        .map((alias) => ({ id: idMatch[1], alias }));
-    }
-  );
-}
-
-function firstYear(text) {
-  const match = (text || '').match(/\d{3,4}/);
-  return match == null ? null : parseInt(match[0], 10);
-}
-
-function firstMatch(text, regexp) {
-  const match = text.match(regexp);
-  return match == null ? null : match[1];
-}
-
-function findMissingModernFrenchSpacing(data) {
-  const textData = stripXmlComments(data).replace(
-    /<picture\b[\s\S]*?<\/picture>/g,
-    ''
-  );
-  const lines = textData.split('\n');
-  for (let i = 0; i < lines.length; i++) {
-    const text = lines[i].replace(/<[^>]+>/g, '');
-    const match = text.match(/\S([?!;:])/);
-    if (match != null) {
-      return {
-        line: i + 1,
-        sign: match[1],
-        text: lines[i],
-      };
-    }
-  }
-  return null;
-}
-
-function ignoredTestsAtLine(data) {
-  const partRegexp = /<(?:text|section)\b[^>]*>/g;
-  const lineStarts = [0];
-  let lineBreakIndex = -1;
-
-  while ((lineBreakIndex = data.indexOf('\n', lineBreakIndex + 1)) !== -1) {
-    lineStarts.push(lineBreakIndex + 1);
-  }
-
-  const ignoredAtLine = new Map();
-  let currentIgnoredTests = [];
-  let partIndex = 0;
-  const parts = Array.from(data.matchAll(partRegexp));
-
-  lineStarts.forEach((lineStart, lineIndex) => {
-    while (partIndex < parts.length && parts[partIndex].index <= lineStart) {
-      const ignoreTestsMatch = parts[partIndex][0].match(
-        /\signore-tests="([^"]*)"/
-      );
-      currentIgnoredTests =
-        ignoreTestsMatch == null
-          ? []
-          : ignoreTestsMatch[1]
-              .split(',')
-              .map((testName) => testName.trim())
-              .filter((testName) => testName.length > 0);
-      partIndex += 1;
-    }
-    ignoredAtLine.set(lineIndex, currentIgnoredTests);
-  });
-
-  return ignoredAtLine;
-}
-
-// Regulære expressions som fanger typiske fejl i vores XML.
-// Disse kan enten være et regexp direkte eller et regexp med en whitelist.
-const regexps = [
-  /\^/,
-  /^,[a-zæøåA-ZÆØÅ]/m, // Enkelt komma først på linjen
-  /^\s[-a-zæøåA-ZÆØÅ]/m, // Enkelt mellemrum først på linjen
-  /^\.[a-zæøåA-ZÆØÅ]/m, // Enkelt punktum ...
-  { regexp: /[a-zæøå] \.[^\.]/, whitelist: [/\. \. \./] }, // Mellemrum foran punktum
-  /^-[a-zæøåA-ZÆØÅ]/m, // Enkelt bindestreg ...
-  /<firstline><\/firstline>/, // Tom <firstline> ...
-  /<source pages="">/,
-  /^.*[^\.]\.\s*[a-z;]\s*$/, // Løse bogstaver efter sidste punktum
-  { testName: 'loose-letters', regexp: / [a-hj-np-z]\s*$/m, onlylangs: ['da'] }, // Løst bogstav sidst på dansk linje. Tillad i og o.
-  { testName: 'loose-letters', regexp: / [b-z]\s*$/m, onlylangs: ['en'] }, // Løst bogstav sidst på engelsk linje. Tillad a.
-  {
-    regexp: /[a-zæøå],[a-zæøå]/,
-    whitelist: [/<keywords>/, /<quality>/, /\signore-tests="[^"]*,/],
-  },
-  { regexp: /mmm/, whitelist: [/<note>.*\]/] },
-  ///iii/, // Problematisk da den rammer lowercase romertal. Fiks fejlere og drop reglen.
-  /\s,\s*$/m, // luft foran afsluttende komma
-  { regexp: /\s!\s*$/m, ignorelangs: ['fr'] }, // luft foran afsluttende udråbstegn (tilladt på fransk)
-  { regexp: /\s\?\s*$/m, ignorelangs: ['fr'] }, // luft foran afsluttende spørgsmål (tilladt på fransk)
-  { regexp: /\s;\s*$/m, ignorelangs: ['fr'] }, // luft foran afsluttende semikolon (tilladt på fransk)
-  //{ regexp: /\s:\s*$/m, ignorelangs: ['fr'] }, // luft foran afsluttende kolon (tilladt på fransk og i versgentagelser :)
-  { regexp: /lll/, whitelist: [/Allliebe/] },
-  /,;/,
-  /,\./,
-  {
-    regexp: /;,/,
-    whitelist: [/&/],
-  },
-  {
-    regexp: /aaa/,
-    whitelist: [
-      /[Ss]maaalfer/,
-      /Smaaarbeider/,
-      /<note>.*\]/,
-      /[Uu]paaagtet/,
-      /Koleraaar/,
-      /Græsstraaarme/,
-    ],
-  },
-  /sss/,
-  {
-    regexp: / ,[^,]/,
-    whitelist: [/<metrik>/],
-  },
-];
+import {
+  collectPoemLineQualityFindings,
+  formatPoemLineIssue,
+  findPoemLineFindingsInText,
+} from '../tools/text-quality-poem-lines.js';
 
 describe('Check workfiles', () => {
-  const allPoetIds = fs
-    .readdirSync('fdirs')
-    .filter((p) => p.indexOf('.') === -1);
-
-  let filenameLangs = {};
-  let filenameBornYears = {};
-  let filenameWorkYears = {};
-
-  let filenames = allPoetIds.map((poetId) => {
-    const infoFilename = `fdirs/${poetId}/info.xml`;
-    if (!fs.existsSync(infoFilename)) {
-      throw new Error(`Missing info.xml in fdirs/${poetId}.`);
-    }
-    const infoData = loadText(infoFilename);
-    const person = firstMatch(infoData, /(<person\b[^>]*>)/);
-    if (person == null) {
-      throw new Error(`${infoFilename} is malformed.`);
-    }
-    const lang = firstMatch(person, /\slang="([^"]+)"/);
-    const bornYear = firstYear(firstMatch(infoData, /<born>([\s\S]*?)<\/born>/));
-    const workIds = firstMatch(infoData, /<works>([\s\S]*?)<\/works>/);
-    let items = workIds
-      ? workIds
-          .toString()
-          .replace('<works>', '')
-          .replace('</works>', '')
-          .replace('<works/>', '')
-          .trim()
-          .split(',')
-          .filter((x) => x.length > 0)
-      : [];
-    return items.map((w) => {
-      const filename = `${poetId}/${w}.xml`;
-      filenameLangs[filename] = lang;
-      filenameBornYears[filename] = bornYear;
-      filenameWorkYears[filename] = firstYear(w);
-      return filename;
-    });
-  });
-
-  filenames = flatten(filenames);
-
-  let seenTextIds = new Map();
-  let duplicateTextIds = [];
-  let seenTextAliases = new Map();
-  let duplicateTextAliases = [];
-
-  filenames.forEach((filename) => {
-    const data = loadText(`fdirs/${filename}`);
-    textIds(data).forEach((textId) => {
-      if (seenTextIds.has(textId)) {
-        duplicateTextIds.push(
-          `Text id "${textId}" is used in both ${seenTextIds.get(
-            textId
-          )} and ${filename}.`
-        );
-      }
-      seenTextIds.set(textId, filename);
-    });
-    textAliases(data).forEach(({ id, alias }) => {
-      if (seenTextAliases.has(alias)) {
-        duplicateTextAliases.push(
-          `Text alias "${alias}" is used by both ${seenTextAliases.get(
-            alias
-          )} and ${filename}:${id}.`
-        );
-      }
-      seenTextAliases.set(alias, `${filename}:${id}`);
-    });
-  });
-
-  it('Text ids are unique across workfiles', () => {
-    if (duplicateTextIds.length > 0) {
-      fail(duplicateTextIds.join('\n'));
+  it('has no poem-line quality issues', () => {
+    const issues = collectPoemLineQualityFindings();
+    if (issues.length > 0) {
+      throw new Error(issues.map(formatPoemLineIssue).join('\n'));
     }
   });
 
-  it('Text aliases do not conflict with text ids', () => {
-    if (duplicateTextAliases.length > 0) {
-      fail(duplicateTextAliases.join('\n'));
-    }
-    seenTextAliases.forEach((textId, alias) => {
-      if (seenTextIds.has(alias)) {
-        fail(
-          `Text alias "${alias}" in ${textId} conflicts with text id in ${seenTextIds.get(
-            alias
-          )}.`
-        );
-      }
+  it('allows mmm in a correction note marked with a closing bracket', () => {
+    const issues = findPoemLineFindingsInText({
+      file: 'fdirs/test/notes.xml',
+      data: '<text id="note"><note>Himmel] Himmmel</note></text>',
+      lang: 'da',
+      shouldUseModernFrenchPunctuationSpacing: false,
     });
+
+    expect(issues.filter((issue) => issue.rule === 'm-ellipsis')).toEqual([]);
   });
 
-  filenames.forEach((filename) => {
-    const fullpath = `fdirs/${filename}`;
-    const lang = filenameLangs[filename];
-    it(`Workfile fdirs/${filename} is fine`, () => {
-      const data = loadText(fullpath);
-      const ignoredTests = ignoredTestsAtLine(data);
-      expect(fileExists(fullpath)).toBeTruthy;
-      expect(data.length > 0);
-      checkNotesGroups(filename, data);
-      regexps.forEach((rule) => {
-        let regexp = rule.regexp || rule;
-        let whitelist = rule.whitelist || [];
-        let ignorelangs = rule.ignorelangs || [];
-        let onlylangs = rule.onlylangs || [];
-
-        if (ignorelangs.indexOf(lang) > -1) {
-          return;
-        }
-        if (onlylangs.length > 0 && onlylangs.indexOf(lang) === -1) {
-          return;
-        }
-        if (!regexp) {
-          console.log('Regexp is missing from rule');
-        }
-
-        if (regexp.test(data)) {
-          data.split('\n').forEach((line, lineIndex) => {
-            if (
-              regexp.test(line) &&
-              (rule.testName == null ||
-                ignoredTests.get(lineIndex).indexOf(rule.testName) === -1) &&
-              !whitelist.find((w) => {
-                return w.test(line);
-              })
-            ) {
-              fail(`'${regexp.toString()}' found in xml [${line}]`);
-            }
-          });
-        }
-      });
-
-      const shouldUseModernFrenchPunctuationSpacing =
-        lang === 'fr' &&
-        ((filenameBornYears[filename] != null &&
-          filenameBornYears[filename] >= 1800) ||
-          (filenameWorkYears[filename] != null &&
-            filenameWorkYears[filename] >= 1800));
-      if (shouldUseModernFrenchPunctuationSpacing) {
-        const missingFrenchSpacing = findMissingModernFrenchSpacing(data);
-        if (missingFrenchSpacing != null) {
-          fail(
-            `French spacing missing before '${missingFrenchSpacing.sign}' in ${filename}:${missingFrenchSpacing.line} [${missingFrenchSpacing.text}]`
-          );
-        }
-      }
+  it('still reports mmm in a note without a closing bracket', () => {
+    const issues = findPoemLineFindingsInText({
+      file: 'fdirs/test/notes.xml',
+      data: '<text id="note"><note>Himmel Himmmel</note></text>',
+      lang: 'da',
+      shouldUseModernFrenchPunctuationSpacing: false,
     });
+
+    expect(issues.filter((issue) => issue.rule === 'm-ellipsis')).toHaveLength(1);
+  });
+
+  it('does not let a closing bracket outside a note excuse mmm', () => {
+    const issues = findPoemLineFindingsInText({
+      file: 'fdirs/test/notes.xml',
+      data: '<text id="note">Himmel] Himmmel</text>',
+      lang: 'da',
+      shouldUseModernFrenchPunctuationSpacing: false,
+    });
+
+    expect(issues.filter((issue) => issue.rule === 'm-ellipsis')).toHaveLength(1);
   });
 });

--- a/package.json
+++ b/package.json
@@ -26,7 +26,8 @@
     "report-salmonsen-biographies": "node tools/report-salmonsen-biographies.js",
     "build-static": "node tools/build-static.js",
     "build-static-force-reload": "node tools/build-static.js --force-reload",
-    "build-facsimiles": "node tools/build-facsimiles.js"
+    "build-facsimiles": "node tools/build-facsimiles.js",
+    "check-text-quality": "node tools/check-text-quality.js"
   },
   "dependencies": {
     "@xmldom/xmldom": "^0.9.10",

--- a/tools/README.md
+++ b/tools/README.md
@@ -45,6 +45,21 @@ npm run report-ocr-candidates
 npm run report-ocr-candidates -- fdirs/digter/vaerk.xml
 ```
 
+### Tekstkvalitetskontrol
+
+`check-text-quality` kører alle tekstkvalitetskontroller (OCR-kandidater + linje-regler) i én kommando og returnerer et stabilt output.
+
+```sh
+npm run check-text-quality
+npm run check-text-quality -- fdirs/digter/vaerk.xml
+```
+
+Med JSON-output:
+
+```sh
+node tools/check-text-quality.js --json
+```
+
 ### Salmonsen-biografier
 
 `report-salmonsen-biographies.js` viser fremdriften for biografier til

--- a/tools/check-text-quality.js
+++ b/tools/check-text-quality.js
@@ -1,0 +1,113 @@
+import { findOcrCandidates } from './report-ocr-candidates.js';
+import { collectPoemLineQualityFindings } from './text-quality-poem-lines.js';
+
+const normalizePath = filename => filename.replace(/^\.\//, '').replace(/^fdirs\//, '').replace(/\\/g, '/');
+
+const parseArgs = () => {
+  const args = process.argv.slice(2);
+  const json = args.includes('--json');
+  const files = args.filter(arg => !arg.startsWith('--')).map(normalizePath);
+  return { json, files: files.length === 0 ? null : files };
+};
+
+const compareTextQualityIssues = (a, b) => {
+  if (a.file < b.file) return -1;
+  if (a.file > b.file) return 1;
+  if (a.line < b.line) return -1;
+  if (a.line > b.line) return 1;
+  if (a.rule < b.rule) return -1;
+  if (a.rule > b.rule) return 1;
+  return 0;
+};
+
+const asHumanLine = issue =>
+  `${issue.severity}\t${issue.file}:${issue.line ?? ''}\t${issue.rule}\t${issue.textId ?? ''}\t${issue.description}\t${issue.excerpt ?? ''}`;
+
+const toOcrIssue = candidate => ({
+  file: candidate.file,
+  line: candidate.line,
+  textId: candidate.textId,
+  rule: candidate.rule,
+  severity: candidate.priority,
+  description: candidate.reason ?? candidate.rule,
+  excerpt: candidate.context,
+  source: 'ocr-candidates',
+});
+
+const toPoemLineIssue = issue => ({
+  file: issue.file,
+  line: issue.line,
+  textId: issue.textId,
+  rule: issue.rule,
+  severity: issue.severity,
+  description: issue.description,
+  excerpt: issue.excerpt,
+  source: 'poem-lines',
+});
+
+const formatSummary = (issues, technicalError = null) => {
+  if (technicalError != null) {
+    return {
+      status: 'technical-error',
+      summary: {
+        qualityIssues: issues.length,
+        technicalError,
+      },
+      issues,
+    };
+  }
+
+  return {
+    status: issues.length > 0 ? 'quality-failure' : 'ok',
+    summary: {
+      qualityIssues: issues.length,
+    },
+    issues,
+  };
+};
+
+const run = () => {
+  const { json, files } = parseArgs();
+  const rootDir = process.cwd();
+  const result = {
+    issues: [],
+  };
+
+  try {
+    const ocrCandidates = findOcrCandidates({
+      rootDir,
+      files,
+      disabledTests: process.env.DISABLED_TESTS ?? '',
+    });
+    const poemLineFindings = collectPoemLineQualityFindings({ rootDir, files });
+    result.issues = [...poemLineFindings.map(toPoemLineIssue), ...ocrCandidates.map(toOcrIssue)].sort(compareTextQualityIssues);
+  } catch (error) {
+    const summary = formatSummary(result.issues, error.message);
+    if (json) {
+      console.log(JSON.stringify(summary, null, 2));
+    } else {
+      console.error(`Teknisk fejl under tekstkvalitetskontrol: ${error.message}`);
+      if (error.stack != null) {
+        console.error(error.stack);
+      }
+      const text = JSON.stringify(summary, null, 2);
+      console.error(text);
+    }
+    process.exitCode = 2;
+    return;
+  }
+
+  const summary = formatSummary(result.issues);
+  if (json) {
+    console.log(JSON.stringify(summary, null, 2));
+  } else if (result.issues.length > 0) {
+    result.issues.forEach(issue => console.log(asHumanLine(issue)));
+    console.error(`${result.issues.length} tekstkvalitetsfejl fundet.`);
+  } else {
+    console.log('Ingen tekstkvalitetsfejl fundet.');
+  }
+
+  process.exitCode = result.issues.length > 0 ? 1 : 0;
+};
+
+run();

--- a/tools/check-text-quality.js
+++ b/tools/check-text-quality.js
@@ -1,7 +1,7 @@
 import { findOcrCandidates } from './report-ocr-candidates.js';
 import { collectPoemLineQualityFindings } from './text-quality-poem-lines.js';
 
-const normalizePath = filename => filename.replace(/^\.\//, '').replace(/^fdirs\//, '').replace(/\\/g, '/');
+const normalizePath = filename => filename.replace(/^\.\//, '').replace(/\\/g, '/');
 
 const parseArgs = () => {
   const args = process.argv.slice(2);

--- a/tools/text-quality-poem-lines.js
+++ b/tools/text-quality-poem-lines.js
@@ -367,15 +367,16 @@ const collectPoemLineQualityFindings = ({
   const aliasLocations = new Map();
 
   for (const item of fileMetadata) {
-    const fullpath = `fdirs/${item.filename}`;
+    const relativePath = path.join('fdirs', item.filename);
+    const fullpath = path.join(rootDir, relativePath);
     const data = loadText(fullpath);
     if (data == null) {
-      throw new Error(`Missing file ${fullpath}.`);
+      throw new Error(`Missing file ${relativePath}.`);
     }
     fileByFilename.set(item.filename, {
       data,
       ...item,
-      path: fullpath,
+      path: relativePath,
     });
   }
 

--- a/tools/text-quality-poem-lines.js
+++ b/tools/text-quality-poem-lines.js
@@ -1,0 +1,476 @@
+import fs from 'fs';
+import path from 'path';
+import { fileExists, loadText } from './libs/helpers.js';
+
+const flatten = array => [].concat(...array);
+
+const lineNumberAt = (text, index) => text.slice(0, index).split('\n').length;
+
+const parseIntOrNull = value => {
+  const parsed = parseInt(value, 10);
+  return Number.isNaN(parsed) ? null : parsed;
+};
+
+const firstYear = text => {
+  const match = (text || '').match(/\d{3,4}/);
+  return match == null ? null : parseIntOrNull(match[0]);
+};
+
+const firstMatch = (text, regexp) => {
+  const match = text.match(regexp);
+  return match == null ? null : match[1];
+};
+
+const normalizeFileName = filename =>
+  filename.replace(/^\.\//, '').replace(/^fdirs\//, '').replace(/\\/g, '/');
+
+const stripXmlComments = data => data.replace(/<!--[\s\S]*?-->/g, '');
+
+const parsePoetWorkFiles = (rootDir = process.cwd()) => {
+  const fdirs = path.join(rootDir, 'fdirs');
+  const poetIds = fs.existsSync(fdirs)
+    ? fs
+        .readdirSync(fdirs)
+        .filter((poetId) => poetId.indexOf('.') === -1)
+    : [];
+
+  const metadata = [];
+
+  for (const poetId of poetIds) {
+    const infoFilename = path.join(rootDir, 'fdirs', poetId, 'info.xml');
+    if (!fileExists(infoFilename)) {
+      throw new Error(`Missing info.xml in fdirs/${poetId}.`);
+    }
+
+    const infoData = loadText(infoFilename);
+    if (infoData == null) {
+      throw new Error(`Missing info.xml in fdirs/${poetId}.`);
+    }
+
+    const person = firstMatch(infoData, /(<person\b[^>]*>)/);
+    if (person == null) {
+      throw new Error(`fdirs/${poetId}/info.xml is malformed.`);
+    }
+
+    const lang = firstMatch(person, /\slang="([^"]+)"/);
+    const bornYear = firstYear(firstMatch(infoData, /<born>([\s\S]*?)<\/born>/));
+    const workIds = firstMatch(infoData, /<works>([\s\S]*?)<\/works>/);
+
+    const works = workIds
+      ? workIds
+          .toString()
+          .replace('<works>', '')
+          .replace('</works>', '')
+          .replace('<works/>', '')
+          .trim()
+          .split(',')
+          .filter((workId) => workId.length > 0)
+          .map((workId) => workId.trim())
+      : [];
+
+    for (const workId of works) {
+      const filename = `${poetId}/${workId}.xml`;
+      metadata.push({
+        filename: normalizeFileName(filename),
+        lang,
+        bornYear,
+        workYear: parseIntOrNull(workId),
+      });
+    }
+  }
+
+  return metadata;
+};
+
+const collectTextIds = data =>
+  Array.from(stripXmlComments(data).matchAll(/<(?:text|section)\b[^>]*\sid="([^"]+)"/g)).map(
+    (match) => ({
+      id: match[1],
+      line: lineNumberAt(data, match.index),
+    })
+  );
+
+const collectTextAliases = data =>
+  Array.from(stripXmlComments(data).matchAll(/<(?:text|section)\b[^>]*>/g)).flatMap(
+    (partMatch) => {
+      const part = partMatch[0];
+      const idMatch = part.match(/\sid="([^"]+)"/);
+      const aliasesMatch = part.match(/\saliases="([^"]*)"/);
+
+      if (idMatch == null || aliasesMatch == null) {
+        return [];
+      }
+
+      return aliasesMatch[1]
+        .split(',')
+        .map(alias => alias.trim())
+        .filter((alias) => alias.length > 0)
+        .map((alias) => ({
+          id: idMatch[1],
+          alias,
+          line: lineNumberAt(data, partMatch.index),
+        }));
+    }
+  );
+
+const checkNotesGroups = (filename, data) => {
+  const headRegexp = /<(workhead|head)>[\s\S]*?<\/\1>/g;
+  const idRegexp = /<(?:text|section)[^>]*\sid="([^"]+)"/g;
+  let currentId = 'workhead';
+  const ids = Array.from(data.matchAll(idRegexp));
+  let idIndex = 0;
+  let headMatch;
+
+  while ((headMatch = headRegexp.exec(data)) != null) {
+    while (idIndex < ids.length && ids[idIndex].index < headMatch.index) {
+      currentId = ids[idIndex][1];
+      idIndex += 1;
+    }
+    const notesGroups = headMatch[0].match(/<notes>/g) || [];
+    if (notesGroups.length > 1) {
+      return {
+        file: filename,
+        line: lineNumberAt(data, headMatch.index),
+        rule: 'notes-groups',
+        severity: 'high',
+        description: `${filename} ${currentId} has ${notesGroups.length} <notes> groups.`,
+        excerpt: headMatch[0].slice(0, 120),
+      };
+    }
+  }
+
+  return null;
+};
+
+const findMissingModernFrenchSpacing = data => {
+  const textData = stripXmlComments(data).replace(
+    /<picture\b[\s\S]*?<\/picture>/g,
+    ''
+  );
+  const lines = textData.split('\n');
+  for (let i = 0; i < lines.length; i += 1) {
+    const text = lines[i].replace(/<[^>]+>/g, '');
+    const match = text.match(/\S([?!;:])/);
+    if (match != null) {
+      return {
+        file: '',
+        line: i + 1,
+        sign: match[1],
+        text: lines[i],
+      };
+    }
+  }
+
+  return null;
+};
+
+const ignoredTestsAtLine = data => {
+  const partRegexp = /<(?:text|section)\b[^>]*>/g;
+  const lineStarts = [0];
+  let lineBreakIndex = -1;
+
+  while ((lineBreakIndex = data.indexOf('\n', lineBreakIndex + 1)) !== -1) {
+    lineStarts.push(lineBreakIndex + 1);
+  }
+
+  const ignoredAtLine = new Map();
+  let currentIgnoredTests = [];
+  let partIndex = 0;
+  const parts = Array.from(data.matchAll(partRegexp));
+
+  lineStarts.forEach((lineStart, lineIndex) => {
+    while (partIndex < parts.length && parts[partIndex].index <= lineStart) {
+      const ignoreTestsMatch = parts[partIndex][0].match(
+        /\signore-tests="([^"]*)"/
+      );
+      currentIgnoredTests =
+        ignoreTestsMatch == null
+          ? []
+          : ignoreTestsMatch[1]
+              .split(',')
+              .map((testName) => testName.trim())
+              .filter((testName) => testName.length > 0);
+      partIndex += 1;
+    }
+    ignoredAtLine.set(lineIndex, currentIgnoredTests);
+  });
+
+  return ignoredAtLine;
+};
+
+const regexps = [
+  { testName: 'caret', regexp: /\^/ },
+  { testName: 'leading-comma', regexp: /^,[a-zæøåA-ZÆØÅ]/m },
+  { testName: 'leading-space', regexp: /^\s[-a-zæøåA-ZÆØÅ]/m },
+  { testName: 'leading-period', regexp: /^\.[a-zæøåA-ZÆØÅ]/m },
+  {
+    testName: 'period-space',
+    regexp: /[a-zæøå] \.[^\.]/,
+    whitelist: [/\. \. \./],
+  },
+  { testName: 'leading-dash', regexp: /^-[a-zæøåA-ZÆØÅ]/m },
+  { testName: 'empty-firstline', regexp: /<firstline><\/firstline>/ },
+  { testName: 'missing-source-pages', regexp: /<source pages=""\/>/ },
+  { testName: 'dot-followed-by-lowercase', regexp: /^.*[^\.]\.\s*[a-z;]\s*$/ },
+  {
+    testName: 'loose-letters',
+    regexp: / [a-hj-np-z]\s*$/m,
+    onlylangs: ['da'],
+  },
+  {
+    testName: 'loose-letters',
+    regexp: / [b-z]\s*$/m,
+    onlylangs: ['en'],
+  },
+  {
+    testName: 'comma-missing-space',
+    regexp: /[a-zæøå],[a-zæøå]/,
+    whitelist: [/<keywords>/, /<quality>/, /\signore-tests="[^"]*,/],
+  },
+  {
+    testName: 'm-ellipsis',
+    regexp: /mmm/,
+    whitelist: [/<note\b[^>]*>.*\]/],
+  },
+  { testName: 'space-before-comma', regexp: /\s,\s*$/m },
+  {
+    testName: 'space-before-exclamation',
+    regexp: /\s!\s*$/m,
+    ignorelangs: ['fr'],
+  },
+  {
+    testName: 'space-before-question',
+    regexp: /\s\?\s*$/m,
+    ignorelangs: ['fr'],
+  },
+  {
+    testName: 'space-before-semicolon',
+    regexp: /\s;\s*$/m,
+    ignorelangs: ['fr'],
+  },
+  { testName: 'lll', regexp: /lll/, whitelist: [/Allliebe/] },
+  { testName: 'comma-semicolon', regexp: /,;/ },
+  { testName: 'comma-period', regexp: /,\./ },
+  {
+    testName: 'comma-comma',
+    regexp: /;,/,
+    whitelist: [/&/],
+  },
+  {
+    testName: 'smaa',
+    regexp: /aaa/,
+    whitelist: [
+      /[Ss]maaalfer/,
+      /Smaaarbeider/,
+      /<note\b[^>]*>.*\]/,
+      /[Uu]paaagtet/,
+      /Koleraaar/,
+      /Græsstraaarme/,
+    ],
+  },
+  { testName: 'sss', regexp: /sss/ },
+  {
+    testName: 'space-before-comma-with-markup',
+    regexp: / ,[^,]/,
+    whitelist: [/<metrik>/],
+  },
+];
+
+const shouldCheckRule = (rule, lang) => {
+  const ignorelangs = rule.ignorelangs || [];
+  const onlylangs = rule.onlylangs || [];
+
+  if (ignorelangs.indexOf(lang) > -1) {
+    return false;
+  }
+  if (onlylangs.length > 0 && onlylangs.indexOf(lang) === -1) {
+    return false;
+  }
+
+  return true;
+};
+
+const findPoemLineFindingsInText = ({
+  file,
+  data,
+  lang,
+  shouldUseModernFrenchPunctuationSpacing,
+}) => {
+  const issues = [];
+  const ignoredTests = ignoredTestsAtLine(data);
+  const lineData = data.split('\n');
+
+  for (const rule of regexps) {
+    const regexp = rule.regexp;
+    const whitelist = rule.whitelist || [];
+
+    if (!shouldCheckRule(rule, lang)) {
+      continue;
+    }
+    if (!regexp) {
+      continue;
+    }
+
+    if (regexp.test(data)) {
+      lineData.forEach((line, lineIndex) => {
+        if (
+          regexp.test(line) &&
+          (rule.testName == null ||
+            ignoredTests.get(lineIndex).indexOf(rule.testName) === -1) &&
+          !whitelist.find((w) => w.test(line))
+        ) {
+          issues.push({
+            file,
+            line: lineIndex + 1,
+            rule: rule.testName ?? `regex:${regexp}`,
+            severity: 'medium',
+            description: `'${regexp}' found in xml`,
+            excerpt: line,
+          });
+        }
+      });
+    }
+  }
+
+  if (shouldUseModernFrenchPunctuationSpacing) {
+    const missingFrenchSpacing = findMissingModernFrenchSpacing(data);
+    if (missingFrenchSpacing != null) {
+      issues.push({
+        file,
+        line: missingFrenchSpacing.line,
+        rule: 'missing-modern-french-spacing',
+        severity: 'medium',
+        description: `French spacing missing before '${missingFrenchSpacing.sign}'`,
+        excerpt: missingFrenchSpacing.text,
+      });
+    }
+  }
+
+  return issues;
+};
+
+const formatPoemLineIssue = issue =>
+  `${issue.file}:${issue.line} ${issue.rule}: ${issue.description} [${issue.excerpt}]`;
+
+const collectPoemLineQualityFindings = ({
+  rootDir = process.cwd(),
+  files = null,
+} = {}) => {
+  const fileMetadata = parsePoetWorkFiles(rootDir);
+  const allowedFiles = files == null
+    ? null
+    : new Set(files.map((filename) => normalizeFileName(filename)));
+
+  const issues = [];
+  const fileByFilename = new Map();
+  const textIdLocations = new Map();
+  const aliasLocations = new Map();
+
+  for (const item of fileMetadata) {
+    const fullpath = `fdirs/${item.filename}`;
+    const data = loadText(fullpath);
+    if (data == null) {
+      throw new Error(`Missing file ${fullpath}.`);
+    }
+    fileByFilename.set(item.filename, {
+      data,
+      ...item,
+      path: fullpath,
+    });
+  }
+
+  const textIds = flatten(
+    Array.from(fileByFilename.entries()).map(([filename, entry]) =>
+      collectTextIds(entry.data).map((textId) => ({ ...textId, file: filename }))
+    )
+  );
+
+  const aliases = flatten(
+    Array.from(fileByFilename.entries()).map(([filename, entry]) =>
+      collectTextAliases(entry.data).map((alias) => ({ ...alias, file: filename }))
+    )
+  );
+
+  textIds.forEach(({ id, line, file }) => {
+    const existing = textIdLocations.get(id);
+    if (existing != null) {
+      issues.push({
+        file,
+        line,
+        rule: 'duplicate-text-id',
+        severity: 'high',
+        description: `Text id "${id}" is used in both ${existing.file} and ${file}.`,
+        excerpt: '',
+      });
+    } else {
+      textIdLocations.set(id, { file, line });
+    }
+  });
+
+  aliases.forEach(({ alias, id, line, file }) => {
+    const existing = aliasLocations.get(alias);
+    if (existing != null) {
+      issues.push({
+        file,
+        line,
+        rule: 'duplicate-text-alias',
+        severity: 'high',
+        description: `Text alias "${alias}" is used by both ${existing.file}:${existing.id} and ${file}:${id}.`,
+        excerpt: '',
+      });
+    } else {
+      aliasLocations.set(alias, { file, id, line });
+    }
+  });
+
+  aliasLocations.forEach((aliasInfo, alias) => {
+    const textIdLocation = textIdLocations.get(alias);
+    if (textIdLocation != null) {
+      issues.push({
+        file: aliasInfo.file,
+        line: aliasInfo.line,
+        rule: 'alias-conflicts-with-text-id',
+        severity: 'high',
+        description: `Text alias "${alias}" in ${aliasInfo.file}:${aliasInfo.id} conflicts with text id in ${textIdLocation.file}.`,
+        excerpt: '',
+      });
+    }
+  });
+
+  Array.from(fileByFilename.entries()).forEach(([filename, entry]) => {
+    if (allowedFiles != null && !allowedFiles.has(filename)) {
+      return;
+    }
+
+    const notesIssue = checkNotesGroups(entry.path, entry.data);
+    if (notesIssue != null) {
+      issues.push({
+        ...notesIssue,
+        file: entry.path,
+      });
+    }
+
+    const shouldUseModernFrenchPunctuationSpacing =
+      entry.lang === 'fr' &&
+      ((entry.bornYear != null && entry.bornYear >= 1800) ||
+        (entry.workYear != null && entry.workYear >= 1800));
+
+    issues.push(
+      ...findPoemLineFindingsInText({
+        file: entry.path,
+        data: entry.data,
+        lang: entry.lang,
+        shouldUseModernFrenchPunctuationSpacing,
+      })
+    );
+  });
+
+  return issues;
+};
+
+export {
+  collectPoemLineQualityFindings,
+  formatPoemLineIssue,
+  findPoemLineFindingsInText,
+  parsePoetWorkFiles,
+};


### PR DESCRIPTION
## Opsummering
Saml alle tekstkvalitetskontroller i én fælles JavaScript-kommando, så de kan anvendes ens i agent og senere CI.

Dette løser trin 1:
- Finder og forener regelbaserede poem-line kontroller i ny `tools/text-quality-poem-lines.js`.
- Laver fælles entrypoint `tools/check-text-quality.js`, som kører både OCR-kandidater og poem-line tests.
- Opdaterer `__tests__/poem-lines.js` til at bruge fælles modul.
- Tilføjer script i `package.json`: `check-text-quality`.
- Dokumenterer kommandoen i `tools/README.md` inkl. JSON-output.

## Tekniske detaljer
- `npm run check-text-quality` kører nu alle tekstkvalitetskontroller.
- `--json` giver maskinlæsbart output uden at ændre funktionsadfærden.
- Exitkoder: `0` uden fejl, `1` kvalitetsfejl, `2` teknisk fejl.
- `ignore-tests` fra XML bibeholdes for linje-reglerne.

## Test
- Hele testpakken er kørt: `npm test`
- Resultat: `57 passed, 317 passed`.
