### PR TITLE
Revert direct text-quality commit from master

### DIFF
--- a/fdirs/aakjaer/1899.xml
+++ b/fdirs/aakjaer/1899.xml
@@ -1149,7 +1149,7 @@ og drager efter sig en blodig Strime.
 - Som Hvalen dødsramt kløv det brede Hav
 for i dets tavse Dyb at naa en Grav,
 
-saa saà jeg alt det saarede og slagne,
+saa saå jeg alt det saarede og slagne,
 det lumpent svegne og det koldt bedragne
 
 at ile rastløst imod Ørkners Øde
@@ -3276,7 +3276,7 @@ Min Mor gik rundt og Grise skar,
 min Far han spilled Lire,
 hvis det var <i>ham</i>, der var min Far,
 for se, jeg havde fire, —
-for én var for lidt for Per Søwren!
+for én var for lidt for Per SøwrenI
 
 Hvorfor jeg egentlig blev til,
 derpaa jeg grunder stændigt,

--- a/fdirs/andersen/1830.xml
+++ b/fdirs/andersen/1830.xml
@@ -2291,7 +2291,7 @@ For Gud og Dyd skal da dens Toner klinge,
 Og som en Virak Guddoms Thronen naae;
 Saa vil Du glædes, Fryd vil Dig forynge,
 Da skal din Søn i Aft'nen for Dig synge,
-Du sang jo før for ham i Barndoms Tid,
+Du sang jo for for ham i Barndoms Tid,
 Skjøndt ei saa stærk, men from, enfoldig, blid.
 
 Jeg veed det Moder, hvad mig Gud forlener,

--- a/fdirs/baggesen/1791.xml
+++ b/fdirs/baggesen/1791.xml
@@ -6042,7 +6042,7 @@ Da mærktes en Aande, saa kielen og varm -
 
 Og førend en Lyd ham fra Læberne foer,
 Det drukned' i heftige Kysse hvert Ord -
-Og førend det hvisked' ham ham hvidt eller sort,<note>ham] ham ham</note>
+Og førend det hvisked' ham ham hvidt eller sort,
 Med bløde smaae Hænder det trakte ham bort.
 
 Det førte ham tyst i letsvævende Fied:

--- a/fdirs/bergsoe/1867.xml
+++ b/fdirs/bergsoe/1867.xml
@@ -3723,7 +3723,7 @@ Dér drage de nu hen, de skinnende Flokke,
 Og svinde i det Fjerne som Sneeskyens Fnokke.
 
 Hen over Skibets Reisning saae jeg dem iilsomt drage;
-Men een var træt og mattet, og den blev tilbage.
+Men een var træt og måttet, og den blev tilbage.
 
 Som Støvgran, der hvirvles i Sollysets Lue,
 Som vingeskudt Maage, som høgslaaet Due,

--- a/fdirs/blicherclausen/1901.xml
+++ b/fdirs/blicherclausen/1901.xml
@@ -3918,7 +3918,7 @@ og selv om man ikke kender sin Mor,
 
 Tosse-Trine gik mest omkring
     og solgte Brød for en Bager,
-bød det sig, handled hun ogsaa med Ben
+bød det sig, håndled hun ogsaa med Ben
     og Klude og gamle Sager.
 
 Men hver Gang hun halede op fra sin Kurv,

--- a/fdirs/bruunmc/1797.xml
+++ b/fdirs/bruunmc/1797.xml
@@ -1560,7 +1560,7 @@ Den Gamle rysted' Hovedet
 Og sagdes ''Knøs, lad du kun af
 ''Fra denne Fangst! Forsøg kun ei
 ''At jage efter denne Fugl!
-''Flye langt, det er et farligt Dyr.
+''Flye langt, det er er farligt Dyr.
 ''Held dig, om du ei fanger den!
 ''Thi viid, min Beste, denne, som
 ''Nu flyer for dig, vil komme selv,

--- a/fdirs/bruuntc/1783.xml
+++ b/fdirs/bruuntc/1783.xml
@@ -2211,7 +2211,7 @@ Saa har jeg ei min Ven et Bogstav derimod,
 </body>
 </text>
 
-<text id="bruuntc2017110910" ignore-tests="single-circumflex-a-in-text">
+<text id="bruuntc2017110910">
 <head>
     <title>De gamle Mænds Almanak</title>
     <firstline>Blandt Millioner Daarligheder</firstline>

--- a/fdirs/dam/michelangelo.xml
+++ b/fdirs/dam/michelangelo.xml
@@ -2097,7 +2097,7 @@ Ret aldrig, kære Herre, blev jeg færdig,
 </body>
 </text>
 
-<text id="dam2004112804" ignore-tests="repeated-adjacent-word">
+<text id="dam2004112804">
 <head>
    <firstline>Saa ny en Glæde, værd at agte paa!</firstline>
    <source pages="73-77"/>

--- a/fdirs/drachmann/1875.xml
+++ b/fdirs/drachmann/1875.xml
@@ -2945,7 +2945,7 @@ Der var en Kløft. Jeg saae den fra Begyndelsen,
 Men der var Blomster hængt udover den;
 Dog alt som Blomsterskjulet visned hen
 Saa vided Kløften sig. Var det Forsyndelsen
-Og var det Straffen? Handled jeg ei ret?
+Og var det Straffen? Håndled jeg ei ret?
 Jeg veed det ei. Selv har jeg ham forladt;
 Da Grunden vakled gik jeg fra ham stille,
 Jeg vilde ikke vente indtil brat

--- a/fdirs/drachmann/1879.xml
+++ b/fdirs/drachmann/1879.xml
@@ -2456,7 +2456,7 @@ Selv har jeg sét paa de yderste Skær
 noget, som vinkende funkled for Øjet;
 saa blev jeg »syg«, og jeg krøb i min Skal.
 Jeg er jo den, som kun hidtil har lovet;
-han — han kan fylke en Hær.
+han han kan fylke en Hær.
 Godtfolk, som spaaed hans Fald,
 I har løjet! —
 

--- a/fdirs/drachmann/1884.xml
+++ b/fdirs/drachmann/1884.xml
@@ -1342,7 +1342,7 @@ her er Pauker og Piber, Basuner og Bas,
 Klokker af Glas,
 Hakkebræt, Giger og Harpe —
 her er Hvin, af de skærende, skarpe!
-Her er Dødningedans
+er er Dødningedans
 tillands og tilvands;
 her er Stormen med Spillemænd ude —
 vi var sidst ved den stejlede Skude.

--- a/fdirs/egeberg/1898.xml
+++ b/fdirs/egeberg/1898.xml
@@ -184,7 +184,7 @@ som fører op mod Lyset, op mod Solen.
 </body>
 </text>
 
-<text id="egeberg2019080606" ignore-tests="repeated-adjacent-word">
+<text id="egeberg2019080606">
 <head>
     <title>Mangen Gang i Livet det mig hændte -</title>
     <firstline>Mangen Gang i Livet det mig hændte</firstline>

--- a/fdirs/gjellerup/1910.xml
+++ b/fdirs/gjellerup/1910.xml
@@ -862,7 +862,7 @@ som raabte Vaarens Nat paa dig, du flygtende
 </body>
 </text>
 
-<text id="gjellerup2017120605" ignore-tests="suspicious-wordform">
+<text id="gjellerup2017120605">
 <head>
     <title>Vølsungerne i Rom</title>
     <subtitle>Strofer skrevne efter Opførelsen af Wagners ,,Niebelungens Ring'' i Rom, 1883.</subtitle>
@@ -1879,7 +1879,7 @@ af hvad din Tro som Livets Indhold priste.
 Saaledes var det, men det <i>er</i> ei saa.
 Nu føler du dig først forstaaet og skattet
 af En, du selv kan skatte og forstaa.
-Din Tro, der fast af Skuffelser var mattet,
+Din Tro, der fast af Skuffelser var måttet,
 vil Haand i Haand med hans vel fremad naa
 og se, at Livet selv som <i>sit</i> bekræfter
 hvad Stort og Skjønt din Sjæl har længtes efter.

--- a/fdirs/hansena/1884.xml
+++ b/fdirs/hansena/1884.xml
@@ -1931,7 +1931,7 @@ trofaste Blik, hendes Aasyn og nærende Barm.
 
 »Og I skal dø, før I har naa’t, hvad I tror.« -
 Ja, og den gavmilde Sol og den genfødte Jord,
-mens vi er Støv, skal vandre skinnende Veje;
+mens vi er Støv, skål vandre skinnende Veje;
 o, men naar hun stadig hernede vil blive,
 og naar den gamle Verden, med Lænkerne sprængte,
 jubler sin Tak, vandt vi saa ej, hvad vi tænkte?

--- a/fdirs/ingemann/1811.xml
+++ b/fdirs/ingemann/1811.xml
@@ -5098,7 +5098,7 @@ Da Blod paa Dolken klæbede.
 </body>
 </text>
 
-<text id="ingemann2018040947" ignore-tests="repeated-adjacent-word">
+<text id="ingemann2018040947">
 <head>
     <title>Tredie Sang</title>
     <firstline>Ung Pervitz saae det kolde Skaal at bløde</firstline>

--- a/fdirs/ipsen/1892.xml
+++ b/fdirs/ipsen/1892.xml
@@ -1503,7 +1503,7 @@ som var i mange Tungemaal forfaren.
 Ham bød han føre Blanseflor til Havnen
 og sælge hende der til Babilon.
 
-Saaledes handled Kongen i sin Vrede,
+Saaledes håndled Kongen i sin Vrede,
 men ej for Fordels Skyld. Som sagt saa gjort:
 Købmanden førte Blanseflor til Havnen,
 og førend selv han vidste, var hun solgt,

--- a/fdirs/mylius/1904.xml
+++ b/fdirs/mylius/1904.xml
@@ -1733,7 +1733,7 @@ men fortrøstningsfulde: han har <i>intet</i> gjort!
 — Ja, han er uskyldig. Han har ikke stjaalet,
 er blot ynksom fattig, derfor nemt forfulgt;
 Far kan, trods sin Klogskab, ogsaa fejle Maalet,
-— vidste han vel altid, hvad <i>jeg</i> handled dulgt?
+— vidste han vel altid, hvad <i>jeg</i> håndled dulgt?
 
 Der er koldt paa Bukken, men min Hjærne brænder
 ud i Nattemulmets barske Regn og Rusk.

--- a/fdirs/roerdam/1919.xml
+++ b/fdirs/roerdam/1919.xml
@@ -2902,7 +2902,7 @@ og hvad mer var mit. Var det at synde?
 hvad af Attrå selv jeg havde vakt.
     Han gav glad sit Guld
         for Støv tilspilde -
-var det sært, jeg handled, som han vilde?
+var det sært, jeg håndled, som han vilde?
 
     Rigtigt eller galt -
         Gid end han elsked!

--- a/fdirs/schandorph/1863.xml
+++ b/fdirs/schandorph/1863.xml
@@ -1824,8 +1824,8 @@ End tuder Stormen saa vildt paa Hav,
 og Maagernes Hvinen Gjenlyd gav,
 alt Natten var brudt paa Himlen frem
 og hyllede Kysten i dunkelt Gjern -
-    end sidder den Kvinde i Vindveskarmen
-    og støtter sit Hoved fast til Armen.
+end sidder den Kvinde i Vindveskarmen
+og støtter sit Hoved fåst til Armen.
 
 Vel havde Øjet lukket sig til,
 men Slummeren var ej styrkende mild,

--- a/fdirs/stuckenberg/andre.xml
+++ b/fdirs/stuckenberg/andre.xml
@@ -423,7 +423,7 @@ Vaarens Dage var længst forbi
 
 da var det som Vaaren atter mig tog
     med Eders Arme, - skinnende hvælved
-    sig Himlen! og naar I taled ,
+    sig Himlen! og naar I tåled,
     Luften omkring mig af Sommer skælved.
 
 I gav mig tilbage min Sommer, min Sol!

--- a/fdirs/wessel/1862.xml
+++ b/fdirs/wessel/1862.xml
@@ -28,7 +28,7 @@
 </head>
 <content>
 
-<text id="wesselfortaellingera4" ignore-tests="repeated-adjacent-word">
+<text id="wesselfortaellingera4">
 <head>
     <title>Gaffelen</title>
     <toctitle>Gaffelen</toctitle>

--- a/fdirs/wilster/1827.xml
+++ b/fdirs/wilster/1827.xml
@@ -3550,7 +3550,7 @@ For Hædersmænd paa Fødselsdage,
 Til Bal med Punsch og Søsterkage,
 Til Drikkelag, til gamle Klubber,
 Paa Pølsepind maa koges Supper.
-Folk er saa slemme at forlange<note>er] er er </note>
+Folk er er saa slemme at forlange
 Til hvert et Gilde nye Sange;
 Man siger, det paa Maden drøier,
 Naar Folk sig lidt ved Sang fornøier.

--- a/fdirs/wormw/andre.xml
+++ b/fdirs/wormw/andre.xml
@@ -139,7 +139,7 @@ At du, som nu staaer grøn, aflægge skal dit Klæde,
 </body>
 </text>
 
-<text id="wormw2002111603" ignore-tests="single-circumflex-a-in-text">
+<text id="wormw2002111603">
 <head>
    <title>Til Sr. Nicolai Wesling og Jomfru Antonette Höybye</title>
    <subtitle>Paa deres Bryllups Dag</subtitle>
@@ -217,7 +217,7 @@ At jeg af Brud og Brudgom lod
 Dog slutted jeg, det ikke blev
    Af Bruden slet optaget,
 Om jeg et ærbart Ønske skrev,
-   Som bôer i Naboe-Laget.
+   Som bÔer i Naboe-Laget.
 Velkommen i vor Naboe-Lag
    Dydædle ANTONETTE!
 Gid du fornøyet Dag fra Dag


### PR DESCRIPTION
## Summary

Reverts commit `5372d15c3` from protected `master` so the text-quality corrections can be submitted through a normal feature PR.

## Reason

The repository requires changes to enter `master` through a pull request.
